### PR TITLE
feat: Enhanced Placement Change System (v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,96 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ---
 
+## [0.4.0] — 2026-04-13
+
+### Added
+- **Enhanced Placement Change System** — intent-based `requestPlacementChange` with
+  five intents: `resize`, `maximize`, `fullscreen`, `minimize`, `restore`. Replaces
+  the previous dimension-only model with explicit intent declarations.
+- **Placement policy** — `SHARCContainer` accepts a `placementPolicy` constructor
+  option for container-local enforcement of dimension limits (`maxWidth`, `maxHeight`),
+  intent allowlists (`allowedIntents`), close region requirements (`requireCloseRegion`),
+  offscreen control (`allowOffscreen`), and custom validators (`customValidator`).
+  Policy is never sent over the wire.
+- **Container-owned close button** — the container renders a 50 DIP close button as a
+  DOM sibling to the ad iframe (outside the sandbox, z-index 2147483647) on `resize`,
+  `maximize`, and `fullscreen` intents. Removed on `restore`/`minimize`. Accessible:
+  `role="button"`, `aria-label`, `tabindex="0"`, Enter/Space keyboard handlers.
+  Publisher customization via `closeButtonStyles` constructor option with enforced
+  minimum size.
+- **Close region hint** — creative can send `closeRegion: { position, size }` on
+  `requestPlacementChange` to suggest where the container positions its close button.
+  Offscreen hints are silently overridden to `top-right` (never rejected).
+  `closeButtonPosition` (position + rect) included in `placementChange` notification
+  for OMID `addFriendlyObstruction` registration.
+- **`getPlacementConstraints()`** — new creative SDK method (async) that queries
+  container placement constraints before requesting a change. Follows the Permissions
+  API query-before-request pattern. New protocol message
+  `SHARC:Creative:getPlacementConstraints`.
+- **`getCachedConstraints()`** — synchronous creative SDK accessor returning the last
+  known constraints. Returns unconstrained defaults (never null) before any query or
+  event. Cache updated by `constraintsChange` events and `getPlacementConstraints()`
+  responses.
+- **`constraintsChange` event** — container sends
+  `SHARC:Container:placementConstraintsChange` when placement constraints change
+  mid-session (device rotation, viewport resize, publisher policy update). Includes
+  `reason` field (`'rotation'`, `'viewportResize'`, `'policyUpdate'`). Debounced at
+  200ms.
+- **`placementTransitionEnd` event** — container sends
+  `SHARC:Container:placementTransitionEnd` when a placement animation completes or is
+  skipped. No corresponding start event (avoids hanging states on app background).
+  Every `requestPlacementChange` with a `transition` field produces exactly one end
+  event.
+- **Animated placement transitions** — creative can send `transition: { duration, easing }`
+  hint on `requestPlacementChange`. Container animates via `transform: scale()` (GPU
+  composited) and snaps to final `width`/`height` on `transitionend`. Duration capped
+  at 500ms; easing restricted to five CSS keywords (`linear`, `ease`, `ease-in`,
+  `ease-out`, `ease-in-out`). Safety timeout at `duration + 100ms`.
+- **Three new feature strings:** `com.iabtechlab.sharc.placement.resize`,
+  `com.iabtechlab.sharc.placement.constraints`, `com.iabtechlab.sharc.placement.animate`.
+  Auto-registered by the container.
+- **`updatePlacementPolicy()`** — container method to update placement policy
+  mid-session. Triggers `constraintsChange` notification with `reason: 'policyUpdate'`.
+
+### Changed
+- **`requestPlacementChange` can now reject** — rejects with `2203` for policy
+  violations (intent not allowed, dimensions exceed limits, offscreen violation) or
+  `2211` for malformed requests (missing required `closeRegion`, unknown intent,
+  non-string intent). Backward compatible: rejection only occurs when a publisher
+  configures a `placementPolicy`.
+- **MRAID bridge `resize()` wired end-to-end** — `mraid.resize()` now maps to
+  `requestPlacementChange({ intent: 'resize' })` with `closeRegion` hint derived
+  from `setResizeProperties()`. Previously fired `COMMAND_NOT_SUPPORTED`.
+- **MRAID bridge close indicator injection removed** — `_injectCloseIndicator`,
+  `_removeCloseIndicator`, and `_closePositionCSS` removed. The container now owns
+  the close button in all placement states.
+- **MRAID bridge `useCustomClose` is reporting-only** — the flag is stored but
+  triggers no rendering action. The container always renders its own close button.
+- **MRAID bridge `supports('resize')` updated** — now checks for the
+  `com.iabtechlab.sharc.placement.resize` feature string.
+- **`docs/api-reference.md` updated** — new message types, fields, rejection
+  semantics, feature strings, and placement policy documentation.
+
+### Fixed
+- **`getSupportedFeatures()` not wired into `window.SHARC`** — the class method
+  existed but was unreachable from the `window.SHARC` global. Now exposed.
+- **`allowOffscreen` accepted but silently ignored** — the field passed through the
+  wire and was discarded. Now enforced in the validation pipeline.
+- **Position not reset on `restore`/`minimize`** — the container reset dimensions but
+  not `position`/`left`/`top` CSS, causing MRAID resize creatives to appear visually
+  misplaced after close. Now snapshots pre-resize CSS state and restores it.
+
+### Protocol
+- New creative message: `SHARC:Creative:getPlacementConstraints`
+- New container messages: `SHARC:Container:placementConstraintsChange`,
+  `SHARC:Container:placementTransitionEnd`
+- New fields on `SHARC:Creative:requestPlacementChange`: `intent`, `targetDimensions`,
+  `targetPosition`, `closeRegion`, `allowOffscreen`, `transition`
+- New fields on `SHARC:Container:placementChange`: `transition`, `closeButtonPosition`
+- `requestPlacementChange` can now reject (was resolve-only)
+
+---
+
 ## [0.3.1] — 2026-04-12
 
 ### Fixed
@@ -250,7 +340,8 @@ messages are sent at additional transition points; no new message types.
 - `supportedFeatures` extension mechanism
 
 <!-- Version compare links (Update when new tags are pushed) -->
-[Unreleased]: https://github.com/jeffreycarlson/SHARC/compare/v0.3.1...main
+[Unreleased]: https://github.com/jeffreycarlson/SHARC/compare/v0.4.0...main
+[0.4.0]: https://github.com/jeffreycarlson/SHARC/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/jeffreycarlson/SHARC/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/jeffreycarlson/SHARC/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/jeffreycarlson/SHARC/compare/v0.2.0...v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 - **MRAID bridge `resize()` wired end-to-end** — `mraid.resize()` now maps to
   `requestPlacementChange({ intent: 'resize' })` with `closeRegion` hint derived
   from `setResizeProperties()`. Previously fired `COMMAND_NOT_SUPPORTED`.
+- **`allowOffscreen: false` now enforced** — previously, `allowOffscreen` was accepted
+  but silently ignored (documented as bug 2.2 in architecture doc). Creatives that sent
+  `allowOffscreen: false` will now see rejection when the resized ad extends beyond
+  viewport bounds. This is a behavioral change even on the zero-policy path.
 - **MRAID bridge close indicator injection removed** — `_injectCloseIndicator`,
   `_removeCloseIndicator`, and `_closePositionCSS` removed. The container now owns
   the close button in all placement states.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,10 +1,10 @@
 # SHARC API Reference
 
-**Version:** 1.0 (Reference Implementation)  
+**Version:** 1.1 (Reference Implementation)  
 **Status:** Authoritative for v1 implementation  
-**Last Updated:** 2026-04-03  
+**Last Updated:** 2026-04-13  
 
-This document is the definitive developer-facing reference for the SHARC protocol. It reflects all decisions approved by Jeffrey Carlson on 2026-04-03, including the MessageChannel transport, Page Lifecycle state machine, and Structured Clone serialization.
+This document is the definitive developer-facing reference for the SHARC protocol. It reflects all decisions approved by Jeffrey Carlson, including the MessageChannel transport, Page Lifecycle state machine, Structured Clone serialization, and the Enhanced Placement Change System (v0.4.0).
 
 ---
 
@@ -535,6 +535,11 @@ Sent when the container's placement properties change (usually in response to a 
 ```typescript
 interface ContainerPlacementChangeArgs {
   placementUpdate: CurrentPlacement;
+  transition?: TransitionHint;       // Animation timing applied (if any)
+  closeButtonPosition?: {            // Position of the container's close button
+    position: string;                // e.g. "top-right"
+    rect: { x: number; y: number; width: number; height: number };
+  };
 }
 
 interface CurrentPlacement {
@@ -551,6 +556,8 @@ interface PlacementDimensions {
   anchor?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
 }
 ```
+
+The `closeButtonPosition` field enables OMID `addFriendlyObstruction` registration — the creative (or OMID bridge) can report the close button's exact position to the verification vendor.
 
 ---
 
@@ -574,6 +581,62 @@ Messages prefixed with `"WARNING:"` indicate that the container has detected a s
 ```
 "WARNING: requestPlacementChange sent without required containerDimensions"
 ```
+
+---
+
+### SHARC:Container:placementConstraintsChange
+
+Sent when placement constraints change mid-session (device rotation, browser resize, publisher policy update). Allows the creative to update its understanding of what the container allows.
+
+**Direction:** Container → Creative  
+**Requires response:** No
+
+**Args:**
+
+```typescript
+interface PlacementConstraintsChangeArgs {
+  constraints: {
+    maxWidth: number | null;
+    maxHeight: number | null;
+    allowedIntents: string[];
+    requireCloseRegion: boolean;
+    allowOffscreen: boolean;
+  };
+  reason: "rotation" | "viewportResize" | "policyUpdate";
+}
+```
+
+The container debounces resize/orientation events (200ms) to avoid flooding the creative during drag-resize.
+
+| `reason` | Trigger | Creative should... |
+|----------|---------|-------------------|
+| `rotation` | Device orientation change | Re-check if current placement still fits |
+| `viewportResize` | Browser/app window resize | Re-check if current placement still fits |
+| `policyUpdate` | Publisher changed policy mid-session | Re-query constraints, may need to restore |
+
+The creative SDK caches the constraints from this event in `getCachedConstraints()`.
+
+---
+
+### SHARC:Container:placementTransitionEnd
+
+Sent when a container-side placement animation completes (or immediately if animation is skipped). Every placement change request that includes a `transition` field produces exactly one `placementTransitionEnd` event — no hanging states.
+
+**Direction:** Container → Creative  
+**Requires response:** No
+
+**Args:**
+
+```typescript
+interface PlacementTransitionEndArgs {
+  finalDimensions: {
+    width: number;   // DIPs
+    height: number;  // DIPs
+  };
+}
+```
+
+There is no `placementTransitionStart` event — the creative already knows when a transition begins (it is the moment `requestPlacementChange()` resolves). A separate start event would be fragile: if the app backgrounds mid-animation, the creative would receive a start with no corresponding end, creating a hanging state.
 
 ---
 
@@ -808,39 +871,92 @@ The reject does NOT always mean navigation was blocked — `2105` specifically m
 
 ### SHARC:Creative:requestPlacementChange
 
-Requests that the container change its size or position.
+Requests that the container change its size or position. Uses an intent-based model where the creative declares what kind of change it wants.
 
 **Direction:** Creative → Container  
-**Requires response:** `resolve`
+**Requires response:** `resolve` or `reject`
 
 **Args:**
 
 ```typescript
 interface RequestPlacementChangeArgs {
-  changePlacement: {
-    containerDimensions?: {
-      width: number;   // DIPs
-      height: number;  // DIPs
-    };
-    inline?: boolean;  // true = in-content; false = over content
+  intent: "resize" | "maximize" | "fullscreen" | "minimize" | "restore";
+  targetDimensions?: {       // Required when intent === 'resize'
+    width: number;           // DIPs
+    height: number;          // DIPs
   };
+  targetPosition?: {         // Optional offset for resize
+    x: number;               // DIPs
+    y: number;               // DIPs
+  };
+  closeRegion?: CloseRegion; // Positioning hint for the container's close button
+  allowOffscreen?: boolean;  // Whether ad content may extend beyond viewport
+  transition?: TransitionHint; // Animation preference (container may ignore)
+}
+
+interface CloseRegion {
+  position: "top-left" | "top-right" | "bottom-left" | "bottom-right"
+           | "top-center" | "center-left" | "center-right" | "bottom-center";
+  size: number;              // DIPs, minimum 50
+}
+
+interface TransitionHint {
+  duration: number;          // Milliseconds, capped at 500ms by container
+  easing: string;            // CSS keyword: "linear" | "ease" | "ease-in" | "ease-out" | "ease-in-out"
 }
 ```
 
-All fields are optional. Omitted fields are unchanged. The container responds with the actual resulting placement — which may differ from the requested placement if the container enforces size constraints.
+**Intent descriptions:**
+
+| Intent | Behavior |
+|--------|----------|
+| `resize` | Change to specific dimensions. Requires `targetDimensions`. |
+| `maximize` | Expand to maximum available placement size. |
+| `fullscreen` | Expand to fill the viewport. |
+| `minimize` / `restore` | Return to the original pre-change placement. |
+
+**Close region:** The `closeRegion` field is a **positioning hint**, not a rendering directive. The container always owns and renders the close button (a DOM element outside the sandbox). If the hinted position would place the close button offscreen, the container silently overrides to `top-right` — it does NOT reject the placement change.
 
 **resolve value:**
 
 ```typescript
-// The Container:placementChange message is also sent alongside the resolve
-// resolve value contains the same placement data
 interface RequestPlacementChangeResolveValue {
-  containerDimensions: PlacementDimensions;
-  inline: boolean;
+  placementUpdate: CurrentPlacement;
+  transition?: TransitionHint;       // Actual animation applied (if any)
+  closeButtonPosition?: {            // Position of the container's close button
+    position: string;                // e.g. "top-right"
+    rect: { x: number; y: number; width: number; height: number };
+  };
 }
 ```
 
-The container always resolves (never rejects) this message, but the resulting dimensions may not match the request.
+**reject** — The container may reject with:
+- `2203` (`FEATURE_NOT_SUPPORTED`) — intent not allowed, dimensions exceed policy limits, or offscreen violation.
+- `2211` (`MESSAGE_SPEC_VIOLATION`) — malformed request (e.g., missing required `closeRegion` when policy demands it, unknown intent value, non-string intent).
+
+**Backward compatibility:** When no `placementPolicy` is configured on the container, the validation pipeline is skipped entirely — the container behaves identically to pre-0.4.0 behavior. Rejection only occurs when a publisher configures policy constraints. Creatives that do not handle rejection will see an unhandled Promise rejection.
+
+**Placement policy (container-local, never on wire):**
+
+Publishers configure placement constraints via the `placementPolicy` constructor option on `SHARCContainer`. This controls what the container allows:
+
+```typescript
+interface PlacementPolicy {
+  maxWidth?: number;                     // DIPs, default: Infinity
+  maxHeight?: number;                    // DIPs, default: Infinity
+  allowedIntents?: string[];             // Default: all intents
+  requireCloseRegion?: boolean;          // Default: false
+  allowOffscreen?: boolean;              // Default: true
+  customValidator?: (args) => {          // Sync function, default: null
+    allowed: boolean;
+    reason?: string;
+  };
+}
+```
+
+**Container-owned close button:** On `resize`, `maximize`, and `fullscreen` intents, the container renders a 50 DIP close button as a DOM sibling to the iframe (outside the sandbox, z-index: 2147483647). On `restore`/`minimize`, the close button is removed. For resize state, the close button triggers restore; for maximize/fullscreen, it triggers close. The close button is keyboard-focusable with Enter/Space handlers and has `role="button"` and `aria-label="Close advertisement"`.
+
+**Animation:** When a `transition` hint is provided and the container supports animation (`com.iabtechlab.sharc.placement.animate` feature), the container animates using `transform: scale()` for GPU compositing, then snaps to final `width`/`height` on `transitionend`. The container fires `SHARC:Container:placementTransitionEnd` when animation completes (or immediately if animation is skipped). Duration is capped at 500ms; easing is restricted to five CSS keywords.
 
 ---
 
@@ -856,6 +972,35 @@ Requests that the container close the ad. The container is not required to honor
 **resolve** — Container will close. The container will send `Container:close`.
 
 **reject** — Container cannot close at this time (e.g., a required display duration has not elapsed). The creative may unload itself and send a `Creative:log` message, but the container remains open.
+
+---
+
+### SHARC:Creative:getPlacementConstraints
+
+Queries the container's placement constraints before requesting a change. Follows the Permissions API query-before-request pattern.
+
+**Direction:** Creative → Container  
+**Requires response:** `resolve`
+
+**Args:** None
+
+**resolve value:**
+
+```typescript
+interface GetPlacementConstraintsResolveValue {
+  maxWidth: number | null;       // null = no limit
+  maxHeight: number | null;      // null = no limit
+  allowedIntents: string[];      // e.g. ["resize", "maximize", "restore"]
+  requireCloseRegion: boolean;   // Whether closeRegion is required on resize
+  allowOffscreen: boolean;       // Whether content may extend beyond viewport
+}
+```
+
+The `customValidator` is intentionally omitted — it is opaque container-side logic that creatives should not inspect.
+
+The creative SDK caches the response in `getCachedConstraints()` (synchronous accessor) and updates the cache on `constraintsChange` events. Before any query or event, `getCachedConstraints()` returns unconstrained defaults (never null).
+
+**Feature detection:** Use `SHARC.hasFeature('com.iabtechlab.sharc.placement.constraints')` before calling.
 
 ---
 
@@ -920,6 +1065,9 @@ interface Feature {
 
 Examples:
 - `com.iabtechlab.sharc.audio` — IAB-defined audio control extension
+- `com.iabtechlab.sharc.placement.resize` — Container supports validated resize with close region enforcement
+- `com.iabtechlab.sharc.placement.constraints` — Creative can query placement constraints via `getPlacementConstraints()`
+- `com.iabtechlab.sharc.placement.animate` — Container supports animated placement transitions
 - `com.iabtechlab.sharc.location` — IAB-defined location extension
 - `com.example.customtracking` — Third-party tracking extension
 
@@ -1021,6 +1169,9 @@ All timeouts have configurable defaults. SSAI/live environments may set `createS
 | `SHARC:Container:startCreative` | resolve or reject | After init resolved |
 | `SHARC:Container:stateChange` | None | On any state transition |
 | `SHARC:Container:placementChange` | None | After placement changes |
+| `SHARC:Container:placementConstraintsChange` | None | When placement constraints change (rotation, resize, policy update) |
+| `SHARC:Container:placementTransitionEnd` | None | When placement animation completes or is skipped |
+| `SHARC:Container:audioVolumeChange` | None | When audio state changes |
 | `SHARC:Container:log` | None | Debug/warning messages |
 | `SHARC:Container:fatalError` | resolve | On unrecoverable container error |
 | `SHARC:Container:close` | resolve | When close sequence begins |
@@ -1033,10 +1184,11 @@ All timeouts have configurable defaults. SSAI/live environments may set `createS
 | `SHARC:Creative:fatalError` | None | On unrecoverable creative error |
 | `SHARC:Creative:getContainerState` | resolve | Any time |
 | `SHARC:Creative:getPlacementOptions` | resolve | Any time |
+| `SHARC:Creative:getPlacementConstraints` | resolve | Any time after init (requires `com.iabtechlab.sharc.placement.constraints` feature) |
 | `SHARC:Creative:log` | None | Debug/warning messages |
 | `SHARC:Creative:reportInteraction` | resolve | On user interaction |
 | `SHARC:Creative:requestNavigation` | resolve or reject | On clickthrough |
-| `SHARC:Creative:requestPlacementChange` | resolve | On resize/expand |
+| `SHARC:Creative:requestPlacementChange` | resolve or reject | On resize/expand/restore |
 | `SHARC:Creative:requestClose` | resolve or reject | When creative wants to close |
 | `SHARC:Creative:getFeatures` | resolve | Any time after init |
 | `SHARC:Creative:request[FeatureName]` | resolve or reject | When using an extension |

--- a/docs/architecture-placement-changes.md
+++ b/docs/architecture-placement-changes.md
@@ -1,0 +1,1200 @@
+# Architecture Design: Enhanced Placement Change System
+
+**Version:** 0.3 (Draft)  
+**Author:** Software Architecture, SHARC Working Group  
+**Status:** Draft — Pending Review  
+**PRD:** `docs/prd-placement-changes.md` v1.1  
+**Last Updated:** 2026-04-12
+
+---
+
+## Table of Contents
+
+1. [Overview and Relationship to PRD](#1-overview-and-relationship-to-prd)
+2. [Pre-existing Bugs to Fix](#2-pre-existing-bugs-to-fix)
+3. [Protocol Changes](#3-protocol-changes)
+4. [Container-Side Design](#4-container-side-design)
+5. [Creative SDK Design](#5-creative-sdk-design)
+6. [Animation Strategy](#6-animation-strategy)
+7. [Close Region Ownership Model](#7-close-region-ownership-model)
+8. [MRAID Bridge Changes](#8-mraid-bridge-changes)
+9. [Wire Protocol Additions](#9-wire-protocol-additions)
+10. [Decisions and Trade-offs](#10-decisions-and-trade-offs)
+
+---
+
+## 1. Overview and Relationship to PRD
+
+This document is the architecture design of record for the Enhanced Placement Change System described in `docs/prd-placement-changes.md`. It covers the technical design decisions, module boundaries, wire protocol changes, and integration patterns that implement the five PRD milestones:
+
+1. **Placement policy** (container-local enforcement)
+2. **Close region validation** (protocol wire change + container validation)
+3. **MRAID `resize()` end-to-end** (bridge wiring + close region)
+4. **`getPlacementConstraints()` query** (new protocol message)
+5. **Animation hints** (additive protocol field)
+
+This document also addresses six implementation concerns raised by the frontend developer review that the PRD does not cover, most importantly: the close button ownership model (container-owned in all states as of v0.3), the CSS animation strategy (transform-based rather than width/height transitions), position reset on restore, `allowOffscreen` enforcement, `constraintsChange` event semantics, and a pre-existing `getSupportedFeatures` exposure bug.
+
+**v0.3 design change:** The container owns the close button in ALL placement change states (resize, maximize, fullscreen). The close button is a DOM element on the publisher page, outside the sandbox. The creative's `closeRegion` field is a positioning hint, not a rendering directive. See Section 7 for the full rationale and ADR-PC-006 for the decision record.
+
+**Guiding constraint:** The placement change system is the most complex request/response flow in SHARC. Every design choice here must preserve two invariants: (a) the container has final authority over all placement mutations, and (b) the creative never needs more than one round trip to achieve a valid placement change once it has queried constraints.
+
+---
+
+## 2. Pre-existing Bugs to Fix
+
+These bugs exist in the current codebase and must be fixed as part of this work. They are not new features; they are correctness issues that would be exposed or worsened by the placement change enhancements.
+
+### 2.1 `getSupportedFeatures()` Not Wired into `window.SHARC`
+
+**Location:** `sharc-creative.js`, line 651 (class method) vs. lines 713-738 (window.SHARC exposure block)
+
+The `SHARCCreativeSDK` class defines `getSupportedFeatures()` at line 651, which returns `this._features`. However, the `window.SHARC` exposure block (line 713-738) does not include it. The method is unreachable from creative code that uses the `window.SHARC` global.
+
+**Fix:** Add to the exposure block:
+
+```javascript
+window.SHARC = {
+  // ...existing entries...
+  getSupportedFeatures: () => _sdkInstance.getSupportedFeatures(),
+};
+```
+
+This is a one-line addition. It must ship before or alongside the placement constraints feature, because `getPlacementConstraints` depends on feature detection working correctly from the creative's perspective.
+
+### 2.2 `allowOffscreen` Accepted but Silently Ignored
+
+**Location:** `sharc-container.js`, line 978 (destructuring) and line 743 of `sharc-mraid-bridge.js` (sent on wire)
+
+The MRAID bridge sends `allowOffscreen` in the `requestPlacementChange` args (line 743). The container destructures it from `msg.args` but never evaluates it. The field passes through the wire and is silently discarded.
+
+**Fix:** Enforce `allowOffscreen` in the validation pipeline (see Section 4.3, step 5). When `allowOffscreen === false` (either from the request or the placement policy), the container must validate that the entire resized ad fits within viewport bounds. When `allowOffscreen` is absent from the request, fall back to the placement policy's `allowOffscreen` value, then to `true` (permissive default for backward compatibility).
+
+### 2.3 Position Not Reset on `restore`/`minimize`
+
+**Location:** `sharc-container.js`, lines 999-1004
+
+The `minimize`/`restore` case resets dimensions to `environmentData.currentPlacement` but explicitly does not reset `position`, `left`, or `top` CSS properties. The inline comment acknowledges this: "does not reset position/left/top CSS." If a creative resizes with a `targetPosition` offset (e.g., an MRAID resize with `offsetX`/`offsetY`), then triggers `restore`, the iframe stays at the offset position with the original dimensions. The MRAID bridge's `close()` from resized state maps to `requestPlacementChange({ intent: 'restore' })`, so this bug causes MRAID resize creatives to appear visually misplaced after close.
+
+**Fix:** The `minimize`/`restore` case must reset iframe positioning. The container needs to store the pre-resize position state and restore it. See Section 4.5 for the full design.
+
+---
+
+## 3. Protocol Changes
+
+### 3.1 New Message Type
+
+| Message | Direction | Purpose |
+|---------|-----------|---------|
+| `SHARC:Creative:getPlacementConstraints` | Creative -> Container | Query what the container allows before requesting a change |
+
+### 3.2 New Fields on Existing Messages
+
+| Message | Field | Type | Required | Notes |
+|---------|-------|------|----------|-------|
+| `Creative:requestPlacementChange` | `closeRegion` | `CloseRegion` | No (unless policy demands it) | Placement hint: creative suggests where the container should position its close button |
+| `Creative:requestPlacementChange` | `allowOffscreen` | `boolean` | No | Creative declares whether it expects to extend beyond viewport |
+| `Creative:requestPlacementChange` | `transition` | `TransitionHint` | No | Animation preference; container may ignore |
+| `Container:placementChange` | `transition` | `TransitionHint` | No | Actual animation timing applied by container |
+
+### 3.3 Updated Semantics
+
+**`requestPlacementChange` can now reject.** The current api-reference.md states the container always resolves. This changes to:
+
+- **resolve**: Placement change accepted. Resolve value contains actual resulting placement.
+- **reject with 2203**: Policy violation — intent not allowed, dimensions exceed limits, offscreen violation.
+- **reject with 2211**: Malformed request — missing required `closeRegion` (when policy demands it). Note: an offscreen close region hint does NOT cause rejection; the container overrides to a visible default position (see Section 4.4).
+
+This is a behavioral contract change. Creatives that do not handle rejection will see an unhandled Promise rejection. The mitigation is that rejection only occurs when a publisher configures a `placementPolicy` — the zero-policy default path is identical to today.
+
+### 3.4 New Feature Strings
+
+| Feature String | Meaning |
+|---------------|---------|
+| `com.iabtechlab.sharc.placement.resize` | Container supports validated resize with close region enforcement |
+| `com.iabtechlab.sharc.placement.constraints` | Creative can query placement constraints |
+| `com.iabtechlab.sharc.placement.animate` | Container supports animated placement transitions |
+
+---
+
+## 4. Container-Side Design
+
+### 4.1 Placement Policy Option
+
+The `SHARCContainer` constructor accepts a new `placementPolicy` option. This is purely container-local configuration — it is never sent over the wire.
+
+```javascript
+const container = new SHARCContainer({
+  creativeUrl: '...',
+  containerEl: document.getElementById('ad-slot'),
+  environmentData: { /* ... */ },
+  placementPolicy: {
+    maxWidth: 728,
+    maxHeight: 480,
+    allowedIntents: ['resize', 'restore'],
+    requireCloseRegion: true,
+    allowOffscreen: false,
+    customValidator: null,
+  },
+});
+```
+
+**Storage:** The policy is stored as `this._placementPolicy` at construction time. Missing fields fall back to permissive defaults: `maxWidth: Infinity`, `maxHeight: Infinity`, `allowedIntents: ['resize', 'maximize', 'fullscreen', 'minimize', 'restore']`, `requireCloseRegion: false`, `allowOffscreen: true`, `customValidator: null`.
+
+**Location for changes:** `sharc-container.js` constructor (around line 85-130).
+
+### 4.2 Pre-resize Position Snapshot
+
+To fix the restore/position bug (Section 2.3), the container must store the iframe's position state before any resize modifies it.
+
+**New private field:** `this._preResizeCSSState`
+
+```javascript
+// Stored before the first resize intent is applied
+this._preResizeCSSState = null;
+
+// In _handleRequestPlacementChange, before applying resize:
+if (intent === 'resize' && !this._preResizeCSSState) {
+  this._preResizeCSSState = {
+    position: this._iframe.style.position || '',
+    left:     this._iframe.style.left || '',
+    top:      this._iframe.style.top || '',
+    width:    this._iframe.style.width || '',
+    height:   this._iframe.style.height || '',
+  };
+}
+```
+
+This snapshot is taken once, on the first resize. Subsequent resizes (without an intervening restore) do not overwrite it. The restore case uses it to reset. See Section 4.5.
+
+### 4.3 Validation Pipeline
+
+The rewritten `_handleRequestPlacementChange` applies validation before execution. The pipeline runs top-to-bottom; the first failing check rejects the message and short-circuits.
+
+**Validation order:**
+
+1. **Intent allowlist.** If `_placementPolicy.allowedIntents` is configured and `intent` is not in the list, reject with `2203`: `"Intent '[intent]' not allowed by placement policy"`.
+
+2. **Dimension limits.** If `intent === 'resize'` and `targetDimensions` is present, validate `width <= maxWidth` and `height <= maxHeight`. Reject with `2203` if exceeded.
+
+3. **Close region presence.** If `intent === 'resize'` and `_placementPolicy.requireCloseRegion === true`, validate that `closeRegion` is present in the request. Reject with `2211` if missing.
+
+4. **Close region hint resolution.** If `closeRegion` is present, resolve the effective close button position using `_resolveClosePosition()` (Section 4.4). If the hinted position would be offscreen, the container overrides to `top-right` -- it does NOT reject the placement change. Store the resolved position for use by the close button renderer (Section 4.7).
+
+5. **Offscreen enforcement.** Determine the effective `allowOffscreen` value: use the request's `allowOffscreen` if explicitly set, otherwise fall back to `_placementPolicy.allowOffscreen`, otherwise `true`. If the effective value is `false` and `intent === 'resize'`, validate the entire resized ad fits within viewport bounds. Reject with `2203` if it would extend offscreen.
+
+6. **Custom validator.** If `_placementPolicy.customValidator` is defined, call it with the full request args. If it returns `{ allowed: false, reason: '...' }`, reject with `2203` and the reason string.
+
+7. **Execute.** All checks passed. Apply the placement change and resolve.
+
+**Backward compatibility:** When `_placementPolicy` is `undefined` (the default), steps 1-6 are skipped entirely — the method behaves exactly as it does today.
+
+```javascript
+_handleRequestPlacementChange(msg) {
+  const args = msg.args || {};
+  const { intent, targetDimensions, targetPosition, closeRegion, allowOffscreen, transition } = args;
+
+  // ── Validation pipeline (only when policy is configured) ──
+  if (this._placementPolicy) {
+    const rejection = this._validatePlacementRequest(args);
+    if (rejection) {
+      this._protocol._reject(msg, rejection.code, rejection.message);
+      return;
+    }
+  }
+
+  // ── Execution (with position snapshot, animation, and close button) ──
+  let updatedPlacement = { ...(this.environmentData.currentPlacement || {}) };
+
+  // Resolve close button position from hint (Section 4.4)
+  const resolvedClose = closeRegion
+    ? this._resolveClosePosition(closeRegion, targetDimensions || updatedPlacement, targetPosition)
+    : { position: 'top-right', size: 50, overridden: false };
+
+  switch (intent) {
+    case 'resize':
+      this._snapshotPreResizeState();
+      this._currentIntent = 'resize';
+      if (targetDimensions) {
+        updatedPlacement = { ...updatedPlacement, ...targetDimensions };
+        this._applyIframeDimensions(targetDimensions, transition);
+      }
+      if (targetPosition) {
+        this._applyIframePosition(targetPosition);
+      }
+      this._createCloseButton(resolvedClose.position);   // Container-owned close
+      break;
+    case 'maximize':
+    case 'fullscreen':
+      this._snapshotPreResizeState();
+      this._currentIntent = intent;
+      updatedPlacement = this._getMaxPlacement();
+      this._applyIframeDimensions(updatedPlacement, transition);
+      this._createCloseButton('top-right');               // Container-owned close
+      break;
+    case 'minimize':
+    case 'restore':
+      this._currentIntent = null;
+      updatedPlacement = this._restorePreResizeState();
+      this._removeCloseButton();                          // Remove close on restore
+      break;
+    default:
+      console.warn('[SHARCContainer] Unknown placement intent:', intent);
+  }
+
+  this.environmentData.currentPlacement = updatedPlacement;
+  const resolvePayload = { placementUpdate: updatedPlacement };
+  if (transition && this._supportsAnimation()) {
+    resolvePayload.transition = this._clampTransition(transition);
+  }
+  this._protocol._resolve(msg, resolvePayload);
+  this.notifyPlacementChange(updatedPlacement);
+}
+```
+
+### 4.4 Close Region Hint Validation
+
+The creative's `closeRegion` field on `requestPlacementChange` is a **placement hint** -- the creative suggests where the container's close button should be positioned, and the container decides whether to honor the hint or fall back to a default.
+
+The container validates the hint and uses it to position its own close button (see Section 4.7). If the hinted position would place the close button offscreen, the container **accepts the resize but overrides the close position to a visible default (top-right)** rather than rejecting the placement change. The close button is a safety mechanism that should never prevent a valid resize from executing.
+
+```javascript
+/**
+ * Validates a close region hint and returns the effective close position.
+ * The container always renders its own close button — this determines WHERE.
+ * @param {Object} closeRegion - { position: string, size: number } hint from creative
+ * @param {Object} targetDimensions - { width, height }
+ * @param {Object} targetPosition - { x, y } or null (use current iframe position)
+ * @returns {{ position: string, size: number, overridden: boolean }}
+ * @private
+ */
+_resolveClosePosition(closeRegion, targetDimensions, targetPosition) {
+  const size = Math.max(closeRegion.size || 50, 50);  // Enforce minimum 50 DIPs
+  const hintedPosition = closeRegion.position || 'top-right';
+
+  // Compute close region screen-space rect for the hinted position
+  const adX = targetPosition ? targetPosition.x : (this._iframe ? this._iframe.offsetLeft : 0);
+  const adY = targetPosition ? targetPosition.y : (this._iframe ? this._iframe.offsetTop : 0);
+  const adW = targetDimensions.width;
+  const adH = targetDimensions.height;
+
+  const rect = this._computeCloseRegionRect(adX, adY, adW, adH, hintedPosition, size);
+
+  // Check against viewport — if offscreen, override to default, do NOT reject
+  const viewport = this._getViewportBounds();
+  if (rect.left < 0 || rect.top < 0 ||
+      rect.right > viewport.width || rect.bottom > viewport.height) {
+    console.warn('[SHARCContainer] Close region hint offscreen at', hintedPosition, '— defaulting to top-right');
+    return { position: 'top-right', size, overridden: true };
+  }
+
+  return { position: hintedPosition, size, overridden: false };
+}
+```
+
+**Key behavioral change from v0.2:** The close region geometry check no longer rejects the placement change request. Previously, an offscreen close region would reject with error code `2211`. Now, the container accepts the resize and silently overrides the close button to a visible default position. This aligns with the principle that the close affordance is the container's responsibility -- the creative's hint is advisory, not authoritative.
+
+The validation pipeline step 4 (Section 4.3) is updated accordingly: the `closeRegion` geometry check calls `_resolveClosePosition` to determine where the container will render its close button, but never short-circuits with a rejection based on close position alone. The `closeRegion.size` minimum of 50 DIPs is still enforced, but since the container renders the close button, the size field is informational -- the container ensures its close button meets the 50 DIP minimum regardless.
+
+### 4.5 Position Reset on Restore
+
+The `minimize`/`restore` case must reset both dimensions and position. The container uses the `_preResizeCSSState` snapshot stored at resize time.
+
+```javascript
+/**
+ * Snapshots the iframe's CSS state before resize, if not already captured.
+ * @private
+ */
+_snapshotPreResizeState() {
+  if (this._preResizeCSSState || !this._iframe) return;
+  this._preResizeCSSState = {
+    position: this._iframe.style.position,
+    left:     this._iframe.style.left,
+    top:      this._iframe.style.top,
+    width:    this._iframe.style.width,
+    height:   this._iframe.style.height,
+  };
+}
+
+/**
+ * Restores iframe CSS state to the pre-resize snapshot.
+ * Clears the snapshot so the next resize captures fresh state.
+ * @returns {Object} The original placement dimensions to use as updatedPlacement.
+ * @private
+ */
+_restorePreResizeState() {
+  if (this._preResizeCSSState && this._iframe) {
+    this._iframe.style.position = this._preResizeCSSState.position;
+    this._iframe.style.left     = this._preResizeCSSState.left;
+    this._iframe.style.top      = this._preResizeCSSState.top;
+    this._iframe.style.width    = this._preResizeCSSState.width;
+    this._iframe.style.height   = this._preResizeCSSState.height;
+  }
+  this._preResizeCSSState = null;
+
+  // Return the original placement from environmentData
+  // Note: environmentData.currentPlacement has been mutated by resize.
+  // We need the ORIGINAL placement. Store it separately.
+  return { ...(this._originalPlacement || this.environmentData.currentPlacement || {}) };
+}
+```
+
+**Additional requirement:** The container must store `this._originalPlacement` at construction time (a copy of `environmentData.currentPlacement`). This is the placement state to restore to, independent of any mutations that `_handleRequestPlacementChange` applies to `environmentData.currentPlacement`.
+
+```javascript
+// In constructor, after environmentData is stored:
+this._originalPlacement = { ...(this.environmentData.currentPlacement || {}) };
+```
+
+**Location for changes:** `sharc-container.js`, constructor (around line 130) and `_handleRequestPlacementChange` (lines 999-1004).
+
+### 4.6 `getPlacementConstraints` Handler
+
+New handler registered alongside the existing `GET_PLACEMENT_OPTIONS` handler (line 581 of `sharc-container.js`).
+
+```javascript
+proto.addListener(CreativeMessages.GET_PLACEMENT_CONSTRAINTS, (msg) => {
+  this._onMessage && this._onMessage('received', msg);
+  const policy = this._placementPolicy || {};
+  proto._resolve(msg, {
+    maxWidth:           policy.maxWidth != null ? policy.maxWidth : null,
+    maxHeight:          policy.maxHeight != null ? policy.maxHeight : null,
+    allowedIntents:     policy.allowedIntents || ['resize', 'maximize', 'fullscreen', 'minimize', 'restore'],
+    requireCloseRegion: !!policy.requireCloseRegion,
+    allowOffscreen:     policy.allowOffscreen !== false,
+  });
+});
+```
+
+The `customValidator` is intentionally omitted from the response. It is opaque container-side logic that creatives should not inspect.
+
+### 4.7 Container-Side Close Button Rendering
+
+The container renders the close button as a DOM element on the publisher page, positioned as a **sibling** to the ad iframe. This element lives outside the sandbox and is immune to creative CSS, JavaScript, and DOM manipulation.
+
+**Implementation:**
+
+```javascript
+/**
+ * Creates and positions the container-owned close button.
+ * Called on resize, maximize, and fullscreen intents.
+ * @param {string} position - Resolved close position ('top-right', 'top-left', etc.)
+ * @private
+ */
+_createCloseButton(position) {
+  this._removeCloseButton();
+
+  const btn = document.createElement('div');
+  btn.className = 'sharc-close-button';
+  btn.setAttribute('role', 'button');
+  btn.setAttribute('aria-label', 'Close advertisement');
+  btn.setAttribute('tabindex', '0');
+
+  // Default styling — X icon via CSS, no external assets
+  btn.style.cssText = [
+    'position:absolute',
+    'width:50px',
+    'height:50px',
+    'min-width:50px',
+    'min-height:50px',
+    'z-index:2147483647',
+    'cursor:pointer',
+    'background:rgba(0,0,0,0.6)',
+    'border-radius:50%',
+    'display:flex',
+    'align-items:center',
+    'justify-content:center',
+    'font-size:24px',
+    'color:#fff',
+    'line-height:1',
+    'user-select:none',
+    '-webkit-user-select:none',
+    'pointer-events:auto',
+    'box-sizing:border-box',
+  ].join(';');
+
+  // Apply publisher customization if provided
+  if (this._closeButtonStyles) {
+    Object.assign(btn.style, this._closeButtonStyles);
+    // Enforce minimum size regardless of publisher customization
+    if (parseInt(btn.style.width) < 50) btn.style.width = '50px';
+    if (parseInt(btn.style.height) < 50) btn.style.height = '50px';
+  }
+
+  // Position relative to the iframe
+  this._applyClosePosition(btn, position);
+
+  // X glyph (Unicode multiplication sign — renders well cross-platform)
+  btn.textContent = '\u00D7';
+
+  // Click handler — behavior depends on current state
+  const handleClose = () => {
+    if (this._currentIntent === 'maximize' || this._currentIntent === 'fullscreen') {
+      this._initiateClose();
+    } else {
+      // resize state: restore to original placement
+      this._handleRequestPlacementChange({
+        args: { intent: 'restore' },
+        messageId: this._protocol._nextMessageId(),
+        type: 'synthetic',
+      });
+    }
+  };
+
+  btn.addEventListener('click', handleClose);
+  btn.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleClose();
+    }
+  });
+
+  // Insert as sibling to iframe, within the container element
+  this._containerEl.style.position = this._containerEl.style.position || 'relative';
+  this._containerEl.appendChild(btn);
+  this._closeButton = btn;
+}
+
+/**
+ * Removes the container-owned close button.
+ * Called on restore, close, and destroy.
+ * @private
+ */
+_removeCloseButton() {
+  if (this._closeButton && this._closeButton.parentNode) {
+    this._closeButton.parentNode.removeChild(this._closeButton);
+  }
+  this._closeButton = null;
+}
+
+/**
+ * Positions the close button relative to the iframe based on the
+ * resolved position string.
+ * @param {HTMLElement} btn - The close button element
+ * @param {string} position - Position enum value
+ * @private
+ */
+_applyClosePosition(btn, position) {
+  // Reset all positioning
+  btn.style.top = btn.style.bottom = btn.style.left = btn.style.right = 'auto';
+  btn.style.transform = '';
+
+  switch (position) {
+    case 'top-left':      btn.style.top = '0'; btn.style.left = '0'; break;
+    case 'top-center':    btn.style.top = '0'; btn.style.left = '50%';
+                          btn.style.transform = 'translateX(-50%)'; break;
+    case 'top-right':     btn.style.top = '0'; btn.style.right = '0'; break;
+    case 'center-left':   btn.style.top = '50%'; btn.style.left = '0';
+                          btn.style.transform = 'translateY(-50%)'; break;
+    case 'center-right':  btn.style.top = '50%'; btn.style.right = '0';
+                          btn.style.transform = 'translateY(-50%)'; break;
+    case 'bottom-left':   btn.style.bottom = '0'; btn.style.left = '0'; break;
+    case 'bottom-center': btn.style.bottom = '0'; btn.style.left = '50%';
+                          btn.style.transform = 'translateX(-50%)'; break;
+    case 'bottom-right':  btn.style.bottom = '0'; btn.style.right = '0'; break;
+    default:              btn.style.top = '0'; btn.style.right = '0'; break;
+  }
+}
+```
+
+**Constructor option for publisher customization:**
+
+```javascript
+const container = new SHARCContainer({
+  creativeUrl: '...',
+  containerEl: document.getElementById('ad-slot'),
+  closeButtonStyles: {                    // NEW — optional publisher customization
+    background: 'rgba(0,0,0,0.8)',
+    borderRadius: '4px',
+    fontSize: '20px',
+  },
+});
+```
+
+The `closeButtonStyles` option is stored as `this._closeButtonStyles` and applied via `Object.assign` over the defaults. The container enforces a minimum size of 50 DIPs (per MRAID 3.0 spec) regardless of publisher customization -- if the publisher sets `width: '30px'`, the container overrides to `50px`.
+
+**Lifecycle:**
+
+| Event | Close button action |
+|-------|-------------------|
+| `resize` intent accepted | `_createCloseButton(resolvedPosition)` |
+| `maximize` intent accepted | `_createCloseButton('top-right')` |
+| `fullscreen` intent accepted | `_createCloseButton('top-right')` |
+| `restore` intent accepted | `_removeCloseButton()` |
+| `minimize` intent accepted | `_removeCloseButton()` |
+| Container `destroy()` | `_removeCloseButton()` |
+| Ad closed | `_removeCloseButton()` |
+
+**Accessibility:**
+
+- `role="button"` -- announces as a button to screen readers
+- `aria-label="Close advertisement"` -- descriptive label for screen readers
+- `tabindex="0"` -- keyboard focusable in tab order
+- Enter and Space key handlers -- standard button keyboard interaction
+- Minimum 50 DIP size -- meets WCAG 2.5.5 Target Size (Enhanced) at Level AAA
+
+**Integration with animation (Section 6):** During a `transform: scale()` animation, the close button is already visible and correctly positioned because it is a sibling element, not a child of the scaled iframe. The close button does not scale with the iframe -- it remains at its native size throughout the animation.
+
+---
+
+## 5. Creative SDK Design
+
+### 5.1 `getPlacementConstraints()` Method
+
+Add to `SHARCCreativeSDK` class (after `getPlacementOptions()` at line 472):
+
+```javascript
+/**
+ * Queries the container's placement constraints.
+ * Returns what the container allows before the creative requests a change.
+ * Use SHARC.hasFeature('com.iabtechlab.sharc.placement.constraints') to check availability.
+ *
+ * @returns {Promise<{maxWidth: number|null, maxHeight: number|null,
+ *           allowedIntents: string[], requireCloseRegion: boolean, allowOffscreen: boolean}>}
+ */
+getPlacementConstraints() {
+  if (this._dead) return Promise.reject(new Error('SDK is dead'));
+  return this._proto.getPlacementConstraints();
+}
+```
+
+Add to the `window.SHARC` exposure block (line 713-738):
+
+```javascript
+getPlacementConstraints: () => _sdkInstance.getPlacementConstraints(),
+```
+
+### 5.2 Dual-Mode Constraints: Synchronous Cache + Change Event
+
+The PRD specifies `getPlacementConstraints()` as an async query. The frontend review correctly identifies that constraints can change mid-session (device rotation, browser resize, publisher page layout change). A creative that queries constraints once at init and caches them may make invalid requests after a rotation.
+
+**Design:** Two access patterns, following the `hasFeature()` precedent (synchronous cached value from init data, updated asynchronously):
+
+1. **`getPlacementConstraints()`** — Async round trip to the container. Always returns fresh data. Used at init time and after receiving a `constraintsChange` event.
+
+2. **`SHARC.on('constraintsChange', callback)`** — Fired by the container when placement constraints change (rotation, viewport resize, publisher policy update). The callback receives the new constraints object.
+
+**Container-side:** The container monitors for constraint-relevant changes and sends `Container:placementConstraintsChange` when they occur. This is a container-initiated notification, not a request/response.
+
+```javascript
+// New message type in ContainerMessages (sharc-protocol.js)
+PLACEMENT_CONSTRAINTS_CHANGE: 'SHARC:Container:placementConstraintsChange'
+```
+
+**When the container fires this:**
+
+- On `window.resize` / `orientationchange` if viewport-derived constraints (maxWidth, maxHeight) change — `reason: 'rotation'` or `reason: 'viewportResize'`
+- On explicit `updatePlacementPolicy()` call from the publisher — `reason: 'policyUpdate'`
+
+The container debounces resize/orientation events (200ms) to avoid flooding the creative during drag-resize.
+
+**`constraintsChange` payload includes a `reason` field** so the creative knows WHY constraints changed and can decide whether to re-request a placement change or just update its UI:
+
+| `reason` | Trigger | Creative should... |
+|----------|---------|-------------------|
+| `'rotation'` | Device orientation change | Re-check if current placement still fits |
+| `'viewportResize'` | Browser/app window resize, iPad Split View | Re-check if current placement still fits |
+| `'policyUpdate'` | Publisher changed policy mid-session | Re-query constraints, may need to restore |
+
+**Creative SDK event wiring:**
+
+```javascript
+// In SHARCCreativeSDK, add to the protocol listener setup:
+this._proto.addListener('SHARC:Container:placementConstraintsChange', (msg) => {
+  this._cachedConstraints = msg.args.constraints;
+  this._emit('constraintsChange', msg.args);  // { constraints, reason }
+  this._proto._resolve(msg, {});
+});
+```
+
+**Synchronous cached access (convenience method):**
+
+```javascript
+/**
+ * Returns the last known placement constraints.
+ * Synchronous — uses cached data from the last getPlacementConstraints()
+ * call or the last constraintsChange event. Before any query or event,
+ * returns unconstrained defaults (never null).
+ * @returns {Object}
+ */
+getCachedConstraints() {
+  return this._cachedConstraints || {
+    maxWidth: null,
+    maxHeight: null,
+    allowedIntents: ['resize', 'maximize', 'fullscreen', 'minimize', 'restore'],
+    requireCloseRegion: false,
+    allowOffscreen: true,
+  };
+}
+```
+
+Add to `window.SHARC`:
+
+```javascript
+getCachedConstraints: () => _sdkInstance.getCachedConstraints(),
+```
+
+### 5.3 Transition End Event
+
+Creatives need to know when a container-side animation completes, so they can synchronize their own internal rendering (e.g., delaying asset reveal until the container has finished expanding).
+
+**One event only: `placementTransitionEnd`.** There is no `placementTransitionStart` event.
+
+| Event | Fired When | Payload |
+|-------|-----------|---------|
+| `placementTransitionEnd` | Container completes (or skips) an animated placement change | `{ finalDimensions }` |
+
+**Why no start event?** The creative already knows when a transition begins — it is the moment `requestPlacementChange()` resolves. A separate start event is redundant and fragile: if the container sends a `placementChange` with a `transition` field but ultimately does not animate (e.g., `prefers-reduced-motion`, publisher policy, or the app backgrounds mid-animation), the creative receives a start event with no corresponding end. This creates a hanging state that is difficult to recover from — analogous to the iOS pattern where developers key on `viewDidAppear` (settled state) rather than `viewWillAppear` (transitional). An app-background event during animation would leave the creative in an unknown "transitioning" state with no resolution.
+
+**Container-side flow:**
+
+```
+Container                                    Creative
+   |── Container:placementChange ──────────▶  |  (immediate — includes transition hint)
+   |                                           |
+   |   [container animation runs]              |
+   |                                           |
+   |── Container:placementTransitionEnd ───▶   |
+   |                                           |  SDK emits 'placementTransitionEnd'
+```
+
+```javascript
+// New message type in ContainerMessages (sharc-protocol.js)
+PLACEMENT_TRANSITION_END: 'SHARC:Container:placementTransitionEnd'
+```
+
+**The container MUST fire `placementTransitionEnd` even when animation is skipped** (e.g., `prefers-reduced-motion`, duration clamped to 0). In that case, `finalDimensions` reflects the instantly-applied dimensions. This guarantees that every placement change with a `transition` field in the request produces exactly one `placementTransitionEnd` event — no hanging states.
+
+**Why not reuse `placementChange` for the end event?** The `placementChange` notification fires immediately when the container decides to apply the change (before animation starts). The end event fires when the animation completes. These are temporally distinct moments with different semantics — collapsing them would force creatives to guess when the visual transition actually finished.
+
+---
+
+## 6. Animation Strategy
+
+### 6.1 The Problem with CSS `width`/`height` Transitions
+
+The PRD's Section 6.5 specifies CSS transitions on `width` and `height` properties:
+
+```javascript
+iframe.style.transition = `width ${duration}ms ${easing}, height ${duration}ms ${easing}`;
+```
+
+The frontend review correctly identifies this as problematic. Transitioning `width`/`height` triggers layout recalculation on every animation frame. In Safari WKWebView, this is synchronous and blocks the main thread. The iframe's internal document also receives continuous `resize` events during the transition, causing the creative's own layout to thrash.
+
+### 6.2 Recommended Strategy: `transform: scale()` with Snap
+
+The container should animate using `transform: scale()` for the visual transition, then snap to the final `width`/`height` values on `transitionend`. This approach composites on the GPU and does not trigger layout recalculation during the animation.
+
+**Implementation in `_applyAnimatedDimensions`:**
+
+```javascript
+/**
+ * Applies an animated dimension change using transform: scale().
+ * The visual transition runs on the GPU compositor. On completion,
+ * snaps to final width/height and removes the transform.
+ *
+ * @param {Object} fromDims - { width, height } current dimensions
+ * @param {Object} toDims - { width, height } target dimensions
+ * @param {Object} transition - { duration, easing }
+ * @private
+ */
+_applyAnimatedDimensions(fromDims, toDims, transition) {
+  if (!this._iframe) return;
+
+  const duration = this._clampDuration(transition.duration);
+  const easing = this._sanitizeEasing(transition.easing || 'ease-out');
+
+  const scaleX = toDims.width / fromDims.width;
+  const scaleY = toDims.height / fromDims.height;
+
+  // Set transform-origin based on anchor point (default: top-left)
+  this._iframe.style.transformOrigin = 'top left';
+  this._iframe.style.transition = `transform ${duration}ms ${easing}`;
+  this._iframe.style.transform = `scale(${scaleX}, ${scaleY})`;
+
+  const cleanup = () => {
+    this._iframe.removeEventListener('transitionend', onEnd);
+    // Snap to final dimensions — single layout recalc
+    this._iframe.style.transition = '';
+    this._iframe.style.transform = '';
+    this._applyIframeDimensions(toDims);
+
+    // Notify creative that transition completed
+    this._protocol.sendMessage(ContainerMessages.PLACEMENT_TRANSITION_END, {
+      finalDimensions: toDims,
+    });
+  };
+
+  const onEnd = (e) => {
+    if (e.propertyName === 'transform') cleanup();
+  };
+
+  this._iframe.addEventListener('transitionend', onEnd);
+
+  // Safety timeout: if transitionend never fires (tab hidden, etc.), snap anyway
+  setTimeout(cleanup, duration + 100);
+}
+```
+
+### 6.3 Why `transform: scale()` Instead of `width`/`height`
+
+| Concern | `width`/`height` transition | `transform: scale()` + snap |
+|---------|---------------------------|----------------------------|
+| Layout recalc during animation | Every frame (synchronous in WebKit) | None — composited on GPU |
+| Creative internal resize events | Continuous during transition | One event at snap point |
+| Visual quality | Pixel-perfect throughout | Slightly blurry during scale, pixel-perfect at snap |
+| Complexity | Simple CSS | Moderate — requires scale calc, cleanup, safety timeout |
+| Safari WKWebView perf | Poor — main thread blocked | Good — compositor thread |
+
+**Trade-off acknowledged:** During the `scale()` animation, the iframe content appears slightly scaled (bitmap upscale/downscale) rather than reflowed. This is a 100-500ms visual artifact. At typical ad animation durations (200-300ms), this is imperceptible to users. The snap to final dimensions at `transitionend` ensures pixel-perfect rendering for the steady state.
+
+**OMID bridge interaction:** During the `transform: scale()` animation, the iframe's `getBoundingClientRect()` reports continuously changing dimensions that reflect the visual transform, not the layout dimensions. The OMID bridge (`sharc-omid-bridge.js`) must suppress viewability geometry reporting during the transition and only report the final snapped dimensions after `placementTransitionEnd`. Otherwise, OMID measurement sessions may record incorrect geometry data during the animation. The OMID bridge should listen for `placementTransitionEnd` and resume geometry reporting at that point.
+
+Additionally, the container-rendered close button must be registered as a friendly obstruction with the OM SDK via `addFriendlyObstruction()`. The `closeButtonPosition` field in `Container:placementChange` provides the coordinates needed for this registration. The OMID bridge should update the obstruction registration whenever `closeButtonPosition` changes (e.g., on resize, maximize, or close position override).
+
+### 6.4 `transform-origin` and Anchor Point
+
+The `transform-origin` must align with the creative's `anchorPoint` (if provided) so the animation expands from the correct corner:
+
+| `anchorPoint` | `transform-origin` |
+|--------------|-------------------|
+| `top-left` (default) | `top left` |
+| `top-right` | `top right` |
+| `bottom-left` | `bottom left` |
+| `bottom-right` | `bottom right` |
+
+### 6.5 Duration Capping
+
+The container caps `transition.duration` to prevent creatives from using excessively long animations that block close button access.
+
+**Decision:** Maximum duration is 500ms. The container silently clamps values above 500 to 500. Values below 0 are treated as 0 (instant). This answers PRD Open Question 4.
+
+```javascript
+_clampDuration(duration) {
+  if (typeof duration !== 'number' || duration < 0) return 0;
+  return Math.min(duration, 500);
+}
+```
+
+### 6.6 Easing Validation
+
+Only the five CSS keyword values are accepted: `linear`, `ease`, `ease-in`, `ease-out`, `ease-in-out`. Custom `cubic-bezier()` values are rejected (silently replaced with `ease-out`). This answers PRD Open Question 3 — the validation burden of arbitrary cubic-bezier strings is not worth the marginal creative flexibility.
+
+---
+
+## 7. Close Region Ownership Model
+
+The container owns the close button in ALL placement change states. This is the defining design change in v0.3 and follows SHARC's core principle: the container has authority over the trust boundary.
+
+### 7.1 Design Principle: Close is a Safety Mechanism
+
+The close affordance is not a UI element -- it is a **safety mechanism** that guarantees users can always dismiss an ad. Safety mechanisms must live outside the sandbox. A creative running inside a sandboxed iframe (with `allow-scripts` but not `allow-same-origin`) can manipulate its own DOM arbitrarily: it can set `z-index: 2147483647`, overlay opaque elements, intercept click events, or apply CSS transforms that visually hide injected elements. Any close button rendered inside the creative's iframe is vulnerable to accidental or deliberate interference.
+
+The container's close button is a DOM element on the **publisher page**, positioned as a sibling to the iframe. It is immune to creative CSS, creative JavaScript, and creative DOM manipulation. This is the same trust model used by browser-native UI (e.g., the Fullscreen API's "Press Escape to exit" overlay, or iOS WKWebView's navigation chrome).
+
+### 7.2 Ownership Rules by Intent
+
+| Intent | Who renders close | Close position source | Notes |
+|--------|------------------|----------------------|-------|
+| `resize` | **Container** renders close button as iframe sibling | Creative's `closeRegion` hint, or default `top-right` | Changed in v0.3 -- was creative-rendered |
+| `maximize` | **Container** renders close button as iframe sibling | Container default (`top-right`) | Unchanged |
+| `fullscreen` | **Container** renders close button as iframe sibling | Container default (`top-right`) | Unchanged |
+| `minimize`/`restore` | N/A -- close button removed | N/A | Returns to default; no close button needed |
+
+### 7.3 The `closeRegion` Field is a Hint
+
+When a creative sends `requestPlacementChange` with a `closeRegion` field, it is expressing a **preference** for where the container should position the close button. The container evaluates the hint:
+
+- If the hinted position is onscreen: the container honors it.
+- If the hinted position is offscreen: the container silently overrides to `top-right` and accepts the resize.
+- If no `closeRegion` is provided: the container uses `top-right` by default.
+
+The creative never renders the close button. The creative never needs to know whether its hint was honored -- the close button is always visible and functional regardless.
+
+### 7.4 Why This Changed from v0.2
+
+In v0.2, the resize intent placed close button responsibility on the creative (or the MRAID bridge injecting into creative DOM). This created three problems:
+
+1. **Trust boundary violation.** A creative could claim to have a close button at a declared `closeRegion` but render nothing there, or render a transparent element that intercepts clicks without actually closing.
+
+2. **Bridge complexity.** The MRAID bridge had to inject DOM elements (`_injectCloseIndicator`) into the creative's document, manage their lifecycle, and hope creative CSS did not interfere. This added ~60 LOC of fragile DOM manipulation to the bridge.
+
+3. **Inconsistency.** Maximize and fullscreen already used container-rendered close. Having resize use creative-rendered close meant two different trust models for the same safety mechanism. This is confusing for implementers and creates a security gap for the most common placement change intent.
+
+---
+
+## 8. MRAID Bridge Changes
+
+### 8.1 `resize()` Wiring Update
+
+The existing `resize()` function (line 721 of `sharc-mraid-bridge.js`) already sends `intent: 'resize'` with `targetDimensions` and `targetPosition`. The changes are:
+
+1. **Add `closeRegion` hint field:**
+
+```javascript
+// In mraid.resize(), replace the SHARC.requestPlacementChange call:
+SHARC.requestPlacementChange({
+  intent: 'resize',
+  targetDimensions: {
+    width: _s._resizeProps.width,
+    height: _s._resizeProps.height,
+  },
+  targetPosition: {
+    x: pos.x + (_s._resizeProps.offsetX || 0),
+    y: pos.y + (_s._resizeProps.offsetY || 0),
+  },
+  closeRegion: {                                    // NEW — hint only
+    position: _s._resizeProps.customClosePosition,
+    size: 50,
+  },
+  allowOffscreen: _s._resizeProps.allowOffscreen || false,
+}).then(function () {
+  _s._placementMode = 'resized';
+  // No close indicator injection — container renders the close button
+  _emit('stateChange', mraid.getState());
+  _emit('sizeChange', _s._resizeProps.width, _s._resizeProps.height);
+}).catch(function (err) {
+  _emit('error', 'resize failed: ' + (err && err.message), 'resize');
+});
+```
+
+The bridge sends `closeRegion` as a hint so the container knows the creative's preferred close button position. The bridge does **not** inject any DOM elements into the creative -- the container renders the close button on the publisher page (see Section 4.7).
+
+2. **Update `mraid.supports('resize')`:**
+
+The bridge should check the feature string to determine resize support:
+
+```javascript
+// In the supports() function:
+if (feature === 'resize') {
+  return SHARC.hasFeature('com.iabtechlab.sharc.placement.resize');
+}
+```
+
+3. **`close()` and `collapse()` -- simplified:**
+
+With container-owned close, the bridge's `close()` and `collapse()` no longer need to clean up injected DOM elements:
+
+```javascript
+close: function () {
+  if (_s._placementMode === 'expanded' || _s._placementMode === 'resized') {
+    mraid.collapse();
+  } else {
+    SHARC.requestClose().catch(function () {});
+  }
+},
+```
+
+### 8.2 Size Budget Impact
+
+The v0.3 close button ownership change **reduces** the MRAID bridge size by approximately 60 LOC (removal of `_injectCloseIndicator`, `_removeCloseIndicator`, `_closePositionCSS` helpers and their call sites). This is a net simplification of the bridge.
+
+### 8.3 `useCustomClose` Semantics Under Container-Owned Close
+
+MRAID 3.0 deprecated `useCustomClose()` but still requires it to function. With the container now owning the close button in all states, `useCustomClose` no longer controls whether a close button is rendered -- one is ALWAYS rendered by the container.
+
+The `useCustomClose` value now only affects what the bridge **reports** to the creative:
+
+- `useCustomClose: false` (default): The bridge can report to the creative (via MRAID state queries) that a close button exists. The container renders it.
+- `useCustomClose: true`: The bridge reports that the creative is providing its own close UI. The container STILL renders its close button -- both may be visible. This is intentional: the container's close button is a safety mechanism, not a UI preference.
+
+In practice, most MRAID creatives that set `useCustomClose: true` position their own close button in the same region as the container's. The visual overlap is acceptable because the container's close button is a small element (50 DIPs) and the creative's custom close is typically in the same corner.
+
+### 8.4 Removed Helpers
+
+The following bridge helpers from v0.2 are **removed** in v0.3:
+
+- `_injectCloseIndicator(position)` -- No longer needed. The container renders close.
+- `_removeCloseIndicator()` -- No longer needed. No injected element to remove.
+- `_closePositionCSS(position)` -- No longer needed. Close button positioning is container-side.
+
+The bridge no longer mutates the creative's DOM for close button purposes. This eliminates the class of bugs where creative CSS interferes with an injected close indicator.
+
+---
+
+## 9. Wire Protocol Additions
+
+### 9.1 `Creative:getPlacementConstraints`
+
+**Direction:** Creative -> Container (request/resolve)
+
+**Request:**
+```javascript
+{
+  sessionId: string,
+  messageId: number,
+  timestamp: number,
+  type: 'SHARC:Creative:getPlacementConstraints',
+  args: {}
+}
+```
+
+**Resolve:**
+```javascript
+{
+  sessionId: string,
+  messageId: number,
+  timestamp: number,
+  type: 'resolve',
+  args: {
+    messageId: number,  // original request messageId
+    value: {
+      maxWidth: number | null,       // null = unconstrained
+      maxHeight: number | null,
+      allowedIntents: string[],
+      requireCloseRegion: boolean,
+      allowOffscreen: boolean
+    }
+  }
+}
+```
+
+### 9.2 `Container:placementConstraintsChange`
+
+**Direction:** Container -> Creative (notification, requires resolve)
+
+**Message:**
+```javascript
+{
+  sessionId: string,
+  messageId: number,
+  timestamp: number,
+  type: 'SHARC:Container:placementConstraintsChange',
+  args: {
+    maxWidth: number | null,
+    maxHeight: number | null,
+    allowedIntents: string[],
+    requireCloseRegion: boolean,
+    allowOffscreen: boolean
+  }
+}
+```
+
+### 9.3 `Container:placementTransitionEnd`
+
+**Direction:** Container -> Creative (notification, requires resolve)
+
+**Message:**
+```javascript
+{
+  sessionId: string,
+  messageId: number,
+  timestamp: number,
+  type: 'SHARC:Container:placementTransitionEnd',
+  args: {
+    finalDimensions: { width: number, height: number }
+  }
+}
+```
+
+### 9.4 Updated `Creative:requestPlacementChange` Args
+
+```javascript
+{
+  intent: 'resize' | 'maximize' | 'fullscreen' | 'minimize' | 'restore',
+  targetDimensions?: { width: number, height: number },
+  targetPosition?: { x: number, y: number },
+  anchorPoint?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right',
+  closeRegion?: {                          // NEW — positioning hint, not a declaration
+    position: string,                      // See PRD Appendix C for enum
+    size?: number                          // Default 50, minimum 50 (informational — container enforces its own minimum)
+  },
+  allowOffscreen?: boolean,                // NEW — now enforced
+  transition?: {                           // NEW
+    duration: number,                      // ms, capped at 500
+    easing?: string                        // CSS keyword, default 'ease-out'
+  }
+}
+```
+
+### 9.5 Updated `Container:placementChange` Args
+
+```javascript
+{
+  placementUpdate: {
+    width: number,
+    height: number,
+    position?: { x: number, y: number, width: number, height: number }
+  },
+  closeButtonPosition?: {                  // NEW — actual rendered close button coordinates
+    position: string,                      // enum: top-left|top-center|top-right|...
+    x: number,                             // absolute x coordinate on publisher page
+    y: number,                             // absolute y coordinate on publisher page
+    width: number,                         // rendered width (≥50 DIP)
+    height: number                         // rendered height (≥50 DIP)
+  },
+  transition?: {                           // NEW — actual timing applied
+    duration: number,
+    easing: string
+  }
+}
+```
+
+**`closeButtonPosition` semantics:** Always present when the container renders a close button (resize, maximize, fullscreen intents). Absent on restore/minimize. The creative uses this to avoid rendering content behind the close button. The OMID bridge uses it to register the close button as a friendly obstruction via `addFriendlyObstruction()` so it does not count against viewability measurement.
+```
+
+### 9.6 Protocol Message Registry Additions
+
+Add to `CreativeMessages` in `sharc-protocol.js`:
+
+```javascript
+GET_PLACEMENT_CONSTRAINTS: 'SHARC:Creative:getPlacementConstraints',
+```
+
+Add to `ContainerMessages` in `sharc-protocol.js`:
+
+```javascript
+PLACEMENT_CONSTRAINTS_CHANGE: 'SHARC:Container:placementConstraintsChange',
+PLACEMENT_TRANSITION_END: 'SHARC:Container:placementTransitionEnd',
+```
+
+---
+
+## 10. Decisions and Trade-offs
+
+### Web Standards Alignment
+
+SHARC's design principle — "Don't invent new patterns when the platform already has them" — extends to the placement change system. The state machine aligns with the Chrome/WebKit Page Lifecycle API; the placement change system follows these web platform patterns:
+
+| SHARC Concept | Web Standard Precedent | What We Adopt | What We Do Not |
+|---|---|---|---|
+| `requestPlacementChange` reject semantics | **Fullscreen API** | Promise-based request; container (UA) can reject | `fullscreenchange`/`fullscreenerror` event pair (we use resolve/reject + `placementChange`) |
+| `getPlacementConstraints()` + `constraintsChange` | **Permissions API** + **ResizeObserver** | Query-before-request pattern; debounced change notification | Frame-aligned batching (impossible cross-MessageChannel); `PermissionStatus` shape |
+| `transition: { duration, easing }` | **Web Animations API** | `duration` (ms), `easing` (CSS keyword) vocabulary | `fill`, `delay`, `iterations`, `KeyframeEffect` |
+| `getCachedConstraints()` sync read | **Visual Viewport API** | Sync cached access updated by async events | True sync property (impossible cross-process; cache may be stale) |
+
+**Framing:** These are design influences, not compliance claims. SHARC is "informed by" these patterns, not "implementing" these APIs. The distinction matters for standards body positioning — SHARC consistently follows web platform idioms, which lowers the learning curve for implementers and differentiates it from MRAID's proprietary API surface.
+
+**Not referenced in this spec** (useful for positioning materials only): CSS Containment / Container Queries, Popover API, Fenced Frames, CSS Anchor Positioning. These are either too abstract, too nascent, or architecturally opposed to be useful as technical design references.
+
+---
+
+### ADR-PC-001: Close Region Geometry — Container-Only Validation
+
+**Status:** Accepted (revised in v0.3 — supersedes v0.2 dual-copy approach)
+
+**Context:** In v0.2, the close region geometry algorithm was duplicated in both the MRAID bridge (client-side pre-validation) and the container (server-side enforcement). The rationale was that bridge-side pre-validation prevented wasted round trips. With v0.3's design change (container owns the close button in all states), the bridge no longer renders close indicators and the close region is a hint, not a declaration.
+
+**Decision:** The close region geometry algorithm lives only in the container (`_resolveClosePosition`, `_computeCloseRegionRect`). The MRAID bridge sends the creative's `customClosePosition` as a `closeRegion` hint but does not validate it. The bridge still validates resize **dimensions** client-side (width/height bounds), but close region positioning is entirely the container's responsibility.
+
+**Consequences:**
+- *Easier:* Single source of truth for close region geometry. No risk of bridge and container copies diverging. The bridge is simpler -- ~60 fewer LOC. The container never rejects based on close position (it overrides to a visible default), so there are no wasted round trips to prevent.
+- *Harder:* If a creative's close position hint is offscreen, it does not find out until after the resize succeeds and the close button appears in a different position than requested. In practice this is a non-issue -- the creative does not render the close button and has no reason to care about its exact position.
+
+---
+
+### ADR-PC-002: `transform: scale()` Animation Instead of CSS `width`/`height`
+
+**Status:** Accepted
+
+**Context:** The PRD specifies CSS transitions on `width`/`height`. The frontend review identified that this causes layout thrash in Safari WKWebView, where layout recalculation during transitions is synchronous.
+
+**Decision:** Animate using `transform: scale()` for the visual transition. Snap to final `width`/`height` on `transitionend`. This composites on the GPU and avoids layout recalc during animation.
+
+**Consequences:**
+- *Easier:* Performance is dramatically better on Safari/WKWebView. No layout thrash. Creative does not receive continuous resize events during animation.
+- *Harder:* Slight visual blur during the scale animation (bitmap scaling). Requires cleanup logic (`transitionend` listener + safety timeout). Requires `transform-origin` calculation to align with anchor point.
+- *Risk:* If the creative uses CSS that is sensitive to its own `transform` property (unlikely for ad creatives), the scale animation could interfere. The snap at `transitionend` clears the transform, limiting exposure.
+
+---
+
+### ADR-PC-003: `customValidator` Is Synchronous
+
+**Status:** Accepted
+
+**Context:** PRD Open Question 1 asks whether `customValidator` should be async (return a Promise) to allow publishers to call external policy services.
+
+**Decision:** `customValidator` is synchronous. It returns `{ allowed: boolean, reason?: string }`, not a Promise.
+
+**Consequences:**
+- *Easier:* Placement change validation completes in a single synchronous pass. No async coordination, no timeout management for the validator call. The 50ms latency target for `getPlacementConstraints` is trivially met.
+- *Harder:* Publishers cannot call external services in the validator. If a publisher needs server-side policy evaluation, they must pre-fetch the policy and configure `placementPolicy` with the results at container construction time.
+- *Rationale:* Async validators would add unpredictable latency to every placement change request. Ad creatives are latency-sensitive — a 200ms policy service call would be unacceptable. The synchronous model forces publishers to resolve policy before the ad session starts, which is the right time to do it.
+
+---
+
+### ADR-PC-004: `getPlacementConstraints` Returns Constraints Separately from Current Placement
+
+**Status:** Accepted
+
+**Context:** PRD Open Question 2 asks whether `getPlacementConstraints` should also return `currentPlacement`, combining the `getPlacementOptions` and `getPlacementConstraints` queries.
+
+**Decision:** Keep them separate. `getPlacementConstraints` returns only the policy constraints. `getPlacementOptions` returns only the current placement state.
+
+**Consequences:**
+- *Easier:* Each message has a single responsibility. The constraint response is small and cacheable. `getPlacementOptions` is unchanged — no backward compatibility risk.
+- *Harder:* A creative that needs both must make two round trips. In practice, `getPlacementConstraints` is called once at init (and cached), while `getPlacementOptions` is called on demand. The two-call pattern is tolerable.
+- *Rationale:* Constraints are static (they change only on rotation/resize events). Current placement is dynamic (changes on every placement mutation). Combining them would force the creative to make a full round trip to read constraints that haven't changed.
+
+---
+
+### ADR-PC-005: Easing Restricted to CSS Keywords, No Custom `cubic-bezier()`
+
+**Status:** Accepted
+
+**Context:** PRD Open Question 3 asks whether animation hints should support custom `cubic-bezier()` values.
+
+**Decision:** Only the five CSS easing keywords are accepted: `linear`, `ease`, `ease-in`, `ease-out`, `ease-in-out`. Custom `cubic-bezier()` values are silently replaced with `ease-out`.
+
+**Consequences:**
+- *Easier:* No CSS injection risk from malformed cubic-bezier strings. Validation is a simple set membership check. The five keywords cover all practical ad animation use cases.
+- *Harder:* Creative developers who want precise easing curves cannot specify them via the SHARC protocol. They can still apply custom easing to their own internal animations — the `transition` hint only governs the container's iframe resize animation.
+
+---
+
+### ADR-PC-006: Container Owns Close Button Rendering in All States
+
+**Status:** Accepted (reversed from v0.2 — replaces bridge-injected close indicator)
+
+**Context:** In v0.2, the MRAID bridge injected a DOM close indicator into the creative's document when `useCustomClose: false` and the creative was in resized state. This was necessary because SHARC's v0.2 design had the creative responsible for its own close UI on resize. The bridge had to reconcile the MRAID expectation (SDK renders close) with the SHARC model (creative renders close).
+
+The v0.2 approach had three problems: (1) the injected close element lived inside the sandbox and was vulnerable to creative CSS/DOM interference, (2) the bridge was mutating the creative's DOM -- a responsibility that added complexity and fragility, and (3) resize used a different trust model than maximize/fullscreen, creating an inconsistency in the security boundary.
+
+**Decision:** The container renders the close button in ALL placement change states (resize, maximize, fullscreen). The close button is a DOM element on the publisher page, positioned as a sibling to the iframe. The MRAID bridge does not inject any close indicators. The `closeRegion` on `requestPlacementChange` is a positioning hint, not a rendering directive.
+
+**Consequences:**
+- *Easier:* The close affordance is immune to creative interference -- it lives outside the sandbox. The MRAID bridge is simpler (no `_injectCloseIndicator`, `_removeCloseIndicator`, `_closePositionCSS`). Consistent trust model across all placement change intents. No risk of creative CSS hiding the close button.
+- *Harder:* The container must manage close button DOM lifecycle (create on resize/maximize, remove on restore/close). The close button is visually "on top of" the iframe content, which could overlap creative content in the close region corner. Publishers need a `closeButtonStyles` customization option if they want to adjust the appearance.
+- *Rationale:* The close button is a safety mechanism, not a UI preference. Safety mechanisms must live outside the trust boundary they protect. This follows the same pattern as the Fullscreen API's browser-controlled exit affordance and iOS WKWebView's navigation chrome.
+
+---
+
+### ADR-PC-007: No `placementTransitionStart` Event — End-Only Transition Lifecycle
+
+**Status:** Accepted
+
+**Context:** The initial design included both `placementTransitionStart` and `placementTransitionEnd` events. The frontend review identified that `placementTransitionStart` is fragile: if the container sends a `placementChange` with a `transition` field but does not animate (e.g., `prefers-reduced-motion`, app backgrounded mid-animation, publisher policy), the creative receives a start with no corresponding end — a hanging state.
+
+**Decision:** Only `placementTransitionEnd` is emitted. The creative infers "start" from its own `requestPlacementChange()` resolving. The container MUST fire `placementTransitionEnd` even when animation is skipped (with the instantly-applied `finalDimensions`).
+
+**Consequences:**
+- *Easier:* No hanging states. Every placement change with a `transition` hint produces exactly one `placementTransitionEnd`. Simpler SDK surface (one event, not two). Follows the iOS `viewDidAppear` pattern where developers key on the settled state, not the transitional one.
+- *Harder:* If a creative needs to hide content during the scale animation to avoid visual tearing, it must do so optimistically when `requestPlacementChange()` resolves, not in response to a discrete start event. In practice, the 100-500ms animation window is short enough that this is a non-issue.
+- *Rationale:* An app-background event during animation would prevent `transitionend` from firing, leaving a dangling start with no resolution. The end-only model eliminates this class of bug entirely.
+
+---
+
+### ADR-PC-008: `getCachedConstraints()` Returns Unconstrained Defaults, Never Null
+
+**Status:** Accepted
+
+**Context:** The frontend review recommended dropping `getCachedConstraints()` entirely, arguing it's a footgun that returns null before the first query. The PM and architect recommended keeping it for sync access in tight code paths (e.g., inside a `placementChange` handler).
+
+**Decision:** Keep `getCachedConstraints()` but return unconstrained defaults (not null) before any query or `constraintsChange` event populates the cache. The unconstrained default is permissive: `{ maxWidth: null, maxHeight: null, allowedIntents: [...all...], requireCloseRegion: false, allowOffscreen: true }`.
+
+**Consequences:**
+- *Easier:* No null-check required. A creative that calls `getCachedConstraints()` before init gets a safe permissive default. The Visual Viewport API analogy holds — `visualViewport.width` always returns a value.
+- *Harder:* A creative may act on stale/default constraints before the first `constraintsChange` event arrives. Mitigated by documentation: "Values are stale until the first `constraintsChange` event or `getPlacementConstraints()` response."
+
+---
+
+## Appendix: Files to Modify
+
+| File | Changes | Section Reference |
+|------|---------|-------------------|
+| `examples/sharc-protocol.js` | Add `GET_PLACEMENT_CONSTRAINTS` to `CreativeMessages`; add `PLACEMENT_CONSTRAINTS_CHANGE` and `PLACEMENT_TRANSITION_END` to `ContainerMessages` | Section 9.6 |
+| `examples/sharc-container.js` | Add `placementPolicy` and `closeButtonStyles` constructor options; add `_originalPlacement`, `_preResizeCSSState`, `_closeButton`, `_closeButtonStyles`, `_currentIntent` fields; rewrite `_handleRequestPlacementChange` with validation pipeline; add `_validatePlacementRequest`, `_resolveClosePosition`, `_computeCloseRegionRect`, `_snapshotPreResizeState`, `_restorePreResizeState`, `_applyAnimatedDimensions`, `_clampDuration`, `_sanitizeEasing` helpers; add `_createCloseButton`, `_removeCloseButton`, `_applyClosePosition` close button rendering methods; add `getPlacementConstraints` handler; add `placementConstraintsChange` notification on resize/orientation; call `_createCloseButton` on resize/maximize/fullscreen, `_removeCloseButton` on restore/minimize/close/destroy | Sections 4.1-4.7, 6.2-6.5 |
+| `examples/sharc-creative.js` | Add `getPlacementConstraints()` method; add `getCachedConstraints()` method (returns unconstrained defaults before first population); add `getSupportedFeatures` to `window.SHARC` exposure block (bug fix); add `getPlacementConstraints` and `getCachedConstraints` to `window.SHARC` exposure block; add `constraintsChange` (with `reason` field) and `placementTransitionEnd` event wiring | Sections 2.1, 5.1-5.3 |
+| `examples/sharc-mraid-bridge.js` | Add `closeRegion` hint to `resize()` request; **remove** `_injectCloseIndicator`, `_removeCloseIndicator`, `_closePositionCSS` helpers; simplify `close()`/`collapse()` (no close indicator cleanup needed); update `supports('resize')` to check feature string; update `useCustomClose` semantics (reporting-only, no rendering) | Sections 8.1-8.4 |
+| `docs/api-reference.md` | Document `getPlacementConstraints` message; document `closeRegion` as a hint field (not a declaration); document `allowOffscreen`, `transition` fields; document `placementConstraintsChange` notification; document `placementTransitionEnd` notification; update `requestPlacementChange` to document rejection semantics (note: close region position no longer causes rejection); document `closeButtonStyles` constructor option; add new feature strings | Sections 3, 4.7, 9 |
+| `CHANGELOG.md` | MINOR version bump | N/A |

--- a/docs/architecture-placement-changes.md
+++ b/docs/architecture-placement-changes.md
@@ -294,7 +294,7 @@ _resolveClosePosition(closeRegion, targetDimensions, targetPosition) {
 
 **Key behavioral change from v0.2:** The close region geometry check no longer rejects the placement change request. Previously, an offscreen close region would reject with error code `2211`. Now, the container accepts the resize and silently overrides the close button to a visible default position. This aligns with the principle that the close affordance is the container's responsibility -- the creative's hint is advisory, not authoritative.
 
-The validation pipeline step 4 (Section 4.3) is updated accordingly: the `closeRegion` geometry check calls `_resolveClosePosition` to determine where the container will render its close button, but never short-circuits with a rejection based on close position alone. The `closeRegion.size` minimum of 50 DIPs is still enforced, but since the container renders the close button, the size field is informational -- the container ensures its close button meets the 50 DIP minimum regardless.
+The validation pipeline step 4 (Section 4.3) is updated accordingly: the `closeRegion` geometry check calls `_resolveClosePosition` to determine where the container will render its close button, but never short-circuits with a rejection based on close position alone. The container clamps `closeRegion.size` to a minimum of 50 DIPs rather than rejecting -- since the container renders the close button, the size field is informational and the container ensures its close button meets the 50 DIP minimum regardless.
 
 ### 4.5 Position Reset on Restore
 
@@ -600,9 +600,18 @@ The container debounces resize/orientation events (200ms) to avoid flooding the 
 
 ```javascript
 // In SHARCCreativeSDK, add to the protocol listener setup:
+// Note: constraints are flat top-level fields in args, not nested under
+// a 'constraints' key. The container sends { maxWidth, maxHeight,
+// allowedIntents, requireCloseRegion, allowOffscreen, reason }.
 this._proto.addListener('SHARC:Container:placementConstraintsChange', (msg) => {
-  this._cachedConstraints = msg.args.constraints;
-  this._emit('constraintsChange', msg.args);  // { constraints, reason }
+  this._cachedConstraints = {
+    maxWidth: msg.args.maxWidth,
+    maxHeight: msg.args.maxHeight,
+    allowedIntents: msg.args.allowedIntents,
+    requireCloseRegion: msg.args.requireCloseRegion,
+    allowOffscreen: msg.args.allowOffscreen,
+  };
+  this._emit('constraintsChange', msg.args);  // { maxWidth, maxHeight, allowedIntents, requireCloseRegion, allowOffscreen, reason }
   this._proto._resolve(msg, {});
 });
 ```

--- a/docs/mraid-bridge-design.md
+++ b/docs/mraid-bridge-design.md
@@ -227,12 +227,12 @@ The SHARC state (`active`, `passive`, `hidden`, `frozen`, `ready`) feeds `isView
 | `mraid.getMaxSize()` | ✅ Supported | `env.currentPlacement.maxExpandSize` | Returns `{width, height}` |
 | `mraid.getScreenSize()` | ✅ Supported | `env.currentPlacement.viewportSize` | Returns `{width, height}` |
 | `mraid.getCurrentPosition()` | ✅ Supported | Updated from `placementChange` events | Returns `{x, y, width, height}` |
-| `mraid.isAudioMuted()` | ✅ Supported (MRAID 3.0) | `env.isMuted` from SHARC init | Cached at init; no live update in SHARC v1 |
+| `mraid.isAudioMuted()` | ✅ Supported (MRAID 3.0) | `env.isMuted` from SHARC init | Live-updated via audioVolumeChange (v0.3.0). Not limited to init-time snapshot. |
 | `mraid.setExpandProperties(props)` | ✅ Supported | Stored locally; applied on `expand()` | Only `width`/`height` honored; `useCustomClose` is no-op |
 | `mraid.getExpandProperties()` | ✅ Supported | Returns stored expand properties object | |
 | `mraid.setResizeProperties(props)` | ⏳ Deferred | Stored locally; `resize()` is deferred | See §7 |
 | `mraid.getResizeProperties()` | ⏳ Deferred | Returns stored resize properties (stub) | |
-| `mraid.resize()` | ⏳ Deferred | Fires `error` event `COMMAND_NOT_SUPPORTED` | See §7 |
+| `mraid.resize()` | ✅ Implemented | `SHARC.requestPlacementChange({ intent: 'resize', targetDimensions })` | ✅ Implemented (v0.3.0). Validates input per MRAID 3.0 §4.4.3. see §7.1 |
 | `mraid.setOrientationProperties()` | ❌ Excluded | No-op; accepted silently | OS-level concern; no SHARC equivalent |
 | `mraid.getOrientationProperties()` | ❌ Excluded | Returns safe stub `{allowOrientationChange:true, forceOrientation:'none'}` | Does not throw |
 | `mraid.storePicture(url)` | ❌ Excluded | Fires `error` event `COMMAND_NOT_SUPPORTED` | Privacy removal; intentional |
@@ -752,7 +752,7 @@ MRAID `error` events carry `(message, action)`. The bridge fires this consistent
 
 ---
 
-## 7. Deferred to v2
+## 7. Implemented features
 
 ### 7.1 `mraid.resize()` — Implemented
 

--- a/docs/prd-placement-changes.md
+++ b/docs/prd-placement-changes.md
@@ -1,0 +1,964 @@
+# PRD: Enhanced Placement Change System
+
+**Status**: Draft
+**Author**: Alex (Product Manager)
+**Last Updated**: 2026-04-12
+**Version**: 1.2
+**Stakeholders**: SHARC Protocol Lead, MRAID Bridge Maintainer, SafeFrame Bridge Maintainer, Test Harness Owner
+
+### Revision History
+
+| Version | Date | Change Summary |
+|---------|------|---------------|
+| 1.0 | 2026-04-12 | Initial draft |
+| 1.1 | 2026-04-12 | Added Phase 2 test plan: test matrix (31 cases across 4 surfaces), test creative specs, harness updates, success criteria |
+| 1.2 | 2026-04-12 | Design change: container renders close button in ALL cases (not just maximize/fullscreen). `closeRegion` becomes a placement hint. MRAID bridge no longer injects close indicators. Updated Sections 6.2, 6.3, 7.4, Stories 2/3, test cases TC-MR-006/TC-MR-007, and open questions. |
+
+---
+
+## 1. Problem Statement
+
+SHARC's placement change system has a fundamental trust gap: the container blindly accepts every `Creative:requestPlacementChange` message. A creative can request any size, any position, and any intent — and the container will honor it without validation. This is architecturally unsound for a secure ad container standard.
+
+**Three concrete problems exist today:**
+
+1. **No publisher control over placement changes.** Publishers cannot constrain what creatives are allowed to do. A creative can maximize to fullscreen, resize to arbitrary dimensions, or request placement changes the publisher's page layout cannot accommodate. There is no policy layer between the creative's request and the container's execution.
+
+2. **MRAID `resize()` is broken.** The MRAID bridge's `resize()` method wires through to `requestPlacementChange` with intent `resize`, but the container has no concept of close regions, offset validation, or max-size enforcement at the protocol level. This blocks approximately 30-40% of expandable mobile creatives that use MRAID resize rather than expand. The bridge performs client-side validation (close button positioning, max size checks), but the container itself applies no server-side enforcement.
+
+3. **Creatives cannot discover constraints before requesting.** The current `getPlacementOptions` message returns the current placement state, not what the container allows. A creative that wants to resize has no way to ask "What are my limits?" before firing a request. The result is a try-fail-retry pattern that produces flickering, wasted round trips, and poor user experience.
+
+**Who is affected:**
+
+- **Publishers / SSPs**: Cannot enforce brand safety, layout integrity, or UX standards on ad placement behavior. A rogue creative can break page layout.
+- **Creative developers**: Cannot build adaptive resize logic because they have no way to discover container constraints. Must hardcode dimensions or accept rejection blindly.
+- **MRAID creative vendors**: ~30-40% of expandable mobile creatives use `mraid.resize()` which currently fires `COMMAND_NOT_SUPPORTED` through the SHARC bridge.
+
+**Cost of not solving:**
+
+- SHARC cannot claim MRAID 3.0 resize compliance. Blocks adoption by mobile-first DSPs and creative studios.
+- Publishers who evaluate SHARC will reject it for lacking basic placement governance — a capability that both MRAID (via SDK-level enforcement) and SafeFrame (via host-side geometry management) provide today.
+- Creative developers default to MRAID expand (fullscreen) when resize is broken, producing worse user experiences.
+
+**Evidence:**
+
+- MRAID bridge code: `resize()` is implemented but the container lacks close region validation, making the end-to-end flow incomplete.
+- `_handleRequestPlacementChange` in `sharc-container.js` (line 977): no validation, no policy check — every intent is accepted.
+- SafeFrame `$sf.ext.expand()` with directional offsets already maps to SHARC resize intent correctly, but the container-side enforcement gap applies equally.
+
+---
+
+## 2. Goals & Success Metrics
+
+| Goal | Metric | Current Baseline | Target | Measurement Window |
+|------|--------|-----------------|--------|--------------------|
+| Enable publisher placement governance | % of requestPlacementChange messages validated against policy | 0% | 100% | Immediate on implementation |
+| Unblock MRAID resize() | MRAID 3.0 compliance test pass rate for resize operations | 0% (fires error) | 100% pass | 30 days post-implementation |
+| Eliminate try-fail-retry pattern | Creative round trips per successful placement change | Unmeasured (no constraint query exists) | 1 round trip (query then request) | 60 days post-implementation |
+| Maintain backward compatibility | Existing creatives that do not use resize continue to function | 100% | 100% | Immediate — regression gate |
+| Creative SDK stays under size budget | sharc-creative.js minified size | ~4.2KB | <5KB | Per-release check |
+
+---
+
+## 3. Non-Goals
+
+Explicitly out of scope for this initiative:
+
+- **SafeFrame push expand (`exp-push`).** Requires publisher page reflow, which is architecturally blocked by the `allow-scripts`-only sandbox. Deferred to a future `com.iabtechlab.sharc.layout` extension with a publisher callback model. Revisit when publisher demand materializes.
+- **MRAID two-part expand (URL argument to `expand()`).** Dead pattern from 2012 with near-zero production usage. The bridge already fires an error event when a URL is passed. Migration path: responsive markup with lazy asset loading.
+- **Responsive negotiation (`preferredDimensions` + `minimumDimensions`).** A forward-looking native capability where the container responds with what it actually granted. Deferred to v2 — requires protocol-level negotiation semantics that are out of scope here.
+- **Viewport-aware auto-restore (`autoRestore: 'onScrollOut'`).** Container would automatically restore placement when the ad scrolls out of view. Requires scroll context awareness that is not yet in the protocol. Deferred to v2.
+- **Publisher page reflow coordination.** When a creative resizes, the publisher page may need to reflow content around the new dimensions. This is publisher-side implementation and is not governed by the SHARC protocol.
+- **Animation rendering.** Animation hints (Section 7.5) tell the container *what* transition to perform. How the container renders the animation (CSS transitions, Web Animations API, native platform animation) is implementation-specific and out of scope for the protocol.
+
+---
+
+## 4. Scope Summary: What Changes Where
+
+Before diving into detailed requirements, this table clarifies what is a protocol change (affects `api-reference.md` and wire format) versus what stays container-local.
+
+| Change | Protocol Wire Change | Container-Only | Creative SDK Change | Bridge Change |
+|--------|---------------------|----------------|--------------------|----|
+| Placement policy (maxWidth, maxHeight, allowedIntents, etc.) | No | Yes — constructor option | No | No |
+| Close region hint on placement requests | Yes — new optional field in `requestPlacementChange` args | Close button rendering + hint interpretation | SDK passes through | MRAID bridge populates from `customClosePosition` |
+| Close button rendering (all intents) | No — container-side DOM rendering | Yes — renders close button as sibling to iframe | No | No — bridge no longer injects close indicators |
+| `getPlacementConstraints()` query | Yes — new Creative message type | Resolve handler | New SDK method | Bridge can use internally |
+| Animation hints | Yes — new optional field on placement messages | Container interprets | SDK passes through | Bridge can populate |
+| MRAID `resize()` bridge wiring | No — uses existing `requestPlacementChange` | Policy enforcement | No | Yes — already partially wired |
+| Feature strings for new capabilities | Yes — advertised in `Container:init` | Registered per policy | `hasFeature()` check | `supports()` mapping |
+
+---
+
+## 5. User Personas & Stories
+
+### Persona 1: Publisher Ad Ops Engineer (Primary)
+
+Mid-market publisher running 50M+ monthly ad impressions. Integrates SHARC container into their page. Needs to control what ad creatives can do to the page layout without reviewing every creative.
+
+### Persona 2: Creative Developer at a DSP
+
+Builds expandable rich media units for mobile and web. Uses MRAID resize() for non-fullscreen expansion. Needs reliable, predictable placement change behavior across containers.
+
+### Persona 3: SSP Integration Engineer
+
+Integrates SHARC into an SSP's ad serving stack. Needs to configure placement policies per publisher and trust that the container enforces them.
+
+---
+
+**Story 1 (Publisher Policy):** As a publisher ad ops engineer, I want to configure maximum dimensions and allowed placement intents for each ad slot so that no creative can break my page layout regardless of what it requests.
+
+**Acceptance Criteria:**
+- [ ] Given a `SHARCContainer` constructed with `placementPolicy: { maxWidth: 728, maxHeight: 480, allowedIntents: ['resize', 'restore'] }`, when a creative sends `requestPlacementChange({ intent: 'maximize' })`, then the container rejects with error code `2203` and message indicating the intent is not allowed.
+- [ ] Given a placement policy with `maxWidth: 400`, when a creative sends `requestPlacementChange({ intent: 'resize', targetDimensions: { width: 500, height: 250 } })`, then the container rejects with error code `2203` and message indicating dimensions exceed policy.
+- [ ] Given no `placementPolicy` option is provided, when a creative sends any valid `requestPlacementChange`, then the container behaves exactly as it does today (full backward compatibility).
+
+**Story 2 (Close Region Hint):** As a creative developer, I want to suggest where the container should position its close button on a resized ad so that the close affordance does not obscure my creative content.
+
+**Acceptance Criteria:**
+- [ ] Given a creative sends `requestPlacementChange({ intent: 'resize', targetDimensions: { width: 320, height: 480 }, closeRegion: { position: 'top-right', size: 50 } })`, then the container renders its close button as a DOM element on the publisher page (sibling to the iframe, outside the sandbox), positioned at the hinted location relative to the iframe bounds.
+- [ ] Given a creative sends `requestPlacementChange({ intent: 'resize' })` without a `closeRegion` field, then the container renders its close button at the default position (top-right) — the close button is always present regardless of whether a hint is provided.
+- [ ] Given a creative sends a `closeRegion` hint that would place the close button offscreen, then the container accepts the resize but overrides the close button position to the default (top-right), ensuring the close affordance is always visible and accessible.
+- [ ] Given any placement change intent (resize, maximize, fullscreen), the container always renders a close button outside the sandbox. The creative cannot suppress, hide, or interfere with this affordance.
+
+**Story 3 (MRAID resize):** As a creative developer using MRAID, I want `mraid.resize()` to work correctly inside a SHARC container so that my existing expandable creatives run without modification.
+
+**Acceptance Criteria:**
+- [ ] Given an MRAID creative calls `mraid.setResizeProperties({ width: 320, height: 480, offsetX: 0, offsetY: -100, customClosePosition: 'top-right', allowOffscreen: false })` then `mraid.resize()`, when the MRAID bridge translates this to `SHARC.requestPlacementChange({ intent: 'resize', targetDimensions: { width: 320, height: 480 }, targetPosition: { x: <computed>, y: <computed> }, closeRegion: { position: 'top-right', size: 50 }, allowOffscreen: false })`, then the container validates and resolves, the container renders a close button at the hinted position outside the sandbox, and `mraid.getState()` returns `'resized'`.
+- [ ] Given the container's placement policy rejects the resize request, when the bridge receives the rejection, then `mraid.addEventListener('error', fn)` fires with an appropriate error message and `mraid.getState()` remains `'default'`.
+- [ ] Given a creative calls `mraid.close()` while in `'resized'` state, then the bridge sends `requestPlacementChange({ intent: 'restore' })` and `mraid.getState()` returns `'default'`.
+- [ ] The MRAID bridge does NOT inject any close indicator into the creative DOM. The container's close button (rendered outside the sandbox) is the sole close affordance. `useCustomClose` has no effect on the container's close button — it is always present.
+
+**Story 4 (Constraint Discovery):** As a creative developer, I want to query the container's placement constraints before requesting a change so that I can adapt my resize behavior to what is actually allowed.
+
+**Acceptance Criteria:**
+- [ ] Given a creative calls `SHARC.getPlacementConstraints()`, when the container has a placement policy configured, then the promise resolves with `{ maxWidth, maxHeight, allowedIntents, requireCloseRegionHint, allowOffscreen }` reflecting the active policy.
+- [ ] Given a creative calls `SHARC.getPlacementConstraints()` and the container has no placement policy, then the promise resolves with `{ maxWidth: Infinity, maxHeight: Infinity, allowedIntents: ['resize', 'maximize', 'fullscreen', 'minimize', 'restore'], requireCloseRegionHint: false, allowOffscreen: true }` (unconstrained defaults).
+- [ ] `getPlacementConstraints()` completes in a single round trip with no side effects.
+
+**Story 5 (Animation Hints):** As a creative developer, I want to declare animation intent on placement changes so that the container can coordinate smooth transitions rather than jarring instant resizes.
+
+**Acceptance Criteria:**
+- [ ] Given a creative sends `requestPlacementChange({ intent: 'resize', targetDimensions: { width: 320, height: 480 }, transition: { duration: 300, easing: 'ease-out' } })`, when the container supports the `com.iabtechlab.sharc.placement.animate` feature, then the container applies the transition timing to the iframe resize.
+- [ ] Given the container does not support `com.iabtechlab.sharc.placement.animate`, when a creative includes `transition` in the request, then the field is silently ignored and the placement change executes immediately. No error is fired.
+- [ ] The `transition` field is additive and optional on all placement change requests. Its absence never causes a rejection.
+
+---
+
+## 6. Functional Requirements
+
+### 6.1 Placement Policy (Container-Only — No Wire Change)
+
+The `SHARCContainer` constructor accepts a new optional `placementPolicy` option. This is **never sent over the wire** — it is a container-local enforcement layer.
+
+```typescript
+interface PlacementPolicy {
+  maxWidth?: number;           // Maximum allowed width in DIPs. Default: Infinity (unconstrained)
+  maxHeight?: number;          // Maximum allowed height in DIPs. Default: Infinity
+  allowedIntents?: string[];   // Subset of ['resize', 'maximize', 'fullscreen', 'minimize', 'restore']
+                               // Default: all intents allowed
+  requireCloseRegionHint?: boolean; // If true, reject resize requests without a closeRegion hint. Default: false
+                               // When false (default), the container uses top-right as the default close button position.
+  allowOffscreen?: boolean;    // If true, allow resized ad to extend beyond viewport. Default: true
+  customValidator?: (request: RequestPlacementChangeArgs) => { allowed: boolean, reason?: string };
+                               // Escape hatch: publisher-defined validation function.
+                               // Called AFTER built-in policy checks pass. Return { allowed: false, reason: '...' } to reject.
+                               // Default: null (no custom validation)
+}
+```
+
+**Constructor usage:**
+
+```javascript
+const container = new SHARCContainer({
+  creativeUrl: '...',
+  containerEl: document.getElementById('ad-slot'),
+  environmentData: { ... },
+  placementPolicy: {
+    maxWidth: 728,
+    maxHeight: 480,
+    allowedIntents: ['resize', 'restore'],
+    requireCloseRegion: true,
+    allowOffscreen: false,
+  },
+});
+```
+
+**Enforcement order in `_handleRequestPlacementChange`:**
+
+1. Validate `intent` is in `allowedIntents` (if configured). Reject with `2203` if not.
+2. Validate `targetDimensions.width <= maxWidth` and `targetDimensions.height <= maxHeight` (if configured). Reject with `2203` if exceeded.
+3. If `closeRegion` is present, validate `closeRegion.size >= 50`. Reject with `2211` if below minimum.
+4. If `closeRegion` is present, compute the close button position. If the hinted position would be offscreen, override to the default position (top-right) — do NOT reject the placement change.
+5. If `allowOffscreen === false` and `intent === 'resize'`, validate the entire resized ad fits within viewport bounds. Reject with `2203` if it would extend offscreen.
+6. If `customValidator` is defined, call it with the full request args. Reject with `2203` and the validator's reason string if it returns `{ allowed: false }`.
+7. If all checks pass, execute the placement change as today.
+
+**Backward compatibility:** When `placementPolicy` is not provided (or is `undefined`), the container behaves exactly as it does today — every request is accepted. This is the zero-change default path.
+
+### 6.2 Close Region Field — Placement Hint (Protocol Wire Change)
+
+Add an optional `closeRegion` field to `Creative:requestPlacementChange` args. This is a **protocol change** that must be documented in `api-reference.md`.
+
+```typescript
+interface RequestPlacementChangeArgs {
+  intent: 'resize' | 'maximize' | 'fullscreen' | 'minimize' | 'restore';
+  targetDimensions?: { width: number; height: number };
+  targetPosition?: { x: number; y: number };
+  anchorPoint?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+  closeRegion?: CloseRegion;       // NEW — v1 (placement hint)
+  allowOffscreen?: boolean;        // NEW — v1
+  transition?: TransitionHint;     // NEW — v1 (see §6.5)
+}
+
+interface CloseRegion {
+  position: 'top-left' | 'top-center' | 'top-right'
+          | 'center-left' | 'center-right'
+          | 'bottom-left' | 'bottom-center' | 'bottom-right';
+  size?: number;  // Minimum 50 DIPs. Default: 50. Container MUST reject values below 50.
+}
+```
+
+**Semantics:**
+
+- `closeRegion` is a **placement hint**, not a declaration that the creative rendered a close button. The creative is saying "put the close button here" — the container decides whether to honor the hint.
+- The **container always renders the close button** as a DOM element on the publisher page, positioned as a sibling to the sandboxed iframe. The close affordance lives outside the sandbox where the creative cannot hide, obscure, or interfere with it. This applies to ALL intents: resize, maximize, and fullscreen.
+- When `closeRegion` is provided, the container SHOULD honor the hinted position if it would be fully onscreen and accessible. The container MAY override the hint if the position would be offscreen, inaccessible, or conflicts with publisher policy.
+- When `closeRegion` is omitted, the container renders the close button at the default position (top-right). The close button is always present — omitting the hint never suppresses it.
+- `size` defaults to 50 DIPs if omitted. The container MUST reject any explicit `size` value below 50.
+- `closeRegion` is **optional for all intents**, including resize. The container has a sensible default (top-right) when no hint is provided.
+
+**Container-side close button rendering:**
+
+The container renders the close button as a positioned DOM element on the publisher page. The rendering process:
+
+1. On any accepted placement change (resize, maximize, fullscreen), the container creates or repositions a close button element as a sibling to the ad iframe.
+2. The close button is positioned using the `closeRegion` hint (if provided and valid) or the default position (top-right of the iframe bounds).
+3. The close button has a minimum tap target of 50x50 DIPs and uses a z-index above the iframe.
+4. Clicking/tapping the close button triggers `requestPlacementChange({ intent: 'restore' })` on behalf of the creative.
+
+**Close button position validation:**
+
+If the creative provides a `closeRegion` hint that would place the close button offscreen (e.g., the iframe is near a viewport edge and the hinted position extends beyond it), the container does NOT reject the placement change. Instead, the container accepts the resize and overrides the close button position to the default (top-right) or the nearest onscreen position. The placement change itself succeeds — only the close button position is adjusted.
+
+This is a deliberate departure from the previous design where an offscreen close region caused rejection with error `2211`. The new model separates placement validation (can the ad resize to these dimensions?) from close button positioning (where should the close affordance appear?). The container resolves both independently.
+
+### 6.3 MRAID `resize()` Bridge Wiring (Bridge Change)
+
+The MRAID bridge `resize()` method is already implemented and maps resize properties to `SHARC.requestPlacementChange()`. The bridge already:
+- Validates resize properties via `setResizeProperties()` (min 50x50, max size check)
+- Computes `targetPosition` from `_initialPosition` + offset
+- Sends `intent: 'resize'` with `targetDimensions` and `targetPosition`
+- Transitions `_placementMode` to `'resized'` on success
+
+**What needs to change in the bridge:**
+
+1. **Add `closeRegion` as a placement hint.** Map `_s._resizeProps.customClosePosition` to `closeRegion.position`. This tells the container where the creative would prefer the close button, not where the creative rendered one:
+
+```javascript
+SHARC.requestPlacementChange({
+  intent: 'resize',
+  targetDimensions: {
+    width: _s._resizeProps.width,
+    height: _s._resizeProps.height,
+  },
+  targetPosition: {
+    x: pos.x + (_s._resizeProps.offsetX || 0),
+    y: pos.y + (_s._resizeProps.offsetY || 0),
+  },
+  closeRegion: {                                    // NEW — placement hint
+    position: _s._resizeProps.customClosePosition,  // Already validated by setResizeProperties
+    size: 50,
+  },
+  allowOffscreen: _s._resizeProps.allowOffscreen || false,  // Already exists
+});
+```
+
+2. **Remove close indicator injection logic.** The bridge NO LONGER needs to inject close indicators into the creative DOM for `useCustomClose: false`. The container renders the close button outside the sandbox in all cases. This eliminates the `_injectCloseIndicator` / `_removeCloseIndicator` code path and the associated DOM manipulation inside the sandboxed iframe.
+
+3. **Simplify `useCustomClose` semantics.** In the MRAID bridge context:
+   - `useCustomClose: false` (default) — the creative does not render its own close visual. The container's close button (always present outside the sandbox) is the sole close affordance. No bridge action needed.
+   - `useCustomClose: true` — the creative renders its own close visual in addition to the container's close button. The container's close affordance is still present. The bridge simply passes `customClosePosition` as the `closeRegion` hint.
+   - In both cases, the container's close button is always rendered. The `useCustomClose` flag only affects whether the creative provides a redundant visual cue within its own content.
+
+4. **Remove bridge-side close button onscreen validation.** Since the container owns close button rendering and positioning (including fallback to default position when the hint is offscreen), the bridge no longer needs to validate close button screen position in `setResizeProperties()`. The bridge should still validate min 50x50 dimensions and max size constraints.
+
+### 6.4 `getPlacementConstraints()` Query (Protocol Wire Change)
+
+Add a new creative-to-container message type for constraint discovery.
+
+**New message type in `CreativeMessages`:**
+
+```javascript
+const CreativeMessages = Object.freeze({
+  // ...existing entries...
+  GET_PLACEMENT_CONSTRAINTS: 'SHARC:Creative:getPlacementConstraints',
+});
+```
+
+**Wire format:**
+
+```
+Creative → Container:
+{
+  type: "SHARC:Creative:getPlacementConstraints",
+  args: {}
+}
+
+Container → Creative (resolve):
+{
+  type: "resolve",
+  args: {
+    messageId: <original>,
+    value: {
+      maxWidth: number | null,         // null = unconstrained
+      maxHeight: number | null,        // null = unconstrained
+      allowedIntents: string[],        // e.g. ['resize', 'maximize', 'restore']
+      requireCloseRegionHint: boolean,
+      allowOffscreen: boolean
+    }
+  }
+}
+```
+
+**Container implementation:**
+
+The handler reads from the configured `placementPolicy` (or returns unconstrained defaults). The `customValidator` escape hatch is NOT exposed to the creative — it is opaque server-side logic.
+
+**Creative SDK method:**
+
+```javascript
+/**
+ * Queries the container's placement constraints.
+ * Returns what the container allows before the creative requests a change.
+ * Requires: com.iabtechlab.sharc.placement.constraints feature.
+ *
+ * @returns {Promise<PlacementConstraints>}
+ */
+SHARC.getPlacementConstraints = function() {
+  if (this._dead) return Promise.reject(new Error('SDK is dead'));
+  return this._proto.getPlacementConstraints()
+    .then(function(value) { return value; });
+};
+```
+
+**Feature string:** `com.iabtechlab.sharc.placement.constraints`
+
+The container advertises this feature in `supportedFeatures` when a `placementPolicy` is configured. When no policy is configured, the feature is still advertised (the response will be unconstrained defaults). Creatives use `SHARC.hasFeature('com.iabtechlab.sharc.placement.constraints')` to check availability before calling.
+
+### 6.5 Animation Hints (Protocol Wire Change — Additive)
+
+Add an optional `transition` field to `requestPlacementChange` args and to `Container:placementChange` notifications.
+
+```typescript
+interface TransitionHint {
+  duration: number;    // Milliseconds. Recommended range: 100–500ms. Container MAY cap.
+  easing?: string;     // CSS easing keyword: 'linear' | 'ease' | 'ease-in' | 'ease-out' | 'ease-in-out'
+                       // Default: 'ease-out'
+}
+```
+
+**On the request (Creative → Container):**
+
+The creative includes `transition` to declare its preferred animation timing. The container MAY honor, modify, or ignore the hint. The container has final authority over animation behavior.
+
+**On the notification (Container → Creative):**
+
+When the container applies an animated transition, it includes the actual `transition` used in the `Container:placementChange` message so the creative can synchronize its own internal animations:
+
+```javascript
+// Container:placementChange args
+{
+  placementUpdate: { width: 320, height: 480, ... },
+  transition: { duration: 300, easing: 'ease-out' }  // Actual timing applied
+}
+```
+
+**Feature string:** `com.iabtechlab.sharc.placement.animate`
+
+This feature is opt-in. Containers that do not support animation simply do not advertise the feature and ignore the `transition` field. No error is fired when a creative includes `transition` and the container does not support it — the field is silently dropped.
+
+**Container implementation:**
+
+When the container supports animation and receives a `transition` hint:
+
+1. Apply CSS transition to the iframe: `iframe.style.transition = 'width ${duration}ms ${easing}, height ${duration}ms ${easing}'`
+2. Apply the new dimensions (which triggers the CSS transition)
+3. After the transition completes, remove the transition property to avoid interfering with future instant changes
+4. Include the actual applied `transition` in the `Container:placementChange` notification
+
+### 6.6 Feature String: `com.iabtechlab.sharc.placement.resize`
+
+This feature string signals that the container supports validated resize operations with close region enforcement. Containers SHOULD advertise this when:
+
+- The container has a functioning placement change handler for `intent: 'resize'`
+- The container validates `closeRegion` when present
+- The container enforces `placementPolicy` constraints
+
+The MRAID bridge uses this feature to determine whether `mraid.resize()` should attempt the SHARC path or fire `COMMAND_NOT_SUPPORTED`. Update the bridge's `supports('resize')` check:
+
+```javascript
+// In mraid.supports():
+if (feature === 'resize') {
+  return SHARC.hasFeature('com.iabtechlab.sharc.placement.resize');
+}
+```
+
+---
+
+## 7. Non-Functional Requirements
+
+### 7.1 Backward Compatibility
+
+- **Existing creatives MUST NOT break.** When `placementPolicy` is not configured, placement change behavior is identical to today. The absence of `closeRegion`, `allowOffscreen`, or `transition` fields in a request MUST NOT cause rejection.
+- **Existing container instantiations MUST NOT break.** The `placementPolicy` option defaults to `undefined`, which means no enforcement.
+- **New fields are additive.** `closeRegion`, `allowOffscreen`, and `transition` are optional on the wire. Containers that do not understand them ignore them (Structured Clone passes unknown fields through without error).
+
+### 7.2 Creative SDK Size Budget
+
+`sharc-creative.js` must remain under 5KB minified with zero dependencies. The `getPlacementConstraints()` method adds approximately 150 bytes minified. The `transition` pass-through adds zero bytes (it is already part of the `args` object forwarded by `requestPlacementChange`).
+
+### 7.3 Performance
+
+- `getPlacementConstraints()` MUST resolve within 50ms (single MessageChannel round trip, no I/O).
+- Placement policy validation in `_handleRequestPlacementChange` MUST add less than 1ms to request processing (all checks are in-memory comparisons).
+- Animation hints MUST NOT block the resolve of the placement change request. The container resolves the request immediately; the animation is applied asynchronously.
+
+### 7.4 Security
+
+- **The close affordance is container-rendered, outside the sandbox, and immune to creative manipulation.** The close button is a DOM element on the publisher page (sibling to the iframe), not injected into the sandboxed iframe. The creative cannot hide, reposition, overlay, or apply CSS to the close button because it exists in a separate DOM tree outside the sandbox boundary. This is the strongest possible guarantee that users can always close an ad — it follows SHARC's core pattern where the container has authority over the trust boundary.
+- **`placementPolicy` is never sent to the creative.** The creative learns constraints only via `getPlacementConstraints()`, which returns the policy values but not the `customValidator` function.
+- **`customValidator` runs in the container's execution context**, not in the sandboxed iframe. Publishers can use it to enforce business rules without exposing logic to creatives.
+- **`closeRegion` is a hint, not an instruction.** The container decides close button placement. Even if a creative sends a misleading hint (e.g., `position: 'bottom-left'` to push the close button to a less visible location), the container/publisher can override to a standard position. The creative has no mechanism to suppress or relocate the close affordance.
+- **`closeRegion.size` minimum of 50 DIPs is enforced container-side.** Even if a creative sends `size: 10`, the container rejects it. This prevents creatives from requesting an impractically small close target.
+- **Existing security invariants are preserved:** sandbox attributes unchanged, Structured Clone serialization, rate limiting, URL validation.
+
+---
+
+## 8. Technical Design Details
+
+### 8.1 New Error Semantics for Placement Rejection
+
+Today, `_handleRequestPlacementChange` always resolves. With placement policy, it must be able to reject. The api-reference.md currently states:
+
+> "The container always resolves (never rejects) this message, but the resulting dimensions may not match the request."
+
+This must be updated. The new behavior:
+
+- **resolve**: Placement change was accepted. The resolve value contains the actual resulting placement (which may differ from the request if the container applied its own constraints).
+- **reject**: Placement change was denied by policy. Error codes:
+  - `2203` (Feature not supported) — intent not allowed, dimensions exceed policy, or offscreen violation
+  - `2211` (Creative sending malformed messages) — missing required `closeRegion`, `closeRegion.size < 50`, or close region offscreen
+
+This is a **behavioral change** to the protocol contract. It must be clearly documented in the api-reference.md update.
+
+### 8.2 Protocol Message Additions Summary
+
+| Change | Message | Direction | Type |
+|--------|---------|-----------|------|
+| New message type | `SHARC:Creative:getPlacementConstraints` | Creative -> Container | Request/resolve |
+| New optional field | `closeRegion` on `requestPlacementChange` args | Creative -> Container | Additive |
+| New optional field | `allowOffscreen` on `requestPlacementChange` args | Creative -> Container | Additive |
+| New optional field | `transition` on `requestPlacementChange` args | Creative -> Container | Additive |
+| New optional field | `transition` on `Container:placementChange` args | Container -> Creative | Additive |
+| New feature strings | `com.iabtechlab.sharc.placement.resize`, `.constraints`, `.animate` | In `Container:init` | Feature advertisement |
+
+### 8.3 Files to Modify
+
+| File | Change | Scope |
+|------|--------|-------|
+| `examples/sharc-protocol.js` | Add `GET_PLACEMENT_CONSTRAINTS` to `CreativeMessages` | Protocol |
+| `examples/sharc-container.js` | Add `placementPolicy` option to constructor; rewrite `_handleRequestPlacementChange` with validation pipeline; add `_handleGetPlacementConstraints` handler; add `_validateCloseRegion` helper; add animation hint application | Container |
+| `examples/sharc-creative.js` | Add `getPlacementConstraints()` public method | Creative SDK |
+| `examples/sharc-mraid-bridge.js` | Add `closeRegion` to `resize()` request args; update `mraid.supports('resize')` to check feature string | Bridge |
+| `docs/api-reference.md` | Document new message type, new fields, updated rejection semantics, new feature strings | Documentation |
+| `CHANGELOG.md` | MINOR version bump (backward-compatible feature addition) | Documentation |
+
+### 8.4 Migration Path for Existing Integrations
+
+**Publishers upgrading SHARC container:**
+- No action required unless they want to enforce placement policies. Existing code continues to work unchanged.
+- To enable governance: add `placementPolicy` to the `SHARCContainer` constructor options.
+
+**Creative developers:**
+- No action required. Existing creatives that send `requestPlacementChange` without `closeRegion` or `transition` continue to work. The container will render a close button at the default position (top-right).
+- To use constraint discovery: check `SHARC.hasFeature('com.iabtechlab.sharc.placement.constraints')`, then call `SHARC.getPlacementConstraints()`.
+- To hint close button position: add `closeRegion` to placement change requests. The container will attempt to honor the hint. Recommended when the creative has content in the top-right corner that would be obscured by the default close button position.
+
+**MRAID creatives:**
+- No action required. The bridge handles the mapping. `mraid.resize()` will start working for creatives that previously received `COMMAND_NOT_SUPPORTED`.
+- **Behavioral change:** The bridge no longer injects a close indicator into the creative DOM for `useCustomClose: false`. The container's close button (rendered outside the sandbox) replaces this. Creatives that relied on the bridge-injected close indicator will now see the container's close button instead — same user-facing behavior, different rendering location.
+
+---
+
+## 9. Milestones & Implementation Order
+
+Implementation is split into two phases. Phase 1 covers the core implementation, ordered to maximize incremental value and minimize risk. Phase 2 is a comprehensive test plan that validates Phase 1 across all four test surfaces. Each Phase 1 milestone is independently shippable; Phase 2 test development can begin in parallel once the first milestone lands.
+
+### Phase 1: Implementation
+
+Implementation milestones are ordered for incremental value. Each milestone is independently shippable and testable.
+
+### Milestone 1: Placement Policy (Container-Only)
+
+**Scope:** Add `placementPolicy` constructor option and validation pipeline to `_handleRequestPlacementChange`. No protocol wire changes. No creative SDK changes. No bridge changes.
+
+**Deliverables:**
+- [ ] `placementPolicy` option parsing and defaults in `SHARCContainer` constructor
+- [ ] Validation pipeline in `_handleRequestPlacementChange` (intent check, dimension check, custom validator)
+- [ ] Rejection path with appropriate error codes (`2203`, `2211`)
+- [ ] Test harness UI: policy configuration panel (max width/height, allowed intents checkboxes)
+- [ ] Update `api-reference.md` to document that `requestPlacementChange` can now reject
+
+**Effort:** S (1-2 engineer-days)
+**Risk:** Low — container-only change, no wire protocol impact
+
+### Milestone 2: Container-Rendered Close Button + Close Region Hints
+
+**Scope:** Container renders close button as a DOM element on the publisher page for ALL placement changes. Add `closeRegion` hint field to the protocol. Container interprets hints and falls back to default positioning. Requires Milestone 1 for the rejection path.
+
+**Deliverables:**
+- [ ] Close button DOM rendering in `sharc-container.js` — create/reposition a close button element as a sibling to the ad iframe on every accepted placement change
+- [ ] Close button positioned using `closeRegion` hint when provided and valid, default top-right otherwise
+- [ ] Close button click handler triggers `requestPlacementChange({ intent: 'restore' })`
+- [ ] `closeRegion` hint field added to `requestPlacementChange` args (protocol documentation)
+- [ ] `_resolveCloseButtonPosition` helper that interprets the hint and falls back to default when hint would be offscreen
+- [ ] Integration with placement policy's `requireCloseRegionHint` flag
+- [ ] Test harness: close button visible on publisher page after resize/maximize/fullscreen, with position reflecting hint or default
+
+**Effort:** M (2-3 engineer-days)
+**Risk:** Low-Medium — additive protocol field, backward compatible. Close button z-index and positioning relative to the iframe requires care across browser layout engines.
+
+### Milestone 3: MRAID `resize()` End-to-End
+
+**Scope:** Wire the MRAID bridge's `resize()` to include `closeRegion` hint in the SHARC request. Remove close indicator injection logic from the bridge. Validate with MRAID 3.0 compliance test vectors. Requires Milestone 2.
+
+**Deliverables:**
+- [ ] Add `closeRegion` hint mapping to `mraid.resize()` in `sharc-mraid-bridge.js` (map `customClosePosition` to `closeRegion.position`)
+- [ ] Remove `_injectCloseIndicator` / `_removeCloseIndicator` code paths from the bridge (container handles close rendering)
+- [ ] Simplify `useCustomClose` handling: no longer triggers bridge-side DOM injection
+- [ ] Remove bridge-side close button onscreen validation from `setResizeProperties()` (container owns positioning)
+- [ ] Update `mraid.supports('resize')` to return `true` when `com.iabtechlab.sharc.placement.resize` feature is present
+- [ ] Run MRAID 3.0 compliance test suite resize tests (adapt from `compliance-ads/` vectors)
+- [ ] Test harness: MRAID resize test creative that exercises `setResizeProperties` -> `resize()` -> `close()` cycle
+
+**Effort:** M (2-3 engineer-days)
+**Risk:** Medium — MRAID compliance edge cases; removing bridge-side close indicator injection is a behavioral change for existing MRAID creatives that relied on `useCustomClose: false`
+
+### Milestone 4: `getPlacementConstraints()` Query
+
+**Scope:** New protocol message and creative SDK method. Requires Milestone 1 (container has policy to report).
+
+**Deliverables:**
+- [ ] `GET_PLACEMENT_CONSTRAINTS` message type in `sharc-protocol.js`
+- [ ] Handler in `sharc-container.js` that reads from `placementPolicy` config
+- [ ] `getPlacementConstraints()` method on `SHARCCreativeSDK`
+- [ ] `com.iabtechlab.sharc.placement.constraints` feature string registration
+- [ ] Test harness: constraint display panel in creative that shows queried constraints
+- [ ] Update `api-reference.md` with new message type documentation
+
+**Effort:** S (1-2 engineer-days)
+**Risk:** Low — straightforward request/resolve pattern
+
+### Milestone 5: Animation Hints
+
+**Scope:** Additive `transition` field on placement change requests and notifications. Opt-in feature. Can be implemented independently of Milestones 1-4.
+
+**Deliverables:**
+- [ ] `transition` field handling in `_handleRequestPlacementChange`
+- [ ] CSS transition application and cleanup in `_applyIframeDimensions`
+- [ ] `transition` field forwarded in `Container:placementChange` notification
+- [ ] `com.iabtechlab.sharc.placement.animate` feature string registration
+- [ ] Test harness: animation toggle with duration/easing controls
+- [ ] Update `api-reference.md` with `TransitionHint` documentation
+
+**Effort:** S (1-2 engineer-days)
+**Risk:** Low — purely additive, no behavioral change when absent
+
+### Phase 1 Estimated Effort
+
+6-10 engineer-days across all 5 milestones. Recommended sprint plan: Milestones 1+2 in Sprint 1, Milestones 3+4 in Sprint 2, Milestone 5 in Sprint 3 (or parallel with Sprint 2).
+
+---
+
+### Phase 2: Test Plan
+
+Phase 2 validates the Phase 1 implementation across all four test surfaces. There is no automated test runner -- all verification is browser-based, visual, and protocol-trace-driven. A human tester loads the test creative in the harness, interacts with UI controls, and reads the protocol trace in the log pane to verify expected behavior.
+
+#### 9.1 Test Surfaces
+
+| # | Surface | Entry Point | Loading Model | Notes |
+|---|---------|------------|---------------|-------|
+| 1 | SHARC Core Harness | `examples/test/index.html` | Direct `<script>` in creative HTML | Tests native SHARC placement change API. Creative loads `sharc-protocol.js` + `sharc-creative.js` directly. |
+| 2 | MRAID Bridge Harness | `examples/test/mraid-test.html` | Wrapper model: `.html` (DOM) + `.js` (logic) split, `__SHARC_TEST_mraidCreativeInit` callback | Tests MRAID `resize()`/`expand()`/`close()` through the SHARC-MRAID bridge. Creative uses `window.mraid` API. |
+| 3 | SafeFrame Bridge Harness | `examples/test/safeframe-test.html` | Wrapper model: `.html` (DOM) + `.js` (logic) split, `__SHARC_TEST_sfCreativeInit` callback | Tests SafeFrame `$sf.ext.expand()`/`collapse()` through the SHARC-SafeFrame bridge. Creative uses `window.$sf.ext` API. |
+| 4 | MRAID Compliance Suite | `examples/test/mraid-3-compliance-runner.html` | Compliance runner loads self-contained HTML files directly (bypasses wrapper model) | Formal IAB MRAID 3.0 compliance vectors. Self-contained creatives with inline `<script>`. Uses `EventTester`/`SequentialRunner` pattern from existing negative tests. |
+
+#### 9.2 Test Matrix
+
+##### SHARC Core Harness Tests
+
+| ID | Description | Preconditions | Steps | Expected Result | Validates |
+|----|-------------|---------------|-------|-----------------|-----------|
+| TC-PC-001 | Resize with targetDimensions | Container loaded, creative in `active` state | 1. Click "Resize 320x480" button 2. Observe iframe dimensions in harness | iframe changes to 320x480. Protocol log shows `requestPlacementChange` resolve with matching `placementUpdate`. `placementChange` event fires in creative log. | Milestone 1 -- basic resize intent |
+| TC-PC-002 | Resize with targetPosition | Container loaded, creative active | 1. Click "Resize + Offset" button (sets targetPosition x:10, y:-50) 2. Observe iframe position in harness | iframe moves to specified position. Protocol log shows `targetPosition` in request args and correct position in resolve. | Milestone 1 -- position handling |
+| TC-PC-003 | Resize with closeRegion hint | Container loaded, creative active | 1. Click "Resize with Close Region" button (sends closeRegion: top-right, size: 50) 2. Observe publisher page and protocol log | Request accepted. Protocol log shows `closeRegion` in request args. Container renders close button at hinted position (top-right of resized iframe). Close button is a DOM element on the publisher page, outside the sandbox. | Milestone 2 -- close region hint honored |
+| TC-PC-004 | Maximize then restore | Container loaded, creative active | 1. Click "Maximize" button 2. Verify iframe fills available space 3. Click "Restore" button 4. Verify iframe returns to original dimensions AND original position | After maximize: iframe fills container area. After restore: iframe returns to exact original width, height, x, and y position. Protocol log shows two `requestPlacementChange` messages (maximize, restore) and two `placementChange` events. | Milestone 1 -- restore resets both size and position |
+| TC-PC-005 | Resize with offset then restore | Container loaded, creative active | 1. Click "Resize + Offset" (moves iframe to non-default position) 2. Verify iframe moved 3. Click "Restore" button 4. Verify iframe returns to original position | After restore: iframe returns to the position it occupied before the resize, not just the original dimensions. This is the key regression test for the restore-resets-position fix. | Milestone 1 -- restore resets position after offset |
+| TC-PC-006 | Policy rejection -- dimensions exceed max | Container loaded, policy panel set to maxWidth: 400, maxHeight: 300 | 1. Click "Resize 500x400" button 2. Observe protocol log | `requestPlacementChange` rejected with error code `2203`. Creative log shows rejection. Iframe dimensions unchanged. | Milestone 1 -- dimension policy enforcement |
+| TC-PC-007 | Policy rejection -- intent not allowed | Container loaded, policy panel `allowedIntents` set to `['resize', 'restore']` only | 1. Click "Maximize" button 2. Observe protocol log | `requestPlacementChange` rejected with error code `2203` and message indicating maximize intent not allowed. Iframe unchanged. | Milestone 1 -- intent policy enforcement |
+| TC-PC-008 | Resize without closeRegion hint -- default close button | Container loaded, creative active | 1. Click "Resize (no close region)" button (sends resize without closeRegion field) 2. Observe publisher page | Resize succeeds. Container renders close button at default position (top-right of iframe). Close button is a DOM element on the publisher page, outside the sandbox. Protocol log shows successful resolve. | Milestone 2 -- default close button rendering |
+| TC-PC-009 | Resize with offscreen closeRegion hint -- close button overridden | Container loaded, creative active | 1. Click "Resize Offscreen Close" button (sends resize that hints close region beyond viewport edge) 2. Observe publisher page and protocol log | Resize succeeds (placement change is accepted). Container renders close button at default position (top-right) instead of the offscreen hint. Protocol log shows successful resolve. Close button is visible and functional. | Milestone 2 -- close hint override when offscreen |
+| TC-PC-010 | getPlacementConstraints with policy | Container loaded, policy panel configured with maxWidth: 728, maxHeight: 480, allowedIntents: ['resize', 'restore'] | 1. Click "Get Constraints" button 2. Observe constraint display panel in creative | Promise resolves with `{ maxWidth: 728, maxHeight: 480, allowedIntents: ['resize', 'restore'], requireCloseRegionHint: false, allowOffscreen: true }`. Values displayed in creative's constraint panel. | Milestone 4 -- constraint query |
+| TC-PC-011 | getPlacementConstraints with no policy | Container loaded, no placementPolicy configured | 1. Click "Get Constraints" button 2. Observe constraint display panel | Promise resolves with unconstrained defaults: `{ maxWidth: null, maxHeight: null, allowedIntents: ['resize', 'maximize', 'fullscreen', 'minimize', 'restore'], requireCloseRegionHint: false, allowOffscreen: true }`. | Milestone 4 -- unconstrained defaults |
+| TC-PC-012 | Animation hint on resize | Container loaded, `com.iabtechlab.sharc.placement.animate` feature enabled | 1. Click "Resize Animated" button (sends transition: { duration: 300, easing: 'ease-out' }) 2. Observe iframe resize behavior visually | iframe resizes with a visible smooth transition (not instant snap). Protocol log shows `transition` in both the request args and the `placementChange` notification. | Milestone 5 -- animation hints |
+| TC-PC-013 | constraintsChange event | Container loaded, creative active | 1. Resize the browser window (simulating viewport change) 2. Observe creative log | `constraintsChange` event fires in creative with updated constraint values. Protocol log shows the notification. | Milestone 4 -- dynamic constraint updates |
+| TC-PC-014 | allowOffscreen=false rejection | Container loaded, policy `allowOffscreen: false` | 1. Click "Resize Offscreen" button (sends resize that would extend iframe beyond viewport bounds, with allowOffscreen: false) 2. Observe protocol log | Rejected with error code `2203`. Iframe unchanged. | Milestone 1 -- offscreen policy enforcement |
+
+##### MRAID Bridge Harness Tests
+
+| ID | Description | Preconditions | Steps | Expected Result | Validates |
+|----|-------------|---------------|-------|-----------------|-----------|
+| TC-MR-001 | setResizeProperties + resize() positive | MRAID creative loaded, state is `default` | 1. Click "Set Resize Props" (width:320, height:480, offsetX:0, offsetY:-100, customClosePosition:'top-right', allowOffscreen:false) 2. Click "resize()" 3. Observe state display and protocol log | State changes to `resized`. Protocol log shows `requestPlacementChange` with intent `resize`, `targetDimensions`, `targetPosition`, `closeRegion: { position: 'top-right', size: 50 }`. `sizeChange` event fires. `stateChange` event fires with 'resized'. `getCurrentPosition()` returns updated dimensions. | Milestone 3 -- MRAID resize end-to-end |
+| TC-MR-002 | resize() with customClosePosition variations | MRAID creative loaded, state `default` | 1. For each of: top-left, top-center, top-right, center-left, center-right, bottom-left, bottom-center, bottom-right: set resize props with that position, call resize(), verify, call close() 2. Observe protocol log for each cycle | Each resize succeeds. Protocol log shows correct `closeRegion.position` value matching the MRAID `customClosePosition` for each iteration. State cycles: default -> resized -> default. | Milestone 3 -- close position enum mapping |
+| TC-MR-003 | resize() then close() | MRAID creative loaded, state `resized` (from TC-MR-001) | 1. Click "close()" 2. Observe state display and protocol log | State returns to `default`. Protocol log shows `requestPlacementChange` with intent `restore`. `stateChange` fires with 'default'. `getCurrentPosition()` returns original default position dimensions. Iframe returns to original size AND position. | Milestone 3 -- resize close/restore cycle |
+| TC-MR-004 | resize() with allowOffscreen=false rejection | MRAID creative loaded, state `default` | 1. Set resize props with large offsetX that would push ad offscreen, allowOffscreen: false 2. Call resize() 3. Observe log | `error` event fires with message indicating offscreen violation. State remains `default`. No `stateChange` or `sizeChange` event. | Milestone 3 -- bridge offscreen enforcement |
+| TC-MR-005 | resize() exceeding maxSize | MRAID creative loaded, state `default` | 1. Set resize props with width and height exceeding `getMaxSize()` values 2. Call resize() or setResizeProperties() 3. Observe log | `error` event fires. State remains `default`. Bridge-side validation rejects before reaching container. | Milestone 3 -- bridge max size validation |
+| TC-MR-006 | resize() with useCustomClose=false -- container close button present | MRAID creative loaded, state `default`, container supports resize feature | 1. Set resize props with useCustomClose: false 2. Call resize() 3. Observe resized ad and publisher page | Container renders a close button as a DOM element on the publisher page, positioned over the iframe at the hinted `customClosePosition`. No close indicator is injected into the creative DOM. Tapping the container's close button triggers restore. State is `resized`. | Milestone 3 -- container-rendered close button |
+| TC-MR-007 | resize() with useCustomClose=true -- container close button still present | MRAID creative loaded, state `default` | 1. Set resize props with useCustomClose: true 2. Call resize() 3. Observe resized ad and publisher page | Container's close button is STILL rendered on the publisher page (always present). Creative may also render its own close visual inside the ad. Both close mechanisms work. State is `resized`. | Milestone 3 -- useCustomClose does not suppress container close |
+| TC-MR-008 | expand() then resize() -- error | MRAID creative loaded, state `expanded` (call expand() first) | 1. Call expand() and wait for state `expanded` 2. Set resize props 3. Call resize() 4. Observe log | `error` event fires with message indicating resize is not allowed from expanded state. State remains `expanded`. | Milestone 3 -- state guard (matches existing negative test) |
+| TC-MR-009 | supports('resize') returns true | MRAID creative loaded, container has `com.iabtechlab.sharc.placement.resize` feature | 1. Click "supports()" button 2. Observe log for `resize` entry | `mraid.supports('resize')` returns `true`. Log displays feature support list including resize. | Milestone 3 -- feature string mapping |
+
+##### SafeFrame Bridge Harness Tests
+
+| ID | Description | Preconditions | Steps | Expected Result | Validates |
+|----|-------------|---------------|-------|-----------------|-----------|
+| TC-SF-001 | expand() with directional offsets | SafeFrame creative loaded, registered | 1. Click "Expand Directional" button (calls `$sf.ext.expand({ t:50, l:0, r:100, b:0 })`) 2. Observe iframe dimensions and protocol log | Callback fires with status `expanded`. Iframe expands by 50px top and 100px right from original bounds. Protocol log shows `requestPlacementChange` with intent `resize`, `targetDimensions` reflecting original + offsets, and computed `targetPosition`. `$sf.ext.geom()` returns updated geometry. | Milestone 3 -- SafeFrame directional expand |
+| TC-SF-002 | expand() default -- full maximize | SafeFrame creative loaded, registered | 1. Click "expand()" button (calls `$sf.ext.expand({})` or `$sf.ext.expand()` with no directional args) 2. Observe iframe | Callback fires with status `expanded`. Iframe maximizes to fill available space. Protocol log shows `requestPlacementChange` with intent `maximize`. | Milestone 1 -- SafeFrame expand-to-maximize mapping |
+| TC-SF-003 | expand then collapse -- full reset | SafeFrame creative loaded, currently expanded (from TC-SF-001 or TC-SF-002) | 1. Click "collapse()" button 2. Observe iframe dimensions and position | Callback fires with status `collapsed`. Iframe returns to exact original size and position. Protocol log shows `requestPlacementChange` with intent `restore`. `$sf.ext.geom()` returns original geometry. | Milestone 1 -- SafeFrame collapse/restore |
+| TC-SF-004 | expand with push:true -- fails | SafeFrame creative loaded, registered | 1. Click "expand({push:true})" button 2. Observe log | Callback fires with status `failed` and error message indicating push expand is not supported. No iframe dimension change. Protocol log shows no `requestPlacementChange` (bridge rejects before sending). | Non-goal validation -- push expand blocked |
+| TC-SF-005 | status() during expand lifecycle | SafeFrame creative loaded, registered | 1. Call `$sf.ext.status()` before expand -- log result 2. Click expand 3. Call `$sf.ext.status()` during/after expand callback -- log result 4. Click collapse 5. Call `$sf.ext.status()` after collapse callback -- log result | Status sequence: `ready` (or equivalent) before expand, `expanded` (or `expanding` then `expanded`) after expand, `collapsed` (or `ready`) after collapse. Each call returns the correct current state string. | Milestone 3 -- SafeFrame status lifecycle |
+
+##### MRAID Compliance Suite Tests
+
+These are formal compliance vectors loaded through `mraid-3-compliance-runner.html`. They follow the `EventTester` + `SequentialRunner` pattern established by the existing `resize-negative` tests. Creatives are self-contained HTML files with inline scripts.
+
+| ID | Description | Preconditions | Steps | Expected Result | Validates |
+|----|-------------|---------------|-------|-----------------|-----------|
+| TC-CP-001 | MRAID resize positive -- full cycle | Compliance runner loaded, container supports resize feature | Runner auto-executes: 1. `setResizeProperties(valid props)` 2. `resize()` 3. Wait for `stateChange` to `resized` 4. Verify `getCurrentPosition()` matches requested size 5. `close()` 6. Wait for `stateChange` to `default` 7. Verify `getCurrentPosition()` matches original | All event checks pass. Log shows PASSED for each step. `stateChange` fires twice (resized, default). `sizeChange` fires twice. Position values match at each step. | Milestone 3 -- MRAID 3.0 resize compliance |
+| TC-CP-002 | MRAID resize with all 8 customClosePosition values | Compliance runner loaded | Runner auto-executes: for each of the 8 positions (top-left, top-center, top-right, center-left, center-right, bottom-left, bottom-center, bottom-right): 1. `setResizeProperties` with that position 2. `resize()` 3. Wait for `stateChange` to `resized` 4. `close()` 5. Wait for `stateChange` to `default` | All 8 iterations pass. Log shows PASSED for each position value. No errors fired. | Milestone 3 -- close position coverage |
+| TC-CP-003 | MRAID resize + sizeChange event | Compliance runner loaded | Runner auto-executes: 1. Register `sizeChange` listener 2. `setResizeProperties({ width: 320, height: 480, ... })` 3. `resize()` 4. Wait for `sizeChange` event 5. Verify event args contain width: 320, height: 480 | `sizeChange` event fires with correct dimensions matching the resize request. Log shows PASSED. | Milestone 3 -- sizeChange event compliance |
+
+#### 9.3 Test Creative Specifications
+
+Each test surface requires new or updated test creatives. The following specifies what needs to be built.
+
+##### Creative 1: SHARC Core Placement Test Creative
+
+**Files:**
+- `examples/test/test-placement-creative.html` -- self-contained creative (direct `<script>` loading, same pattern as `test-creative.html`)
+
+**Harness:** SHARC Core (`examples/test/index.html`)
+
+**What it tests:** Native SHARC placement change API -- resize, maximize, restore, close region, constraints query, animation hints, policy rejections.
+
+**UI Controls (buttons):**
+- "Resize 320x480" -- sends `requestPlacementChange({ intent: 'resize', targetDimensions: { width: 320, height: 480 } })`
+- "Resize 500x400" -- sends oversized request to test policy rejection
+- "Resize + Offset" -- sends resize with `targetPosition: { x: 10, y: -50 }`
+- "Resize with Close Region" -- sends resize with `closeRegion: { position: 'top-right', size: 50 }`
+- "Resize (no close region)" -- sends resize without closeRegion field
+- "Resize Offscreen Close" -- sends resize with closeRegion hint that would be beyond viewport (tests hint override)
+- "Resize Offscreen" -- sends resize where entire ad extends beyond viewport
+- "Resize Animated" -- sends resize with `transition: { duration: 300, easing: 'ease-out' }`
+- "Maximize" -- sends `requestPlacementChange({ intent: 'maximize' })`
+- "Restore" -- sends `requestPlacementChange({ intent: 'restore' })`
+- "Get Constraints" -- calls `SHARC.getPlacementConstraints()`
+- "Clear Log"
+
+**Status Displays:**
+- Current state (from `stateChange` events)
+- Current dimensions (from `placementChange` events)
+- Current position (x, y from `placementChange`)
+- Last constraints query result (formatted JSON)
+
+**Protocol Trace Expectations:**
+- Each button press produces a `requestPlacementChange` (or `getPlacementConstraints`) in the log
+- Successful resizes show resolve with `placementUpdate`
+- Rejections show reject with error code and message
+- `placementChange` events appear for every successful change
+- Animation resizes show `transition` in both request and notification
+
+##### Creative 2: MRAID Resize Test Creative (updates to existing)
+
+**Files:**
+- `examples/test/test-mraid-creative.html` -- add resize controls to existing DOM
+- `examples/test/test-mraid-creative.js` -- add resize functions to existing logic
+
+**Harness:** MRAID Bridge (`examples/test/mraid-test.html`)
+
+**What it tests:** MRAID `setResizeProperties()` + `resize()` + `close()` cycle through the SHARC-MRAID bridge.
+
+**New UI Controls (add to existing `#ad-controls` div):**
+- "Set Resize Props" -- calls `mraid.setResizeProperties()` with configurable values (default: width:320, height:480, offsetX:0, offsetY:-100, customClosePosition:'top-right', allowOffscreen:false)
+- "resize()" -- calls `mraid.resize()`
+- "supports('resize')" -- calls `mraid.supports('resize')` and logs result
+- Update existing "resize()" button to use the new flow instead of the current stub
+
+**New State Displays (add to existing `#ad-state` div):**
+- `resizeProps:` -- shows currently set resize properties
+- `customClose:` -- shows current customClosePosition value
+
+**Protocol Trace Expectations:**
+- `setResizeProperties` logs the validated properties
+- `resize()` shows `requestPlacementChange` with intent `resize`, `closeRegion`, `targetDimensions`, `targetPosition`
+- `stateChange` to `resized` appears after successful resize
+- `sizeChange` event fires with new dimensions
+- `close()` from resized state shows `requestPlacementChange` with intent `restore`
+
+##### Creative 3: SafeFrame Directional Expand Test Creative (updates to existing)
+
+**Files:**
+- `examples/test/test-safeframe-creative.html` -- add directional expand controls to existing DOM
+- `examples/test/test-safeframe-creative.js` -- add directional expand functions
+
+**Harness:** SafeFrame Bridge (`examples/test/safeframe-test.html`)
+
+**What it tests:** SafeFrame `$sf.ext.expand()` with directional offsets (t/l/r/b), and status tracking through the expand/collapse lifecycle.
+
+**New UI Controls (add to existing `#ad-controls` div):**
+- "Expand Directional" -- calls `$sf.ext.expand({ t:50, l:0, r:100, b:0 })`
+- "status()" button is already present; verify it reports correct state during lifecycle
+
+**New State Displays:**
+- `expand-dir:` -- shows the last directional expand offsets used
+
+**Protocol Trace Expectations:**
+- Directional expand logs `requestPlacementChange` with intent `resize`, computed `targetDimensions` (original + offsets), and `targetPosition`
+- Callback fires with status `expanded`
+- `$sf.ext.geom()` returns geometry reflecting the expanded bounds
+- Collapse resets to original bounds; callback fires with `collapsed`
+
+##### Creative 4: MRAID Resize Positive Compliance Vector
+
+**Files:**
+- `examples/compliance-ads/resize-positive/resize-positive.html` -- self-contained creative with inline `<script>` (same model as `resize-negative/`)
+- `examples/compliance-ads/resize-positive/resize-positive-tests.js` -- test logic using `EventTester`/`SequentialRunner` pattern
+
+**Harness:** MRAID Compliance Suite (`examples/test/mraid-3-compliance-runner.html`)
+
+**What it tests:** Formal MRAID 3.0 resize compliance -- positive cases. The mirror image of the existing `resize-negative` test vector.
+
+**Test Sequence (automated, sequential):**
+1. `setResizeProperties({ width: 320, height: 480, offsetX: 0, offsetY: 0, customClosePosition: 'top-right', allowOffscreen: false })` -- expect no error
+2. `resize()` -- expect `stateChange` to `resized`
+3. Verify `getCurrentPosition().width === 320` and `getCurrentPosition().height === 480`
+4. `close()` -- expect `stateChange` to `default`
+5. Verify `getCurrentPosition()` matches `getDefaultPosition()`
+6. Iterate `customClosePosition` through all 8 values, each time: set props, resize, verify stateChange, close, verify stateChange
+7. Verify `sizeChange` fires with correct dimensions on each resize
+
+**UI:** Minimal -- log div for test results (same pattern as `resize-negative-tests.js`). Uses the `logInfoOnUi`/`logErrorOnUi` helpers and the `EventTester`/`SequentialRunner` infrastructure.
+
+##### Creative 5: MRAID Resize sizeChange Compliance Vector
+
+**Files:**
+- `examples/compliance-ads/resize-sizechange/resize-sizechange.html`
+- `examples/compliance-ads/resize-sizechange/resize-sizechange-tests.js`
+
+**Harness:** MRAID Compliance Suite
+
+**What it tests:** That `sizeChange` event fires with the correct width and height values after a successful `resize()` call.
+
+**Test Sequence:**
+1. Register `sizeChange` listener
+2. `setResizeProperties({ width: 320, height: 480, offsetX: 0, offsetY: 0 })`
+3. `resize()`
+4. Wait for `sizeChange` event
+5. Verify event arguments: `width === 320`, `height === 480`
+6. Pass if correct, fail if event does not fire within timeout or values mismatch
+
+#### 9.4 Test Harness Updates
+
+The existing harness HTML files need modifications to support the new test creatives and policy configuration.
+
+##### `examples/test/index.html` -- SHARC Core Harness
+
+- **Policy Configuration Panel:** Add a collapsible panel to the harness (outside the ad iframe) with controls for configuring `placementPolicy` on the `SHARCContainer` constructor:
+  - `maxWidth` number input (default: empty = unconstrained)
+  - `maxHeight` number input (default: empty = unconstrained)
+  - `allowedIntents` checkboxes: resize, maximize, fullscreen, minimize, restore (all checked by default)
+  - `requireCloseRegionHint` checkbox (default: unchecked)
+  - `allowOffscreen` checkbox (default: checked)
+  - "Apply Policy" button -- recreates the container with the new policy
+- **Creative Selector:** Add dropdown or input to select between `test-creative.html` (existing) and `test-placement-creative.html` (new)
+- **Dimension/Position Readout:** Display the iframe's current computed dimensions and offset position below the ad slot, updated on every placement change
+
+##### `examples/test/mraid-test.html` -- MRAID Bridge Harness
+
+- **Feature Configuration:** Add a checkbox or toggle to enable/disable `com.iabtechlab.sharc.placement.resize` feature on the container (controls whether `mraid.supports('resize')` returns true)
+- **Resize Properties Panel:** Add a collapsible panel with inputs for resize properties (width, height, offsetX, offsetY, customClosePosition dropdown, allowOffscreen checkbox, useCustomClose checkbox) so the tester can configure properties interactively rather than using hardcoded values. Note: `useCustomClose` no longer triggers bridge-side close indicator injection; it only controls whether the creative renders its own additional close visual.
+
+##### `examples/test/safeframe-test.html` -- SafeFrame Bridge Harness
+
+- **Directional Expand Panel:** Add a panel with number inputs for t, l, r, b offset values, pre-populated with reasonable defaults (e.g., t:50, l:0, r:100, b:0)
+- No policy panel needed -- SafeFrame creatives do not configure container policy
+
+##### `examples/test/mraid-3-compliance-runner.html` -- Compliance Runner
+
+- **Add new test vectors to the runner's test list:** Register `resize-positive` and `resize-sizechange` alongside the existing `resize-negative` and other test sets
+- No structural changes to the runner itself -- it already loads arbitrary compliance creatives
+
+#### 9.5 Success Criteria
+
+Phase 2 is complete when all of the following conditions are met:
+
+**Test Coverage:**
+- All 14 SHARC Core test cases (TC-PC-001 through TC-PC-014) have corresponding UI controls and are manually executable
+- All 9 MRAID Bridge test cases (TC-MR-001 through TC-MR-009) are manually executable
+- All 5 SafeFrame Bridge test cases (TC-SF-001 through TC-SF-005) are manually executable
+- All 3 Compliance Suite test cases (TC-CP-001 through TC-CP-003) auto-execute and produce PASSED/FAILED output
+
+**Pass Rate:**
+- 100% of test cases pass on Chrome latest (primary browser)
+- 100% of test cases pass on Safari latest (secondary -- validates WebKit WKWebView path)
+- 0 test cases produce ambiguous results (every test clearly shows PASSED or FAILED in protocol trace)
+
+**Regression Gate:**
+- All existing test creatives (`test-creative.html`, `test-mraid-creative.html`, `test-safeframe-creative.html`) continue to function identically after harness updates
+- All existing compliance vectors (`resize-negative`, `loadandevents`) continue to pass
+- No new globals introduced on `window` beyond the `__SHARC_TEST_*` namespace
+
+**Documentation:**
+- Each new test creative file has a header comment explaining what it tests and which test cases it covers
+- Test harness UI additions have tooltip or label text explaining each control's purpose
+- `CHANGELOG.md` includes a MINOR entry documenting the new test creatives and harness updates
+
+**Artifact Checklist:**
+
+| Artifact | Status |
+|----------|--------|
+| `examples/test/test-placement-creative.html` | Created |
+| `examples/test/test-mraid-creative.html` (updated) | Updated with resize controls |
+| `examples/test/test-mraid-creative.js` (updated) | Updated with resize functions |
+| `examples/test/test-safeframe-creative.html` (updated) | Updated with directional expand controls |
+| `examples/test/test-safeframe-creative.js` (updated) | Updated with directional expand functions |
+| `examples/test/index.html` (updated) | Updated with policy panel and creative selector |
+| `examples/test/mraid-test.html` (updated) | Updated with feature toggle and resize props panel |
+| `examples/test/safeframe-test.html` (updated) | Updated with directional expand panel |
+| `examples/compliance-ads/resize-positive/resize-positive.html` | Created |
+| `examples/compliance-ads/resize-positive/resize-positive-tests.js` | Created |
+| `examples/compliance-ads/resize-sizechange/resize-sizechange.html` | Created |
+| `examples/compliance-ads/resize-sizechange/resize-sizechange-tests.js` | Created |
+| All 31 test cases executable and passing | Verified |
+
+#### Phase 2 Estimated Effort
+
+4-6 engineer-days. Recommended approach: build test creatives in parallel with Phase 1 milestones. Each milestone's test cases can be validated as soon as the implementation lands.
+
+| Work Item | Effort | Dependency |
+|-----------|--------|------------|
+| SHARC Core test creative + harness policy panel | M (2-3 days) | Milestone 1 implementation |
+| MRAID test creative updates + harness resize panel | S (1 day) | Milestone 3 implementation |
+| SafeFrame test creative updates + directional expand panel | S (0.5 day) | Milestone 1 implementation |
+| Compliance vectors (resize-positive, resize-sizechange) | S (1 day) | Milestone 3 implementation |
+| Cross-browser verification (Chrome + Safari) | S (0.5 day) | All above complete |
+
+---
+
+## 10. Intentionally Deprecated
+
+| Pattern | Status | Migration Path |
+|---------|--------|----------------|
+| MRAID two-part expand (`expand(url)`) | Deprecated — fires error event | Use responsive markup with lazy asset loading. The creative should load secondary assets via `fetch()` or `<img>` after the initial expand. |
+| SafeFrame push expand (`exp-push`) | Deferred indefinitely | Not achievable within sandbox constraints. Future `com.iabtechlab.sharc.layout` extension if publisher demand materializes. |
+
+---
+
+## 11. Open Questions
+
+| # | Question | Owner | Deadline | Status |
+|---|----------|-------|----------|--------|
+| 1 | Should `customValidator` be async (return a Promise)? | Protocol Lead | Before Milestone 1 dev start | **Resolved: Synchronous.** See ADR-PC-003. Async validators add unpredictable latency. Publishers pre-fetch policy at container construction time. |
+| 2 | Should `getPlacementConstraints()` return `currentPlacement` alongside constraints? | Protocol Lead | Before Milestone 4 dev start | **Resolved: Separate queries.** See ADR-PC-004. Constraints are static (change on rotation); placement is dynamic (changes on every mutation). |
+| 3 | Should animation hints support custom cubic-bezier values? | Creative SDK Owner | Before Milestone 5 dev start | **Resolved: CSS keywords only.** See ADR-PC-005. Five keywords (`linear`, `ease`, `ease-in`, `ease-out`, `ease-in-out`). No CSS injection risk. |
+| 4 | Should the container enforce a maximum `transition.duration`? | Protocol Lead | Before Milestone 5 dev start | **Resolved: 500ms cap.** Container silently clamps values above 500ms. Prevents long animations blocking close button access. |
+| 5 | Should `closeRegion` hint be required for resize intent, or should the container always have a sensible default position (e.g., top-right)? | Protocol Lead | Before Milestone 2 dev start | **Resolved: Optional.** Recommended but not required. Container defaults to top-right, 50 DIP. The `requireCloseRegionHint` policy flag exists for publishers who want creatives to be explicit, but defaults to `false`. Not a creative burden — documentation recommends providing it ("helps the container position the close button where it won't obscure your content") but never mandates it. |
+| 6 | Should the container-rendered close button support publisher-configurable styling (e.g., icon, color, opacity), or should it use a fixed standard appearance? | Protocol Lead | Before Milestone 2 dev start | **Resolved: Defer to v2.** For v1, the container provides a default close button (X icon via CSS, no external assets). In v2, `closeButtonStyles` becomes configurable — either container default or publisher-controlled. Avoids scope creep on v1. |
+| 7 | Should the `Container:placementChange` notification include the actual close button position used? | Protocol Lead | Before Milestone 2 dev start | **Resolved: Yes.** `placementChange` includes `closeButtonPosition: { position, x, y, width, height }` with actual rendered coordinates. Two purposes: (a) creative avoids rendering content behind the close button, (b) OMID bridge registers it as a friendly obstruction via `addFriendlyObstruction` so it doesn't count against viewability measurement. |
+
+---
+
+## 12. Appendix
+
+### A. Current `_handleRequestPlacementChange` (No Validation)
+
+```javascript
+// sharc-container.js, line 977 — current implementation
+_handleRequestPlacementChange(msg) {
+  const { intent, targetDimensions, targetPosition, anchorPoint } = (msg.args || {});
+  let updatedPlacement = { ...(this.environmentData.currentPlacement || {}) };
+
+  switch (intent) {
+    case 'resize':
+      if (targetDimensions) {
+        updatedPlacement = { ...updatedPlacement, ...targetDimensions };
+        this._applyIframeDimensions(targetDimensions);
+      }
+      if (targetPosition) {
+        this._applyIframePosition(targetPosition);
+      }
+      break;
+    case 'maximize':
+    case 'fullscreen':
+      updatedPlacement = this._getMaxPlacement();
+      this._applyIframeDimensions(updatedPlacement);
+      break;
+    case 'minimize':
+    case 'restore':
+      updatedPlacement = this.environmentData.currentPlacement || {};
+      this._applyIframeDimensions(updatedPlacement);
+      break;
+    default:
+      console.warn('[SHARCContainer] Unknown placement intent:', intent);
+  }
+
+  this.environmentData.currentPlacement = updatedPlacement;
+  this._protocol._resolve(msg, { placementUpdate: updatedPlacement });
+  this.notifyPlacementChange(updatedPlacement);
+}
+```
+
+Note the complete absence of any validation, policy checking, or rejection path. Every request is resolved.
+
+### B. MRAID Resize Properties → SHARC Request Mapping
+
+| MRAID Property | SHARC Field | Notes |
+|---------------|-------------|-------|
+| `width` | `targetDimensions.width` | Direct map |
+| `height` | `targetDimensions.height` | Direct map |
+| `offsetX` | `targetPosition.x` (computed) | `initialPosition.x + offsetX` |
+| `offsetY` | `targetPosition.y` (computed) | `initialPosition.y + offsetY` |
+| `customClosePosition` | `closeRegion.position` | Direct map of enum values |
+| `allowOffscreen` | `allowOffscreen` | Direct map |
+| (implicit 50px) | `closeRegion.size` | Always 50 per MRAID spec |
+
+### C. Close Region Position Enum Mapping
+
+| Value | Close Button Anchor | Use Case |
+|-------|-------------------|----------|
+| `top-left` | Top-left corner of resized ad | Left-anchored expand |
+| `top-center` | Top-center of resized ad | Centered banner expand |
+| `top-right` | Top-right corner of resized ad | Standard (MRAID default) |
+| `center-left` | Center-left of resized ad | Side panel |
+| `center-right` | Center-right of resized ad | Side panel |
+| `bottom-left` | Bottom-left corner of resized ad | Bottom-anchored expand |
+| `bottom-center` | Bottom-center of resized ad | Footer expand |
+| `bottom-right` | Bottom-right corner of resized ad | Bottom-right expand |
+
+### D. Feature String Registry (Post-Implementation)
+
+| Feature String | Capability | Advertised When |
+|---------------|-----------|-----------------|
+| `com.iabtechlab.sharc.placement.resize` | Container supports validated resize with close region | Container has resize intent handler with close region validation |
+| `com.iabtechlab.sharc.placement.constraints` | Creative can query placement constraints | Always (returns unconstrained defaults if no policy) |
+| `com.iabtechlab.sharc.placement.animate` | Container supports animated placement transitions | Container has CSS transition implementation |

--- a/docs/test-creative-specs.md
+++ b/docs/test-creative-specs.md
@@ -1,0 +1,2002 @@
+# Test Creative Specifications: Enhanced Placement Change System
+
+**Version:** 1.0  
+**Date:** 2026-04-12  
+**Author:** Frontend Developer  
+**PRD:** `docs/prd-placement-changes.md`  
+**Architecture:** `docs/architecture-placement-changes.md`
+
+---
+
+## Overview
+
+This document specifies four test creatives and one compliance test suite for verifying the Enhanced Placement Change System. All creatives follow the established SHARC test harness patterns documented in `examples/test/CREATIVE-AUTHORING.md`.
+
+**Test creative types:**
+
+| # | Creative | Path | Loading Model | Bridge |
+|---|----------|------|---------------|--------|
+| 1 | SHARC Core Placement | `examples/test/test-placement-creative.{html,js}` | Wrapper (mraid-wrapper.html or direct) | None (native SHARC SDK) |
+| 2 | MRAID Resize | `examples/test/test-mraid-resize-creative.{html,js}` | Wrapper (mraid-wrapper.html) | MRAID bridge |
+| 3 | MRAID Resize Positive Compliance | `examples/compliance-ads/resize-positive/resize-positive-tests.{html,js}` | Compliance runner (mraid-3-compliance-runner.html) | MRAID bridge |
+| 4 | SafeFrame Directional Expand | `examples/test/test-safeframe-expand-creative.{html,js}` | Wrapper (safeframe-wrapper.html) | SafeFrame bridge |
+
+**Conventions applied throughout:**
+
+- Test creatives in wrapper model are split into `.html` (DOM + styles only, NO `<script>` tags) + companion `.js` (all logic)
+- `.js` files expose `window.__SHARC_TEST_mraidCreativeInit()` or `window.__SHARC_TEST_sfCreativeInit()` callback
+- The `__SHARC_TEST_` prefix is intentionally ugly to prevent copying to production
+- Compliance ads under `compliance-ads/` use the compliance runner loading path (self-contained HTML with inline scripts)
+- Verification is visual: read the log pane, observe iframe behavior, check status indicators
+- All JS uses `'use strict'` and ES5-compatible syntax (no arrow functions, no `const`/`let`, no template literals)
+- All log helpers follow the `logEntry(type, msg)` pattern with `escHtml()` sanitization
+
+---
+
+## 1. SHARC Core Placement Test Creative
+
+**Purpose:** Test the native SHARC placement change API directly, without any bridge layer. Exercises `requestPlacementChange()`, `getPlacementOptions()`, and the `placementChange` event.
+
+**Note:** This creative loads differently from MRAID/SafeFrame test creatives. It uses the SHARC SDK directly (like `test-creative.html`) and is loaded as a standalone creative within the SHARC container, not through a bridge wrapper. It follows the same DOM/JS pattern as `test-creative.html` which loads `sharc-protocol.js` and `sharc-creative.js` via `<script src>` tags. However, since it may also be loaded through the wrapper model for testing purposes, the JS file provides a `__SHARC_TEST_placementCreativeInit` callback that is optional -- the creative self-boots via `SHARC.onReady()` when loaded standalone.
+
+### 1.1 HTML File: `examples/test/test-placement-creative.html`
+
+```html
+<!doctype html>
+<!--
+  test-placement-creative.html - SHARC Core Placement Change Test Creative
+
+  Tests the native SHARC requestPlacementChange API directly without any
+  bridge layer. Exercises resize, maximize, restore, and constraint queries.
+
+  Can be loaded either:
+    a) Directly by the SHARC container (like test-creative.html)
+    b) Via mraid-wrapper.html for bridge-bypass testing
+
+  NOTE: This file contains DOM structure and styles ONLY when loaded via
+  wrapper model. All script logic lives in test-placement-creative.js.
+  Do NOT add <script> tags here - they won't execute when injected via innerHTML.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SHARC Placement Change Test</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0f172a;
+      color: #eee;
+      overflow: hidden;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* -- Ad Banner -------------------------------------------------- */
+    #ad-banner {
+      background: linear-gradient(135deg, #7c3aed 0%, #2563eb 100%);
+      padding: 10px 16px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      min-height: 50px;
+      flex-shrink: 0;
+      user-select: none;
+    }
+    #ad-banner .brand {
+      font-size: 16px;
+      font-weight: 700;
+      color: #fff;
+    }
+    .brand-wrap { display: flex; flex-direction: column; gap: 2px; }
+    .brand-sub { font-size: 10px; color: rgba(255,255,255,0.65); }
+
+    /* -- State Display ---------------------------------------------- */
+    #ad-state {
+      background: rgba(0,0,0,0.45);
+      padding: 6px 16px;
+      font-size: 10px;
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      flex-wrap: wrap;
+      border-bottom: 1px solid rgba(255,255,255,0.08);
+      flex-shrink: 0;
+    }
+    .state-item { display: flex; gap: 3px; align-items: center; }
+    .state-label { color: rgba(255,255,255,0.45); }
+    .state-value {
+      color: #7c3aed;
+      font-weight: 700;
+      font-family: monospace;
+      font-size: 10px;
+    }
+    .state-value.ok { color: #4ade80; }
+    .state-value.warn { color: #fb923c; }
+    .state-value.err { color: #f87171; }
+
+    /* -- Controls --------------------------------------------------- */
+    #ad-controls {
+      padding: 8px 16px;
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+      flex-shrink: 0;
+      background: rgba(0,0,0,0.25);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+    }
+    .ad-btn {
+      background: #1e293b;
+      color: #fff;
+      border: 1px solid rgba(255,255,255,0.18);
+      padding: 5px 10px;
+      border-radius: 5px;
+      font-size: 10px;
+      cursor: pointer;
+      transition: background 0.15s;
+      white-space: nowrap;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+    }
+    .ad-btn:hover { background: #334155; }
+    .ad-btn:active { background: #7c3aed; }
+    .ad-btn.danger { border-color: #f87171; color: #f87171; }
+    .ad-btn.success { border-color: #4ade80; color: #4ade80; }
+
+    /* -- Test Results ----------------------------------------------- */
+    #test-results {
+      padding: 6px 16px;
+      font-size: 10px;
+      background: rgba(0,0,0,0.3);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+      flex-shrink: 0;
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .test-badge {
+      padding: 2px 8px;
+      border-radius: 3px;
+      font-family: monospace;
+      font-size: 9px;
+      font-weight: 700;
+    }
+    .test-badge.pass { background: #166534; color: #4ade80; }
+    .test-badge.fail { background: #7f1d1d; color: #f87171; }
+    .test-badge.pending { background: #1e293b; color: #94a3b8; }
+
+    /* -- Protocol Log ----------------------------------------------- */
+    #log-header {
+      padding: 5px 16px;
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: rgba(255,255,255,0.35);
+      background: rgba(0,0,0,0.3);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+      flex-shrink: 0;
+    }
+    #protocol-log {
+      flex: 1;
+      overflow-y: auto;
+      padding: 6px 16px;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 10px;
+      line-height: 1.65;
+    }
+    #protocol-log::-webkit-scrollbar { width: 4px; }
+    #protocol-log::-webkit-scrollbar-thumb { background: #1e293b; border-radius: 2px; }
+
+    .log-entry { padding: 1px 0; border-bottom: 1px solid rgba(255,255,255,0.03); }
+    .log-entry .ts { color: rgba(255,255,255,0.25); margin-right: 6px; }
+    .log-entry.event .msg { color: #60a5fa; }
+    .log-entry.action .msg { color: #a78bfa; }
+    .log-entry.error .msg { color: #f87171; }
+    .log-entry.info .msg { color: rgba(255,255,255,0.55); }
+    .log-entry.ok .msg { color: #4ade80; }
+  </style>
+</head>
+<body>
+
+  <!-- Ad Banner -->
+  <div id="ad-banner">
+    <div class="brand-wrap">
+      <div class="brand">SHARC Placement Test</div>
+      <div class="brand-sub">Native SHARC SDK - No Bridge</div>
+    </div>
+  </div>
+
+  <!-- Live State Display -->
+  <div id="ad-state">
+    <div class="state-item">
+      <span class="state-label">container:</span>
+      <span class="state-value" id="disp-container-state">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">dims:</span>
+      <span class="state-value" id="disp-dimensions">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">pos:</span>
+      <span class="state-value" id="disp-position">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">constraints:</span>
+      <span class="state-value" id="disp-constraints">--</span>
+    </div>
+  </div>
+
+  <!-- Creative Controls -->
+  <div id="ad-controls">
+    <button class="ad-btn" onclick="testResize320x480()">Resize 320x480</button>
+    <button class="ad-btn" onclick="testResizeWithOffset()">Resize+Offset</button>
+    <button class="ad-btn" onclick="testMaximize()">Maximize</button>
+    <button class="ad-btn" onclick="testRestore()">Restore</button>
+    <button class="ad-btn" onclick="testQueryConstraints()">Query Constraints</button>
+    <button class="ad-btn" onclick="testResizeWithAnimation()">Resize+Anim</button>
+    <button class="ad-btn" onclick="testGetPlacementOptions()">Get Placement</button>
+    <button class="ad-btn danger" onclick="clearLog()">Clear Log</button>
+  </div>
+
+  <!-- Test Results -->
+  <div id="test-results">
+    <span class="test-badge pending" id="result-resize">resize: --</span>
+    <span class="test-badge pending" id="result-offset">offset: --</span>
+    <span class="test-badge pending" id="result-maximize">maximize: --</span>
+    <span class="test-badge pending" id="result-restore">restore: --</span>
+    <span class="test-badge pending" id="result-constraints">constraints: --</span>
+    <span class="test-badge pending" id="result-animation">animation: --</span>
+  </div>
+
+  <div id="log-header">SHARC Placement Event Log</div>
+
+  <!-- Protocol Log -->
+  <div id="protocol-log">
+    <div class="log-entry info">
+      <span class="ts">[init]</span>
+      <span class="msg">Placement test creative loaded. Waiting for SHARC SDK...</span>
+    </div>
+  </div>
+
+</body>
+</html>
+```
+
+### 1.2 JS File: `examples/test/test-placement-creative.js`
+
+```javascript
+// WARNING: __SHARC_TEST_placementCreativeInit is a SHARC test harness convention.
+// This creative also self-boots via SHARC.onReady() when loaded standalone.
+// See CREATIVE-AUTHORING.md.
+'use strict';
+
+// Self-boot path: when loaded standalone (not via wrapper), SHARC SDK is
+// available immediately via <script src> tags in the HTML.
+// Wrapper path: the wrapper calls __SHARC_TEST_placementCreativeInit() after
+// injecting DOM. Both paths converge in initPlacementCreative().
+
+(function () {
+
+  var initialized = false;
+
+  function initPlacementCreative() {
+    if (initialized) return;
+    initialized = true;
+
+    /* -- Logging helpers ------------------------------------------- */
+    var logEl = document.getElementById('protocol-log');
+
+    function logEntry(type, msg) {
+      var entry = document.createElement('div');
+      entry.className = 'log-entry ' + type;
+      var ts = new Date().toISOString().slice(11, 23);
+      entry.innerHTML =
+        '<span class="ts">[' + ts + ']</span>' +
+        '<span class="msg">' + escHtml(String(msg)) + '</span>';
+      logEl.appendChild(entry);
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    function escHtml(s) {
+      return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    window.clearLog = function clearLog() {
+      logEl.innerHTML = '';
+      logEntry('info', 'Log cleared.');
+    };
+
+    /* -- Test result helpers --------------------------------------- */
+    function setResult(id, passed, detail) {
+      var el = document.getElementById(id);
+      if (!el) return;
+      var label = id.replace('result-', '');
+      el.textContent = label + ': ' + (passed ? 'PASS' : 'FAIL');
+      el.className = 'test-badge ' + (passed ? 'pass' : 'fail');
+      logEntry(passed ? 'ok' : 'error', (passed ? 'PASS' : 'FAIL') + ' [' + label + '] ' + (detail || ''));
+    }
+
+    /* -- State display update ------------------------------------- */
+    function updateDisplay(placement) {
+      if (placement) {
+        var dimsEl = document.getElementById('disp-dimensions');
+        if (placement.width !== undefined && placement.height !== undefined) {
+          dimsEl.textContent = placement.width + 'x' + placement.height;
+        }
+        var posEl = document.getElementById('disp-position');
+        if (placement.x !== undefined && placement.y !== undefined) {
+          posEl.textContent = placement.x + ',' + placement.y;
+        }
+      }
+    }
+
+    /* -- SHARC event listeners ------------------------------------ */
+    SHARC.onReady(function (env, features) {
+      logEntry('ok', 'onReady called');
+      logEntry('info', '  env: version=' + (env && env.version));
+      if (features && features.length > 0) {
+        logEntry('info', '  features: ' + features.map(function (f) { return f.name || f; }).join(', '));
+      }
+      document.getElementById('disp-container-state').textContent = 'ready';
+      return Promise.resolve();
+    });
+
+    SHARC.onStart(function () {
+      logEntry('ok', 'onStart called');
+      document.getElementById('disp-container-state').textContent = 'active';
+      document.getElementById('disp-container-state').className = 'state-value ok';
+      return Promise.resolve();
+    });
+
+    SHARC.on('stateChange', function (state) {
+      logEntry('event', 'stateChange -> ' + state);
+      document.getElementById('disp-container-state').textContent = state;
+    });
+
+    SHARC.on('placementChange', function (placement) {
+      logEntry('event', 'placementChange: ' + JSON.stringify(placement));
+      updateDisplay(placement);
+    });
+
+    /* -- Test actions (exposed globally for onclick= buttons) ----- */
+
+    window.testResize320x480 = function testResize320x480() {
+      logEntry('action', 'requestPlacementChange({ intent: "resize", 320x480, closeRegion })');
+      SHARC.requestPlacementChange({
+        intent: 'resize',
+        targetDimensions: { width: 320, height: 480 },
+        closeRegion: { position: 'top-right', size: 50 }
+      }).then(function (result) {
+        logEntry('ok', 'resize resolved: ' + JSON.stringify(result));
+        var passed = true;
+        if (result && result.width) {
+          passed = (result.width === 320 && result.height === 480);
+        }
+        setResult('result-resize', passed, JSON.stringify(result));
+        updateDisplay(result);
+      }).catch(function (err) {
+        logEntry('error', 'resize rejected: ' + JSON.stringify(err));
+        setResult('result-resize', false, (err && err.message) || String(err));
+      });
+    };
+
+    window.testResizeWithOffset = function testResizeWithOffset() {
+      logEntry('action', 'requestPlacementChange({ intent: "resize", 320x480, targetPosition })');
+      SHARC.requestPlacementChange({
+        intent: 'resize',
+        targetDimensions: { width: 320, height: 480 },
+        targetPosition: { x: 10, y: -50 },
+        closeRegion: { position: 'top-right', size: 50 }
+      }).then(function (result) {
+        logEntry('ok', 'resize+offset resolved: ' + JSON.stringify(result));
+        setResult('result-offset', true, JSON.stringify(result));
+        updateDisplay(result);
+      }).catch(function (err) {
+        logEntry('error', 'resize+offset rejected: ' + JSON.stringify(err));
+        setResult('result-offset', false, (err && err.message) || String(err));
+      });
+    };
+
+    window.testMaximize = function testMaximize() {
+      logEntry('action', 'requestPlacementChange({ intent: "maximize" })');
+      SHARC.requestPlacementChange({
+        intent: 'maximize'
+      }).then(function (result) {
+        logEntry('ok', 'maximize resolved: ' + JSON.stringify(result));
+        setResult('result-maximize', true, JSON.stringify(result));
+        updateDisplay(result);
+      }).catch(function (err) {
+        logEntry('error', 'maximize rejected: ' + JSON.stringify(err));
+        setResult('result-maximize', false, (err && err.message) || String(err));
+      });
+    };
+
+    window.testRestore = function testRestore() {
+      logEntry('action', 'requestPlacementChange({ intent: "restore" })');
+      SHARC.requestPlacementChange({
+        intent: 'restore'
+      }).then(function (result) {
+        logEntry('ok', 'restore resolved: ' + JSON.stringify(result));
+        setResult('result-restore', true, JSON.stringify(result));
+        updateDisplay(result);
+      }).catch(function (err) {
+        logEntry('error', 'restore rejected: ' + JSON.stringify(err));
+        setResult('result-restore', false, (err && err.message) || String(err));
+      });
+    };
+
+    window.testQueryConstraints = function testQueryConstraints() {
+      logEntry('action', 'getPlacementConstraints()');
+      // NOTE: getPlacementConstraints() is a new API proposed in the architecture doc.
+      // If not yet implemented, this will error -- which is the expected behavior for
+      // testing prior to implementation.
+      if (typeof SHARC.getPlacementConstraints !== 'function') {
+        logEntry('error', 'SHARC.getPlacementConstraints is not a function (not yet implemented)');
+        setResult('result-constraints', false, 'API not yet available');
+        return;
+      }
+      SHARC.getPlacementConstraints().then(function (constraints) {
+        logEntry('ok', 'constraints: ' + JSON.stringify(constraints));
+        var el = document.getElementById('disp-constraints');
+        if (constraints) {
+          var parts = [];
+          if (constraints.maxWidth) parts.push('maxW:' + constraints.maxWidth);
+          if (constraints.maxHeight) parts.push('maxH:' + constraints.maxHeight);
+          if (constraints.allowedIntents) parts.push('intents:' + constraints.allowedIntents.join(','));
+          el.textContent = parts.join(' ') || 'none';
+        }
+        setResult('result-constraints', true, JSON.stringify(constraints));
+      }).catch(function (err) {
+        logEntry('error', 'constraints rejected: ' + JSON.stringify(err));
+        setResult('result-constraints', false, (err && err.message) || String(err));
+      });
+    };
+
+    window.testResizeWithAnimation = function testResizeWithAnimation() {
+      logEntry('action', 'requestPlacementChange({ intent: "resize", 320x480, transition })');
+      SHARC.requestPlacementChange({
+        intent: 'resize',
+        targetDimensions: { width: 320, height: 480 },
+        closeRegion: { position: 'top-right', size: 50 },
+        transition: { duration: 300, easing: 'ease-out' }
+      }).then(function (result) {
+        logEntry('ok', 'resize+anim resolved: ' + JSON.stringify(result));
+        setResult('result-animation', true, JSON.stringify(result));
+        updateDisplay(result);
+      }).catch(function (err) {
+        logEntry('error', 'resize+anim rejected: ' + JSON.stringify(err));
+        setResult('result-animation', false, (err && err.message) || String(err));
+      });
+    };
+
+    window.testGetPlacementOptions = function testGetPlacementOptions() {
+      logEntry('action', 'getPlacementOptions()');
+      SHARC.getPlacementOptions().then(function (opts) {
+        logEntry('ok', 'placementOptions: ' + JSON.stringify(opts));
+        updateDisplay(opts);
+      }).catch(function (err) {
+        logEntry('error', 'getPlacementOptions rejected: ' + JSON.stringify(err));
+      });
+    };
+
+    logEntry('info', 'Placement test creative initialized.');
+  }
+
+  // Wrapper path: expose init callback
+  window.__SHARC_TEST_placementCreativeInit = initPlacementCreative;
+
+  // Self-boot path: if SHARC SDK is already on window, init immediately
+  if (typeof window.SHARC !== 'undefined' && typeof window.SHARC.onReady === 'function') {
+    initPlacementCreative();
+  }
+
+}());
+```
+
+### 1.3 Protocol Trace Entries to Verify
+
+| Action | Expected Log Entries |
+|--------|---------------------|
+| Page load | `onReady called`, `onStart called` |
+| Resize 320x480 button | `requestPlacementChange` action log, then either `resize resolved` (ok) or `resize rejected` (error); `placementChange` event with width/height |
+| Resize+Offset button | Same as resize, plus `targetPosition` in the request args |
+| Maximize button | `maximize resolved`, `placementChange` event |
+| Restore button | `restore resolved`, `placementChange` event with original dimensions |
+| Query Constraints | `constraints: {...}` with `maxWidth`, `maxHeight`, `allowedIntents` -- or error if API not yet implemented |
+| Resize+Anim button | Same as resize, with `transition` in args |
+
+### 1.4 Pass/Fail Criteria
+
+| Test | PASS Condition | FAIL Condition |
+|------|---------------|----------------|
+| resize | Promise resolves; `placementChange` fires with width=320, height=480 | Promise rejects or dimensions mismatch |
+| offset | Promise resolves; `placementChange` fires | Promise rejects |
+| maximize | Promise resolves; `placementChange` fires | Promise rejects |
+| restore | Promise resolves; dimensions return to original | Promise rejects or dimensions do not reset |
+| constraints | Promise resolves with a non-null object containing `maxWidth`, `maxHeight`, or `allowedIntents` | Promise rejects or API not available |
+| animation | Promise resolves; visual transition observed (manual check) | Promise rejects |
+
+---
+
+## 2. MRAID Resize Test Creative
+
+**Purpose:** Test MRAID `resize()` and `setResizeProperties()` through the SHARC MRAID bridge. Verifies the full MRAID 3.0 resize lifecycle including state transitions, error handling, and close region behavior.
+
+### 2.1 HTML File: `examples/test/test-mraid-resize-creative.html`
+
+```html
+<!doctype html>
+<!--
+  test-mraid-resize-creative.html - MRAID Resize Test Creative (DOM structure only)
+
+  Tests MRAID resize() through the SHARC MRAID bridge. Exercises
+  setResizeProperties, resize, close from resized state, and error paths.
+
+  This creative is loaded inside mraid-wrapper.html which:
+    1. Injects window.mraid via sharc-mraid-bridge.js
+    2. Loads this file via XHR and injects the <body> DOM
+    3. Dynamically loads test-mraid-resize-creative.js via <script src>
+    4. Calls window.__SHARC_TEST_mraidCreativeInit() after the script loads
+
+  NOTE: This file contains DOM structure and styles ONLY.
+  All script logic lives in test-mraid-resize-creative.js.
+  Do NOT add <script> tags here - they won't execute when injected via innerHTML.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MRAID Resize Test Creative</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #1a1a2e;
+      color: #eee;
+      overflow: hidden;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* -- Ad Banner -------------------------------------------------- */
+    #ad-banner {
+      background: linear-gradient(135deg, #dc2626 0%, #9333ea 100%);
+      padding: 10px 16px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      min-height: 50px;
+      flex-shrink: 0;
+      user-select: none;
+    }
+    #ad-banner .brand {
+      font-size: 16px;
+      font-weight: 700;
+      color: #fff;
+    }
+    .brand-wrap { display: flex; flex-direction: column; gap: 2px; }
+    .brand-sub { font-size: 10px; color: rgba(255,255,255,0.65); }
+
+    /* -- Config Panel ----------------------------------------------- */
+    #config-panel {
+      background: rgba(0,0,0,0.4);
+      padding: 8px 16px;
+      font-size: 10px;
+      border-bottom: 1px solid rgba(255,255,255,0.08);
+      flex-shrink: 0;
+    }
+    .config-row {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      margin-bottom: 4px;
+      flex-wrap: wrap;
+    }
+    .config-row label {
+      color: rgba(255,255,255,0.5);
+      min-width: 50px;
+    }
+    .config-row input[type="number"] {
+      width: 60px;
+      background: #0f172a;
+      border: 1px solid rgba(255,255,255,0.2);
+      color: #fff;
+      padding: 3px 6px;
+      border-radius: 3px;
+      font-size: 10px;
+      font-family: monospace;
+    }
+    .config-row select {
+      background: #0f172a;
+      border: 1px solid rgba(255,255,255,0.2);
+      color: #fff;
+      padding: 3px 6px;
+      border-radius: 3px;
+      font-size: 10px;
+    }
+    .config-row input[type="checkbox"] {
+      accent-color: #dc2626;
+    }
+
+    /* -- State Display ---------------------------------------------- */
+    #ad-state {
+      background: rgba(0,0,0,0.45);
+      padding: 6px 16px;
+      font-size: 10px;
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      flex-wrap: wrap;
+      border-bottom: 1px solid rgba(255,255,255,0.08);
+      flex-shrink: 0;
+    }
+    .state-item { display: flex; gap: 3px; align-items: center; }
+    .state-label { color: rgba(255,255,255,0.45); }
+    .state-value {
+      color: #dc2626;
+      font-weight: 700;
+      font-family: monospace;
+      font-size: 10px;
+    }
+    .state-value.ok { color: #4ade80; }
+    .state-value.warn { color: #fb923c; }
+    .state-value.err { color: #f87171; }
+
+    /* -- Controls --------------------------------------------------- */
+    #ad-controls {
+      padding: 8px 16px;
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+      flex-shrink: 0;
+      background: rgba(0,0,0,0.25);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+    }
+    .ad-btn {
+      background: #1e1e3a;
+      color: #fff;
+      border: 1px solid rgba(255,255,255,0.18);
+      padding: 5px 10px;
+      border-radius: 5px;
+      font-size: 10px;
+      cursor: pointer;
+      transition: background 0.15s;
+      white-space: nowrap;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+    }
+    .ad-btn:hover { background: #2d2d50; }
+    .ad-btn:active { background: #dc2626; }
+    .ad-btn.danger { border-color: #f87171; color: #f87171; }
+
+    /* -- Protocol Log ----------------------------------------------- */
+    #log-header {
+      padding: 5px 16px;
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: rgba(255,255,255,0.35);
+      background: rgba(0,0,0,0.3);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+      flex-shrink: 0;
+    }
+    #protocol-log {
+      flex: 1;
+      overflow-y: auto;
+      padding: 6px 16px;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 10px;
+      line-height: 1.65;
+    }
+    #protocol-log::-webkit-scrollbar { width: 4px; }
+    #protocol-log::-webkit-scrollbar-thumb { background: #1e1e3a; border-radius: 2px; }
+
+    .log-entry { padding: 1px 0; border-bottom: 1px solid rgba(255,255,255,0.03); }
+    .log-entry .ts { color: rgba(255,255,255,0.25); margin-right: 6px; }
+    .log-entry.event .msg { color: #60a5fa; }
+    .log-entry.action .msg { color: #a78bfa; }
+    .log-entry.error .msg { color: #f87171; }
+    .log-entry.info .msg { color: rgba(255,255,255,0.55); }
+    .log-entry.ok .msg { color: #4ade80; }
+
+    /* -- No-mraid fallback ------------------------------------------ */
+    #no-mraid {
+      display: none;
+      padding: 20px;
+      text-align: center;
+      color: rgba(255,255,255,0.4);
+      font-size: 12px;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Ad Banner -->
+  <div id="ad-banner">
+    <div class="brand-wrap">
+      <div class="brand">MRAID Resize Test</div>
+      <div class="brand-sub">MRAID 3.0 resize() via SHARC Bridge</div>
+    </div>
+  </div>
+
+  <!-- Resize Config Panel -->
+  <div id="config-panel">
+    <div class="config-row">
+      <label>width:</label>
+      <input type="number" id="cfg-width" value="320" min="50">
+      <label>height:</label>
+      <input type="number" id="cfg-height" value="480" min="50">
+    </div>
+    <div class="config-row">
+      <label>offsetX:</label>
+      <input type="number" id="cfg-offsetX" value="0">
+      <label>offsetY:</label>
+      <input type="number" id="cfg-offsetY" value="0">
+    </div>
+    <div class="config-row">
+      <label>closePos:</label>
+      <select id="cfg-closePos">
+        <option value="top-right" selected>top-right</option>
+        <option value="top-left">top-left</option>
+        <option value="top-center">top-center</option>
+        <option value="bottom-left">bottom-left</option>
+        <option value="bottom-right">bottom-right</option>
+        <option value="bottom-center">bottom-center</option>
+        <option value="center">center</option>
+      </select>
+      <label>offscreen:</label>
+      <input type="checkbox" id="cfg-offscreen">
+    </div>
+  </div>
+
+  <!-- Live State Display -->
+  <div id="ad-state">
+    <div class="state-item">
+      <span class="state-label">state:</span>
+      <span class="state-value" id="disp-state">loading</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">curPos:</span>
+      <span class="state-value" id="disp-curpos">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">maxSize:</span>
+      <span class="state-value" id="disp-maxsize">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">viewable:</span>
+      <span class="state-value" id="disp-viewable">--</span>
+    </div>
+  </div>
+
+  <!-- Controls -->
+  <div id="ad-controls">
+    <button class="ad-btn" onclick="testSetResizeProps()">setResizeProperties</button>
+    <button class="ad-btn" onclick="testResize()">resize()</button>
+    <button class="ad-btn" onclick="testClose()">close()</button>
+    <button class="ad-btn" onclick="testExpandThenResize()">expand+resize</button>
+    <button class="ad-btn" onclick="testResizeNoProps()">resize (no props)</button>
+    <button class="ad-btn" onclick="testCollapse()">collapse()</button>
+    <button class="ad-btn danger" onclick="clearLog()">Clear Log</button>
+  </div>
+
+  <div id="log-header">MRAID Resize Event Log</div>
+
+  <!-- Protocol Log -->
+  <div id="protocol-log">
+    <div class="log-entry info">
+      <span class="ts">[init]</span>
+      <span class="msg">MRAID resize creative loaded. Waiting for window.mraid...</span>
+    </div>
+  </div>
+
+  <div id="no-mraid">
+    window.mraid not available.<br>
+    Load via mraid-wrapper.html?creative=test/test-mraid-resize-creative.html
+  </div>
+
+</body>
+</html>
+```
+
+### 2.2 JS File: `examples/test/test-mraid-resize-creative.js`
+
+```javascript
+// WARNING: __SHARC_TEST_mraidCreativeInit is a SHARC test harness convention.
+// Real MRAID creatives do NOT use this pattern. See CREATIVE-AUTHORING.md.
+'use strict';
+
+window.__SHARC_TEST_mraidCreativeInit = function init() {
+
+    /* -- Logging helpers ------------------------------------------- */
+    var logEl = document.getElementById('protocol-log');
+
+    function logEntry(type, msg) {
+      var entry = document.createElement('div');
+      entry.className = 'log-entry ' + type;
+      var ts = new Date().toISOString().slice(11, 23);
+      entry.innerHTML =
+        '<span class="ts">[' + ts + ']</span>' +
+        '<span class="msg">' + escHtml(String(msg)) + '</span>';
+      logEl.appendChild(entry);
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    function escHtml(s) {
+      return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    window.clearLog = function clearLog() {
+      logEl.innerHTML = '';
+      logEntry('info', 'Log cleared.');
+    };
+
+    /* -- Config readers -------------------------------------------- */
+    function getResizeConfig() {
+      return {
+        width:               parseInt(document.getElementById('cfg-width').value, 10) || 320,
+        height:              parseInt(document.getElementById('cfg-height').value, 10) || 480,
+        offsetX:             parseInt(document.getElementById('cfg-offsetX').value, 10) || 0,
+        offsetY:             parseInt(document.getElementById('cfg-offsetY').value, 10) || 0,
+        customClosePosition: document.getElementById('cfg-closePos').value,
+        allowOffscreen:      document.getElementById('cfg-offscreen').checked
+      };
+    }
+
+    /* -- State display update -------------------------------------- */
+    function updateDisplay() {
+      if (typeof window.mraid === 'undefined') return;
+      var m = window.mraid;
+
+      var stateEl = document.getElementById('disp-state');
+      var state = m.getState();
+      stateEl.textContent = state;
+      stateEl.className = 'state-value ' +
+        (state === 'default' ? 'ok' :
+         state === 'resized' ? 'warn' :
+         state === 'expanded' ? 'warn' : '');
+
+      var viewableEl = document.getElementById('disp-viewable');
+      viewableEl.textContent = String(m.isViewable());
+      viewableEl.className = 'state-value ' + (m.isViewable() ? 'ok' : 'warn');
+
+      var curPos = m.getCurrentPosition();
+      document.getElementById('disp-curpos').textContent =
+        curPos.width + 'x' + curPos.height + ' @' + curPos.x + ',' + curPos.y;
+
+      var maxSize = m.getMaxSize();
+      document.getElementById('disp-maxsize').textContent =
+        maxSize.width + 'x' + maxSize.height;
+    }
+
+    /* -- MRAID event handlers -------------------------------------- */
+    function onMraidReady() {
+      logEntry('ok', 'ready event fired');
+      logEntry('info', '  getState()         = ' + mraid.getState());
+      logEntry('info', '  getPlacementType() = ' + mraid.getPlacementType());
+      logEntry('info', '  getMaxSize()       = ' + JSON.stringify(mraid.getMaxSize()));
+      logEntry('info', '  getCurrentPosition()= ' + JSON.stringify(mraid.getCurrentPosition()));
+      logEntry('info', '  getResizeProperties()= ' + JSON.stringify(mraid.getResizeProperties()));
+      updateDisplay();
+    }
+
+    function onStateChange(state) {
+      logEntry('event', 'stateChange("' + state + '")');
+      updateDisplay();
+    }
+
+    function onSizeChange(w, h) {
+      logEntry('event', 'sizeChange(' + w + ', ' + h + ')');
+      updateDisplay();
+    }
+
+    function onError(message, action) {
+      logEntry('error', 'error("' + message + '", "' + action + '")');
+    }
+
+    function onViewableChange(viewable) {
+      logEntry('event', 'viewableChange(' + viewable + ')');
+      updateDisplay();
+    }
+
+    /* -- Test actions ---------------------------------------------- */
+
+    window.testSetResizeProps = function testSetResizeProps() {
+      var cfg = getResizeConfig();
+      logEntry('action', 'mraid.setResizeProperties(' + JSON.stringify(cfg) + ')');
+      mraid.setResizeProperties(cfg);
+      logEntry('info', '  getResizeProperties() = ' + JSON.stringify(mraid.getResizeProperties()));
+    };
+
+    window.testResize = function testResize() {
+      logEntry('action', 'mraid.resize()');
+      mraid.resize();
+    };
+
+    window.testClose = function testClose() {
+      logEntry('action', 'mraid.close() -- should collapse from resized/expanded to default');
+      mraid.close();
+    };
+
+    window.testCollapse = function testCollapse() {
+      logEntry('action', 'mraid.collapse()');
+      mraid.collapse();
+    };
+
+    window.testExpandThenResize = function testExpandThenResize() {
+      logEntry('action', 'mraid.expand() then mraid.resize() -- resize should error from expanded');
+      mraid.expand();
+      // Wait for expand to complete, then try resize
+      var listener = function (state) {
+        if (state === 'expanded') {
+          mraid.removeEventListener('stateChange', listener);
+          logEntry('action', 'Now in expanded state -- calling mraid.resize()');
+          var cfg = getResizeConfig();
+          mraid.setResizeProperties(cfg);
+          mraid.resize();
+        }
+      };
+      mraid.addEventListener('stateChange', listener);
+    };
+
+    window.testResizeNoProps = function testResizeNoProps() {
+      logEntry('action', 'mraid.resize() without setResizeProperties -- should error');
+      // Reset resize props by creating fresh bridge state (not possible externally).
+      // Instead just call resize directly; the bridge tracks whether setResizeProperties
+      // was called with valid dimensions.
+      mraid.resize();
+    };
+
+    /* -- Bootstrap ------------------------------------------------- */
+    (function bootstrap() {
+      var m = window.mraid;
+
+      if (!m) {
+        logEntry('error', 'window.mraid not found. Load via mraid-wrapper.html');
+        document.getElementById('no-mraid').style.display = 'block';
+        return;
+      }
+
+      mraid.addEventListener('ready', onMraidReady);
+      mraid.addEventListener('stateChange', onStateChange);
+      mraid.addEventListener('sizeChange', onSizeChange);
+      mraid.addEventListener('viewableChange', onViewableChange);
+      mraid.addEventListener('error', onError);
+
+      logEntry('info', 'mraid object found. getState() = "' + mraid.getState() + '"');
+
+      if (mraid.getState() === 'loading') {
+        logEntry('info', 'State is "loading" -- waiting for ready event...');
+      } else {
+        logEntry('ok', 'State is "' + mraid.getState() + '" -- calling onMraidReady directly');
+        onMraidReady();
+      }
+
+      updateDisplay();
+    }());
+};
+```
+
+### 2.3 Protocol Trace Entries to Verify
+
+| Action | Expected Log Entries |
+|--------|---------------------|
+| Page load | `mraid object found`, `ready event fired`, current position and max size logged |
+| setResizeProperties | `setResizeProperties({...})` action, then `getResizeProperties()` confirming stored values |
+| resize() | `resize()` action, `stateChange("resized")` event, `sizeChange(w, h)` event |
+| close() from resized | `close()` action, `stateChange("default")` event, current position resets |
+| expand+resize | `expand()` action, `stateChange("expanded")`, then `resize()` followed by `error("resize is only valid from default state...", "resize")` |
+| resize (no props) | `resize()` action, `error("setResizeProperties must be called before resize()", "resize")` |
+
+### 2.4 Pass/Fail Criteria
+
+| Test | PASS Condition | FAIL Condition |
+|------|---------------|----------------|
+| setResizeProperties | `getResizeProperties()` returns matching values; no error event | Error event fires |
+| resize() | `stateChange("resized")` fires, `sizeChange` fires with matching w/h, `getState()` returns `"resized"` | Error event fires or state does not transition |
+| close from resized | `stateChange("default")` fires, `getCurrentPosition()` returns original dimensions | State does not return to default or position not reset |
+| expand+resize | Error event fires with action `"resize"` and message containing "default state" | No error fires (resize should fail from expanded state) |
+| resize without props | Error event fires with message about `setResizeProperties` | No error fires |
+
+---
+
+## 3. MRAID Resize Positive Compliance Test
+
+**Purpose:** Automated compliance test for MRAID 3.0 resize positive cases. Follows the same `EventTester`/`SequentialRunner` pattern as the existing `resize-negative-tests.js`. Runs automatically on load and logs CHECK/FAIL results.
+
+**Loading path:** Loaded through `mraid-3-compliance-runner.html` (compliance runner), not through the wrapper model. This means the HTML file is self-contained with inline `<script>` tags.
+
+### 3.1 HTML File: `examples/compliance-ads/resize-positive/resize-test.html`
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Mraid 3.0 Compliance resize positive test</title>
+</head>
+
+<body>
+    <script src="resize-positive-tests.js" type="text/javascript"></script>
+    <div id="resize_positive_tests_log">
+    </div>
+</body>
+
+</html>
+```
+
+### 3.2 JS File: `examples/compliance-ads/resize-positive/resize-positive-tests.js`
+
+```javascript
+// ==============================  MRAID INIT  ================================
+if (document.readyState === 'complete') {
+  readyCheck();
+} else {
+    window.addEventListener('load', readyCheck, false);
+}
+
+function readyCheck() {
+    if (window.MRAID_ENV) {
+        console.log('Version: ' + window.MRAID_ENV.version +
+            ' SDK: ' + window.MRAID_ENV.sdk +
+            ' SDKv: ' + window.MRAID_ENV.sdkVersion);
+    } else {
+        console.error('MRAID_ENV NOT FOUND');
+    }
+
+    logDiv = document.getElementById('resize_positive_tests_log');
+    logDiv.style = 'margin:10px';
+
+    var _mraid = window.mraid;
+
+    if (!_mraid) {
+        logErrorOnUi('window.mraid not found.');
+        return;
+    }
+
+    if (_mraid.getState() === 'loading') {
+        _mraid.addEventListener('ready', function () {
+            startTests(_mraid, function () {
+                console.log('[ALL POSITIVE RESIZE TESTS FINISHED]');
+            }, 3000, logInfoOnUi, logErrorOnUi);
+        });
+    } else {
+        startTests(_mraid, function () {
+            console.log('[ALL POSITIVE RESIZE TESTS FINISHED]');
+        }, 3000, logInfoOnUi, logErrorOnUi);
+    }
+}
+
+var logDiv;
+
+function logOnUi(color, message) {
+    var messageDiv = document.createElement('div');
+    messageDiv.innerText = '[' + new Date().toLocaleString() + '] ' + message;
+    messageDiv.style = 'width:100%;padding: 10px 0px;padding-right:10px;color:' + color;
+    logDiv.appendChild(messageDiv);
+}
+
+function logInfoOnUi(message) {
+    logOnUi('dodgerblue', message);
+    console.log(message);
+}
+
+function logErrorOnUi(message) {
+    logOnUi('tomato', message);
+    console.error(message);
+}
+
+// ============================================================================
+
+/**
+ * Sequentially executes resize positive tests. Covers cases when resize
+ * operations should succeed.
+ *
+ * @param mraid MRAID instance to use.
+ * @param done Callback function, executed once all tests ran.
+ * @param waitTimeout How long to wait for events.
+ * @param log Callback that should get log strings.
+ * @param error Callback that receives error strings.
+ */
+function startTests(mraid, done, waitTimeout, log, error) {
+    this.error = error || console.error;
+    this.log = log || console.log;
+
+    var testQueue = [];
+    var currentTest = 0;
+
+    function runNext() {
+        if (currentTest >= testQueue.length) {
+            log('=== ALL POSITIVE RESIZE TESTS COMPLETE ===');
+            if (done) done();
+            return;
+        }
+        var test = testQueue[currentTest];
+        currentTest++;
+        log('--- Test: ' + test.description + ' ---');
+        test.run(function () {
+            runNext();
+        });
+    }
+
+    // ===========================  TEST 1  ====================================
+    // Basic resize: set properties, call resize(), verify stateChange + sizeChange
+    testQueue.push({
+        description: 'Basic resize to 320x480 with top-right close',
+        run: function (next) {
+            var resolved = false;
+            var stateOk = false;
+            var sizeOk = false;
+
+            function checkDone() {
+                if (stateOk && sizeOk && !resolved) {
+                    resolved = true;
+                    mraid.removeEventListener('stateChange', onState);
+                    mraid.removeEventListener('sizeChange', onSize);
+                    clearTimeout(timer);
+
+                    // Verify getState
+                    if (mraid.getState() === 'resized') {
+                        log('CHECK: getState() === "resized" after resize');
+                    } else {
+                        error('FAIL: getState() === "' + mraid.getState() + '", expected "resized"');
+                    }
+
+                    // Verify getCurrentPosition
+                    var pos = mraid.getCurrentPosition();
+                    if (pos.width === 320 && pos.height === 480) {
+                        log('CHECK: getCurrentPosition() width=320, height=480');
+                    } else {
+                        error('FAIL: getCurrentPosition() width=' + pos.width + ', height=' + pos.height);
+                    }
+
+                    // Verify getMaxSize unchanged
+                    var maxSize = mraid.getMaxSize();
+                    log('CHECK: getMaxSize() unchanged = ' + JSON.stringify(maxSize));
+
+                    // Now close back to default
+                    closeToDefault(mraid, waitTimeout, log, error, next);
+                }
+            }
+
+            function onState(state) {
+                if (state === 'resized') {
+                    log('CHECK: stateChange("resized") received');
+                    stateOk = true;
+                    checkDone();
+                }
+            }
+
+            function onSize(w, h) {
+                if (w === 320 && h === 480) {
+                    log('CHECK: sizeChange(320, 480) received');
+                    sizeOk = true;
+                    checkDone();
+                } else {
+                    error('FAIL: sizeChange(' + w + ', ' + h + '), expected (320, 480)');
+                }
+            }
+
+            var timer = setTimeout(function () {
+                if (!resolved) {
+                    resolved = true;
+                    mraid.removeEventListener('stateChange', onState);
+                    mraid.removeEventListener('sizeChange', onSize);
+                    error('FAIL: Timeout waiting for resize stateChange/sizeChange');
+                    next();
+                }
+            }, waitTimeout);
+
+            mraid.addEventListener('stateChange', onState);
+            mraid.addEventListener('sizeChange', onSize);
+
+            mraid.setResizeProperties({
+                width: 320,
+                height: 480,
+                offsetX: 0,
+                offsetY: 0,
+                customClosePosition: 'top-right',
+                allowOffscreen: false
+            });
+            mraid.resize();
+        }
+    });
+
+    // ===========================  TEST 2  ====================================
+    // Resize with offset: verify targetPosition passed through
+    testQueue.push({
+        description: 'Resize with offset (offsetX=10, offsetY=-50)',
+        run: function (next) {
+            var resolved = false;
+
+            function onState(state) {
+                if (state === 'resized' && !resolved) {
+                    resolved = true;
+                    mraid.removeEventListener('stateChange', onState);
+                    clearTimeout(timer);
+
+                    log('CHECK: stateChange("resized") after offset resize');
+                    var pos = mraid.getCurrentPosition();
+                    log('CHECK: getCurrentPosition() = ' + JSON.stringify(pos));
+
+                    closeToDefault(mraid, waitTimeout, log, error, next);
+                }
+            }
+
+            var timer = setTimeout(function () {
+                if (!resolved) {
+                    resolved = true;
+                    mraid.removeEventListener('stateChange', onState);
+                    error('FAIL: Timeout waiting for offset resize');
+                    next();
+                }
+            }, waitTimeout);
+
+            mraid.addEventListener('stateChange', onState);
+            mraid.setResizeProperties({
+                width: 320,
+                height: 480,
+                offsetX: 10,
+                offsetY: -50,
+                customClosePosition: 'top-right',
+                allowOffscreen: false
+            });
+            mraid.resize();
+        }
+    });
+
+    // ===========================  TEST 3  ====================================
+    // Close from resized: verify return to default state and original position
+    testQueue.push({
+        description: 'Close from resized returns to default with original position',
+        run: function (next) {
+            var resolved = false;
+            var defaultPos = mraid.getDefaultPosition();
+
+            // First resize
+            function onResized(state) {
+                if (state === 'resized') {
+                    mraid.removeEventListener('stateChange', onResized);
+                    log('CHECK: Resized. Now calling close()...');
+
+                    // Listen for close -> default
+                    mraid.addEventListener('stateChange', onDefault);
+                    mraid.close();
+                }
+            }
+
+            function onDefault(state) {
+                if (state === 'default' && !resolved) {
+                    resolved = true;
+                    mraid.removeEventListener('stateChange', onDefault);
+                    clearTimeout(timer);
+
+                    if (mraid.getState() === 'default') {
+                        log('CHECK: getState() === "default" after close from resized');
+                    } else {
+                        error('FAIL: getState() === "' + mraid.getState() + '" after close');
+                    }
+
+                    var pos = mraid.getCurrentPosition();
+                    if (pos.width === defaultPos.width && pos.height === defaultPos.height) {
+                        log('CHECK: Position reset to default (' + pos.width + 'x' + pos.height + ')');
+                    } else {
+                        error('FAIL: Position not reset. Got ' + pos.width + 'x' + pos.height +
+                              ', expected ' + defaultPos.width + 'x' + defaultPos.height);
+                    }
+                    next();
+                }
+            }
+
+            var timer = setTimeout(function () {
+                if (!resolved) {
+                    resolved = true;
+                    mraid.removeEventListener('stateChange', onResized);
+                    mraid.removeEventListener('stateChange', onDefault);
+                    error('FAIL: Timeout in close-from-resized test');
+                    next();
+                }
+            }, waitTimeout * 2);
+
+            mraid.addEventListener('stateChange', onResized);
+            mraid.setResizeProperties({
+                width: 320,
+                height: 480,
+                offsetX: 0,
+                offsetY: 0,
+                customClosePosition: 'top-right',
+                allowOffscreen: false
+            });
+            mraid.resize();
+        }
+    });
+
+    // ===========================  TEST 4  ====================================
+    // All 8 customClosePosition values
+    var closePositions = [
+        'top-left', 'top-right', 'top-center',
+        'bottom-left', 'bottom-right', 'bottom-center',
+        'center'
+    ];
+
+    closePositions.forEach(function (pos) {
+        testQueue.push({
+            description: 'Resize with customClosePosition="' + pos + '"',
+            run: function (next) {
+                var resolved = false;
+
+                function onState(state) {
+                    if (state === 'resized' && !resolved) {
+                        resolved = true;
+                        mraid.removeEventListener('stateChange', onState);
+                        clearTimeout(timer);
+                        log('CHECK: Resize succeeded with customClosePosition="' + pos + '"');
+                        closeToDefault(mraid, waitTimeout, log, error, next);
+                    }
+                }
+
+                var timer = setTimeout(function () {
+                    if (!resolved) {
+                        resolved = true;
+                        mraid.removeEventListener('stateChange', onState);
+                        error('FAIL: Timeout for customClosePosition="' + pos + '"');
+                        next();
+                    }
+                }, waitTimeout);
+
+                mraid.addEventListener('stateChange', onState);
+                mraid.setResizeProperties({
+                    width: 200,
+                    height: 200,
+                    offsetX: 0,
+                    offsetY: 0,
+                    customClosePosition: pos,
+                    allowOffscreen: false
+                });
+                mraid.resize();
+            }
+        });
+    });
+
+    // ===========================  TEST 5  ====================================
+    // Resize from expanded state should error
+    testQueue.push({
+        description: 'Resize from expanded state fires error event',
+        run: function (next) {
+            var resolved = false;
+
+            // First expand
+            function onExpanded(state) {
+                if (state === 'expanded') {
+                    mraid.removeEventListener('stateChange', onExpanded);
+                    log('CHECK: Expanded. Now attempting resize()...');
+
+                    // Listen for error
+                    function onError(message, action) {
+                        if (!resolved && action === 'resize') {
+                            resolved = true;
+                            mraid.removeEventListener('error', onError);
+                            clearTimeout(timer);
+                            log('CHECK: Error fired for resize from expanded: "' + message + '"');
+
+                            // Close back to default
+                            mraid.addEventListener('stateChange', function onClose(state) {
+                                if (state === 'default') {
+                                    mraid.removeEventListener('stateChange', onClose);
+                                    next();
+                                }
+                            });
+                            mraid.close();
+                        }
+                    }
+
+                    mraid.addEventListener('error', onError);
+                    mraid.setResizeProperties({
+                        width: 200,
+                        height: 200,
+                        offsetX: 0,
+                        offsetY: 0
+                    });
+                    mraid.resize();
+                }
+            }
+
+            var timer = setTimeout(function () {
+                if (!resolved) {
+                    resolved = true;
+                    mraid.removeEventListener('stateChange', onExpanded);
+                    error('FAIL: Timeout in resize-from-expanded test');
+                    // Try to close back to default
+                    mraid.close();
+                    setTimeout(next, 500);
+                }
+            }, waitTimeout * 2);
+
+            mraid.addEventListener('stateChange', onExpanded);
+            mraid.expand();
+        }
+    });
+
+    // Start the test sequence
+    runNext();
+}
+
+// ================================ HELPERS ====================================
+
+/**
+ * Closes from any state back to default, waiting for stateChange("default").
+ */
+function closeToDefault(mraid, timeout, log, error, next) {
+    var resolved = false;
+
+    function onState(state) {
+        if (state === 'default' && !resolved) {
+            resolved = true;
+            mraid.removeEventListener('stateChange', onState);
+            clearTimeout(timer);
+            log('CHECK: Returned to default state after close');
+            next();
+        }
+    }
+
+    var timer = setTimeout(function () {
+        if (!resolved) {
+            resolved = true;
+            mraid.removeEventListener('stateChange', onState);
+            error('FAIL: Timeout waiting for close -> default');
+            next();
+        }
+    }, timeout);
+
+    mraid.addEventListener('stateChange', onState);
+    mraid.close();
+}
+// ============================================================================
+```
+
+### 3.3 Shim File: `examples/compliance-ads/resize-positive/resize-test.js`
+
+This shim follows the same pattern as `compliance-ads/resize-negative/resize-test.js`, loading the actual compliance script dynamically.
+
+```javascript
+/**
+ * resize-test.js - Shim for resize-positive compliance ad (null-origin sandbox safe)
+ *
+ * mraid-wrapper.html loads resize-test.html via XHR, injects the <body> DOM
+ * (which contains #resize_positive_tests_log), then loads this file via
+ * <script src="resize-test.js">. window.mraid is already set by the wrapper.
+ *
+ * This shim dynamically loads the actual compliance script via <script src>.
+ */
+(function () {
+  'use strict';
+  var script = document.createElement('script');
+  script.src = 'compliance-ads/resize-positive/resize-positive-tests.js';
+  script.onerror = function () {
+    console.error('[compliance resize-positive] Failed to load resize-positive-tests.js');
+  };
+  document.body.appendChild(script);
+}());
+```
+
+### 3.3 Protocol Trace Entries to Verify
+
+All entries appear in the compliance runner's log pane or browser console.
+
+| Test Phase | Expected Log Entries |
+|------------|---------------------|
+| Basic resize | `CHECK: stateChange("resized")`, `CHECK: sizeChange(320, 480)`, `CHECK: getState() === "resized"`, `CHECK: getCurrentPosition() width=320, height=480`, `CHECK: getMaxSize() unchanged` |
+| Close -> default | `CHECK: Returned to default state after close` |
+| Offset resize | `CHECK: stateChange("resized") after offset resize`, `CHECK: getCurrentPosition()` with offset reflected |
+| Close from resized | `CHECK: getState() === "default" after close from resized`, `CHECK: Position reset to default` |
+| Each closePosition | `CHECK: Resize succeeded with customClosePosition="<pos>"` for each of the 7 positions |
+| Resize from expanded | `CHECK: Expanded`, `CHECK: Error fired for resize from expanded` |
+| Completion | `=== ALL POSITIVE RESIZE TESTS COMPLETE ===` |
+
+### 3.4 Pass/Fail Criteria
+
+| Test | PASS (CHECK) | FAIL |
+|------|-------------|------|
+| Basic resize | `stateChange("resized")` fires, `sizeChange(320, 480)` fires, `getState() === "resized"`, `getCurrentPosition()` matches | Timeout or incorrect values |
+| Offset resize | `stateChange("resized")` fires | Timeout |
+| Close from resized | `getState() === "default"`, position resets to default dimensions | Timeout or position not reset |
+| All close positions | Each position produces `stateChange("resized")` without error | Any position times out or errors |
+| Resize from expanded | Error event fires with action `"resize"` | No error fires (resize should be blocked) |
+
+---
+
+## 4. SafeFrame Directional Expand Test Creative
+
+**Purpose:** Test SafeFrame `$sf.ext.expand()` with directional offsets (`t`, `l`, `r`, `b`) through the SHARC SafeFrame bridge. Verifies overlay expand, push expand rejection, collapse, and callback status transitions.
+
+### 4.1 HTML File: `examples/test/test-safeframe-expand-creative.html`
+
+```html
+<!doctype html>
+<!--
+  test-safeframe-expand-creative.html - SafeFrame Directional Expand Test (DOM only)
+
+  Tests SafeFrame $sf.ext.expand() with directional offsets through the
+  SHARC SafeFrame bridge. Exercises overlay expand, push rejection,
+  collapse, and callback status transitions.
+
+  This creative is loaded inside safeframe-wrapper.html which:
+    1. Injects window.$sf.ext via sharc-safeframe-bridge.js
+    2. Loads this file via XHR and injects the <body> DOM
+    3. Dynamically loads test-safeframe-expand-creative.js via <script src>
+    4. Calls window.__SHARC_TEST_sfCreativeInit() after the script loads
+
+  NOTE: This file contains DOM structure and styles ONLY.
+  All script logic lives in test-safeframe-expand-creative.js.
+  Do NOT add <script> tags here - they won't execute when injected via innerHTML.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SafeFrame Directional Expand Test</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0a1628;
+      color: #eee;
+      overflow: hidden;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* -- Ad Banner -------------------------------------------------- */
+    #ad-banner {
+      background: linear-gradient(135deg, #059669 0%, #0891b2 100%);
+      padding: 10px 16px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      min-height: 50px;
+      flex-shrink: 0;
+      user-select: none;
+    }
+    #ad-banner .brand {
+      font-size: 16px;
+      font-weight: 700;
+      color: #fff;
+    }
+    .brand-wrap { display: flex; flex-direction: column; gap: 2px; }
+    .brand-sub { font-size: 10px; color: rgba(255,255,255,0.65); }
+
+    /* -- Config Panel ----------------------------------------------- */
+    #config-panel {
+      background: rgba(0,0,0,0.4);
+      padding: 8px 16px;
+      font-size: 10px;
+      border-bottom: 1px solid rgba(255,255,255,0.08);
+      flex-shrink: 0;
+    }
+    .config-row {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      margin-bottom: 4px;
+      flex-wrap: wrap;
+    }
+    .config-row label {
+      color: rgba(255,255,255,0.5);
+      min-width: 20px;
+    }
+    .config-row input[type="number"] {
+      width: 55px;
+      background: #0f172a;
+      border: 1px solid rgba(255,255,255,0.2);
+      color: #fff;
+      padding: 3px 6px;
+      border-radius: 3px;
+      font-size: 10px;
+      font-family: monospace;
+    }
+
+    /* -- State Display ---------------------------------------------- */
+    #ad-state {
+      background: rgba(0,0,0,0.45);
+      padding: 6px 16px;
+      font-size: 10px;
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      flex-wrap: wrap;
+      border-bottom: 1px solid rgba(255,255,255,0.08);
+      flex-shrink: 0;
+    }
+    .state-item { display: flex; gap: 3px; align-items: center; }
+    .state-label { color: rgba(255,255,255,0.45); }
+    .state-value {
+      color: #059669;
+      font-weight: 700;
+      font-family: monospace;
+      font-size: 10px;
+    }
+    .state-value.ok { color: #4ade80; }
+    .state-value.warn { color: #fb923c; }
+    .state-value.err { color: #f87171; }
+
+    /* -- Controls --------------------------------------------------- */
+    #ad-controls {
+      padding: 8px 16px;
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+      flex-shrink: 0;
+      background: rgba(0,0,0,0.25);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+    }
+    .ad-btn {
+      background: #0d3349;
+      color: #fff;
+      border: 1px solid rgba(255,255,255,0.18);
+      padding: 5px 10px;
+      border-radius: 5px;
+      font-size: 10px;
+      cursor: pointer;
+      transition: background 0.15s;
+      white-space: nowrap;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+    }
+    .ad-btn:hover { background: #0d4a60; }
+    .ad-btn:active { background: #059669; }
+    .ad-btn.danger { border-color: #f87171; color: #f87171; }
+    .ad-btn.warn { border-color: #fb923c; color: #fb923c; }
+
+    /* -- Protocol Log ----------------------------------------------- */
+    #log-header {
+      padding: 5px 16px;
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: rgba(255,255,255,0.35);
+      background: rgba(0,0,0,0.3);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+      flex-shrink: 0;
+    }
+    #protocol-log {
+      flex: 1;
+      overflow-y: auto;
+      padding: 6px 16px;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 10px;
+      line-height: 1.65;
+    }
+    #protocol-log::-webkit-scrollbar { width: 4px; }
+    #protocol-log::-webkit-scrollbar-thumb { background: #1a3a4a; border-radius: 2px; }
+
+    .log-entry { padding: 1px 0; border-bottom: 1px solid rgba(255,255,255,0.03); }
+    .log-entry .ts { color: rgba(255,255,255,0.25); margin-right: 6px; }
+    .log-entry.event .msg { color: #60a5fa; }
+    .log-entry.action .msg { color: #a78bfa; }
+    .log-entry.error .msg { color: #f87171; }
+    .log-entry.info .msg { color: rgba(255,255,255,0.55); }
+    .log-entry.ok .msg { color: #4ade80; }
+    .log-entry.geom .msg { color: #34d399; }
+    .log-entry.focus .msg { color: #fbbf24; }
+
+    /* -- No-$sf fallback -------------------------------------------- */
+    #no-sf {
+      display: none;
+      padding: 20px;
+      text-align: center;
+      color: rgba(255,255,255,0.4);
+      font-size: 12px;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Ad Banner -->
+  <div id="ad-banner">
+    <div class="brand-wrap">
+      <div class="brand">SF Expand Test</div>
+      <div class="brand-sub">SafeFrame 1.1 Directional Expand</div>
+    </div>
+  </div>
+
+  <!-- Expand Offset Config -->
+  <div id="config-panel">
+    <div class="config-row">
+      <label>t:</label>
+      <input type="number" id="cfg-t" value="50">
+      <label>l:</label>
+      <input type="number" id="cfg-l" value="50">
+      <label>r:</label>
+      <input type="number" id="cfg-r" value="50">
+      <label>b:</label>
+      <input type="number" id="cfg-b" value="50">
+    </div>
+  </div>
+
+  <!-- Live State Display -->
+  <div id="ad-state">
+    <div class="state-item">
+      <span class="state-label">status:</span>
+      <span class="state-value" id="disp-status">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">inView%:</span>
+      <span class="state-value" id="disp-inview">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">focus:</span>
+      <span class="state-value" id="disp-focus">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">geom.self:</span>
+      <span class="state-value" id="disp-geom-self">--</span>
+    </div>
+  </div>
+
+  <!-- Controls -->
+  <div id="ad-controls">
+    <button class="ad-btn" onclick="testExpandOverlay()">expand overlay</button>
+    <button class="ad-btn warn" onclick="testExpandPush()">expand push</button>
+    <button class="ad-btn" onclick="testExpandNoOffsets()">expand (no offsets)</button>
+    <button class="ad-btn" onclick="testCollapse()">collapse()</button>
+    <button class="ad-btn" onclick="testStatus()">status()</button>
+    <button class="ad-btn" onclick="testGeom()">geom()</button>
+    <button class="ad-btn danger" onclick="clearLog()">Clear Log</button>
+  </div>
+
+  <div id="log-header">SafeFrame Expand Event Log</div>
+
+  <!-- Protocol Log -->
+  <div id="protocol-log">
+    <div class="log-entry info">
+      <span class="ts">[init]</span>
+      <span class="msg">SafeFrame expand creative loaded. Waiting for window.$sf...</span>
+    </div>
+  </div>
+
+  <div id="no-sf">
+    <strong>window.$sf not available.</strong><br>
+    Load via:<br>
+    <code>safeframe-wrapper.html?creative=test/test-safeframe-expand-creative.html</code>
+  </div>
+
+</body>
+</html>
+```
+
+### 4.2 JS File: `examples/test/test-safeframe-expand-creative.js`
+
+```javascript
+// WARNING: __SHARC_TEST_sfCreativeInit is a SHARC test harness convention.
+// Real SafeFrame creatives do NOT use this pattern. See CREATIVE-AUTHORING.md.
+'use strict';
+
+window.__SHARC_TEST_sfCreativeInit = function init() {
+
+  /* -- Logging helpers --------------------------------------------- */
+  var logEl = document.getElementById('protocol-log');
+
+  function logEntry(type, msg) {
+    var entry = document.createElement('div');
+    entry.className = 'log-entry ' + type;
+    var ts = new Date().toISOString().slice(11, 23);
+    entry.innerHTML =
+      '<span class="ts">[' + ts + ']</span>' +
+      '<span class="msg">' + escHtml(String(msg)) + '</span>';
+    logEl.appendChild(entry);
+    logEl.scrollTop = logEl.scrollHeight;
+  }
+
+  function escHtml(s) {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  window.clearLog = function clearLog() {
+    logEl.innerHTML = '';
+    logEntry('info', 'Log cleared.');
+  };
+
+  /* -- Config readers ---------------------------------------------- */
+  function getExpandOffsets() {
+    return {
+      t: parseInt(document.getElementById('cfg-t').value, 10) || 0,
+      l: parseInt(document.getElementById('cfg-l').value, 10) || 0,
+      r: parseInt(document.getElementById('cfg-r').value, 10) || 0,
+      b: parseInt(document.getElementById('cfg-b').value, 10) || 0
+    };
+  }
+
+  /* -- State display update ---------------------------------------- */
+  function updateDisplay() {
+    var sf = window.$sf;
+    if (!sf || !sf.ext) return;
+
+    var statusEl = document.getElementById('disp-status');
+    var status = sf.ext.status();
+    statusEl.textContent = status;
+    statusEl.className = 'state-value ' +
+      (status === 'expanded' ? 'ok' :
+       status === 'collapsed' ? '' : 'warn');
+
+    var ivEl = document.getElementById('disp-inview');
+    var iv = sf.ext.inViewPercentage();
+    ivEl.textContent = iv + '%';
+    ivEl.className = 'state-value ' + (iv > 0 ? 'ok' : 'warn');
+
+    var focusEl = document.getElementById('disp-focus');
+    var focus = sf.ext.winHasFocus();
+    focusEl.textContent = String(focus);
+    focusEl.className = 'state-value ' + (focus ? 'ok' : '');
+
+    var geomObj = sf.ext.geom();
+    if (geomObj && geomObj.self) {
+      document.getElementById('disp-geom-self').textContent =
+        'w:' + geomObj.self.w + ' h:' + geomObj.self.h +
+        ' iv:' + (geomObj.self.iv !== undefined ? geomObj.self.iv.toFixed(2) : '?');
+    }
+  }
+
+  /* -- SafeFrame callback ------------------------------------------ */
+  function onSafeFrameEvent(status, data) {
+    switch (status) {
+      case 'geom-update':
+        logEntry('geom', 'geom-update -- iv:' +
+          (data && data.self ? data.self.iv.toFixed(2) : '?') +
+          ' w:' + (data && data.self ? data.self.w : '?') +
+          ' h:' + (data && data.self ? data.self.h : '?'));
+        break;
+      case 'expanded':
+        logEntry('ok', 'expanded -- w:' +
+          (data && data.info ? data.info.w : '?') +
+          ' h:' + (data && data.info ? data.info.h : '?') +
+          ' push:' + (data && data.info ? data.info.push : '?'));
+        break;
+      case 'collapsed':
+        logEntry('ok', 'collapsed');
+        break;
+      case 'failed':
+        logEntry('error', 'failed -- reason:' +
+          (data && data.reason ? data.reason : 'unknown'));
+        break;
+      case 'focus-change':
+        logEntry('focus', 'focus-change -- focus:' +
+          (data && data.focus !== undefined ? data.focus : '?'));
+        break;
+      default:
+        logEntry('info', 'callback: ' + status + ' -- ' + JSON.stringify(data));
+    }
+    updateDisplay();
+  }
+
+  /* -- Test actions ------------------------------------------------ */
+
+  window.testExpandOverlay = function testExpandOverlay() {
+    var sf = window.$sf;
+    if (!sf) return;
+    var offsets = getExpandOffsets();
+    var args = { t: offsets.t, l: offsets.l, r: offsets.r, b: offsets.b, push: false };
+    logEntry('action', '$sf.ext.expand(' + JSON.stringify(args) + ')');
+    sf.ext.expand(args);
+  };
+
+  window.testExpandPush = function testExpandPush() {
+    var sf = window.$sf;
+    if (!sf) return;
+    var offsets = getExpandOffsets();
+    var args = { t: offsets.t, l: offsets.l, r: offsets.r, b: offsets.b, push: true };
+    logEntry('action', '$sf.ext.expand(' + JSON.stringify(args) + ') -- expects failed callback');
+    sf.ext.expand(args);
+  };
+
+  window.testExpandNoOffsets = function testExpandNoOffsets() {
+    var sf = window.$sf;
+    if (!sf) return;
+    logEntry('action', '$sf.ext.expand({}) -- maximize (no directional offsets)');
+    sf.ext.expand({});
+  };
+
+  window.testCollapse = function testCollapse() {
+    var sf = window.$sf;
+    if (!sf) return;
+    logEntry('action', '$sf.ext.collapse()');
+    sf.ext.collapse();
+  };
+
+  window.testStatus = function testStatus() {
+    var sf = window.$sf;
+    if (!sf) return;
+    logEntry('info', '  $sf.ext.status() = "' + sf.ext.status() + '"');
+  };
+
+  window.testGeom = function testGeom() {
+    var sf = window.$sf;
+    if (!sf) return;
+    var g = sf.ext.geom();
+    logEntry('info', '  geom().win  = ' + JSON.stringify(g.win));
+    logEntry('info', '  geom().self = ' + JSON.stringify(g.self));
+    logEntry('info', '  geom().exp  = ' + JSON.stringify(g.exp));
+  };
+
+  /* -- Bootstrap --------------------------------------------------- */
+  (function bootstrap() {
+    var sf = window.$sf;
+
+    if (!sf || !sf.ext) {
+      logEntry('error', 'window.$sf not found. Load via safeframe-wrapper.html');
+      document.getElementById('no-sf').style.display = 'block';
+      return;
+    }
+
+    logEntry('ok', '$sf found -- specVersion: "' + (sf.specVersion || '?') + '"');
+    logEntry('info', '  $sf.ext.supports() = ' + JSON.stringify(sf.ext.supports()));
+    logEntry('info', '  $sf.ext.status()   = "' + sf.ext.status() + '"');
+
+    sf.ext.register(300, 250, onSafeFrameEvent);
+    logEntry('info', '  $sf.ext.register(300, 250, cb) called -- waiting for geom-update...');
+
+    updateDisplay();
+  }());
+};
+```
+
+### 4.3 Protocol Trace Entries to Verify
+
+| Action | Expected Log Entries |
+|--------|---------------------|
+| Page load | `$sf found`, `register(300, 250, cb) called`, `geom-update` callback |
+| expand overlay | `$sf.ext.expand({t:50, l:50, r:50, b:50, push:false})`, then callback `expanded -- w:? h:? push:false`, status updates to `"expanded"` |
+| expand push | `$sf.ext.expand({...push:true})`, then callback `failed -- reason:push-not-supported` |
+| expand (no offsets) | `$sf.ext.expand({})`, then callback `expanded` (maximize path) |
+| collapse | `$sf.ext.collapse()`, then callback `collapsed`, status returns to `"collapsed"` |
+| status() | `$sf.ext.status() = "expanded"` or `"collapsed"` |
+| geom() | `geom().win`, `geom().self`, `geom().exp` with dimension data |
+
+### 4.4 Pass/Fail Criteria
+
+| Test | PASS Condition | FAIL Condition |
+|------|---------------|----------------|
+| Overlay expand | Callback fires with status `"expanded"` and `push: false`; `$sf.ext.status()` returns `"expanded"` | Callback fires `"failed"` or no callback |
+| Push expand | Callback fires with status `"failed"` and reason `"push-not-supported"` | Callback fires `"expanded"` (push should be rejected) |
+| No-offset expand | Callback fires with status `"expanded"` (maximize intent used) | Callback fires `"failed"` |
+| Collapse | Callback fires with status `"collapsed"`; `$sf.ext.status()` returns `"collapsed"` | No callback or status does not change |
+| Expand after collapse | Second expand succeeds after a collapse cycle | Second expand rejected or idempotency guard blocks it |
+
+---
+
+## Harness Page Updates Required (Separate Work)
+
+The following harness page changes are needed but are **not part of this spec** (the spec covers creative-side test assets only):
+
+1. **`examples/test/index.html`** -- Add a link/option for `test-placement-creative.html` as a SHARC core creative.
+
+2. **`examples/test/mraid-test.html`** -- Add `test-mraid-resize-creative.html` to the creative dropdown/selector.
+
+3. **`examples/test/safeframe-test.html`** -- Add `test-safeframe-expand-creative.html` to the creative dropdown/selector.
+
+4. **`examples/test/mraid-3-compliance-runner.html`** -- Add `resize-positive/resize-test.html` to the compliance test list alongside the existing `resize-negative/resize-test.html` entry.
+
+---
+
+## File Summary
+
+| File | Type | Lines (est.) | Loading Model |
+|------|------|-------------|---------------|
+| `examples/test/test-placement-creative.html` | HTML (DOM+styles) | ~180 | Standalone or wrapper |
+| `examples/test/test-placement-creative.js` | JS (all logic) | ~220 | `__SHARC_TEST_placementCreativeInit` + self-boot |
+| `examples/test/test-mraid-resize-creative.html` | HTML (DOM+styles) | ~200 | mraid-wrapper.html |
+| `examples/test/test-mraid-resize-creative.js` | JS (all logic) | ~180 | `__SHARC_TEST_mraidCreativeInit` |
+| `examples/compliance-ads/resize-positive/resize-test.html` | HTML (self-contained) | ~15 | Compliance runner |
+| `examples/compliance-ads/resize-positive/resize-positive-tests.js` | JS (automated tests) | ~350 | Inline `<script>` from HTML |
+| `examples/compliance-ads/resize-positive/resize-test.js` | JS (shim) | ~18 | Wrapper fallback |
+| `examples/test/test-safeframe-expand-creative.html` | HTML (DOM+styles) | ~200 | safeframe-wrapper.html |
+| `examples/test/test-safeframe-expand-creative.js` | JS (all logic) | ~170 | `__SHARC_TEST_sfCreativeInit` |

--- a/examples/compliance-ads/resize-positive/resize-positive-tests.js
+++ b/examples/compliance-ads/resize-positive/resize-positive-tests.js
@@ -1,0 +1,424 @@
+// ==============================  MRAID INIT  ================================
+if (document.readyState === 'complete') {
+  readyCheck();
+} else {
+    window.addEventListener('load', readyCheck, false);
+}
+
+function readyCheck() {
+    if (window.MRAID_ENV) {
+        console.log('Version: ' + window.MRAID_ENV.version +
+            ' SDK: ' + window.MRAID_ENV.sdk +
+            ' SDKv: ' + window.MRAID_ENV.sdkVersion);
+    } else {
+        console.error('MRAID_ENV NOT FOUND');
+    }
+
+    logDiv = document.getElementById('resize_positive_tests_log');
+    logDiv.style = 'margin:10px';
+
+    var _mraid = window.mraid;
+
+    if (!_mraid) {
+        logErrorOnUi('window.mraid not found.');
+        return;
+    }
+
+    if (_mraid.getState() === 'loading') {
+        _mraid.addEventListener('ready', function () {
+            startTests(_mraid, function () {
+                console.log('[ALL POSITIVE RESIZE TESTS FINISHED]');
+            }, 3000, logInfoOnUi, logErrorOnUi);
+        });
+    } else {
+        startTests(_mraid, function () {
+            console.log('[ALL POSITIVE RESIZE TESTS FINISHED]');
+        }, 3000, logInfoOnUi, logErrorOnUi);
+    }
+}
+
+var logDiv;
+
+function logOnUi(color, message) {
+    var messageDiv = document.createElement('div');
+    messageDiv.innerText = '[' + new Date().toLocaleString() + '] ' + message;
+    messageDiv.style = 'width:100%;padding: 10px 0px;padding-right:10px;color:' + color;
+    logDiv.appendChild(messageDiv);
+}
+
+function logInfoOnUi(message) {
+    logOnUi('dodgerblue', message);
+    console.log(message);
+}
+
+function logErrorOnUi(message) {
+    logOnUi('tomato', message);
+    console.error(message);
+}
+
+// ============================================================================
+
+/**
+ * Sequentially executes resize positive tests. Covers cases when resize
+ * operations should succeed.
+ *
+ * @param mraid MRAID instance to use.
+ * @param done Callback function, executed once all tests ran.
+ * @param waitTimeout How long to wait for events.
+ * @param log Callback that should get log strings.
+ * @param error Callback that receives error strings.
+ */
+function startTests(mraid, done, waitTimeout, log, error) {
+    this.error = error || console.error;
+    this.log = log || console.log;
+
+    var testQueue = [];
+    var currentTest = 0;
+
+    function runNext() {
+        if (currentTest >= testQueue.length) {
+            log('=== ALL POSITIVE RESIZE TESTS COMPLETE ===');
+            if (done) done();
+            return;
+        }
+        var test = testQueue[currentTest];
+        currentTest++;
+        log('--- Test: ' + test.description + ' ---');
+        test.run(function () {
+            runNext();
+        });
+    }
+
+    // ===========================  TEST 1  ====================================
+    // Basic resize: set properties, call resize(), verify stateChange + sizeChange
+    testQueue.push({
+        description: 'Basic resize to 320x480 with top-right close',
+        run: function (next) {
+            var resolved = false;
+            var stateOk = false;
+            var sizeOk = false;
+
+            function checkDone() {
+                if (stateOk && sizeOk && !resolved) {
+                    resolved = true;
+                    mraid.removeEventListener('stateChange', onState);
+                    mraid.removeEventListener('sizeChange', onSize);
+                    clearTimeout(timer);
+
+                    // Verify getState
+                    if (mraid.getState() === 'resized') {
+                        log('CHECK: getState() === "resized" after resize');
+                    } else {
+                        error('FAIL: getState() === "' + mraid.getState() + '", expected "resized"');
+                    }
+
+                    // Verify getCurrentPosition
+                    var pos = mraid.getCurrentPosition();
+                    if (pos.width === 320 && pos.height === 480) {
+                        log('CHECK: getCurrentPosition() width=320, height=480');
+                    } else {
+                        error('FAIL: getCurrentPosition() width=' + pos.width + ', height=' + pos.height);
+                    }
+
+                    // Verify getMaxSize unchanged
+                    var maxSize = mraid.getMaxSize();
+                    log('CHECK: getMaxSize() unchanged = ' + JSON.stringify(maxSize));
+
+                    // Now close back to default
+                    closeToDefault(mraid, waitTimeout, log, error, next);
+                }
+            }
+
+            function onState(state) {
+                if (state === 'resized') {
+                    log('CHECK: stateChange("resized") received');
+                    stateOk = true;
+                    checkDone();
+                }
+            }
+
+            function onSize(w, h) {
+                if (w === 320 && h === 480) {
+                    log('CHECK: sizeChange(320, 480) received');
+                    sizeOk = true;
+                    checkDone();
+                } else {
+                    error('FAIL: sizeChange(' + w + ', ' + h + '), expected (320, 480)');
+                }
+            }
+
+            var timer = setTimeout(function () {
+                if (!resolved) {
+                    resolved = true;
+                    mraid.removeEventListener('stateChange', onState);
+                    mraid.removeEventListener('sizeChange', onSize);
+                    error('FAIL: Timeout waiting for resize stateChange/sizeChange');
+                    next();
+                }
+            }, waitTimeout);
+
+            mraid.addEventListener('stateChange', onState);
+            mraid.addEventListener('sizeChange', onSize);
+
+            mraid.setResizeProperties({
+                width: 320,
+                height: 480,
+                offsetX: 0,
+                offsetY: 0,
+                customClosePosition: 'top-right',
+                allowOffscreen: false
+            });
+            mraid.resize();
+        }
+    });
+
+    // ===========================  TEST 2  ====================================
+    // Resize with offset: verify targetPosition passed through
+    testQueue.push({
+        description: 'Resize with offset (offsetX=10, offsetY=-50)',
+        run: function (next) {
+            var resolved = false;
+
+            function onState(state) {
+                if (state === 'resized' && !resolved) {
+                    resolved = true;
+                    mraid.removeEventListener('stateChange', onState);
+                    clearTimeout(timer);
+
+                    log('CHECK: stateChange("resized") after offset resize');
+                    var pos = mraid.getCurrentPosition();
+                    log('CHECK: getCurrentPosition() = ' + JSON.stringify(pos));
+
+                    closeToDefault(mraid, waitTimeout, log, error, next);
+                }
+            }
+
+            var timer = setTimeout(function () {
+                if (!resolved) {
+                    resolved = true;
+                    mraid.removeEventListener('stateChange', onState);
+                    error('FAIL: Timeout waiting for offset resize');
+                    next();
+                }
+            }, waitTimeout);
+
+            mraid.addEventListener('stateChange', onState);
+            mraid.setResizeProperties({
+                width: 320,
+                height: 480,
+                offsetX: 10,
+                offsetY: -50,
+                customClosePosition: 'top-right',
+                allowOffscreen: false
+            });
+            mraid.resize();
+        }
+    });
+
+    // ===========================  TEST 3  ====================================
+    // Close from resized: verify return to default state and original position
+    testQueue.push({
+        description: 'Close from resized returns to default with original position',
+        run: function (next) {
+            var resolved = false;
+            var defaultPos = mraid.getDefaultPosition();
+
+            // First resize
+            function onResized(state) {
+                if (state === 'resized') {
+                    mraid.removeEventListener('stateChange', onResized);
+                    log('CHECK: Resized. Now calling close()...');
+
+                    // Listen for close -> default
+                    mraid.addEventListener('stateChange', onDefault);
+                    mraid.close();
+                }
+            }
+
+            function onDefault(state) {
+                if (state === 'default' && !resolved) {
+                    resolved = true;
+                    mraid.removeEventListener('stateChange', onDefault);
+                    clearTimeout(timer);
+
+                    if (mraid.getState() === 'default') {
+                        log('CHECK: getState() === "default" after close from resized');
+                    } else {
+                        error('FAIL: getState() === "' + mraid.getState() + '" after close');
+                    }
+
+                    var pos = mraid.getCurrentPosition();
+                    if (pos.width === defaultPos.width && pos.height === defaultPos.height) {
+                        log('CHECK: Position reset to default (' + pos.width + 'x' + pos.height + ')');
+                    } else {
+                        error('FAIL: Position not reset. Got ' + pos.width + 'x' + pos.height +
+                              ', expected ' + defaultPos.width + 'x' + defaultPos.height);
+                    }
+                    next();
+                }
+            }
+
+            var timer = setTimeout(function () {
+                if (!resolved) {
+                    resolved = true;
+                    mraid.removeEventListener('stateChange', onResized);
+                    mraid.removeEventListener('stateChange', onDefault);
+                    error('FAIL: Timeout in close-from-resized test');
+                    next();
+                }
+            }, waitTimeout * 2);
+
+            mraid.addEventListener('stateChange', onResized);
+            mraid.setResizeProperties({
+                width: 320,
+                height: 480,
+                offsetX: 0,
+                offsetY: 0,
+                customClosePosition: 'top-right',
+                allowOffscreen: false
+            });
+            mraid.resize();
+        }
+    });
+
+    // ===========================  TEST 4  ====================================
+    // All 8 customClosePosition values
+    var closePositions = [
+        'top-left', 'top-right', 'top-center',
+        'bottom-left', 'bottom-right', 'bottom-center',
+        'center'
+    ];
+
+    closePositions.forEach(function (pos) {
+        testQueue.push({
+            description: 'Resize with customClosePosition="' + pos + '"',
+            run: function (next) {
+                var resolved = false;
+
+                function onState(state) {
+                    if (state === 'resized' && !resolved) {
+                        resolved = true;
+                        mraid.removeEventListener('stateChange', onState);
+                        clearTimeout(timer);
+                        log('CHECK: Resize succeeded with customClosePosition="' + pos + '"');
+                        closeToDefault(mraid, waitTimeout, log, error, next);
+                    }
+                }
+
+                var timer = setTimeout(function () {
+                    if (!resolved) {
+                        resolved = true;
+                        mraid.removeEventListener('stateChange', onState);
+                        error('FAIL: Timeout for customClosePosition="' + pos + '"');
+                        next();
+                    }
+                }, waitTimeout);
+
+                mraid.addEventListener('stateChange', onState);
+                mraid.setResizeProperties({
+                    width: 200,
+                    height: 200,
+                    offsetX: 0,
+                    offsetY: 0,
+                    customClosePosition: pos,
+                    allowOffscreen: false
+                });
+                mraid.resize();
+            }
+        });
+    });
+
+    // ===========================  TEST 5  ====================================
+    // Resize from expanded state should error
+    testQueue.push({
+        description: 'Resize from expanded state fires error event',
+        run: function (next) {
+            var resolved = false;
+
+            // First expand
+            function onExpanded(state) {
+                if (state === 'expanded') {
+                    mraid.removeEventListener('stateChange', onExpanded);
+                    log('CHECK: Expanded. Now attempting resize()...');
+
+                    // Listen for error
+                    function onError(message, action) {
+                        if (!resolved && action === 'resize') {
+                            resolved = true;
+                            mraid.removeEventListener('error', onError);
+                            clearTimeout(timer);
+                            log('CHECK: Error fired for resize from expanded: "' + message + '"');
+
+                            // Close back to default
+                            mraid.addEventListener('stateChange', function onClose(state) {
+                                if (state === 'default') {
+                                    mraid.removeEventListener('stateChange', onClose);
+                                    next();
+                                }
+                            });
+                            mraid.close();
+                        }
+                    }
+
+                    mraid.addEventListener('error', onError);
+                    mraid.setResizeProperties({
+                        width: 200,
+                        height: 200,
+                        offsetX: 0,
+                        offsetY: 0
+                    });
+                    mraid.resize();
+                }
+            }
+
+            var timer = setTimeout(function () {
+                if (!resolved) {
+                    resolved = true;
+                    mraid.removeEventListener('stateChange', onExpanded);
+                    error('FAIL: Timeout in resize-from-expanded test');
+                    // Try to close back to default
+                    mraid.close();
+                    setTimeout(next, 500);
+                }
+            }, waitTimeout * 2);
+
+            mraid.addEventListener('stateChange', onExpanded);
+            mraid.expand();
+        }
+    });
+
+    // Start the test sequence
+    runNext();
+}
+
+// ================================ HELPERS ====================================
+
+/**
+ * Closes from any state back to default, waiting for stateChange("default").
+ */
+function closeToDefault(mraid, timeout, log, error, next) {
+    var resolved = false;
+
+    function onState(state) {
+        if (state === 'default' && !resolved) {
+            resolved = true;
+            mraid.removeEventListener('stateChange', onState);
+            clearTimeout(timer);
+            log('CHECK: Returned to default state after close');
+            next();
+        }
+    }
+
+    var timer = setTimeout(function () {
+        if (!resolved) {
+            resolved = true;
+            mraid.removeEventListener('stateChange', onState);
+            error('FAIL: Timeout waiting for close -> default');
+            next();
+        }
+    }, timeout);
+
+    mraid.addEventListener('stateChange', onState);
+    mraid.close();
+}
+// ============================================================================

--- a/examples/compliance-ads/resize-positive/resize-test.html
+++ b/examples/compliance-ads/resize-positive/resize-test.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Mraid 3.0 Compliance resize positive test</title>
+</head>
+
+<body>
+    <script src="resize-positive-tests.js" type="text/javascript"></script>
+    <div id="resize_positive_tests_log">
+    </div>
+</body>
+
+</html>

--- a/examples/compliance-ads/resize-positive/resize-test.js
+++ b/examples/compliance-ads/resize-positive/resize-test.js
@@ -1,0 +1,18 @@
+/**
+ * resize-test.js - Shim for resize-positive compliance ad (null-origin sandbox safe)
+ *
+ * mraid-wrapper.html loads resize-test.html via XHR, injects the <body> DOM
+ * (which contains #resize_positive_tests_log), then loads this file via
+ * <script src="resize-test.js">. window.mraid is already set by the wrapper.
+ *
+ * This shim dynamically loads the actual compliance script via <script src>.
+ */
+(function () {
+  'use strict';
+  var script = document.createElement('script');
+  script.src = 'compliance-ads/resize-positive/resize-positive-tests.js';
+  script.onerror = function () {
+    console.error('[compliance resize-positive] Failed to load resize-positive-tests.js');
+  };
+  document.body.appendChild(script);
+}());

--- a/examples/sharc-container.js
+++ b/examples/sharc-container.js
@@ -431,12 +431,17 @@ class SHARCContainer {
    * The outbound payload may enrich placementUpdate.position with the iframe's
    * current x/y/width/height when that information is available.
    * @param {Object} placementUpdate - Placement data to send.
-   * @param {Object} [placementUpdate.size] - {width, height} of the new placement.
-   * @param {Object} [placementUpdate.position] - Requested position; outbound payload may be replaced with the iframe's measured bounds.
+   * @param {Object} [extra] - Additional fields to include (e.g. transition, closeButtonPosition).
    */
-  notifyPlacementChange(placementUpdate) {
+  notifyPlacementChange(placementUpdate, extra) {
     const payload = this._buildPlacementChangePayload(placementUpdate);
-    this._protocol.sendPlacementChange(payload);
+    // Send notification with extra fields merged at the args level
+    const args = { placementUpdate: payload };
+    if (extra) {
+      if (extra.transition) args.transition = extra.transition;
+      if (extra.closeButtonPosition) args.closeButtonPosition = extra.closeButtonPosition;
+    }
+    this._protocol._sendMessage(ContainerMessages.PLACEMENT_CHANGE, args);
     this._lastSentPlacement = payload;
   }
 
@@ -743,9 +748,16 @@ class SHARCContainer {
       })
       .filter(Boolean);
 
+    // Auto-register placement feature strings
+    const placementFeatures = [
+      'com.iabtechlab.sharc.placement.resize',
+      'com.iabtechlab.sharc.placement.constraints',
+    ];
+
     const mergedFeatures = [
       ...this._explicitSupportedFeatures,
       ...extensionFeatureNames,
+      ...placementFeatures,
     ];
 
     // Cache for subsequent getFeatures() queries from the creative
@@ -1138,7 +1150,11 @@ class SHARCContainer {
       };
     }
     this._protocol._resolve(msg, resolvePayload);
-    this.notifyPlacementChange(updatedPlacement);
+    // Build notification extras (transition, closeButtonPosition)
+    const notifyExtra = {};
+    if (resolvePayload.transition) notifyExtra.transition = resolvePayload.transition;
+    if (resolvePayload.closeButtonPosition) notifyExtra.closeButtonPosition = resolvePayload.closeButtonPosition;
+    this.notifyPlacementChange(updatedPlacement, Object.keys(notifyExtra).length > 0 ? notifyExtra : undefined);
   }
 
   /**

--- a/examples/sharc-container.js
+++ b/examples/sharc-container.js
@@ -145,6 +145,8 @@ class SHARCContainer {
       autoStart = true,
       visible = false,
       useMarkupInjection = false,
+      placementPolicy,
+      closeButtonStyles,
     } = options;
 
     if (!creativeUrl) throw new Error('[SHARCContainer] creativeUrl is required');
@@ -239,6 +241,33 @@ class SHARCContainer {
      * @type {boolean}
      */
     this._useMarkupInjection = useMarkupInjection;
+
+    /**
+     * Placement policy — container-local enforcement layer.
+     * Never sent over the wire. When undefined, no policy enforcement occurs.
+     * @type {Object|undefined}
+     */
+    this._placementPolicy = placementPolicy || undefined;
+
+    /**
+     * Publisher customization for the container-rendered close button.
+     * Applied via Object.assign over defaults; minimum 50 DIP enforced.
+     * @type {Object|null}
+     */
+    this._closeButtonStyles = closeButtonStyles || null;
+
+    /**
+     * The container-rendered close button DOM element (sibling to iframe).
+     * @type {HTMLElement|null}
+     */
+    this._closeButton = null;
+
+    /**
+     * Tracks the current placement intent ('resize', 'maximize', 'fullscreen', or null).
+     * Used by close button click handler to determine restore vs close behavior.
+     * @type {string|null}
+     */
+    this._currentIntent = null;
 
     /**
      * Snapshot of the original placement from construction time.
@@ -991,12 +1020,26 @@ class SHARCContainer {
    */
   _handleRequestPlacementChange(msg) {
     const args = msg.args || {};
-    const { intent, targetDimensions, targetPosition, anchorPoint, allowOffscreen } = args;
-    let updatedPlacement = { ...(this.environmentData.currentPlacement || {}) };
+    const { intent, targetDimensions, targetPosition, anchorPoint, closeRegion, allowOffscreen, transition } = args;
 
-    // ── Bug fix: enforce allowOffscreen ──
-    // When allowOffscreen === false, validate the entire resized ad fits within viewport bounds.
-    if (intent === 'resize' && allowOffscreen === false && targetDimensions && this._iframe) {
+    // ── Validation pipeline (only when policy is configured) ──
+    if (this._placementPolicy) {
+      const rejection = this._validatePlacementRequest(args);
+      if (rejection) {
+        this._protocol._reject(msg, rejection.code, rejection.message);
+        return;
+      }
+    }
+
+    // ── Offscreen enforcement (applies even without policy — bug fix) ──
+    // Determine effective allowOffscreen: request overrides policy overrides default (true)
+    const effectiveAllowOffscreen = allowOffscreen !== undefined
+      ? allowOffscreen
+      : (this._placementPolicy && this._placementPolicy.allowOffscreen !== undefined
+          ? this._placementPolicy.allowOffscreen
+          : true);
+
+    if (intent === 'resize' && effectiveAllowOffscreen === false && targetDimensions && this._iframe) {
       const pos = targetPosition || {
         x: this._iframe.offsetLeft,
         y: this._iframe.offsetTop,
@@ -1011,38 +1054,183 @@ class SHARCContainer {
       }
     }
 
-    // Apply the placement change based on intent
+    // ── Execution (with position snapshot, animation, and close button) ──
+    let updatedPlacement = { ...(this.environmentData.currentPlacement || {}) };
+
+    // Resolve close button position from hint
+    const resolvedClose = closeRegion
+      ? this._resolveClosePosition(closeRegion, targetDimensions || updatedPlacement, targetPosition)
+      : { position: 'top-right', size: 50, overridden: false };
+
     switch (intent) {
       case 'resize':
         this._snapshotPreResizeState();
+        this._currentIntent = 'resize';
         if (targetDimensions) {
-          updatedPlacement = { ...updatedPlacement, ...targetDimensions };
-          this._applyIframeDimensions(targetDimensions);
+          if (transition && this._supportsAnimation()) {
+            const fromDims = { width: updatedPlacement.width || 0, height: updatedPlacement.height || 0 };
+            updatedPlacement = { ...updatedPlacement, ...targetDimensions };
+            this._applyAnimatedDimensions(fromDims, targetDimensions, transition, anchorPoint);
+          } else {
+            updatedPlacement = { ...updatedPlacement, ...targetDimensions };
+            this._applyIframeDimensions(targetDimensions);
+          }
         }
-        // Apply targetPosition when provided (e.g. from MRAID resize() with offset coords)
         if (targetPosition) {
           this._applyIframePosition(targetPosition);
         }
+        this._createCloseButton(resolvedClose.position);
         break;
       case 'maximize':
       case 'fullscreen':
-        // Expand to fill the container element
         this._snapshotPreResizeState();
+        this._currentIntent = intent;
         updatedPlacement = this._getMaxPlacement();
-        this._applyIframeDimensions(updatedPlacement);
+        if (transition && this._supportsAnimation()) {
+          const fromDims = { width: this.environmentData.currentPlacement.width || 0, height: this.environmentData.currentPlacement.height || 0 };
+          this._applyAnimatedDimensions(fromDims, updatedPlacement, transition, anchorPoint);
+        } else {
+          this._applyIframeDimensions(updatedPlacement);
+        }
+        this._createCloseButton('top-right');
         break;
       case 'minimize':
       case 'restore':
-        // Return to initial dimensions AND position
+        this._currentIntent = null;
         updatedPlacement = this._restorePreResizeState();
+        this._removeCloseButton();
         break;
       default:
         console.warn('[SHARCContainer] Unknown placement intent:', intent);
     }
 
     this.environmentData.currentPlacement = updatedPlacement;
-    this._protocol._resolve(msg, { placementUpdate: updatedPlacement });
+    const resolvePayload = { placementUpdate: updatedPlacement };
+    if (transition && this._supportsAnimation()) {
+      resolvePayload.transition = this._clampTransition(transition);
+    }
+    // Include close button position in resolve when a close button is rendered
+    if (this._closeButton && (intent === 'resize' || intent === 'maximize' || intent === 'fullscreen')) {
+      resolvePayload.closeButtonPosition = {
+        position: resolvedClose.position,
+        x: this._closeButton.getBoundingClientRect ? this._closeButton.getBoundingClientRect().x : 0,
+        y: this._closeButton.getBoundingClientRect ? this._closeButton.getBoundingClientRect().y : 0,
+        width: 50,
+        height: 50,
+      };
+    }
+    this._protocol._resolve(msg, resolvePayload);
     this.notifyPlacementChange(updatedPlacement);
+  }
+
+  /**
+   * Validates a placement request against the configured placement policy.
+   * Returns null if the request is valid, or a rejection object { code, message }.
+   * @param {Object} args - The requestPlacementChange args.
+   * @returns {Object|null}
+   * @private
+   */
+  _validatePlacementRequest(args) {
+    const policy = this._placementPolicy;
+    if (!policy) return null;
+
+    const { intent, targetDimensions, closeRegion } = args;
+
+    // 1. Intent allowlist
+    const allowedIntents = policy.allowedIntents || ['resize', 'maximize', 'fullscreen', 'minimize', 'restore'];
+    if (intent && allowedIntents.indexOf(intent) === -1) {
+      return { code: ErrorCodes.UNSUPPORTED_FEATURE, message: "Intent '" + intent + "' not allowed by placement policy" };
+    }
+
+    // 2. Dimension limits
+    if (intent === 'resize' && targetDimensions) {
+      const maxW = policy.maxWidth != null ? policy.maxWidth : Infinity;
+      const maxH = policy.maxHeight != null ? policy.maxHeight : Infinity;
+      if (targetDimensions.width > maxW || targetDimensions.height > maxH) {
+        return { code: ErrorCodes.UNSUPPORTED_FEATURE, message: 'Dimensions exceed placement policy limits (max: ' + maxW + 'x' + maxH + ')' };
+      }
+    }
+
+    // 3. Close region presence (when required by policy)
+    if (intent === 'resize' && policy.requireCloseRegion && !closeRegion) {
+      return { code: ErrorCodes.MESSAGE_SPEC_VIOLATION, message: 'Placement policy requires closeRegion hint on resize requests' };
+    }
+
+    // 4. Close region size minimum
+    if (closeRegion && typeof closeRegion.size === 'number' && closeRegion.size < 50) {
+      return { code: ErrorCodes.MESSAGE_SPEC_VIOLATION, message: 'closeRegion.size must be at least 50 DIPs' };
+    }
+
+    // 5. Custom validator (synchronous)
+    if (typeof policy.customValidator === 'function') {
+      try {
+        const result = policy.customValidator(args);
+        if (result && result.allowed === false) {
+          return { code: ErrorCodes.UNSUPPORTED_FEATURE, message: result.reason || 'Rejected by custom placement validator' };
+        }
+      } catch (e) {
+        console.warn('[SHARCContainer] customValidator threw:', e);
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Validates a close region hint and returns the effective close position.
+   * The container always renders its own close button — this determines WHERE.
+   * @param {Object} closeRegion - { position: string, size: number } hint from creative
+   * @param {Object} targetDimensions - { width, height }
+   * @param {Object} targetPosition - { x, y } or null
+   * @returns {{ position: string, size: number, overridden: boolean }}
+   * @private
+   */
+  _resolveClosePosition(closeRegion, targetDimensions, targetPosition) {
+    const size = Math.max(closeRegion.size || 50, 50);
+    const hintedPosition = closeRegion.position || 'top-right';
+
+    const adX = targetPosition ? targetPosition.x : (this._iframe ? this._iframe.offsetLeft : 0);
+    const adY = targetPosition ? targetPosition.y : (this._iframe ? this._iframe.offsetTop : 0);
+    const adW = targetDimensions.width || 0;
+    const adH = targetDimensions.height || 0;
+
+    const rect = this._computeCloseRegionRect(adX, adY, adW, adH, hintedPosition, size);
+    const viewport = this._getViewportBounds();
+
+    if (rect.left < 0 || rect.top < 0 ||
+        rect.right > viewport.width || rect.bottom > viewport.height) {
+      console.warn('[SHARCContainer] Close region hint offscreen at', hintedPosition, '— defaulting to top-right');
+      return { position: 'top-right', size: size, overridden: true };
+    }
+
+    return { position: hintedPosition, size: size, overridden: false };
+  }
+
+  /**
+   * Computes the screen-space rect for a close region position.
+   * @param {number} adX - Ad left position
+   * @param {number} adY - Ad top position
+   * @param {number} adW - Ad width
+   * @param {number} adH - Ad height
+   * @param {string} position - Position enum
+   * @param {number} size - Close button size
+   * @returns {{ left: number, top: number, right: number, bottom: number }}
+   * @private
+   */
+  _computeCloseRegionRect(adX, adY, adW, adH, position, size) {
+    let closeX, closeY;
+    switch (position) {
+      case 'top-left':      closeX = adX; closeY = adY; break;
+      case 'top-center':    closeX = adX + (adW - size) / 2; closeY = adY; break;
+      case 'top-right':     closeX = adX + adW - size; closeY = adY; break;
+      case 'center-left':   closeX = adX; closeY = adY + (adH - size) / 2; break;
+      case 'center-right':  closeX = adX + adW - size; closeY = adY + (adH - size) / 2; break;
+      case 'bottom-left':   closeX = adX; closeY = adY + adH - size; break;
+      case 'bottom-center': closeX = adX + (adW - size) / 2; closeY = adY + adH - size; break;
+      case 'bottom-right':  closeX = adX + adW - size; closeY = adY + adH - size; break;
+      default:              closeX = adX + adW - size; closeY = adY; break;
+    }
+    return { left: closeX, top: closeY, right: closeX + size, bottom: closeY + size };
   }
 
   /**
@@ -1147,6 +1335,9 @@ class SHARCContainer {
 
     // Terminate protocol
     this._protocol.terminate();
+
+    // Remove close button
+    this._removeCloseButton();
 
     // Remove iframe from DOM
     if (this._iframe && this._iframe.parentNode) {
@@ -1364,6 +1555,269 @@ class SHARCContainer {
     };
 
     return Promise.all(uris.map(fireOne));
+  }
+
+  // -------------------------------------------------------------------------
+  // Close button rendering (container-owned, outside sandbox)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Creates and positions the container-owned close button.
+   * Called on resize, maximize, and fullscreen intents.
+   * The close button is a DOM sibling to the iframe, outside the sandbox.
+   * @param {string} position - Resolved close position ('top-right', 'top-left', etc.)
+   * @private
+   */
+  _createCloseButton(position) {
+    this._removeCloseButton();
+
+    const btn = document.createElement('div');
+    btn.className = 'sharc-close-button';
+    btn.setAttribute('role', 'button');
+    btn.setAttribute('aria-label', 'Close advertisement');
+    btn.setAttribute('tabindex', '0');
+
+    // Default styling — X icon via CSS, no external assets
+    btn.style.cssText = [
+      'position:absolute',
+      'width:50px',
+      'height:50px',
+      'min-width:50px',
+      'min-height:50px',
+      'z-index:2147483647',
+      'cursor:pointer',
+      'background:rgba(0,0,0,0.6)',
+      'border-radius:50%',
+      'display:flex',
+      'align-items:center',
+      'justify-content:center',
+      'font-size:24px',
+      'color:#fff',
+      'line-height:1',
+      'user-select:none',
+      '-webkit-user-select:none',
+      'pointer-events:auto',
+      'box-sizing:border-box',
+    ].join(';');
+
+    // Apply publisher customization if provided
+    if (this._closeButtonStyles) {
+      Object.assign(btn.style, this._closeButtonStyles);
+      // Enforce minimum size regardless of publisher customization
+      if (parseInt(btn.style.width) < 50) btn.style.width = '50px';
+      if (parseInt(btn.style.height) < 50) btn.style.height = '50px';
+    }
+
+    // Position relative to the iframe
+    this._applyClosePosition(btn, position);
+
+    // X glyph (Unicode multiplication sign — renders well cross-platform)
+    btn.textContent = '\u00D7';
+
+    // Click handler — behavior depends on current state
+    const self = this;
+    const handleClose = () => {
+      if (self._currentIntent === 'maximize' || self._currentIntent === 'fullscreen') {
+        self._initiateClose();
+      } else {
+        // resize state: restore to original placement
+        self._handleRequestPlacementChange({
+          args: { intent: 'restore' },
+          messageId: self._protocol._nextMessageId++,
+          type: 'synthetic',
+        });
+      }
+    };
+
+    btn.addEventListener('click', handleClose);
+    btn.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handleClose();
+      }
+    });
+
+    // Insert as sibling to iframe, within the container element
+    if (!this.containerEl.style.position || this.containerEl.style.position === 'static') {
+      this.containerEl.style.position = 'relative';
+    }
+    this.containerEl.appendChild(btn);
+    this._closeButton = btn;
+  }
+
+  /**
+   * Removes the container-owned close button.
+   * Called on restore, close, and destroy.
+   * @private
+   */
+  _removeCloseButton() {
+    if (this._closeButton && this._closeButton.parentNode) {
+      this._closeButton.parentNode.removeChild(this._closeButton);
+    }
+    this._closeButton = null;
+  }
+
+  /**
+   * Positions the close button relative to the iframe based on the
+   * resolved position string.
+   * @param {HTMLElement} btn - The close button element
+   * @param {string} position - Position enum value
+   * @private
+   */
+  _applyClosePosition(btn, position) {
+    // Reset all positioning
+    btn.style.top = btn.style.bottom = btn.style.left = btn.style.right = 'auto';
+    btn.style.transform = '';
+
+    switch (position) {
+      case 'top-left':      btn.style.top = '0'; btn.style.left = '0'; break;
+      case 'top-center':    btn.style.top = '0'; btn.style.left = '50%';
+                            btn.style.transform = 'translateX(-50%)'; break;
+      case 'top-right':     btn.style.top = '0'; btn.style.right = '0'; break;
+      case 'center-left':   btn.style.top = '50%'; btn.style.left = '0';
+                            btn.style.transform = 'translateY(-50%)'; break;
+      case 'center-right':  btn.style.top = '50%'; btn.style.right = '0';
+                            btn.style.transform = 'translateY(-50%)'; break;
+      case 'bottom-left':   btn.style.bottom = '0'; btn.style.left = '0'; break;
+      case 'bottom-center': btn.style.bottom = '0'; btn.style.left = '50%';
+                            btn.style.transform = 'translateX(-50%)'; break;
+      case 'bottom-right':  btn.style.bottom = '0'; btn.style.right = '0'; break;
+      default:              btn.style.top = '0'; btn.style.right = '0'; break;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Animation support
+  // -------------------------------------------------------------------------
+
+  /**
+   * Returns whether this container supports animated placement transitions.
+   * @returns {boolean}
+   * @private
+   */
+  _supportsAnimation() {
+    // Animation support is opt-in via feature string registration.
+    // Check if the merged features include the animation feature.
+    const features = this._mergedSupportedFeatures || this._explicitSupportedFeatures || [];
+    for (let i = 0; i < features.length; i++) {
+      const f = features[i];
+      if (f === 'com.iabtechlab.sharc.placement.animate' ||
+          (f && f.name === 'com.iabtechlab.sharc.placement.animate')) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Applies an animated dimension change using transform: scale().
+   * The visual transition runs on the GPU compositor. On completion,
+   * snaps to final width/height and removes the transform.
+   *
+   * @param {Object} fromDims - { width, height } current dimensions
+   * @param {Object} toDims - { width, height } target dimensions
+   * @param {Object} transition - { duration, easing }
+   * @param {string} [anchorPoint] - 'top-left', 'top-right', 'bottom-left', 'bottom-right'
+   * @private
+   */
+  _applyAnimatedDimensions(fromDims, toDims, transition, anchorPoint) {
+    if (!this._iframe) return;
+
+    const duration = this._clampDuration(transition.duration);
+    const easing = this._sanitizeEasing(transition.easing || 'ease-out');
+
+    // Duration 0 means instant — skip animation
+    if (duration === 0) {
+      this._applyIframeDimensions(toDims);
+      // Fire placementTransitionEnd even for instant transitions
+      this._protocol._sendMessage(ContainerMessages.PLACEMENT_TRANSITION_END, {
+        finalDimensions: toDims,
+      });
+      return;
+    }
+
+    const fromW = fromDims.width || 1;
+    const fromH = fromDims.height || 1;
+    const scaleX = toDims.width / fromW;
+    const scaleY = toDims.height / fromH;
+
+    // Set transform-origin based on anchor point (default: top-left)
+    const originMap = {
+      'top-left': 'top left',
+      'top-right': 'top right',
+      'bottom-left': 'bottom left',
+      'bottom-right': 'bottom right',
+    };
+    this._iframe.style.transformOrigin = originMap[anchorPoint] || 'top left';
+    this._iframe.style.transition = 'transform ' + duration + 'ms ' + easing;
+    this._iframe.style.transform = 'scale(' + scaleX + ', ' + scaleY + ')';
+
+    let cleanedUp = false;
+    const iframe = this._iframe;
+    const protocol = this._protocol;
+    const self = this;
+
+    const cleanup = () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      iframe.removeEventListener('transitionend', onEnd);
+      // Snap to final dimensions — single layout recalc
+      iframe.style.transition = '';
+      iframe.style.transform = '';
+      iframe.style.transformOrigin = '';
+      self._applyIframeDimensions(toDims);
+
+      // Notify creative that transition completed
+      protocol._sendMessage(ContainerMessages.PLACEMENT_TRANSITION_END, {
+        finalDimensions: toDims,
+      });
+    };
+
+    const onEnd = (e) => {
+      if (e.propertyName === 'transform') cleanup();
+    };
+
+    iframe.addEventListener('transitionend', onEnd);
+
+    // Safety timeout: if transitionend never fires (tab hidden, etc.), snap anyway
+    setTimeout(cleanup, duration + 100);
+  }
+
+  /**
+   * Clamps animation duration to safe bounds.
+   * Max 500ms, min 0. Non-numbers treated as 0.
+   * @param {*} duration
+   * @returns {number}
+   * @private
+   */
+  _clampDuration(duration) {
+    if (typeof duration !== 'number' || duration < 0) return 0;
+    return Math.min(duration, 500);
+  }
+
+  /**
+   * Sanitizes an easing value to one of the five CSS keywords.
+   * Anything else is replaced with 'ease-out'.
+   * @param {string} easing
+   * @returns {string}
+   * @private
+   */
+  _sanitizeEasing(easing) {
+    const ALLOWED = ['linear', 'ease', 'ease-in', 'ease-out', 'ease-in-out'];
+    return ALLOWED.indexOf(easing) !== -1 ? easing : 'ease-out';
+  }
+
+  /**
+   * Clamps a transition hint to safe values.
+   * @param {Object} transition - { duration, easing }
+   * @returns {Object} - { duration, easing }
+   * @private
+   */
+  _clampTransition(transition) {
+    return {
+      duration: this._clampDuration(transition.duration),
+      easing: this._sanitizeEasing(transition.easing || 'ease-out'),
+    };
   }
 
   // -------------------------------------------------------------------------

--- a/examples/sharc-container.js
+++ b/examples/sharc-container.js
@@ -275,6 +275,13 @@ class SHARCContainer {
     this._currentIntent = null;
 
     /**
+     * Timestamp of the last successful placement change execution.
+     * Used to enforce per-message-type rate limiting (max 2/second).
+     * @type {number}
+     */
+    this._lastPlacementChangeTime = 0;
+
+    /**
      * Snapshot of the original placement from construction time.
      * Used by restore to return to the original state, independent of
      * mutations that _handleRequestPlacementChange applies to environmentData.
@@ -1053,6 +1060,17 @@ class SHARCContainer {
     const args = msg.args || {};
     const { intent, targetDimensions, targetPosition, anchorPoint, closeRegion, allowOffscreen, transition } = args;
 
+    // ── Per-message-type rate limit (max 2 placement changes/second) ──
+    // Exempt restore/minimize (user-initiated close/restore) and synthetic messages.
+    if (intent !== 'restore' && intent !== 'minimize' && msg.type !== 'synthetic') {
+      const now = Date.now();
+      if (now - this._lastPlacementChangeTime < 500) {
+        this._protocol._reject(msg, ErrorCodes.OVERLOADING_CHANNEL,
+          'Placement change rate limit exceeded (max 2/second)');
+        return;
+      }
+    }
+
     // ── Basic type guards — run regardless of policy ──
     if (intent !== undefined && typeof intent !== 'string') {
       this._protocol._reject(msg, ErrorCodes.MESSAGE_SPEC_VIOLATION,
@@ -1171,6 +1189,9 @@ class SHARCContainer {
           "Unknown placement intent: '" + intent + "'");
         return;
     }
+
+    // Update rate-limit timestamp on successful execution
+    this._lastPlacementChangeTime = Date.now();
 
     this.environmentData.currentPlacement = updatedPlacement;
     const resolvePayload = { placementUpdate: updatedPlacement };
@@ -1800,6 +1821,11 @@ class SHARCContainer {
     btn.style.minWidth = '50px';
     btn.style.minHeight = '50px';
 
+    // Prevent size collapse via max-width/max-height or overflow clipping
+    btn.style.maxWidth = 'none';
+    btn.style.maxHeight = 'none';
+    btn.style.overflow = 'visible';
+
     // Position relative to the iframe
     this._applyClosePosition(btn, position);
 
@@ -1839,6 +1865,10 @@ class SHARCContainer {
     }
     this.containerEl.appendChild(btn);
     this._closeButton = btn;
+
+    // Notify OMID extension (if present) to register the close button as a
+    // friendly obstruction so it doesn't count against viewability.
+    this._notifyOmidObstruction(btn, true);
   }
 
   /**
@@ -1847,10 +1877,37 @@ class SHARCContainer {
    * @private
    */
   _removeCloseButton() {
-    if (this._closeButton && this._closeButton.parentNode) {
-      this._closeButton.parentNode.removeChild(this._closeButton);
+    if (this._closeButton) {
+      // Notify OMID extension to unregister the friendly obstruction
+      this._notifyOmidObstruction(this._closeButton, false);
+      if (this._closeButton.parentNode) {
+        this._closeButton.parentNode.removeChild(this._closeButton);
+      }
     }
     this._closeButton = null;
+  }
+
+  /**
+   * Notifies the OMID extension (if registered) to add or remove a friendly
+   * obstruction for the given element. No-op if no OMID extension is present.
+   * @param {HTMLElement} element - The DOM element (close button).
+   * @param {boolean} register - true to register, false to unregister.
+   * @private
+   */
+  _notifyOmidObstruction(element, register) {
+    if (!this._extensions || !element) return;
+    for (let i = 0; i < this._extensions.length; i++) {
+      const ext = this._extensions[i];
+      if (ext && typeof ext.getFeatureName === 'function' &&
+          ext.getFeatureName() === 'com.iabtechlab.sharc.omid') {
+        if (register && typeof ext.registerFriendlyObstruction === 'function') {
+          ext.registerFriendlyObstruction(element);
+        } else if (!register && typeof ext.unregisterFriendlyObstruction === 'function') {
+          ext.unregisterFriendlyObstruction();
+        }
+        break;
+      }
+    }
   }
 
   /**
@@ -2032,9 +2089,12 @@ class SHARCContainer {
    */
   _getMaxPlacement(intent) {
     if (intent === 'fullscreen') {
+      // Prefer visualViewport — stable on mobile Safari where innerHeight
+      // fluctuates with the address bar show/hide.
+      const vv = window.visualViewport;
       return {
-        width: window.innerWidth || 300,
-        height: window.innerHeight || 250,
+        width: (vv ? vv.width : window.innerWidth) || 300,
+        height: (vv ? vv.height : window.innerHeight) || 250,
       };
     }
     return {

--- a/examples/sharc-container.js
+++ b/examples/sharc-container.js
@@ -1106,7 +1106,7 @@ class SHARCContainer {
           if (transition && this._supportsAnimation()) {
             const fromDims = { width: updatedPlacement.width || 0, height: updatedPlacement.height || 0 };
             updatedPlacement = { ...updatedPlacement, ...targetDimensions };
-            this._applyAnimatedDimensions(fromDims, targetDimensions, transition, anchorPoint);
+            skippedTransitionEndDimensions = this._applyAnimatedDimensions(fromDims, targetDimensions, transition, anchorPoint);
           } else {
             updatedPlacement = { ...updatedPlacement, ...targetDimensions };
             this._applyIframeDimensions(targetDimensions);
@@ -1127,7 +1127,7 @@ class SHARCContainer {
         updatedPlacement = this._getMaxPlacement();
         if (transition && this._supportsAnimation()) {
           const fromDims = { width: this.environmentData.currentPlacement.width || 0, height: this.environmentData.currentPlacement.height || 0 };
-          this._applyAnimatedDimensions(fromDims, updatedPlacement, transition, anchorPoint);
+          skippedTransitionEndDimensions = this._applyAnimatedDimensions(fromDims, updatedPlacement, transition, anchorPoint);
         } else {
           this._applyIframeDimensions(updatedPlacement);
           if (transition) {
@@ -1880,19 +1880,16 @@ class SHARCContainer {
    * @private
    */
   _applyAnimatedDimensions(fromDims, toDims, transition, anchorPoint) {
-    if (!this._iframe) return;
+    if (!this._iframe) return null;
 
     const duration = this._clampDuration(transition.duration);
     const easing = this._sanitizeEasing(transition.easing || 'ease-out');
 
-    // Duration 0 means instant — skip animation
+    // Duration 0 means instant — skip animation and let the caller
+    // fire placementTransitionEnd after resolve + placementChange.
     if (duration === 0) {
       this._applyIframeDimensions(toDims);
-      // Fire placementTransitionEnd even for instant transitions
-      this._protocol._sendMessage(ContainerMessages.PLACEMENT_TRANSITION_END, {
-        finalDimensions: toDims,
-      });
-      return;
+      return toDims;
     }
 
     const fromW = fromDims.width || 1;
@@ -1940,6 +1937,7 @@ class SHARCContainer {
 
     // Safety timeout: if transitionend never fires (tab hidden, etc.), snap anyway
     setTimeout(cleanup, duration + 100);
+    return null;
   }
 
   /**

--- a/examples/sharc-container.js
+++ b/examples/sharc-container.js
@@ -1068,8 +1068,28 @@ class SHARCContainer {
       }
     }
 
+    // ── Offscreen enforcement for no-policy containers ──
+    if (!this._placementPolicy) {
+      const effectiveAllowOffscreen = allowOffscreen !== undefined ? allowOffscreen : true;
+      if (intent === 'resize' && effectiveAllowOffscreen === false && targetDimensions && this._iframe) {
+        const pos = targetPosition || {
+          x: this._iframe.offsetLeft,
+          y: this._iframe.offsetTop,
+        };
+        const viewport = this._getViewportBounds();
+        if (pos.x < 0 || pos.y < 0 ||
+            pos.x + targetDimensions.width > viewport.width ||
+            pos.y + targetDimensions.height > viewport.height) {
+          this._protocol._reject(msg, ErrorCodes.UNSUPPORTED_FEATURE,
+            'Resize would extend offscreen and allowOffscreen is false');
+          return;
+        }
+      }
+    }
+
     // ── Execution (with position snapshot, animation, and close button) ──
     let updatedPlacement = { ...(this.environmentData.currentPlacement || {}) };
+    let skippedTransitionEndDimensions = null;
 
     // Resolve close button position from hint (use pre-resolved value from validation if available)
     const resolvedClose = args._resolvedClose
@@ -1091,9 +1111,7 @@ class SHARCContainer {
             updatedPlacement = { ...updatedPlacement, ...targetDimensions };
             this._applyIframeDimensions(targetDimensions);
             if (transition) {
-              this._protocol._sendMessage(ContainerMessages.PLACEMENT_TRANSITION_END, {
-                finalDimensions: targetDimensions,
-              });
+              skippedTransitionEndDimensions = targetDimensions;
             }
           }
         }
@@ -1113,9 +1131,7 @@ class SHARCContainer {
         } else {
           this._applyIframeDimensions(updatedPlacement);
           if (transition) {
-            this._protocol._sendMessage(ContainerMessages.PLACEMENT_TRANSITION_END, {
-              finalDimensions: updatedPlacement,
-            });
+            skippedTransitionEndDimensions = updatedPlacement;
           }
         }
         this._createCloseButton('top-right');
@@ -1153,6 +1169,11 @@ class SHARCContainer {
     if (resolvePayload.transition) notifyExtra.transition = resolvePayload.transition;
     if (resolvePayload.closeButtonPosition) notifyExtra.closeButtonPosition = resolvePayload.closeButtonPosition;
     this.notifyPlacementChange(updatedPlacement, Object.keys(notifyExtra).length > 0 ? notifyExtra : undefined);
+    if (skippedTransitionEndDimensions) {
+      this._protocol._sendMessage(ContainerMessages.PLACEMENT_TRANSITION_END, {
+        finalDimensions: skippedTransitionEndDimensions,
+      });
+    }
   }
 
   /**
@@ -1169,7 +1190,11 @@ class SHARCContainer {
     const { intent, targetDimensions, closeRegion } = args;
 
     // 1. Intent allowlist
-    const allowedIntents = policy.allowedIntents || ['resize', 'maximize', 'fullscreen', 'minimize', 'restore'];
+    const knownIntents = ['resize', 'maximize', 'fullscreen', 'restore', 'minimize'];
+    if (intent && knownIntents.indexOf(intent) === -1) {
+      return { code: ErrorCodes.MESSAGE_SPEC_VIOLATION, message: "Unknown placement intent: '" + intent + "'" };
+    }
+    const allowedIntents = policy.allowedIntents || knownIntents;
     if (intent && allowedIntents.indexOf(intent) === -1) {
       return { code: ErrorCodes.UNSUPPORTED_FEATURE, message: "Intent '" + intent + "' not allowed by placement policy" };
     }

--- a/examples/sharc-container.js
+++ b/examples/sharc-container.js
@@ -239,6 +239,21 @@ class SHARCContainer {
      * @type {boolean}
      */
     this._useMarkupInjection = useMarkupInjection;
+
+    /**
+     * Snapshot of the original placement from construction time.
+     * Used by restore to return to the original state, independent of
+     * mutations that _handleRequestPlacementChange applies to environmentData.
+     * @type {Object}
+     */
+    this._originalPlacement = { ...(this.environmentData.currentPlacement || {}) };
+
+    /**
+     * Snapshot of the iframe's CSS state before the first resize.
+     * Restored on minimize/restore to fix position reset bug.
+     * @type {Object|null}
+     */
+    this._preResizeCSSState = null;
   }
 
   // -------------------------------------------------------------------------
@@ -975,12 +990,31 @@ class SHARCContainer {
    * @private
    */
   _handleRequestPlacementChange(msg) {
-    const { intent, targetDimensions, targetPosition, anchorPoint } = (msg.args || {});
+    const args = msg.args || {};
+    const { intent, targetDimensions, targetPosition, anchorPoint, allowOffscreen } = args;
     let updatedPlacement = { ...(this.environmentData.currentPlacement || {}) };
+
+    // ── Bug fix: enforce allowOffscreen ──
+    // When allowOffscreen === false, validate the entire resized ad fits within viewport bounds.
+    if (intent === 'resize' && allowOffscreen === false && targetDimensions && this._iframe) {
+      const pos = targetPosition || {
+        x: this._iframe.offsetLeft,
+        y: this._iframe.offsetTop,
+      };
+      const viewport = this._getViewportBounds();
+      if (pos.x < 0 || pos.y < 0 ||
+          pos.x + targetDimensions.width > viewport.width ||
+          pos.y + targetDimensions.height > viewport.height) {
+        this._protocol._reject(msg, ErrorCodes.UNSUPPORTED_FEATURE,
+          'Resize would extend offscreen and allowOffscreen is false');
+        return;
+      }
+    }
 
     // Apply the placement change based on intent
     switch (intent) {
       case 'resize':
+        this._snapshotPreResizeState();
         if (targetDimensions) {
           updatedPlacement = { ...updatedPlacement, ...targetDimensions };
           this._applyIframeDimensions(targetDimensions);
@@ -993,15 +1027,14 @@ class SHARCContainer {
       case 'maximize':
       case 'fullscreen':
         // Expand to fill the container element
+        this._snapshotPreResizeState();
         updatedPlacement = this._getMaxPlacement();
         this._applyIframeDimensions(updatedPlacement);
         break;
       case 'minimize':
       case 'restore':
-        // Return to initial dimensions
-        // Note: does not reset position/left/top CSS — a prior resize absolute position remains until publisher resets layout
-        updatedPlacement = this.environmentData.currentPlacement || {};
-        this._applyIframeDimensions(updatedPlacement);
+        // Return to initial dimensions AND position
+        updatedPlacement = this._restorePreResizeState();
         break;
       default:
         console.warn('[SHARCContainer] Unknown placement intent:', intent);
@@ -1010,6 +1043,51 @@ class SHARCContainer {
     this.environmentData.currentPlacement = updatedPlacement;
     this._protocol._resolve(msg, { placementUpdate: updatedPlacement });
     this.notifyPlacementChange(updatedPlacement);
+  }
+
+  /**
+   * Snapshots the iframe's CSS state before resize, if not already captured.
+   * @private
+   */
+  _snapshotPreResizeState() {
+    if (this._preResizeCSSState || !this._iframe) return;
+    this._preResizeCSSState = {
+      position: this._iframe.style.position,
+      left:     this._iframe.style.left,
+      top:      this._iframe.style.top,
+      width:    this._iframe.style.width,
+      height:   this._iframe.style.height,
+    };
+  }
+
+  /**
+   * Restores iframe CSS state to the pre-resize snapshot.
+   * Clears the snapshot so the next resize captures fresh state.
+   * @returns {Object} The original placement dimensions to use as updatedPlacement.
+   * @private
+   */
+  _restorePreResizeState() {
+    if (this._preResizeCSSState && this._iframe) {
+      this._iframe.style.position = this._preResizeCSSState.position;
+      this._iframe.style.left     = this._preResizeCSSState.left;
+      this._iframe.style.top      = this._preResizeCSSState.top;
+      this._iframe.style.width    = this._preResizeCSSState.width;
+      this._iframe.style.height   = this._preResizeCSSState.height;
+    }
+    this._preResizeCSSState = null;
+    return { ...(this._originalPlacement || this.environmentData.currentPlacement || {}) };
+  }
+
+  /**
+   * Returns the current viewport bounds.
+   * @returns {{ width: number, height: number }}
+   * @private
+   */
+  _getViewportBounds() {
+    return {
+      width: window.innerWidth || document.documentElement.clientWidth || 0,
+      height: window.innerHeight || document.documentElement.clientHeight || 0,
+    };
   }
 
   /**

--- a/examples/sharc-container.js
+++ b/examples/sharc-container.js
@@ -1052,6 +1052,13 @@ class SHARCContainer {
     const args = msg.args || {};
     const { intent, targetDimensions, targetPosition, anchorPoint, closeRegion, allowOffscreen, transition } = args;
 
+    // ── Type guard on intent ──
+    if (intent !== undefined && typeof intent !== 'string') {
+      this._protocol._reject(msg, ErrorCodes.MESSAGE_SPEC_VIOLATION,
+        'intent must be a string, got ' + typeof intent);
+      return;
+    }
+
     // ── Validation pipeline (only when policy is configured) ──
     if (this._placementPolicy) {
       const rejection = this._validatePlacementRequest(args);
@@ -1061,36 +1068,15 @@ class SHARCContainer {
       }
     }
 
-    // ── Offscreen enforcement (applies even without policy — bug fix) ──
-    // Determine effective allowOffscreen: request overrides policy overrides default (true)
-    const effectiveAllowOffscreen = allowOffscreen !== undefined
-      ? allowOffscreen
-      : (this._placementPolicy && this._placementPolicy.allowOffscreen !== undefined
-          ? this._placementPolicy.allowOffscreen
-          : true);
-
-    if (intent === 'resize' && effectiveAllowOffscreen === false && targetDimensions && this._iframe) {
-      const pos = targetPosition || {
-        x: this._iframe.offsetLeft,
-        y: this._iframe.offsetTop,
-      };
-      const viewport = this._getViewportBounds();
-      if (pos.x < 0 || pos.y < 0 ||
-          pos.x + targetDimensions.width > viewport.width ||
-          pos.y + targetDimensions.height > viewport.height) {
-        this._protocol._reject(msg, ErrorCodes.UNSUPPORTED_FEATURE,
-          'Resize would extend offscreen and allowOffscreen is false');
-        return;
-      }
-    }
-
     // ── Execution (with position snapshot, animation, and close button) ──
     let updatedPlacement = { ...(this.environmentData.currentPlacement || {}) };
 
-    // Resolve close button position from hint
-    const resolvedClose = closeRegion
-      ? this._resolveClosePosition(closeRegion, targetDimensions || updatedPlacement, targetPosition)
-      : { position: 'top-right', size: 50, overridden: false };
+    // Resolve close button position from hint (use pre-resolved value from validation if available)
+    const resolvedClose = args._resolvedClose
+      ? args._resolvedClose
+      : (closeRegion
+        ? this._resolveClosePosition(closeRegion, targetDimensions || updatedPlacement, targetPosition)
+        : { position: 'top-right', size: 50, overridden: false });
 
     switch (intent) {
       case 'resize':
@@ -1104,6 +1090,11 @@ class SHARCContainer {
           } else {
             updatedPlacement = { ...updatedPlacement, ...targetDimensions };
             this._applyIframeDimensions(targetDimensions);
+            if (transition) {
+              this._protocol._sendMessage(ContainerMessages.PLACEMENT_TRANSITION_END, {
+                finalDimensions: targetDimensions,
+              });
+            }
           }
         }
         if (targetPosition) {
@@ -1121,6 +1112,11 @@ class SHARCContainer {
           this._applyAnimatedDimensions(fromDims, updatedPlacement, transition, anchorPoint);
         } else {
           this._applyIframeDimensions(updatedPlacement);
+          if (transition) {
+            this._protocol._sendMessage(ContainerMessages.PLACEMENT_TRANSITION_END, {
+              finalDimensions: updatedPlacement,
+            });
+          }
         }
         this._createCloseButton('top-right');
         break;
@@ -1131,7 +1127,9 @@ class SHARCContainer {
         this._removeCloseButton();
         break;
       default:
-        console.warn('[SHARCContainer] Unknown placement intent:', intent);
+        this._protocol._reject(msg, ErrorCodes.MESSAGE_SPEC_VIOLATION,
+          "Unknown placement intent: '" + intent + "'");
+        return;
     }
 
     this.environmentData.currentPlacement = updatedPlacement;
@@ -1195,7 +1193,36 @@ class SHARCContainer {
       return { code: ErrorCodes.MESSAGE_SPEC_VIOLATION, message: 'closeRegion.size must be at least 50 DIPs' };
     }
 
-    // 5. Custom validator (synchronous)
+    // 4b. Close hint resolution (Section 4.3 step 4)
+    // Resolve close position here so it runs before offscreen and custom validator.
+    if (closeRegion) {
+      const resolvedClose = this._resolveClosePosition(
+        closeRegion,
+        targetDimensions || (this.environmentData.currentPlacement || {}),
+        args.targetPosition
+      );
+      args._resolvedClose = resolvedClose;
+    }
+
+    // 5. Offscreen enforcement (Section 4.3 step 5)
+    const effectiveAllowOffscreen = args.allowOffscreen !== undefined
+      ? args.allowOffscreen
+      : (policy.allowOffscreen !== undefined ? policy.allowOffscreen : true);
+
+    if (intent === 'resize' && effectiveAllowOffscreen === false && targetDimensions && this._iframe) {
+      const pos = args.targetPosition || {
+        x: this._iframe.offsetLeft,
+        y: this._iframe.offsetTop,
+      };
+      const viewport = this._getViewportBounds();
+      if (pos.x < 0 || pos.y < 0 ||
+          pos.x + targetDimensions.width > viewport.width ||
+          pos.y + targetDimensions.height > viewport.height) {
+        return { code: ErrorCodes.UNSUPPORTED_FEATURE, message: 'Resize would extend offscreen and allowOffscreen is false' };
+      }
+    }
+
+    // 6. Custom validator (synchronous)
     if (typeof policy.customValidator === 'function') {
       try {
         const result = policy.customValidator(args);

--- a/examples/sharc-container.js
+++ b/examples/sharc-container.js
@@ -227,6 +227,11 @@ class SHARCContainer {
 
     this._initiallyVisible = visible;
 
+    // Debounced handler for viewport changes that may affect placement constraints
+    this._constraintsDebounceTimer = null;
+    this._constraintsResizeHandler = this._onConstraintsRelevantResize.bind(this);
+    this._constraintsOrientationHandler = this._onConstraintsRelevantOrientation.bind(this);
+
     /**
      * Last placement payload sent via notifyPlacementChange().
      * Used by _syncPlacementState() to skip redundant sends.
@@ -626,6 +631,19 @@ class SHARCContainer {
       this._onMessage && this._onMessage('received', msg);
       proto._resolve(msg, {
         currentPlacementOptions: this.environmentData.currentPlacement || {},
+      });
+    });
+
+    // Creative:getPlacementConstraints
+    proto.addListener(CreativeMessages.GET_PLACEMENT_CONSTRAINTS, (msg) => {
+      this._onMessage && this._onMessage('received', msg);
+      const policy = this._placementPolicy || {};
+      proto._resolve(msg, {
+        maxWidth:           policy.maxWidth != null ? policy.maxWidth : null,
+        maxHeight:          policy.maxHeight != null ? policy.maxHeight : null,
+        allowedIntents:     policy.allowedIntents || ['resize', 'maximize', 'fullscreen', 'minimize', 'restore'],
+        requireCloseRegion: !!policy.requireCloseRegion,
+        allowOffscreen:     policy.allowOffscreen !== false,
       });
     });
 
@@ -1393,6 +1411,9 @@ class SHARCContainer {
     window.addEventListener('blur', this._pageBlurHandler, false);
     document.addEventListener('freeze', this._freezeHandler, false);
     document.addEventListener('resume', this._resumeHandler, false);
+    // Constraint-relevant: viewport resize and orientation change
+    window.addEventListener('resize', this._constraintsResizeHandler, false);
+    window.addEventListener('orientationchange', this._constraintsOrientationHandler, false);
   }
 
   /**
@@ -1405,6 +1426,12 @@ class SHARCContainer {
     window.removeEventListener('blur', this._pageBlurHandler, false);
     document.removeEventListener('freeze', this._freezeHandler, false);
     document.removeEventListener('resume', this._resumeHandler, false);
+    window.removeEventListener('resize', this._constraintsResizeHandler, false);
+    window.removeEventListener('orientationchange', this._constraintsOrientationHandler, false);
+    if (this._constraintsDebounceTimer) {
+      clearTimeout(this._constraintsDebounceTimer);
+      this._constraintsDebounceTimer = null;
+    }
   }
 
   /** @private */
@@ -1468,6 +1495,70 @@ class SHARCContainer {
         this.setState(ContainerStates.HIDDEN);
       }
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // Constraint change notifications
+  // -------------------------------------------------------------------------
+
+  /**
+   * Handles viewport resize events that may affect placement constraints.
+   * Debounced at 200ms to avoid flooding the creative during drag-resize.
+   * @private
+   */
+  _onConstraintsRelevantResize() {
+    this._debounceConstraintsNotification('viewportResize');
+  }
+
+  /**
+   * Handles device orientation changes that may affect placement constraints.
+   * @private
+   */
+  _onConstraintsRelevantOrientation() {
+    this._debounceConstraintsNotification('rotation');
+  }
+
+  /**
+   * Debounces constraint change notifications.
+   * @param {string} reason - 'rotation', 'viewportResize', or 'policyUpdate'
+   * @private
+   */
+  _debounceConstraintsNotification(reason) {
+    if (this._constraintsDebounceTimer) {
+      clearTimeout(this._constraintsDebounceTimer);
+    }
+    this._constraintsDebounceTimer = setTimeout(() => {
+      this._constraintsDebounceTimer = null;
+      this._sendConstraintsChange(reason);
+    }, 200);
+  }
+
+  /**
+   * Sends a placementConstraintsChange notification to the creative.
+   * @param {string} reason - Why constraints changed
+   * @private
+   */
+  _sendConstraintsChange(reason) {
+    if (this._destroyed || this._protocol._terminated) return;
+    const policy = this._placementPolicy || {};
+    this._protocol._sendMessage(ContainerMessages.PLACEMENT_CONSTRAINTS_CHANGE, {
+      maxWidth:           policy.maxWidth != null ? policy.maxWidth : null,
+      maxHeight:          policy.maxHeight != null ? policy.maxHeight : null,
+      allowedIntents:     policy.allowedIntents || ['resize', 'maximize', 'fullscreen', 'minimize', 'restore'],
+      requireCloseRegion: !!policy.requireCloseRegion,
+      allowOffscreen:     policy.allowOffscreen !== false,
+      reason:             reason,
+    });
+  }
+
+  /**
+   * Public method for publishers to update placement policy at runtime.
+   * Triggers a constraintsChange notification to the creative.
+   * @param {Object} newPolicy - New placement policy (same shape as constructor option).
+   */
+  updatePlacementPolicy(newPolicy) {
+    this._placementPolicy = newPolicy || undefined;
+    this._sendConstraintsChange('policyUpdate');
   }
 
   // -------------------------------------------------------------------------

--- a/examples/sharc-container.js
+++ b/examples/sharc-container.js
@@ -752,6 +752,7 @@ class SHARCContainer {
     const placementFeatures = [
       'com.iabtechlab.sharc.placement.resize',
       'com.iabtechlab.sharc.placement.constraints',
+      'com.iabtechlab.sharc.placement.animate',
     ];
 
     const mergedFeatures = [
@@ -1052,20 +1053,30 @@ class SHARCContainer {
     const args = msg.args || {};
     const { intent, targetDimensions, targetPosition, anchorPoint, closeRegion, allowOffscreen, transition } = args;
 
-    // ── Type guard on intent ──
+    // ── Basic type guards — run regardless of policy ──
     if (intent !== undefined && typeof intent !== 'string') {
       this._protocol._reject(msg, ErrorCodes.MESSAGE_SPEC_VIOLATION,
         'intent must be a string, got ' + typeof intent);
       return;
     }
-
-    // ── Validation pipeline (only when policy is configured) ──
-    if (this._placementPolicy) {
-      const rejection = this._validatePlacementRequest(args);
-      if (rejection) {
-        this._protocol._reject(msg, rejection.code, rejection.message);
+    if (targetDimensions) {
+      if (typeof targetDimensions.width !== 'number' || !isFinite(targetDimensions.width) || targetDimensions.width <= 0 ||
+          typeof targetDimensions.height !== 'number' || !isFinite(targetDimensions.height) || targetDimensions.height <= 0) {
+        this._protocol._reject(msg, ErrorCodes.MESSAGE_SPEC_VIOLATION,
+          'targetDimensions width and height must be finite positive numbers');
         return;
       }
+    }
+
+    // ── Validation pipeline (only when policy is configured) ──
+    let validationResolvedClose = null;
+    if (this._placementPolicy) {
+      const validation = this._validatePlacementRequest(args);
+      if (!validation.valid) {
+        this._protocol._reject(msg, validation.code, validation.message);
+        return;
+      }
+      validationResolvedClose = validation.resolvedClose || null;
     }
 
     // ── Offscreen enforcement for no-policy containers ──
@@ -1087,13 +1098,26 @@ class SHARCContainer {
       }
     }
 
+    // ── Sub-state guard: prevent stacking placement changes without restore ──
+    if (this._currentIntent && intent !== 'restore' && intent !== 'minimize') {
+      // Already in a non-default placement — must restore first
+      // Exception: allow same intent (e.g., resize while resized adjusts dimensions)
+      if (this._currentIntent !== intent) {
+        if (msg.type !== 'synthetic') {
+          this._protocol._reject(msg, ErrorCodes.UNSUPPORTED_FEATURE,
+            'Must restore before changing from ' + this._currentIntent + ' to ' + intent);
+        }
+        return;
+      }
+    }
+
     // ── Execution (with position snapshot, animation, and close button) ──
     let updatedPlacement = { ...(this.environmentData.currentPlacement || {}) };
     let skippedTransitionEndDimensions = null;
 
     // Resolve close button position from hint (use pre-resolved value from validation if available)
-    const resolvedClose = args._resolvedClose
-      ? args._resolvedClose
+    const resolvedClose = validationResolvedClose
+      ? validationResolvedClose
       : (closeRegion
         ? this._resolveClosePosition(closeRegion, targetDimensions || updatedPlacement, targetPosition)
         : { position: 'top-right', size: 50, overridden: false });
@@ -1124,7 +1148,7 @@ class SHARCContainer {
       case 'fullscreen':
         this._snapshotPreResizeState();
         this._currentIntent = intent;
-        updatedPlacement = this._getMaxPlacement();
+        updatedPlacement = this._getMaxPlacement(intent);
         if (transition && this._supportsAnimation()) {
           const fromDims = { width: this.environmentData.currentPlacement.width || 0, height: this.environmentData.currentPlacement.height || 0 };
           skippedTransitionEndDimensions = this._applyAnimatedDimensions(fromDims, updatedPlacement, transition, anchorPoint);
@@ -1163,7 +1187,9 @@ class SHARCContainer {
         height: 50,
       };
     }
-    this._protocol._resolve(msg, resolvePayload);
+    if (msg.type !== 'synthetic') {
+      this._protocol._resolve(msg, resolvePayload);
+    }
     // Build notification extras (transition, closeButtonPosition)
     const notifyExtra = {};
     if (resolvePayload.transition) notifyExtra.transition = resolvePayload.transition;
@@ -1178,25 +1204,26 @@ class SHARCContainer {
 
   /**
    * Validates a placement request against the configured placement policy.
-   * Returns null if the request is valid, or a rejection object { code, message }.
+   * Returns { valid: true, resolvedClose?: {...} } if the request is valid,
+   * or { valid: false, code, message } for rejection.
    * @param {Object} args - The requestPlacementChange args.
-   * @returns {Object|null}
+   * @returns {{ valid: true, resolvedClose?: Object } | { valid: false, code: number, message: string }}
    * @private
    */
   _validatePlacementRequest(args) {
     const policy = this._placementPolicy;
-    if (!policy) return null;
+    if (!policy) return { valid: true };
 
     const { intent, targetDimensions, closeRegion } = args;
 
     // 1. Intent allowlist
     const knownIntents = ['resize', 'maximize', 'fullscreen', 'restore', 'minimize'];
     if (intent && knownIntents.indexOf(intent) === -1) {
-      return { code: ErrorCodes.MESSAGE_SPEC_VIOLATION, message: "Unknown placement intent: '" + intent + "'" };
+      return { valid: false, code: ErrorCodes.MESSAGE_SPEC_VIOLATION, message: "Unknown placement intent: '" + intent + "'" };
     }
     const allowedIntents = policy.allowedIntents || knownIntents;
     if (intent && allowedIntents.indexOf(intent) === -1) {
-      return { code: ErrorCodes.UNSUPPORTED_FEATURE, message: "Intent '" + intent + "' not allowed by placement policy" };
+      return { valid: false, code: ErrorCodes.UNSUPPORTED_FEATURE, message: "Intent '" + intent + "' not allowed by placement policy" };
     }
 
     // 2. Dimension limits
@@ -1204,29 +1231,26 @@ class SHARCContainer {
       const maxW = policy.maxWidth != null ? policy.maxWidth : Infinity;
       const maxH = policy.maxHeight != null ? policy.maxHeight : Infinity;
       if (targetDimensions.width > maxW || targetDimensions.height > maxH) {
-        return { code: ErrorCodes.UNSUPPORTED_FEATURE, message: 'Dimensions exceed placement policy limits (max: ' + maxW + 'x' + maxH + ')' };
+        return { valid: false, code: ErrorCodes.UNSUPPORTED_FEATURE, message: 'Dimensions exceed placement policy limits (max: ' + maxW + 'x' + maxH + ')' };
       }
     }
 
     // 3. Close region presence (when required by policy)
     if (intent === 'resize' && policy.requireCloseRegion && !closeRegion) {
-      return { code: ErrorCodes.MESSAGE_SPEC_VIOLATION, message: 'Placement policy requires closeRegion hint on resize requests' };
+      return { valid: false, code: ErrorCodes.MESSAGE_SPEC_VIOLATION, message: 'Placement policy requires closeRegion hint on resize requests' };
     }
 
-    // 4. Close region size minimum
-    if (closeRegion && typeof closeRegion.size === 'number' && closeRegion.size < 50) {
-      return { code: ErrorCodes.MESSAGE_SPEC_VIOLATION, message: 'closeRegion.size must be at least 50 DIPs' };
-    }
-
-    // 4b. Close hint resolution (Section 4.3 step 4)
+    // 4. Close hint resolution (Section 4.3 step 4)
     // Resolve close position here so it runs before offscreen and custom validator.
+    // Note: closeRegion.size is clamped (not rejected) by _resolveClosePosition — the
+    // container renders its own close button, so the size field is informational.
+    let resolvedClose = null;
     if (closeRegion) {
-      const resolvedClose = this._resolveClosePosition(
+      resolvedClose = this._resolveClosePosition(
         closeRegion,
         targetDimensions || (this.environmentData.currentPlacement || {}),
         args.targetPosition
       );
-      args._resolvedClose = resolvedClose;
     }
 
     // 5. Offscreen enforcement (Section 4.3 step 5)
@@ -1243,23 +1267,24 @@ class SHARCContainer {
       if (pos.x < 0 || pos.y < 0 ||
           pos.x + targetDimensions.width > viewport.width ||
           pos.y + targetDimensions.height > viewport.height) {
-        return { code: ErrorCodes.UNSUPPORTED_FEATURE, message: 'Resize would extend offscreen and allowOffscreen is false' };
+        return { valid: false, code: ErrorCodes.UNSUPPORTED_FEATURE, message: 'Resize would extend offscreen and allowOffscreen is false' };
       }
     }
 
     // 6. Custom validator (synchronous)
     if (typeof policy.customValidator === 'function') {
       try {
-        const result = policy.customValidator(args);
+        var result = policy.customValidator(args);
         if (result && result.allowed === false) {
-          return { code: ErrorCodes.UNSUPPORTED_FEATURE, message: result.reason || 'Rejected by custom placement validator' };
+          return { valid: false, code: 2203, message: result.reason || 'Rejected by custom validator' };
         }
       } catch (e) {
         console.warn('[SHARCContainer] customValidator threw:', e);
+        return { valid: false, code: 2203, message: 'Custom validator error: ' + (e.message || 'unknown') };
       }
     }
 
-    return null;
+    return { valid: true, resolvedClose: resolvedClose };
   }
 
   /**
@@ -1762,10 +1787,18 @@ class SHARCContainer {
     // Apply publisher customization if provided
     if (this._closeButtonStyles) {
       Object.assign(btn.style, this._closeButtonStyles);
-      // Enforce minimum size regardless of publisher customization
-      if (parseInt(btn.style.width) < 50) btn.style.width = '50px';
-      if (parseInt(btn.style.height) < 50) btn.style.height = '50px';
+      // Enforce visibility — close button must always be interactive and visible
+      btn.style.opacity = '1';
+      btn.style.visibility = 'visible';
+      btn.style.pointerEvents = 'auto';
+      btn.style.display = 'flex';
     }
+
+    // Enforce minimum 50px regardless — parseInt is fragile with non-px units
+    // (e.g. '3em', 'auto'). CSS min-width/min-height enforces the floor
+    // regardless of what the publisher set for width/height.
+    btn.style.minWidth = '50px';
+    btn.style.minHeight = '50px';
 
     // Position relative to the iframe
     this._applyClosePosition(btn, position);
@@ -1782,7 +1815,7 @@ class SHARCContainer {
         // resize state: restore to original placement
         self._handleRequestPlacementChange({
           args: { intent: 'restore' },
-          messageId: self._protocol._nextMessageId++,
+          messageId: -1,
           type: 'synthetic',
         });
       }
@@ -1796,8 +1829,12 @@ class SHARCContainer {
       }
     });
 
-    // Insert as sibling to iframe, within the container element
-    if (!this.containerEl.style.position || this.containerEl.style.position === 'static') {
+    // Insert as sibling to iframe, within the container element.
+    // The close button uses position: absolute, so it needs a positioned
+    // ancestor. Only override 'static' (the default) — don't clobber the
+    // publisher's existing relative, absolute, or fixed positioning.
+    var computedPosition = window.getComputedStyle(this.containerEl).position;
+    if (computedPosition === 'static') {
       this.containerEl.style.position = 'relative';
     }
     this.containerEl.appendChild(btn);
@@ -1930,13 +1967,16 @@ class SHARCContainer {
     };
 
     const onEnd = (e) => {
-      if (e.propertyName === 'transform') cleanup();
+      // Check both target and property — child elements inside the iframe
+      // can bubble transitionend events, causing premature cleanup.
+      if (e.target === iframe && e.propertyName === 'transform') cleanup();
     };
 
     iframe.addEventListener('transitionend', onEnd);
 
-    // Safety timeout: if transitionend never fires (tab hidden, etc.), snap anyway
-    setTimeout(cleanup, duration + 100);
+    // Safety timeout: if transitionend never fires (tab hidden, etc.), snap anyway.
+    // 300ms margin accounts for slow mobile WebViews.
+    setTimeout(cleanup, duration + 300);
     return null;
   }
 
@@ -1982,11 +2022,21 @@ class SHARCContainer {
   // -------------------------------------------------------------------------
 
   /**
-   * Returns the maximum available placement (fills container element).
+   * Returns the maximum available placement.
+   * For 'fullscreen' intent, returns viewport dimensions so the creative
+   * fills the screen. For 'maximize' or any other intent, fills the
+   * container element.
+   * @param {string} [intent] - The placement change intent
    * @returns {Object}
    * @private
    */
-  _getMaxPlacement() {
+  _getMaxPlacement(intent) {
+    if (intent === 'fullscreen') {
+      return {
+        width: window.innerWidth || 300,
+        height: window.innerHeight || 250,
+      };
+    }
     return {
       width: this.containerEl.offsetWidth || 300,
       height: this.containerEl.offsetHeight || 250,

--- a/examples/sharc-creative.js
+++ b/examples/sharc-creative.js
@@ -732,6 +732,7 @@ if (typeof module !== 'undefined' && module.exports) {
     fatalError: (code, msg) => _sdkInstance.fatalError(code, msg),
     log: (msg) => _sdkInstance.log(msg),
     getEnv: () => _sdkInstance.getEnv(),
+    getSupportedFeatures: () => _sdkInstance.getSupportedFeatures(),
 
     // Internal instance (for testing/debugging)
     _sdk: _sdkInstance,

--- a/examples/sharc-creative.js
+++ b/examples/sharc-creative.js
@@ -90,6 +90,9 @@ class SHARCCreativeSDK {
     /** Feature set for O(1) hasFeature lookup. @type {Set<string>} */
     this._featureSet = new Set();
 
+    /** Cached placement constraints from last query or constraintsChange event. @type {Object|null} */
+    this._cachedConstraints = null;
+
     /** The onReady callback registered by the creative. @type {Function|null} */
     this._onReadyCallback = null;
 
@@ -187,6 +190,27 @@ class SHARCCreativeSDK {
     proto.addListener(ContainerMessages.PLACEMENT_CHANGE, (msg) => {
       const placement = msg.args && msg.args.placementUpdate;
       this._emit('placementChange', placement);
+    });
+
+    // Container:placementConstraintsChange — constraints changed (rotation, resize, policy update)
+    proto.addListener(ContainerMessages.PLACEMENT_CONSTRAINTS_CHANGE, (msg) => {
+      const args = msg.args || {};
+      this._cachedConstraints = {
+        maxWidth:           args.maxWidth != null ? args.maxWidth : null,
+        maxHeight:          args.maxHeight != null ? args.maxHeight : null,
+        allowedIntents:     args.allowedIntents || ['resize', 'maximize', 'fullscreen', 'minimize', 'restore'],
+        requireCloseRegion: !!args.requireCloseRegion,
+        allowOffscreen:     args.allowOffscreen !== false,
+      };
+      this._emit('constraintsChange', args);
+      proto.resolve(msg, {});
+    });
+
+    // Container:placementTransitionEnd — container animation completed (or skipped)
+    proto.addListener(ContainerMessages.PLACEMENT_TRANSITION_END, (msg) => {
+      const args = msg.args || {};
+      this._emit('placementTransitionEnd', args);
+      proto.resolve(msg, {});
     });
 
     // Container:audioVolumeChange — live audio state signal (MRAID 3.0 §4.6)
@@ -473,6 +497,40 @@ class SHARCCreativeSDK {
   }
 
   /**
+   * Queries the container's placement constraints.
+   * Returns what the container allows before the creative requests a change.
+   * Use SHARC.hasFeature('com.iabtechlab.sharc.placement.constraints') to check availability.
+   *
+   * @returns {Promise<{maxWidth: number|null, maxHeight: number|null,
+   *           allowedIntents: string[], requireCloseRegion: boolean, allowOffscreen: boolean}>}
+   */
+  getPlacementConstraints() {
+    if (this._dead) return Promise.reject(new Error('SDK is dead'));
+    return this._proto.getPlacementConstraints().then((value) => {
+      // Cache the result for getCachedConstraints()
+      if (value) this._cachedConstraints = value;
+      return value;
+    });
+  }
+
+  /**
+   * Returns the last known placement constraints.
+   * Synchronous — uses cached data from the last getPlacementConstraints()
+   * call or the last constraintsChange event. Before any query or event,
+   * returns unconstrained defaults (never null).
+   * @returns {Object}
+   */
+  getCachedConstraints() {
+    return this._cachedConstraints || {
+      maxWidth: null,
+      maxHeight: null,
+      allowedIntents: ['resize', 'maximize', 'fullscreen', 'minimize', 'restore'],
+      requireCloseRegion: false,
+      allowOffscreen: true,
+    };
+  }
+
+  /**
    * Requests a placement change.
    *
    * @param {Object} args
@@ -722,6 +780,8 @@ if (typeof module !== 'undefined' && module.exports) {
     off: (event, cb) => _sdkInstance.off(event, cb),
     getContainerState: () => _sdkInstance.getContainerState(),
     getPlacementOptions: () => _sdkInstance.getPlacementOptions(),
+    getPlacementConstraints: () => _sdkInstance.getPlacementConstraints(),
+    getCachedConstraints: () => _sdkInstance.getCachedConstraints(),
     requestPlacementChange: (args) => _sdkInstance.requestPlacementChange(args),
     requestNavigation: (args) => _sdkInstance.requestNavigation(args),
     requestClose: () => _sdkInstance.requestClose(),

--- a/examples/sharc-mraid-bridge.js
+++ b/examples/sharc-mraid-bridge.js
@@ -543,34 +543,10 @@
             return;
           }
         }
-        // Tests 9-12: close button zone stay onscreen
-        // The close button is a 50×50 zone. Default position is top-right of the resized ad.
-        // Close zone screen position = adDefaultPosition + offsetX + (props.width - closeZoneSize)
-        // For default 'top-right': close button is at top-right corner of resized ad
-        var offsetX = typeof props.offsetX === 'number' ? props.offsetX : _s._resizeProps.offsetX;
-        var offsetY = typeof props.offsetY === 'number' ? props.offsetY : _s._resizeProps.offsetY;
-        var allowOffscreen = typeof props.allowOffscreen === 'boolean' ? props.allowOffscreen : _s._resizeProps.allowOffscreen;
-        var closePosition = typeof props.customClosePosition === 'string' ? props.customClosePosition : _s._resizeProps.customClosePosition;
-        var closeZoneSize = 50;
+        // Close button onscreen validation removed — container owns close button rendering
+        // and will override the hint to a visible default if it would be offscreen.
+        // See architecture-placement-changes.md ADR-PC-001.
 
-        // MRAID 3.0 §4.4.3: the close button zone must always remain onscreen,
-        // even when allowOffscreen is true (allowOffscreen governs the ad content,
-        // not the close control). Validate close-button visibility unconditionally.
-        {
-          var defaultPos = mraid.getDefaultPosition();
-          var closeRect = _computeCloseButtonRect(
-            defaultPos.x, defaultPos.y,
-            props.width, props.height,
-            offsetX, offsetY,
-            closePosition, closeZoneSize
-          );
-          var screenSize = mraid.getScreenSize();
-          if (closeRect.left < 0 || closeRect.top < 0 ||
-              closeRect.right > screenSize.width || closeRect.bottom > screenSize.height) {
-            _emit('error', 'Resize would place close button offscreen', 'setResizeProperties');
-            return;
-          }
-        }
         // Store validated properties
         _s._resizeProps.width  = props.width;
         _s._resizeProps.height = props.height;
@@ -740,9 +716,14 @@
             x: pos.x + (_s._resizeProps.offsetX || 0),
             y: pos.y + (_s._resizeProps.offsetY || 0),
           },
+          closeRegion: {
+            position: _s._resizeProps.customClosePosition,
+            size: 50,
+          },
           allowOffscreen: _s._resizeProps.allowOffscreen || false,
         }).then(function () {
           _s._placementMode = 'resized';
+          // No close indicator injection — container renders the close button
           _emit('stateChange', mraid.getState());
           _emit('sizeChange', _s._resizeProps.width, _s._resizeProps.height);
         }).catch(function (err) {
@@ -777,6 +758,10 @@
         if (feature === 'calendar' || feature === 'storePicture' ||
             feature === 'inlineVideo' || feature === 'vpaid') {
           return false;
+        }
+        // resize: check SHARC feature string for validated resize support
+        if (feature === 'resize') {
+          return SHARC.hasFeature('com.iabtechlab.sharc.placement.resize');
         }
         // Container-dependent features — check via SHARC.hasFeature
         if (feature === 'sms') {

--- a/examples/sharc-omid-bridge.js
+++ b/examples/sharc-omid-bridge.js
@@ -738,6 +738,14 @@
   function OmidCompatBridge(options) {
     this.name    = FEATURE_NAME;
     this.options = options || {};
+
+    /**
+     * Currently registered friendly obstruction element (e.g. close button).
+     * Tracked to avoid duplicate registrations and allow clean unregistration.
+     * @type {HTMLElement|null}
+     * @private
+     */
+    this._friendlyObstruction = null;
   }
 
   OmidCompatBridge.prototype = {
@@ -890,6 +898,76 @@
       environmentData.omidServiceScriptUrl =
         this.options.omSdkServiceScriptUrl || '/vendor/omweb-v1.js';
       return environmentData;
+    },
+
+    // ── Friendly obstruction management ────────────────────────────────
+
+    /**
+     * Registers a DOM element as a friendly obstruction on the active OM SDK
+     * AdSession. Called by the container when a close button is rendered over
+     * the ad iframe. The OM SDK will exclude this element from viewability
+     * obstruction calculations.
+     *
+     * Safe to call multiple times with the same element — duplicate registrations
+     * are suppressed. Call `unregisterFriendlyObstruction()` when the element is
+     * removed.
+     *
+     * @param {HTMLElement} element - The DOM element to register (e.g. close button).
+     * @param {string} [purpose='closeAd'] - OM SDK FriendlyObstructionPurpose string.
+     * @param {string} [reason='Container close button'] - Human-readable reason.
+     */
+    registerFriendlyObstruction: function (element, purpose, reason) {
+      if (!element || this._friendlyObstruction === element) return;
+
+      // Unregister previous obstruction if switching elements
+      if (this._friendlyObstruction) {
+        this.unregisterFriendlyObstruction();
+      }
+
+      this._friendlyObstruction = element;
+
+      // The AdSession lives on the creative side (installOmidBridge),
+      // but the container-side bridge does not hold a direct reference.
+      // Use the global SHARC.omid.getAdSession() if available (same window
+      // context in test harness) or degrade gracefully.
+      safeCall('registerFriendlyObstruction', function () {
+        var adSession = null;
+        if (typeof window !== 'undefined' && window.SHARC && window.SHARC.omid &&
+            typeof window.SHARC.omid.getAdSession === 'function') {
+          adSession = window.SHARC.omid.getAdSession();
+        }
+        if (adSession && typeof adSession.addFriendlyObstruction === 'function') {
+          adSession.addFriendlyObstruction(
+            element,
+            purpose || 'closeAd',
+            reason  || 'Container close button'
+          );
+        }
+      });
+    },
+
+    /**
+     * Unregisters the currently tracked friendly obstruction from the OM SDK
+     * AdSession. Called by the container when the close button is removed
+     * (e.g. on restore/minimize).
+     *
+     * Idempotent — safe to call when no obstruction is registered.
+     */
+    unregisterFriendlyObstruction: function () {
+      var element = this._friendlyObstruction;
+      if (!element) return;
+      this._friendlyObstruction = null;
+
+      safeCall('unregisterFriendlyObstruction', function () {
+        var adSession = null;
+        if (typeof window !== 'undefined' && window.SHARC && window.SHARC.omid &&
+            typeof window.SHARC.omid.getAdSession === 'function') {
+          adSession = window.SHARC.omid.getAdSession();
+        }
+        if (adSession && typeof adSession.removeFriendlyObstruction === 'function') {
+          adSession.removeFriendlyObstruction(element);
+        }
+      });
     },
 
   }; // end OmidCompatBridge.prototype

--- a/examples/sharc-protocol.js
+++ b/examples/sharc-protocol.js
@@ -58,6 +58,8 @@ const ContainerMessages = Object.freeze({
   START_CREATIVE: 'SHARC:Container:startCreative',
   STATE_CHANGE: 'SHARC:Container:stateChange',
   PLACEMENT_CHANGE: 'SHARC:Container:placementChange',
+  PLACEMENT_CONSTRAINTS_CHANGE: 'SHARC:Container:placementConstraintsChange',
+  PLACEMENT_TRANSITION_END: 'SHARC:Container:placementTransitionEnd',
   AUDIO_VOLUME_CHANGE: 'SHARC:Container:audioVolumeChange',
   LOG: 'SHARC:Container:log',
   FATAL_ERROR: 'SHARC:Container:fatalError',
@@ -72,6 +74,7 @@ const CreativeMessages = Object.freeze({
   FATAL_ERROR: 'SHARC:Creative:fatalError',
   GET_CONTAINER_STATE: 'SHARC:Creative:getContainerState',
   GET_PLACEMENT_OPTIONS: 'SHARC:Creative:getPlacementOptions',
+  GET_PLACEMENT_CONSTRAINTS: 'SHARC:Creative:getPlacementConstraints',
   LOG: 'SHARC:Creative:log',
   REPORT_INTERACTION: 'SHARC:Creative:reportInteraction',
   REQUEST_NAVIGATION: 'SHARC:Creative:requestNavigation',
@@ -133,8 +136,11 @@ const MESSAGES_REQUIRING_RESPONSE = new Set([
   ContainerMessages.START_CREATIVE,
   ContainerMessages.FATAL_ERROR,
   ContainerMessages.CLOSE,
+  ContainerMessages.PLACEMENT_CONSTRAINTS_CHANGE,
+  ContainerMessages.PLACEMENT_TRANSITION_END,
   CreativeMessages.GET_CONTAINER_STATE,
   CreativeMessages.GET_PLACEMENT_OPTIONS,
+  CreativeMessages.GET_PLACEMENT_CONSTRAINTS,
   CreativeMessages.REPORT_INTERACTION,
   CreativeMessages.REQUEST_PLACEMENT_CHANGE,
   CreativeMessages.REQUEST_CLOSE,
@@ -1014,6 +1020,15 @@ class SHARCCreativeProtocol extends SHARCProtocolBase {
    */
   getPlacementOptions() {
     return this._sendMessage(CreativeMessages.GET_PLACEMENT_OPTIONS, {});
+  }
+
+  /**
+   * Queries the container's placement constraints.
+   * Returns what the container allows before the creative requests a change.
+   * @returns {Promise<Object>} Resolves with constraint information.
+   */
+  getPlacementConstraints() {
+    return this._sendMessage(CreativeMessages.GET_PLACEMENT_CONSTRAINTS, {});
   }
 
   /**

--- a/examples/test/index.html
+++ b/examples/test/index.html
@@ -347,6 +347,15 @@
   <!-- Left Panel: Ad slot and controls -->
   <div class="left-panel">
 
+    <!-- Creative Selector -->
+    <div>
+      <div class="section-label">Test Creative</div>
+      <select id="creative-select" style="width:100%;padding:8px 10px;background:#1a1a2e;color:#e0e0e0;border:1px solid #444;border-radius:6px;font-size:12px;margin-bottom:8px;">
+        <option value="test-creative.html">Default Test Creative</option>
+        <option value="test-placement-creative.html">Placement Change Test</option>
+      </select>
+    </div>
+
     <!-- Ad Slot -->
     <div>
       <div class="section-label">Ad Slot (320×250)</div>
@@ -641,7 +650,7 @@ function loadAd() {
   };
 
   sharcContainer = new SHARC.Container({
-    creativeUrl: 'test-creative.html',
+    creativeUrl: document.getElementById('creative-select').value,
     containerEl,
     environmentData,
     supportedFeatures: [

--- a/examples/test/mraid-3-compliance-runner.html
+++ b/examples/test/mraid-3-compliance-runner.html
@@ -274,6 +274,12 @@
       adDir: 'compliance-ads/resize-negative',
     },
     {
+      id: 'resize-positive',
+      title: 'Resize Positive Tests',
+      desc: 'Tests resize operations that should succeed (basic resize, offset, close positions, close-from-resized)',
+      adDir: 'compliance-ads/resize-positive',
+    },
+    {
       id: 'viewability',
       title: 'Viewability',
       desc: 'Tests viewability measurement triggers and reporting',
@@ -291,6 +297,7 @@
     const paths = {
       loadandevents:     'compliance-ads/loadandevents/ad.html',
       'resize-negative': 'compliance-ads/resize-negative/resize-test.html',
+      'resize-positive': 'compliance-ads/resize-positive/resize-test.html',
       viewability:       'compliance-ads/viewability/ad.html',
     };
     return paths[test.id] || '';

--- a/examples/test/mraid-test.html
+++ b/examples/test/mraid-test.html
@@ -407,8 +407,12 @@
         <div id="ad-loading-overlay"></div>
         <div id="adSlot"></div>
       </div>
-      <div style="margin-top:6px; font-size:10px; color:#555; text-align:center;">
-        Loading: <code>mraid-wrapper.html?creative=test-mraid-creative.html</code>
+      <div style="margin-top:6px; font-size:10px; color:#555;">
+        <div style="margin-bottom:4px; color:#666;">Test Creative</div>
+        <select id="creative-select" style="width:100%;padding:5px 8px;background:#1a1a2e;color:#e0e0e0;border:1px solid #444;border-radius:4px;font-size:11px;">
+          <option value="test/test-mraid-creative.html">Default MRAID Test</option>
+          <option value="test/test-mraid-resize-creative.html">MRAID Resize Test</option>
+        </select>
       </div>
     </div>
 
@@ -776,7 +780,8 @@
 
     logSep('Starting SHARC MRAID session');
     logSys('Constructing SHARCContainer...');
-    logSys('Creative: mraid-wrapper.html?creative=test-mraid-creative.html');
+    var selectedCreative = document.getElementById('creative-select').value;
+    logSys('Creative: mraid-wrapper.html?creative=' + selectedCreative);
     logSys('Size: ' + adWidth + '\xd7' + adHeight + ', instl: ' + instlMode + ' (' + (instlMode ? 'interstitial' : 'inline') + ')');
     showLoadingOverlay();
 
@@ -784,7 +789,7 @@
 
     // The creative URL is the MRAID wrapper page with the test creative as param.
     // Resolve relative to test/index.html (this file is in src/test/).
-    var creativeUrl = '../mraid-wrapper.html?creative=test/test-mraid-creative.html';
+    var creativeUrl = '../mraid-wrapper.html?creative=' + encodeURIComponent(selectedCreative);
 
     var environmentData = {
       currentPlacement: {

--- a/examples/test/safeframe-test.html
+++ b/examples/test/safeframe-test.html
@@ -406,8 +406,12 @@
         <div id="ad-loading-overlay"></div>
         <div id="adSlot"></div>
       </div>
-      <div style="margin-top:6px; font-size:10px; color:#555; text-align:center;">
-        Loading: <code>safeframe-wrapper.html?creative=test-safeframe-creative.html</code>
+      <div style="margin-top:6px; font-size:10px; color:#555;">
+        <div style="margin-bottom:4px; color:#666;">Test Creative</div>
+        <select id="creative-select" style="width:100%;padding:5px 8px;background:#1a1a2e;color:#e0e0e0;border:1px solid #444;border-radius:4px;font-size:11px;">
+          <option value="test/test-safeframe-creative.html">Default SafeFrame Test</option>
+          <option value="test/test-safeframe-expand-creative.html">SafeFrame Expand Test</option>
+        </select>
       </div>
     </div>
 
@@ -754,7 +758,8 @@
 
     logSep('Starting SHARC SafeFrame session');
     logSys('Constructing SHARCContainer...');
-    logSys('Creative: safeframe-wrapper.html?creative=test-safeframe-creative.html');
+    var selectedCreative = document.getElementById('creative-select').value;
+    logSys('Creative: safeframe-wrapper.html?creative=' + selectedCreative);
     logSys('Size: ' + adWidth + '\xd7' + adHeight + ', instl: ' + instlMode + ' (' + (instlMode ? 'interstitial' : 'inline') + ')');
     showLoadingOverlay();
 
@@ -762,7 +767,7 @@
 
     // Wrapper page with test creative as query param.
     // Resolve relative to test/index.html (this file lives in src/test/).
-    var creativeUrl = '../safeframe-wrapper.html?creative=test/test-safeframe-creative.html';
+    var creativeUrl = '../safeframe-wrapper.html?creative=' + encodeURIComponent(selectedCreative);
 
     // environmentData includes sfMeta for $sf.ext.meta() testing
     var environmentData = {

--- a/examples/test/test-mraid-resize-creative.html
+++ b/examples/test/test-mraid-resize-creative.html
@@ -1,0 +1,274 @@
+<!doctype html>
+<!--
+  test-mraid-resize-creative.html - MRAID Resize Test Creative (DOM structure only)
+
+  Tests MRAID resize() through the SHARC MRAID bridge. Exercises
+  setResizeProperties, resize, close from resized state, and error paths.
+
+  This creative is loaded inside mraid-wrapper.html which:
+    1. Injects window.mraid via sharc-mraid-bridge.js
+    2. Loads this file via XHR and injects the <body> DOM
+    3. Dynamically loads test-mraid-resize-creative.js via <script src>
+    4. Calls window.__SHARC_TEST_mraidCreativeInit() after the script loads
+
+  NOTE: This file contains DOM structure and styles ONLY.
+  All script logic lives in test-mraid-resize-creative.js.
+  Do NOT add <script> tags here - they won't execute when injected via innerHTML.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MRAID Resize Test Creative</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #1a1a2e;
+      color: #eee;
+      overflow: hidden;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* -- Ad Banner -------------------------------------------------- */
+    #ad-banner {
+      background: linear-gradient(135deg, #dc2626 0%, #9333ea 100%);
+      padding: 10px 16px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      min-height: 50px;
+      flex-shrink: 0;
+      user-select: none;
+    }
+    #ad-banner .brand {
+      font-size: 16px;
+      font-weight: 700;
+      color: #fff;
+    }
+    .brand-wrap { display: flex; flex-direction: column; gap: 2px; }
+    .brand-sub { font-size: 10px; color: rgba(255,255,255,0.65); }
+
+    /* -- Config Panel ----------------------------------------------- */
+    #config-panel {
+      background: rgba(0,0,0,0.4);
+      padding: 8px 16px;
+      font-size: 10px;
+      border-bottom: 1px solid rgba(255,255,255,0.08);
+      flex-shrink: 0;
+    }
+    .config-row {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      margin-bottom: 4px;
+      flex-wrap: wrap;
+    }
+    .config-row label {
+      color: rgba(255,255,255,0.5);
+      min-width: 50px;
+    }
+    .config-row input[type="number"] {
+      width: 60px;
+      background: #0f172a;
+      border: 1px solid rgba(255,255,255,0.2);
+      color: #fff;
+      padding: 3px 6px;
+      border-radius: 3px;
+      font-size: 10px;
+      font-family: monospace;
+    }
+    .config-row select {
+      background: #0f172a;
+      border: 1px solid rgba(255,255,255,0.2);
+      color: #fff;
+      padding: 3px 6px;
+      border-radius: 3px;
+      font-size: 10px;
+    }
+    .config-row input[type="checkbox"] {
+      accent-color: #dc2626;
+    }
+
+    /* -- State Display ---------------------------------------------- */
+    #ad-state {
+      background: rgba(0,0,0,0.45);
+      padding: 6px 16px;
+      font-size: 10px;
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      flex-wrap: wrap;
+      border-bottom: 1px solid rgba(255,255,255,0.08);
+      flex-shrink: 0;
+    }
+    .state-item { display: flex; gap: 3px; align-items: center; }
+    .state-label { color: rgba(255,255,255,0.45); }
+    .state-value {
+      color: #dc2626;
+      font-weight: 700;
+      font-family: monospace;
+      font-size: 10px;
+    }
+    .state-value.ok { color: #4ade80; }
+    .state-value.warn { color: #fb923c; }
+    .state-value.err { color: #f87171; }
+
+    /* -- Controls --------------------------------------------------- */
+    #ad-controls {
+      padding: 8px 16px;
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+      flex-shrink: 0;
+      background: rgba(0,0,0,0.25);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+    }
+    .ad-btn {
+      background: #1e1e3a;
+      color: #fff;
+      border: 1px solid rgba(255,255,255,0.18);
+      padding: 5px 10px;
+      border-radius: 5px;
+      font-size: 10px;
+      cursor: pointer;
+      transition: background 0.15s;
+      white-space: nowrap;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+    }
+    .ad-btn:hover { background: #2d2d50; }
+    .ad-btn:active { background: #dc2626; }
+    .ad-btn.danger { border-color: #f87171; color: #f87171; }
+
+    /* -- Protocol Log ----------------------------------------------- */
+    #log-header {
+      padding: 5px 16px;
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: rgba(255,255,255,0.35);
+      background: rgba(0,0,0,0.3);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+      flex-shrink: 0;
+    }
+    #protocol-log {
+      flex: 1;
+      overflow-y: auto;
+      padding: 6px 16px;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 10px;
+      line-height: 1.65;
+    }
+    #protocol-log::-webkit-scrollbar { width: 4px; }
+    #protocol-log::-webkit-scrollbar-thumb { background: #1e1e3a; border-radius: 2px; }
+
+    .log-entry { padding: 1px 0; border-bottom: 1px solid rgba(255,255,255,0.03); }
+    .log-entry .ts { color: rgba(255,255,255,0.25); margin-right: 6px; }
+    .log-entry.event .msg { color: #60a5fa; }
+    .log-entry.action .msg { color: #a78bfa; }
+    .log-entry.error .msg { color: #f87171; }
+    .log-entry.info .msg { color: rgba(255,255,255,0.55); }
+    .log-entry.ok .msg { color: #4ade80; }
+
+    /* -- No-mraid fallback ------------------------------------------ */
+    #no-mraid {
+      display: none;
+      padding: 20px;
+      text-align: center;
+      color: rgba(255,255,255,0.4);
+      font-size: 12px;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Ad Banner -->
+  <div id="ad-banner">
+    <div class="brand-wrap">
+      <div class="brand">MRAID Resize Test</div>
+      <div class="brand-sub">MRAID 3.0 resize() via SHARC Bridge</div>
+    </div>
+  </div>
+
+  <!-- Resize Config Panel -->
+  <div id="config-panel">
+    <div class="config-row">
+      <label>width:</label>
+      <input type="number" id="cfg-width" value="320" min="50">
+      <label>height:</label>
+      <input type="number" id="cfg-height" value="480" min="50">
+    </div>
+    <div class="config-row">
+      <label>offsetX:</label>
+      <input type="number" id="cfg-offsetX" value="0">
+      <label>offsetY:</label>
+      <input type="number" id="cfg-offsetY" value="0">
+    </div>
+    <div class="config-row">
+      <label>closePos:</label>
+      <select id="cfg-closePos">
+        <option value="top-right" selected>top-right</option>
+        <option value="top-left">top-left</option>
+        <option value="top-center">top-center</option>
+        <option value="bottom-left">bottom-left</option>
+        <option value="bottom-right">bottom-right</option>
+        <option value="bottom-center">bottom-center</option>
+        <option value="center">center</option>
+      </select>
+      <label>offscreen:</label>
+      <input type="checkbox" id="cfg-offscreen">
+    </div>
+  </div>
+
+  <!-- Live State Display -->
+  <div id="ad-state">
+    <div class="state-item">
+      <span class="state-label">state:</span>
+      <span class="state-value" id="disp-state">loading</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">curPos:</span>
+      <span class="state-value" id="disp-curpos">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">maxSize:</span>
+      <span class="state-value" id="disp-maxsize">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">viewable:</span>
+      <span class="state-value" id="disp-viewable">--</span>
+    </div>
+  </div>
+
+  <!-- Controls -->
+  <div id="ad-controls">
+    <button class="ad-btn" onclick="testSetResizeProps()">setResizeProperties</button>
+    <button class="ad-btn" onclick="testResize()">resize()</button>
+    <button class="ad-btn" onclick="testClose()">close()</button>
+    <button class="ad-btn" onclick="testExpandThenResize()">expand+resize</button>
+    <button class="ad-btn" onclick="testResizeNoProps()">resize (no props)</button>
+    <button class="ad-btn" onclick="testCollapse()">collapse()</button>
+    <button class="ad-btn danger" onclick="clearLog()">Clear Log</button>
+  </div>
+
+  <div id="log-header">MRAID Resize Event Log</div>
+
+  <!-- Protocol Log -->
+  <div id="protocol-log">
+    <div class="log-entry info">
+      <span class="ts">[init]</span>
+      <span class="msg">MRAID resize creative loaded. Waiting for window.mraid...</span>
+    </div>
+  </div>
+
+  <div id="no-mraid">
+    window.mraid not available.<br>
+    Load via mraid-wrapper.html?creative=test/test-mraid-resize-creative.html
+  </div>
+
+</body>
+</html>

--- a/examples/test/test-mraid-resize-creative.js
+++ b/examples/test/test-mraid-resize-creative.js
@@ -1,0 +1,173 @@
+// WARNING: __SHARC_TEST_mraidCreativeInit is a SHARC test harness convention.
+// Real MRAID creatives do NOT use this pattern. See CREATIVE-AUTHORING.md.
+'use strict';
+
+window.__SHARC_TEST_mraidCreativeInit = function init() {
+
+    /* -- Logging helpers ------------------------------------------- */
+    var logEl = document.getElementById('protocol-log');
+
+    function logEntry(type, msg) {
+      var entry = document.createElement('div');
+      entry.className = 'log-entry ' + type;
+      var ts = new Date().toISOString().slice(11, 23);
+      entry.innerHTML =
+        '<span class="ts">[' + ts + ']</span>' +
+        '<span class="msg">' + escHtml(String(msg)) + '</span>';
+      logEl.appendChild(entry);
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    function escHtml(s) {
+      return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    window.clearLog = function clearLog() {
+      logEl.innerHTML = '';
+      logEntry('info', 'Log cleared.');
+    };
+
+    /* -- Config readers -------------------------------------------- */
+    function getResizeConfig() {
+      return {
+        width:               parseInt(document.getElementById('cfg-width').value, 10) || 320,
+        height:              parseInt(document.getElementById('cfg-height').value, 10) || 480,
+        offsetX:             parseInt(document.getElementById('cfg-offsetX').value, 10) || 0,
+        offsetY:             parseInt(document.getElementById('cfg-offsetY').value, 10) || 0,
+        customClosePosition: document.getElementById('cfg-closePos').value,
+        allowOffscreen:      document.getElementById('cfg-offscreen').checked
+      };
+    }
+
+    /* -- State display update -------------------------------------- */
+    function updateDisplay() {
+      if (typeof window.mraid === 'undefined') return;
+      var m = window.mraid;
+
+      var stateEl = document.getElementById('disp-state');
+      var state = m.getState();
+      stateEl.textContent = state;
+      stateEl.className = 'state-value ' +
+        (state === 'default' ? 'ok' :
+         state === 'resized' ? 'warn' :
+         state === 'expanded' ? 'warn' : '');
+
+      var viewableEl = document.getElementById('disp-viewable');
+      viewableEl.textContent = String(m.isViewable());
+      viewableEl.className = 'state-value ' + (m.isViewable() ? 'ok' : 'warn');
+
+      var curPos = m.getCurrentPosition();
+      document.getElementById('disp-curpos').textContent =
+        curPos.width + 'x' + curPos.height + ' @' + curPos.x + ',' + curPos.y;
+
+      var maxSize = m.getMaxSize();
+      document.getElementById('disp-maxsize').textContent =
+        maxSize.width + 'x' + maxSize.height;
+    }
+
+    /* -- MRAID event handlers -------------------------------------- */
+    function onMraidReady() {
+      logEntry('ok', 'ready event fired');
+      logEntry('info', '  getState()         = ' + mraid.getState());
+      logEntry('info', '  getPlacementType() = ' + mraid.getPlacementType());
+      logEntry('info', '  getMaxSize()       = ' + JSON.stringify(mraid.getMaxSize()));
+      logEntry('info', '  getCurrentPosition()= ' + JSON.stringify(mraid.getCurrentPosition()));
+      logEntry('info', '  getResizeProperties()= ' + JSON.stringify(mraid.getResizeProperties()));
+      updateDisplay();
+    }
+
+    function onStateChange(state) {
+      logEntry('event', 'stateChange("' + state + '")');
+      updateDisplay();
+    }
+
+    function onSizeChange(w, h) {
+      logEntry('event', 'sizeChange(' + w + ', ' + h + ')');
+      updateDisplay();
+    }
+
+    function onError(message, action) {
+      logEntry('error', 'error("' + message + '", "' + action + '")');
+    }
+
+    function onViewableChange(viewable) {
+      logEntry('event', 'viewableChange(' + viewable + ')');
+      updateDisplay();
+    }
+
+    /* -- Test actions ---------------------------------------------- */
+
+    window.testSetResizeProps = function testSetResizeProps() {
+      var cfg = getResizeConfig();
+      logEntry('action', 'mraid.setResizeProperties(' + JSON.stringify(cfg) + ')');
+      mraid.setResizeProperties(cfg);
+      logEntry('info', '  getResizeProperties() = ' + JSON.stringify(mraid.getResizeProperties()));
+    };
+
+    window.testResize = function testResize() {
+      logEntry('action', 'mraid.resize()');
+      mraid.resize();
+    };
+
+    window.testClose = function testClose() {
+      logEntry('action', 'mraid.close() -- should collapse from resized/expanded to default');
+      mraid.close();
+    };
+
+    window.testCollapse = function testCollapse() {
+      logEntry('action', 'mraid.collapse()');
+      mraid.collapse();
+    };
+
+    window.testExpandThenResize = function testExpandThenResize() {
+      logEntry('action', 'mraid.expand() then mraid.resize() -- resize should error from expanded');
+      mraid.expand();
+      // Wait for expand to complete, then try resize
+      var listener = function (state) {
+        if (state === 'expanded') {
+          mraid.removeEventListener('stateChange', listener);
+          logEntry('action', 'Now in expanded state -- calling mraid.resize()');
+          var cfg = getResizeConfig();
+          mraid.setResizeProperties(cfg);
+          mraid.resize();
+        }
+      };
+      mraid.addEventListener('stateChange', listener);
+    };
+
+    window.testResizeNoProps = function testResizeNoProps() {
+      logEntry('action', 'mraid.resize() without setResizeProperties -- should error');
+      // Reset resize props by creating fresh bridge state (not possible externally).
+      // Instead just call resize directly; the bridge tracks whether setResizeProperties
+      // was called with valid dimensions.
+      mraid.resize();
+    };
+
+    /* -- Bootstrap ------------------------------------------------- */
+    (function bootstrap() {
+      var m = window.mraid;
+
+      if (!m) {
+        logEntry('error', 'window.mraid not found. Load via mraid-wrapper.html');
+        document.getElementById('no-mraid').style.display = 'block';
+        return;
+      }
+
+      mraid.addEventListener('ready', onMraidReady);
+      mraid.addEventListener('stateChange', onStateChange);
+      mraid.addEventListener('sizeChange', onSizeChange);
+      mraid.addEventListener('viewableChange', onViewableChange);
+      mraid.addEventListener('error', onError);
+
+      logEntry('info', 'mraid object found. getState() = "' + mraid.getState() + '"');
+
+      if (mraid.getState() === 'loading') {
+        logEntry('info', 'State is "loading" -- waiting for ready event...');
+      } else {
+        logEntry('ok', 'State is "' + mraid.getState() + '" -- calling onMraidReady directly');
+        onMraidReady();
+      }
+
+      updateDisplay();
+    }());
+};

--- a/examples/test/test-placement-creative.html
+++ b/examples/test/test-placement-creative.html
@@ -195,6 +195,10 @@
     <button class="ad-btn" onclick="testResizeWithAnimation()">Resize+Anim</button>
     <button class="ad-btn success" onclick="testZeroDurationOrder()">Zero-Order</button>
     <button class="ad-btn" onclick="testGetPlacementOptions()">Get Placement</button>
+    <button class="ad-btn" onclick="testResizeWhileResized()">Resize&#178;</button>
+    <button class="ad-btn" onclick="testMaxWhileResized()">Max (resized)</button>
+    <button class="ad-btn" onclick="testTransitionEnd()">TransEnd</button>
+    <button class="ad-btn" onclick="testConstraintsShape()">Constraints Shape</button>
     <button class="ad-btn danger" onclick="clearLog()">Clear Log</button>
   </div>
 
@@ -207,6 +211,10 @@
     <span class="test-badge pending" id="result-constraints">constraints: --</span>
     <span class="test-badge pending" id="result-animation">animation: --</span>
     <span class="test-badge pending" id="result-zero-order">zero-order: --</span>
+    <span class="test-badge pending" id="result-resize2">resize&#178;: --</span>
+    <span class="test-badge pending" id="result-max-resized">max(resized): --</span>
+    <span class="test-badge pending" id="result-transend">transEnd: --</span>
+    <span class="test-badge pending" id="result-shape">shape: --</span>
   </div>
 
   <div id="log-header">SHARC Placement Event Log</div>

--- a/examples/test/test-placement-creative.html
+++ b/examples/test/test-placement-creative.html
@@ -1,0 +1,223 @@
+<!doctype html>
+<!--
+  test-placement-creative.html - SHARC Core Placement Change Test Creative
+
+  Tests the native SHARC requestPlacementChange API directly without any
+  bridge layer. Exercises resize, maximize, restore, and constraint queries.
+
+  Can be loaded either:
+    a) Directly by the SHARC container (like test-creative.html)
+    b) Via mraid-wrapper.html for bridge-bypass testing
+
+  NOTE: This file contains DOM structure and styles ONLY when loaded via
+  wrapper model. All script logic lives in test-placement-creative.js.
+  Do NOT add <script> tags here - they won't execute when injected via innerHTML.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SHARC Placement Change Test</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0f172a;
+      color: #eee;
+      overflow: hidden;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* -- Ad Banner -------------------------------------------------- */
+    #ad-banner {
+      background: linear-gradient(135deg, #7c3aed 0%, #2563eb 100%);
+      padding: 10px 16px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      min-height: 50px;
+      flex-shrink: 0;
+      user-select: none;
+    }
+    #ad-banner .brand {
+      font-size: 16px;
+      font-weight: 700;
+      color: #fff;
+    }
+    .brand-wrap { display: flex; flex-direction: column; gap: 2px; }
+    .brand-sub { font-size: 10px; color: rgba(255,255,255,0.65); }
+
+    /* -- State Display ---------------------------------------------- */
+    #ad-state {
+      background: rgba(0,0,0,0.45);
+      padding: 6px 16px;
+      font-size: 10px;
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      flex-wrap: wrap;
+      border-bottom: 1px solid rgba(255,255,255,0.08);
+      flex-shrink: 0;
+    }
+    .state-item { display: flex; gap: 3px; align-items: center; }
+    .state-label { color: rgba(255,255,255,0.45); }
+    .state-value {
+      color: #7c3aed;
+      font-weight: 700;
+      font-family: monospace;
+      font-size: 10px;
+    }
+    .state-value.ok { color: #4ade80; }
+    .state-value.warn { color: #fb923c; }
+    .state-value.err { color: #f87171; }
+
+    /* -- Controls --------------------------------------------------- */
+    #ad-controls {
+      padding: 8px 16px;
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+      flex-shrink: 0;
+      background: rgba(0,0,0,0.25);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+    }
+    .ad-btn {
+      background: #1e293b;
+      color: #fff;
+      border: 1px solid rgba(255,255,255,0.18);
+      padding: 5px 10px;
+      border-radius: 5px;
+      font-size: 10px;
+      cursor: pointer;
+      transition: background 0.15s;
+      white-space: nowrap;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+    }
+    .ad-btn:hover { background: #334155; }
+    .ad-btn:active { background: #7c3aed; }
+    .ad-btn.danger { border-color: #f87171; color: #f87171; }
+    .ad-btn.success { border-color: #4ade80; color: #4ade80; }
+
+    /* -- Test Results ----------------------------------------------- */
+    #test-results {
+      padding: 6px 16px;
+      font-size: 10px;
+      background: rgba(0,0,0,0.3);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+      flex-shrink: 0;
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .test-badge {
+      padding: 2px 8px;
+      border-radius: 3px;
+      font-family: monospace;
+      font-size: 9px;
+      font-weight: 700;
+    }
+    .test-badge.pass { background: #166534; color: #4ade80; }
+    .test-badge.fail { background: #7f1d1d; color: #f87171; }
+    .test-badge.pending { background: #1e293b; color: #94a3b8; }
+
+    /* -- Protocol Log ----------------------------------------------- */
+    #log-header {
+      padding: 5px 16px;
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: rgba(255,255,255,0.35);
+      background: rgba(0,0,0,0.3);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+      flex-shrink: 0;
+    }
+    #protocol-log {
+      flex: 1;
+      overflow-y: auto;
+      padding: 6px 16px;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 10px;
+      line-height: 1.65;
+    }
+    #protocol-log::-webkit-scrollbar { width: 4px; }
+    #protocol-log::-webkit-scrollbar-thumb { background: #1e293b; border-radius: 2px; }
+
+    .log-entry { padding: 1px 0; border-bottom: 1px solid rgba(255,255,255,0.03); }
+    .log-entry .ts { color: rgba(255,255,255,0.25); margin-right: 6px; }
+    .log-entry.event .msg { color: #60a5fa; }
+    .log-entry.action .msg { color: #a78bfa; }
+    .log-entry.error .msg { color: #f87171; }
+    .log-entry.info .msg { color: rgba(255,255,255,0.55); }
+    .log-entry.ok .msg { color: #4ade80; }
+  </style>
+</head>
+<body>
+
+  <!-- Ad Banner -->
+  <div id="ad-banner">
+    <div class="brand-wrap">
+      <div class="brand">SHARC Placement Test</div>
+      <div class="brand-sub">Native SHARC SDK - No Bridge</div>
+    </div>
+  </div>
+
+  <!-- Live State Display -->
+  <div id="ad-state">
+    <div class="state-item">
+      <span class="state-label">container:</span>
+      <span class="state-value" id="disp-container-state">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">dims:</span>
+      <span class="state-value" id="disp-dimensions">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">pos:</span>
+      <span class="state-value" id="disp-position">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">constraints:</span>
+      <span class="state-value" id="disp-constraints">--</span>
+    </div>
+  </div>
+
+  <!-- Creative Controls -->
+  <div id="ad-controls">
+    <button class="ad-btn" onclick="testResize320x480()">Resize 320x480</button>
+    <button class="ad-btn" onclick="testResizeWithOffset()">Resize+Offset</button>
+    <button class="ad-btn" onclick="testMaximize()">Maximize</button>
+    <button class="ad-btn" onclick="testRestore()">Restore</button>
+    <button class="ad-btn" onclick="testQueryConstraints()">Query Constraints</button>
+    <button class="ad-btn" onclick="testResizeWithAnimation()">Resize+Anim</button>
+    <button class="ad-btn success" onclick="testZeroDurationOrder()">Zero-Order</button>
+    <button class="ad-btn" onclick="testGetPlacementOptions()">Get Placement</button>
+    <button class="ad-btn danger" onclick="clearLog()">Clear Log</button>
+  </div>
+
+  <!-- Test Results -->
+  <div id="test-results">
+    <span class="test-badge pending" id="result-resize">resize: --</span>
+    <span class="test-badge pending" id="result-offset">offset: --</span>
+    <span class="test-badge pending" id="result-maximize">maximize: --</span>
+    <span class="test-badge pending" id="result-restore">restore: --</span>
+    <span class="test-badge pending" id="result-constraints">constraints: --</span>
+    <span class="test-badge pending" id="result-animation">animation: --</span>
+    <span class="test-badge pending" id="result-zero-order">zero-order: --</span>
+  </div>
+
+  <div id="log-header">SHARC Placement Event Log</div>
+
+  <!-- Protocol Log -->
+  <div id="protocol-log">
+    <div class="log-entry info">
+      <span class="ts">[init]</span>
+      <span class="msg">Placement test creative loaded. Waiting for SHARC SDK...</span>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/examples/test/test-placement-creative.js
+++ b/examples/test/test-placement-creative.js
@@ -300,6 +300,111 @@
       });
     };
 
+    /* -- Edge scenario tests ---------------------------------------- */
+
+    window.testResizeWhileResized = function testResizeWhileResized() {
+      logEntry('action', 'Resize to 320x480, then resize to 300x250 without restore');
+      SHARC.requestPlacementChange({
+        intent: 'resize',
+        targetDimensions: { width: 320, height: 480 },
+        closeRegion: { position: 'top-right', size: 50 }
+      }).then(function (result) {
+        logEntry('info', 'First resize resolved. Now resizing to 300x250...');
+        return SHARC.requestPlacementChange({
+          intent: 'resize',
+          targetDimensions: { width: 300, height: 250 },
+          closeRegion: { position: 'top-right', size: 50 }
+        });
+      }).then(function (result) {
+        logEntry('ok', 'Second resize resolved (same-intent re-entry allowed): ' + JSON.stringify(result));
+        setResult('result-resize2', true, 'Same-intent re-entry works');
+        updateDisplay(result);
+      }).catch(function (err) {
+        logEntry('error', 'Resize-while-resized failed: ' + JSON.stringify(err));
+        setResult('result-resize2', false, (err && err.message) || String(err));
+      });
+    };
+
+    window.testMaxWhileResized = function testMaxWhileResized() {
+      logEntry('action', 'Resize first, then maximize without restore (should reject)');
+      SHARC.requestPlacementChange({
+        intent: 'resize',
+        targetDimensions: { width: 320, height: 480 },
+        closeRegion: { position: 'top-right', size: 50 }
+      }).then(function (result) {
+        logEntry('info', 'Resized. Now attempting maximize without restore...');
+        return SHARC.requestPlacementChange({
+          intent: 'maximize'
+        });
+      }).then(function (result) {
+        logEntry('error', 'Maximize should have been rejected but resolved: ' + JSON.stringify(result));
+        setResult('result-max-resized', false, 'Should have rejected');
+      }).catch(function (err) {
+        logEntry('ok', 'Correctly rejected maximize-while-resized: ' + JSON.stringify(err));
+        var passed = err && err.errorCode === 2203;
+        setResult('result-max-resized', passed, (err && err.message) || String(err));
+        // Clean up: restore
+        SHARC.requestPlacementChange({ intent: 'restore' }).catch(function () {});
+      });
+    };
+
+    window.testTransitionEnd = function testTransitionEnd() {
+      logEntry('action', 'Resize with transition hint, listen for placementTransitionEnd');
+      var gotEnd = false;
+      var listener = function (data) {
+        gotEnd = true;
+        logEntry('ok', 'placementTransitionEnd received: ' + JSON.stringify(data));
+        setResult('result-transend', true, 'Event fired');
+      };
+      SHARC.on('placementTransitionEnd', listener);
+      SHARC.requestPlacementChange({
+        intent: 'resize',
+        targetDimensions: { width: 320, height: 480 },
+        closeRegion: { position: 'top-right', size: 50 },
+        transition: { duration: 200, easing: 'ease-out' }
+      }).then(function () {
+        // Wait for the transition end event (up to 1 second)
+        setTimeout(function () {
+          if (!gotEnd) {
+            logEntry('error', 'placementTransitionEnd not received within 1s');
+            setResult('result-transend', false, 'Event not received');
+          }
+        }, 1000);
+      }).catch(function (err) {
+        logEntry('error', 'Resize rejected: ' + JSON.stringify(err));
+        setResult('result-transend', false, (err && err.message) || String(err));
+      });
+    };
+
+    window.testConstraintsShape = function testConstraintsShape() {
+      logEntry('action', 'Query constraints and verify payload has flat fields (not nested)');
+      if (typeof SHARC.getPlacementConstraints !== 'function') {
+        setResult('result-shape', false, 'API not available');
+        return;
+      }
+      SHARC.getPlacementConstraints().then(function (constraints) {
+        logEntry('info', 'Raw constraints: ' + JSON.stringify(constraints));
+        // Verify flat fields exist (not nested under a 'constraints' key)
+        var hasFlat = constraints.hasOwnProperty('allowedIntents') ||
+                      constraints.hasOwnProperty('maxWidth') ||
+                      constraints.hasOwnProperty('allowOffscreen');
+        var hasNested = constraints.hasOwnProperty('constraints');
+        if (hasFlat && !hasNested) {
+          logEntry('ok', 'Payload uses flat fields (correct)');
+          setResult('result-shape', true, 'Flat fields confirmed');
+        } else if (hasNested) {
+          logEntry('error', 'Payload uses nested constraints key (incorrect)');
+          setResult('result-shape', false, 'Nested shape detected');
+        } else {
+          logEntry('error', 'Payload has neither flat nor nested fields');
+          setResult('result-shape', false, 'Empty payload');
+        }
+      }).catch(function (err) {
+        logEntry('error', 'Constraints query failed: ' + JSON.stringify(err));
+        setResult('result-shape', false, (err && err.message) || String(err));
+      });
+    };
+
     logEntry('info', 'Placement test creative initialized.');
   }
 

--- a/examples/test/test-placement-creative.js
+++ b/examples/test/test-placement-creative.js
@@ -1,0 +1,226 @@
+// WARNING: __SHARC_TEST_placementCreativeInit is a SHARC test harness convention.
+// This creative also self-boots via SHARC.onReady() when loaded standalone.
+// See CREATIVE-AUTHORING.md.
+'use strict';
+
+// Self-boot path: when loaded standalone (not via wrapper), SHARC SDK is
+// available immediately via <script src> tags in the HTML.
+// Wrapper path: the wrapper calls __SHARC_TEST_placementCreativeInit() after
+// injecting DOM. Both paths converge in initPlacementCreative().
+
+(function () {
+
+  var initialized = false;
+
+  function initPlacementCreative() {
+    if (initialized) return;
+    initialized = true;
+
+    /* -- Logging helpers ------------------------------------------- */
+    var logEl = document.getElementById('protocol-log');
+
+    function logEntry(type, msg) {
+      var entry = document.createElement('div');
+      entry.className = 'log-entry ' + type;
+      var ts = new Date().toISOString().slice(11, 23);
+      entry.innerHTML =
+        '<span class="ts">[' + ts + ']</span>' +
+        '<span class="msg">' + escHtml(String(msg)) + '</span>';
+      logEl.appendChild(entry);
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    function escHtml(s) {
+      return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    window.clearLog = function clearLog() {
+      logEl.innerHTML = '';
+      logEntry('info', 'Log cleared.');
+    };
+
+    /* -- Test result helpers --------------------------------------- */
+    function setResult(id, passed, detail) {
+      var el = document.getElementById(id);
+      if (!el) return;
+      var label = id.replace('result-', '');
+      el.textContent = label + ': ' + (passed ? 'PASS' : 'FAIL');
+      el.className = 'test-badge ' + (passed ? 'pass' : 'fail');
+      logEntry(passed ? 'ok' : 'error', (passed ? 'PASS' : 'FAIL') + ' [' + label + '] ' + (detail || ''));
+    }
+
+    /* -- State display update ------------------------------------- */
+    function updateDisplay(placement) {
+      if (placement) {
+        var dimsEl = document.getElementById('disp-dimensions');
+        if (placement.width !== undefined && placement.height !== undefined) {
+          dimsEl.textContent = placement.width + 'x' + placement.height;
+        }
+        var posEl = document.getElementById('disp-position');
+        if (placement.x !== undefined && placement.y !== undefined) {
+          posEl.textContent = placement.x + ',' + placement.y;
+        }
+      }
+    }
+
+    /* -- SHARC event listeners ------------------------------------ */
+    SHARC.onReady(function (env, features) {
+      logEntry('ok', 'onReady called');
+      logEntry('info', '  env: version=' + (env && env.version));
+      if (features && features.length > 0) {
+        logEntry('info', '  features: ' + features.map(function (f) { return f.name || f; }).join(', '));
+      }
+      document.getElementById('disp-container-state').textContent = 'ready';
+      return Promise.resolve();
+    });
+
+    SHARC.onStart(function () {
+      logEntry('ok', 'onStart called');
+      document.getElementById('disp-container-state').textContent = 'active';
+      document.getElementById('disp-container-state').className = 'state-value ok';
+      return Promise.resolve();
+    });
+
+    SHARC.on('stateChange', function (state) {
+      logEntry('event', 'stateChange -> ' + state);
+      document.getElementById('disp-container-state').textContent = state;
+    });
+
+    SHARC.on('placementChange', function (placement) {
+      logEntry('event', 'placementChange: ' + JSON.stringify(placement));
+      updateDisplay(placement);
+    });
+
+    /* -- Test actions (exposed globally for onclick= buttons) ----- */
+
+    window.testResize320x480 = function testResize320x480() {
+      logEntry('action', 'requestPlacementChange({ intent: "resize", 320x480, closeRegion })');
+      SHARC.requestPlacementChange({
+        intent: 'resize',
+        targetDimensions: { width: 320, height: 480 },
+        closeRegion: { position: 'top-right', size: 50 }
+      }).then(function (result) {
+        logEntry('ok', 'resize resolved: ' + JSON.stringify(result));
+        var passed = true;
+        if (result && result.width) {
+          passed = (result.width === 320 && result.height === 480);
+        }
+        setResult('result-resize', passed, JSON.stringify(result));
+        updateDisplay(result);
+      }).catch(function (err) {
+        logEntry('error', 'resize rejected: ' + JSON.stringify(err));
+        setResult('result-resize', false, (err && err.message) || String(err));
+      });
+    };
+
+    window.testResizeWithOffset = function testResizeWithOffset() {
+      logEntry('action', 'requestPlacementChange({ intent: "resize", 320x480, targetPosition })');
+      SHARC.requestPlacementChange({
+        intent: 'resize',
+        targetDimensions: { width: 320, height: 480 },
+        targetPosition: { x: 10, y: -50 },
+        closeRegion: { position: 'top-right', size: 50 }
+      }).then(function (result) {
+        logEntry('ok', 'resize+offset resolved: ' + JSON.stringify(result));
+        setResult('result-offset', true, JSON.stringify(result));
+        updateDisplay(result);
+      }).catch(function (err) {
+        logEntry('error', 'resize+offset rejected: ' + JSON.stringify(err));
+        setResult('result-offset', false, (err && err.message) || String(err));
+      });
+    };
+
+    window.testMaximize = function testMaximize() {
+      logEntry('action', 'requestPlacementChange({ intent: "maximize" })');
+      SHARC.requestPlacementChange({
+        intent: 'maximize'
+      }).then(function (result) {
+        logEntry('ok', 'maximize resolved: ' + JSON.stringify(result));
+        setResult('result-maximize', true, JSON.stringify(result));
+        updateDisplay(result);
+      }).catch(function (err) {
+        logEntry('error', 'maximize rejected: ' + JSON.stringify(err));
+        setResult('result-maximize', false, (err && err.message) || String(err));
+      });
+    };
+
+    window.testRestore = function testRestore() {
+      logEntry('action', 'requestPlacementChange({ intent: "restore" })');
+      SHARC.requestPlacementChange({
+        intent: 'restore'
+      }).then(function (result) {
+        logEntry('ok', 'restore resolved: ' + JSON.stringify(result));
+        setResult('result-restore', true, JSON.stringify(result));
+        updateDisplay(result);
+      }).catch(function (err) {
+        logEntry('error', 'restore rejected: ' + JSON.stringify(err));
+        setResult('result-restore', false, (err && err.message) || String(err));
+      });
+    };
+
+    window.testQueryConstraints = function testQueryConstraints() {
+      logEntry('action', 'getPlacementConstraints()');
+      // NOTE: getPlacementConstraints() is a new API proposed in the architecture doc.
+      // If not yet implemented, this will error -- which is the expected behavior for
+      // testing prior to implementation.
+      if (typeof SHARC.getPlacementConstraints !== 'function') {
+        logEntry('error', 'SHARC.getPlacementConstraints is not a function (not yet implemented)');
+        setResult('result-constraints', false, 'API not yet available');
+        return;
+      }
+      SHARC.getPlacementConstraints().then(function (constraints) {
+        logEntry('ok', 'constraints: ' + JSON.stringify(constraints));
+        var el = document.getElementById('disp-constraints');
+        if (constraints) {
+          var parts = [];
+          if (constraints.maxWidth) parts.push('maxW:' + constraints.maxWidth);
+          if (constraints.maxHeight) parts.push('maxH:' + constraints.maxHeight);
+          if (constraints.allowedIntents) parts.push('intents:' + constraints.allowedIntents.join(','));
+          el.textContent = parts.join(' ') || 'none';
+        }
+        setResult('result-constraints', true, JSON.stringify(constraints));
+      }).catch(function (err) {
+        logEntry('error', 'constraints rejected: ' + JSON.stringify(err));
+        setResult('result-constraints', false, (err && err.message) || String(err));
+      });
+    };
+
+    window.testResizeWithAnimation = function testResizeWithAnimation() {
+      logEntry('action', 'requestPlacementChange({ intent: "resize", 320x480, transition })');
+      SHARC.requestPlacementChange({
+        intent: 'resize',
+        targetDimensions: { width: 320, height: 480 },
+        closeRegion: { position: 'top-right', size: 50 },
+        transition: { duration: 300, easing: 'ease-out' }
+      }).then(function (result) {
+        logEntry('ok', 'resize+anim resolved: ' + JSON.stringify(result));
+        setResult('result-animation', true, JSON.stringify(result));
+        updateDisplay(result);
+      }).catch(function (err) {
+        logEntry('error', 'resize+anim rejected: ' + JSON.stringify(err));
+        setResult('result-animation', false, (err && err.message) || String(err));
+      });
+    };
+
+    window.testGetPlacementOptions = function testGetPlacementOptions() {
+      logEntry('action', 'getPlacementOptions()');
+      SHARC.getPlacementOptions().then(function (opts) {
+        logEntry('ok', 'placementOptions: ' + JSON.stringify(opts));
+        updateDisplay(opts);
+      }).catch(function (err) {
+        logEntry('error', 'getPlacementOptions rejected: ' + JSON.stringify(err));
+      });
+    };
+
+    logEntry('info', 'Placement test creative initialized.');
+  }
+
+  // Wrapper path: expose init callback
+  window.__SHARC_TEST_placementCreativeInit = initPlacementCreative;
+
+  // Self-boot path: if SHARC SDK is already on window, init immediately
+  if (typeof window.SHARC !== 'undefined' && typeof window.SHARC.onReady === 'function') {
+    initPlacementCreative();
+  }
+
+}());

--- a/examples/test/test-placement-creative.js
+++ b/examples/test/test-placement-creative.js
@@ -34,6 +34,10 @@
       return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     }
 
+    function formatSequence(sequence) {
+      return sequence.join(' -> ');
+    }
+
     window.clearLog = function clearLog() {
       logEl.innerHTML = '';
       logEntry('info', 'Log cleared.');
@@ -89,6 +93,10 @@
     SHARC.on('placementChange', function (placement) {
       logEntry('event', 'placementChange: ' + JSON.stringify(placement));
       updateDisplay(placement);
+    });
+
+    SHARC.on('placementTransitionEnd', function (payload) {
+      logEntry('event', 'placementTransitionEnd: ' + JSON.stringify(payload));
     });
 
     /* -- Test actions (exposed globally for onclick= buttons) ----- */
@@ -199,6 +207,86 @@
       }).catch(function (err) {
         logEntry('error', 'resize+anim rejected: ' + JSON.stringify(err));
         setResult('result-animation', false, (err && err.message) || String(err));
+      });
+    };
+
+    window.testZeroDurationOrder = function testZeroDurationOrder() {
+      var target = { width: 320, height: 480 };
+      var expected = ['resolve', 'placementChange', 'placementTransitionEnd'];
+      var sequence = [];
+      var finished = false;
+      var timeoutId = null;
+
+      function cleanup() {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        SHARC.off('placementChange', onPlacementChange);
+        SHARC.off('placementTransitionEnd', onPlacementTransitionEnd);
+      }
+
+      function finish(passed, detail) {
+        if (finished) return;
+        finished = true;
+        cleanup();
+        setResult('result-zero-order', passed, detail);
+      }
+
+      function maybeFinish() {
+        if (sequence.length < expected.length) return;
+        var passed = expected.every(function (step, idx) {
+          return sequence[idx] === step;
+        });
+        finish(passed, formatSequence(sequence));
+      }
+
+      function onPlacementChange(payload) {
+        var placement = payload && payload.placementUpdate;
+        if (!placement || placement.width !== target.width || placement.height !== target.height) return;
+        sequence.push('placementChange');
+        logEntry('info', 'zero-order sequence: ' + formatSequence(sequence));
+        maybeFinish();
+      }
+
+      function onPlacementTransitionEnd(payload) {
+        var dims = payload && payload.finalDimensions;
+        if (!dims || dims.width !== target.width || dims.height !== target.height) return;
+        sequence.push('placementTransitionEnd');
+        logEntry('info', 'zero-order sequence: ' + formatSequence(sequence));
+        maybeFinish();
+      }
+
+      logEntry('action', 'zero-duration ordering regression: resolve -> placementChange -> placementTransitionEnd');
+      (function markPending() {
+        var el = document.getElementById('result-zero-order');
+        if (!el) return;
+        el.textContent = 'zero-order: RUN';
+        el.className = 'test-badge pending';
+      }());
+
+      SHARC.requestPlacementChange({ intent: 'restore' }).catch(function () {
+        return null;
+      }).then(function () {
+        SHARC.on('placementChange', onPlacementChange);
+        SHARC.on('placementTransitionEnd', onPlacementTransitionEnd);
+        timeoutId = setTimeout(function () {
+          finish(false, formatSequence(sequence) || 'timed out waiting for sequence');
+        }, 1000);
+        return SHARC.requestPlacementChange({
+          intent: 'resize',
+          targetDimensions: target,
+          closeRegion: { position: 'top-right', size: 50 },
+          transition: { duration: 0, easing: 'ease-out' }
+        });
+      }).then(function (result) {
+        sequence.push('resolve');
+        logEntry('ok', 'zero-duration resolved: ' + JSON.stringify(result));
+        logEntry('info', 'zero-order sequence: ' + formatSequence(sequence));
+        maybeFinish();
+      }).catch(function (err) {
+        finish(false, (err && err.message) || String(err));
+        logEntry('error', 'zero-duration rejected: ' + JSON.stringify(err));
       });
     };
 

--- a/examples/test/test-safeframe-expand-creative.html
+++ b/examples/test/test-safeframe-expand-creative.html
@@ -1,0 +1,252 @@
+<!doctype html>
+<!--
+  test-safeframe-expand-creative.html - SafeFrame Directional Expand Test (DOM only)
+
+  Tests SafeFrame $sf.ext.expand() with directional offsets through the
+  SHARC SafeFrame bridge. Exercises overlay expand, push rejection,
+  collapse, and callback status transitions.
+
+  This creative is loaded inside safeframe-wrapper.html which:
+    1. Injects window.$sf.ext via sharc-safeframe-bridge.js
+    2. Loads this file via XHR and injects the <body> DOM
+    3. Dynamically loads test-safeframe-expand-creative.js via <script src>
+    4. Calls window.__SHARC_TEST_sfCreativeInit() after the script loads
+
+  NOTE: This file contains DOM structure and styles ONLY.
+  All script logic lives in test-safeframe-expand-creative.js.
+  Do NOT add <script> tags here - they won't execute when injected via innerHTML.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SafeFrame Directional Expand Test</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0a1628;
+      color: #eee;
+      overflow: hidden;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* -- Ad Banner -------------------------------------------------- */
+    #ad-banner {
+      background: linear-gradient(135deg, #059669 0%, #0891b2 100%);
+      padding: 10px 16px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      min-height: 50px;
+      flex-shrink: 0;
+      user-select: none;
+    }
+    #ad-banner .brand {
+      font-size: 16px;
+      font-weight: 700;
+      color: #fff;
+    }
+    .brand-wrap { display: flex; flex-direction: column; gap: 2px; }
+    .brand-sub { font-size: 10px; color: rgba(255,255,255,0.65); }
+
+    /* -- Config Panel ----------------------------------------------- */
+    #config-panel {
+      background: rgba(0,0,0,0.4);
+      padding: 8px 16px;
+      font-size: 10px;
+      border-bottom: 1px solid rgba(255,255,255,0.08);
+      flex-shrink: 0;
+    }
+    .config-row {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      margin-bottom: 4px;
+      flex-wrap: wrap;
+    }
+    .config-row label {
+      color: rgba(255,255,255,0.5);
+      min-width: 20px;
+    }
+    .config-row input[type="number"] {
+      width: 55px;
+      background: #0f172a;
+      border: 1px solid rgba(255,255,255,0.2);
+      color: #fff;
+      padding: 3px 6px;
+      border-radius: 3px;
+      font-size: 10px;
+      font-family: monospace;
+    }
+
+    /* -- State Display ---------------------------------------------- */
+    #ad-state {
+      background: rgba(0,0,0,0.45);
+      padding: 6px 16px;
+      font-size: 10px;
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      flex-wrap: wrap;
+      border-bottom: 1px solid rgba(255,255,255,0.08);
+      flex-shrink: 0;
+    }
+    .state-item { display: flex; gap: 3px; align-items: center; }
+    .state-label { color: rgba(255,255,255,0.45); }
+    .state-value {
+      color: #059669;
+      font-weight: 700;
+      font-family: monospace;
+      font-size: 10px;
+    }
+    .state-value.ok { color: #4ade80; }
+    .state-value.warn { color: #fb923c; }
+    .state-value.err { color: #f87171; }
+
+    /* -- Controls --------------------------------------------------- */
+    #ad-controls {
+      padding: 8px 16px;
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+      flex-shrink: 0;
+      background: rgba(0,0,0,0.25);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+    }
+    .ad-btn {
+      background: #0d3349;
+      color: #fff;
+      border: 1px solid rgba(255,255,255,0.18);
+      padding: 5px 10px;
+      border-radius: 5px;
+      font-size: 10px;
+      cursor: pointer;
+      transition: background 0.15s;
+      white-space: nowrap;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+    }
+    .ad-btn:hover { background: #0d4a60; }
+    .ad-btn:active { background: #059669; }
+    .ad-btn.danger { border-color: #f87171; color: #f87171; }
+    .ad-btn.warn { border-color: #fb923c; color: #fb923c; }
+
+    /* -- Protocol Log ----------------------------------------------- */
+    #log-header {
+      padding: 5px 16px;
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: rgba(255,255,255,0.35);
+      background: rgba(0,0,0,0.3);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+      flex-shrink: 0;
+    }
+    #protocol-log {
+      flex: 1;
+      overflow-y: auto;
+      padding: 6px 16px;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 10px;
+      line-height: 1.65;
+    }
+    #protocol-log::-webkit-scrollbar { width: 4px; }
+    #protocol-log::-webkit-scrollbar-thumb { background: #1a3a4a; border-radius: 2px; }
+
+    .log-entry { padding: 1px 0; border-bottom: 1px solid rgba(255,255,255,0.03); }
+    .log-entry .ts { color: rgba(255,255,255,0.25); margin-right: 6px; }
+    .log-entry.event .msg { color: #60a5fa; }
+    .log-entry.action .msg { color: #a78bfa; }
+    .log-entry.error .msg { color: #f87171; }
+    .log-entry.info .msg { color: rgba(255,255,255,0.55); }
+    .log-entry.ok .msg { color: #4ade80; }
+    .log-entry.geom .msg { color: #34d399; }
+    .log-entry.focus .msg { color: #fbbf24; }
+
+    /* -- No-$sf fallback -------------------------------------------- */
+    #no-sf {
+      display: none;
+      padding: 20px;
+      text-align: center;
+      color: rgba(255,255,255,0.4);
+      font-size: 12px;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Ad Banner -->
+  <div id="ad-banner">
+    <div class="brand-wrap">
+      <div class="brand">SF Expand Test</div>
+      <div class="brand-sub">SafeFrame 1.1 Directional Expand</div>
+    </div>
+  </div>
+
+  <!-- Expand Offset Config -->
+  <div id="config-panel">
+    <div class="config-row">
+      <label>t:</label>
+      <input type="number" id="cfg-t" value="50">
+      <label>l:</label>
+      <input type="number" id="cfg-l" value="50">
+      <label>r:</label>
+      <input type="number" id="cfg-r" value="50">
+      <label>b:</label>
+      <input type="number" id="cfg-b" value="50">
+    </div>
+  </div>
+
+  <!-- Live State Display -->
+  <div id="ad-state">
+    <div class="state-item">
+      <span class="state-label">status:</span>
+      <span class="state-value" id="disp-status">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">inView%:</span>
+      <span class="state-value" id="disp-inview">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">focus:</span>
+      <span class="state-value" id="disp-focus">--</span>
+    </div>
+    <div class="state-item">
+      <span class="state-label">geom.self:</span>
+      <span class="state-value" id="disp-geom-self">--</span>
+    </div>
+  </div>
+
+  <!-- Controls -->
+  <div id="ad-controls">
+    <button class="ad-btn" onclick="testExpandOverlay()">expand overlay</button>
+    <button class="ad-btn warn" onclick="testExpandPush()">expand push</button>
+    <button class="ad-btn" onclick="testExpandNoOffsets()">expand (no offsets)</button>
+    <button class="ad-btn" onclick="testCollapse()">collapse()</button>
+    <button class="ad-btn" onclick="testStatus()">status()</button>
+    <button class="ad-btn" onclick="testGeom()">geom()</button>
+    <button class="ad-btn danger" onclick="clearLog()">Clear Log</button>
+  </div>
+
+  <div id="log-header">SafeFrame Expand Event Log</div>
+
+  <!-- Protocol Log -->
+  <div id="protocol-log">
+    <div class="log-entry info">
+      <span class="ts">[init]</span>
+      <span class="msg">SafeFrame expand creative loaded. Waiting for window.$sf...</span>
+    </div>
+  </div>
+
+  <div id="no-sf">
+    <strong>window.$sf not available.</strong><br>
+    Load via:<br>
+    <code>safeframe-wrapper.html?creative=test/test-safeframe-expand-creative.html</code>
+  </div>
+
+</body>
+</html>

--- a/examples/test/test-safeframe-expand-creative.js
+++ b/examples/test/test-safeframe-expand-creative.js
@@ -1,0 +1,170 @@
+// WARNING: __SHARC_TEST_sfCreativeInit is a SHARC test harness convention.
+// Real SafeFrame creatives do NOT use this pattern. See CREATIVE-AUTHORING.md.
+'use strict';
+
+window.__SHARC_TEST_sfCreativeInit = function init() {
+
+  /* -- Logging helpers --------------------------------------------- */
+  var logEl = document.getElementById('protocol-log');
+
+  function logEntry(type, msg) {
+    var entry = document.createElement('div');
+    entry.className = 'log-entry ' + type;
+    var ts = new Date().toISOString().slice(11, 23);
+    entry.innerHTML =
+      '<span class="ts">[' + ts + ']</span>' +
+      '<span class="msg">' + escHtml(String(msg)) + '</span>';
+    logEl.appendChild(entry);
+    logEl.scrollTop = logEl.scrollHeight;
+  }
+
+  function escHtml(s) {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  window.clearLog = function clearLog() {
+    logEl.innerHTML = '';
+    logEntry('info', 'Log cleared.');
+  };
+
+  /* -- Config readers ---------------------------------------------- */
+  function getExpandOffsets() {
+    return {
+      t: parseInt(document.getElementById('cfg-t').value, 10) || 0,
+      l: parseInt(document.getElementById('cfg-l').value, 10) || 0,
+      r: parseInt(document.getElementById('cfg-r').value, 10) || 0,
+      b: parseInt(document.getElementById('cfg-b').value, 10) || 0
+    };
+  }
+
+  /* -- State display update ---------------------------------------- */
+  function updateDisplay() {
+    var sf = window.$sf;
+    if (!sf || !sf.ext) return;
+
+    var statusEl = document.getElementById('disp-status');
+    var status = sf.ext.status();
+    statusEl.textContent = status;
+    statusEl.className = 'state-value ' +
+      (status === 'expanded' ? 'ok' :
+       status === 'collapsed' ? '' : 'warn');
+
+    var ivEl = document.getElementById('disp-inview');
+    var iv = sf.ext.inViewPercentage();
+    ivEl.textContent = iv + '%';
+    ivEl.className = 'state-value ' + (iv > 0 ? 'ok' : 'warn');
+
+    var focusEl = document.getElementById('disp-focus');
+    var focus = sf.ext.winHasFocus();
+    focusEl.textContent = String(focus);
+    focusEl.className = 'state-value ' + (focus ? 'ok' : '');
+
+    var geomObj = sf.ext.geom();
+    if (geomObj && geomObj.self) {
+      document.getElementById('disp-geom-self').textContent =
+        'w:' + geomObj.self.w + ' h:' + geomObj.self.h +
+        ' iv:' + (geomObj.self.iv !== undefined ? geomObj.self.iv.toFixed(2) : '?');
+    }
+  }
+
+  /* -- SafeFrame callback ------------------------------------------ */
+  function onSafeFrameEvent(status, data) {
+    switch (status) {
+      case 'geom-update':
+        logEntry('geom', 'geom-update -- iv:' +
+          (data && data.self ? data.self.iv.toFixed(2) : '?') +
+          ' w:' + (data && data.self ? data.self.w : '?') +
+          ' h:' + (data && data.self ? data.self.h : '?'));
+        break;
+      case 'expanded':
+        logEntry('ok', 'expanded -- w:' +
+          (data && data.info ? data.info.w : '?') +
+          ' h:' + (data && data.info ? data.info.h : '?') +
+          ' push:' + (data && data.info ? data.info.push : '?'));
+        break;
+      case 'collapsed':
+        logEntry('ok', 'collapsed');
+        break;
+      case 'failed':
+        logEntry('error', 'failed -- reason:' +
+          (data && data.reason ? data.reason : 'unknown'));
+        break;
+      case 'focus-change':
+        logEntry('focus', 'focus-change -- focus:' +
+          (data && data.focus !== undefined ? data.focus : '?'));
+        break;
+      default:
+        logEntry('info', 'callback: ' + status + ' -- ' + JSON.stringify(data));
+    }
+    updateDisplay();
+  }
+
+  /* -- Test actions ------------------------------------------------ */
+
+  window.testExpandOverlay = function testExpandOverlay() {
+    var sf = window.$sf;
+    if (!sf) return;
+    var offsets = getExpandOffsets();
+    var args = { t: offsets.t, l: offsets.l, r: offsets.r, b: offsets.b, push: false };
+    logEntry('action', '$sf.ext.expand(' + JSON.stringify(args) + ')');
+    sf.ext.expand(args);
+  };
+
+  window.testExpandPush = function testExpandPush() {
+    var sf = window.$sf;
+    if (!sf) return;
+    var offsets = getExpandOffsets();
+    var args = { t: offsets.t, l: offsets.l, r: offsets.r, b: offsets.b, push: true };
+    logEntry('action', '$sf.ext.expand(' + JSON.stringify(args) + ') -- expects failed callback');
+    sf.ext.expand(args);
+  };
+
+  window.testExpandNoOffsets = function testExpandNoOffsets() {
+    var sf = window.$sf;
+    if (!sf) return;
+    logEntry('action', '$sf.ext.expand({}) -- maximize (no directional offsets)');
+    sf.ext.expand({});
+  };
+
+  window.testCollapse = function testCollapse() {
+    var sf = window.$sf;
+    if (!sf) return;
+    logEntry('action', '$sf.ext.collapse()');
+    sf.ext.collapse();
+  };
+
+  window.testStatus = function testStatus() {
+    var sf = window.$sf;
+    if (!sf) return;
+    logEntry('info', '  $sf.ext.status() = "' + sf.ext.status() + '"');
+  };
+
+  window.testGeom = function testGeom() {
+    var sf = window.$sf;
+    if (!sf) return;
+    var g = sf.ext.geom();
+    logEntry('info', '  geom().win  = ' + JSON.stringify(g.win));
+    logEntry('info', '  geom().self = ' + JSON.stringify(g.self));
+    logEntry('info', '  geom().exp  = ' + JSON.stringify(g.exp));
+  };
+
+  /* -- Bootstrap --------------------------------------------------- */
+  (function bootstrap() {
+    var sf = window.$sf;
+
+    if (!sf || !sf.ext) {
+      logEntry('error', 'window.$sf not found. Load via safeframe-wrapper.html');
+      document.getElementById('no-sf').style.display = 'block';
+      return;
+    }
+
+    logEntry('ok', '$sf found -- specVersion: "' + (sf.specVersion || '?') + '"');
+    logEntry('info', '  $sf.ext.supports() = ' + JSON.stringify(sf.ext.supports()));
+    logEntry('info', '  $sf.ext.status()   = "' + sf.ext.status() + '"');
+
+    sf.ext.register(300, 250, onSafeFrameEvent);
+    logEntry('info', '  $sf.ext.register(300, 250, cb) called -- waiting for geom-update...');
+
+    updateDisplay();
+  }());
+};


### PR DESCRIPTION
## Summary

- **Intent-based placement changes** — `requestPlacementChange` with `resize`, `maximize`, `fullscreen`, `minimize`, `restore` intents, replacing the dimension-only model
- **Placement policy** — container-local enforcement of dimension limits, intent allowlists, close region requirements, offscreen control, and custom validators
- **Container-owned close button** — 50 DIP accessible close button rendered as DOM sibling outside the sandbox, with publisher customization and OMID friendly obstruction registration
- **Constraints query API** — `getPlacementConstraints()` (async) + `getCachedConstraints()` (sync) + `constraintsChange` event with reason field
- **Animated transitions** — `transform: scale()` with snap, 500ms cap, 5 CSS easing keywords, `placementTransitionEnd` event
- **MRAID resize wired end-to-end** — `mraid.resize()` maps to `requestPlacementChange`, close indicator injection removed
- **Phase 2 test creatives** — 4 test creatives (9 files) covering SHARC core, MRAID resize, MRAID compliance, SafeFrame expand
- **15 review fixes** from security, code, architecture, and frontend reviews
- **Follow-up hardening** — OMID friendly obstruction, placement rate limiting (2/sec), visualViewport for fullscreen, close button style hardening, edge scenario tests

### New protocol messages
- `SHARC:Creative:getPlacementConstraints`
- `SHARC:Container:placementConstraintsChange`
- `SHARC:Container:placementTransitionEnd`

### New feature strings
- `com.iabtechlab.sharc.placement.resize`
- `com.iabtechlab.sharc.placement.constraints`
- `com.iabtechlab.sharc.placement.animate`

### Breaking changes
- `requestPlacementChange` can now reject (was resolve-only) — only when publisher configures `placementPolicy`
- `allowOffscreen: false` now enforced (was silently ignored)

## Test plan

- [ ] Load `http://localhost:8765/examples/test/index.html`, select "Placement Change Test", drive all 10 buttons
- [ ] Load MRAID test harness, select "MRAID Resize Test", exercise setResizeProperties → resize → close lifecycle
- [ ] Load SafeFrame test harness, select "SafeFrame Expand Test", exercise overlay expand → collapse cycle, verify push expand rejection
- [ ] Run MRAID 3.0 compliance runner — verify resize-positive suite passes alongside existing resize-negative
- [ ] Verify close button renders outside sandbox, is keyboard-focusable, meets 50 DIP minimum
- [ ] Verify restore resets iframe to original position and dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)