### PR TITLE
chore: 0.5.2 — release-path housekeeping (#27, #28)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
   publish:
     name: Publish package with npm provenance
     runs-on: ubuntu-latest
+    # Surface the secret presence as a string env var so step-level `if:`
+    # expressions can gate on it. GitHub Actions does not allow direct
+    # access to the `secrets` context inside step `if:` conditions.
+    env:
+      NPM_TOKEN_PRESENT: ${{ secrets.NPM_TOKEN != '' }}
 
     steps:
       - name: Check out repository
@@ -60,13 +65,13 @@ jobs:
         run: npm pack --dry-run
 
       - name: Publish to npm with provenance attestation
-        if: ${{ secrets.NPM_TOKEN != '' }}
+        if: env.NPM_TOKEN_PRESENT == 'true'
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Skip npm publish (NPM_TOKEN not configured)
-        if: ${{ secrets.NPM_TOKEN == '' }}
+        if: env.NPM_TOKEN_PRESENT != 'true'
         run: |
           echo "::notice title=npm publish skipped::NPM_TOKEN secret is not set on this repository. The tag, build, and dist artifact are still produced; add NPM_TOKEN to enable publishing on the next tag push. See RELEASING.md."
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-04-24
+
+### Fixed
+- **Release workflow validation (#28)** — `.github/workflows/release.yml` had
+  failed every push since 2026-04-23 (0s duration, "workflow file issue"
+  message) because GitHub Actions does not allow direct evaluation of the
+  `secrets` context inside step-level `if:` expressions. Surfaced
+  `secrets.NPM_TOKEN`'s presence as a job-level `env: NPM_TOKEN_PRESENT`
+  variable; publish vs skip steps now gate on the env var. Behavior is
+  unchanged: publish runs only when the token is set; otherwise a skip
+  notice is logged. Without this fix the `v*` tag publish path produced no
+  artifact.
+- **Browser harness `?build=dist` basePath (#27)** — `?build=dist` is the
+  documented mechanism for verifying the production bundle behaves
+  identically to source before tagging a release (see
+  `docs/distribution-design.md` §10 step 3). After the 0.5.1
+  `examples/test/` → `test/browser/` move, the dev-mode `basePath` was
+  repointed but the dist-mode branch was missed: `../dist/` from
+  `test/browser/` resolved to `/test/dist/` (does not exist). Repointed
+  `../dist/` → `../../dist/` in `test/browser/index.html` and
+  `test/browser/test-creative.html`. Verified by HTTP probes against the
+  dev server: both `/src/sharc-*.js` and `/dist/sharc-*.js` resolve.
+
 ## [0.5.1] - 2026-04-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SHARC (Secure HTML Ad Richmedia Container)
 
-![Package status](https://img.shields.io/badge/package-v0.5.1%20(publishable--ready%2C%20not%20yet%20published)-informational)
+![Package status](https://img.shields.io/badge/package-v0.5.2%20(publishable--ready%2C%20not%20yet%20published)-informational)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/InteractiveAdvertisingBureau/SHARC/actions/workflows/ci.yml/badge.svg)](https://github.com/InteractiveAdvertisingBureau/SHARC/actions/workflows/ci.yml)
 
@@ -43,9 +43,9 @@ SHARC is packaged as one npm package with versioned subpath exports:
 
 After the package is published, public CDN URL patterns should mirror those entry points and the current `dist/` filenames:
 
-- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.1/dist/sharc-container.js`
-- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.1/dist/sharc-creative.js`
-- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.1/dist/sharc-protocol.js`
+- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.2/dist/sharc-container.js`
+- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.2/dist/sharc-creative.js`
+- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.2/dist/sharc-protocol.js`
 
 Versioning guidance:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iabtechlab/sharc",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol",
   "type": "module",
   "files": [

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -26,7 +26,7 @@
  * container.load();
  * ```
  *
- * @version 0.5.1
+ * @version 0.5.2
  */
 
 'use strict';

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -34,7 +34,7 @@
  * </script>
  * ```
  *
- * @version 0.5.1
+ * @version 0.5.2
  */
 
 'use strict';

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -14,7 +14,7 @@
  *   3. sharc-mraid-bridge.js → window.mraid (this file)
  *   4. <MRAID creative>
  *
- * @version 0.5.1
+ * @version 0.5.2
  * @see mraid-bridge-design.md
  */
 

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -28,7 +28,7 @@
  *   - creativeType and impressionType MUST be set before impressionOccurred()
  *   - AdSession must be started before any events are fired
  *
- * @version 0.5.1
+ * @version 0.5.2
  * @see https://iabtechlab.com/standards/open-measurement-sdk/
  * @see https://github.com/IABTechLab/SHARC
  */

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -13,7 +13,7 @@
  *
  * Both extend SHARCProtocolBase which provides the shared message bus.
  *
- * @version 0.5.1
+ * @version 0.5.2
  * @see https://github.com/IABTechLab/SHARC
  */
 
@@ -27,7 +27,7 @@
 // ---------------------------------------------------------------------------
 
 /** Current SHARC spec version this implementation conforms to. */
-const SHARC_VERSION = '0.5.1';
+const SHARC_VERSION = '0.5.2';
 
 /**
  * Protocol-level message types.

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -19,7 +19,7 @@
  *   - exp-push (push expand) — deferred to v2; fires 'failed' callback
  *   - $sf.ext.cookie() — permanently excluded; fires 'failed' callback
  *
- * @version 0.5.1
+ * @version 0.5.2
  * @see safeframe-bridge-design.md
  */
 

--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -502,7 +502,7 @@
 (function() {
   const urlParams = new URLSearchParams(window.location.search);
   const useDist = urlParams.has('build') && urlParams.get('build') === 'dist';
-  const basePath = useDist ? '../dist/' : '../../src/';
+  const basePath = useDist ? '../../dist/' : '../../src/';
   
   const scripts = [
     'sharc-protocol.js',

--- a/test/browser/test-creative.html
+++ b/test/browser/test-creative.html
@@ -159,7 +159,7 @@
 (function() {
   const urlParams = new URLSearchParams(window.location.search);
   const useDist = urlParams.has('build') && urlParams.get('build') === 'dist';
-  const basePath = useDist ? '../dist/' : '../../src/';
+  const basePath = useDist ? '../../dist/' : '../../src/';
   
   window.SHARC_BUILD = useDist ? 'dist' : 'dev';
   


### PR DESCRIPTION
## Summary
Two small release-path bug fixes blocking the 0.5.x verification + publish flow. Lands as 0.5.2 patch release before 0.6.0 observability work begins.

- **#28** — `release.yml` failed validation on every push since 2026-04-23 (`secrets.*` not allowed in step `if:`). Surfaces `NPM_TOKEN`'s presence via job-level `env: NPM_TOKEN_PRESENT`; publish vs skip steps now gate on the env var.
- **#27** — `?build=dist` basePath was missed during the 0.5.1 `examples/test/` → `test/browser/` move. Repointed `../dist/` → `../../dist/` in `test/browser/index.html` and `test/browser/test-creative.html`. The `?build=dist` mode is the documented way to verify built bundle parity (`docs/distribution-design.md` §10 step 3) and was silently broken.

## Verification
- `npm run build` — green
- `npm run test:smoke` — 6/6 imports green
- `npm run test:treeshake` — all subpath bundles green
- HTTP probes against the dev server — both `/src/sharc-*.js` (dev mode) and `/dist/sharc-*.js` (dist mode) resolve

## Commits
1. `f999038` fix(ci): surface NPM_TOKEN presence via env var so release.yml validates
2. `37564af` fix(test): repoint ?build=dist basePath after test/browser/ relocation
3. `0723798` chore(release): 0.5.2

## Out of scope
- Provisioning the `NPM_TOKEN` secret itself — tracked separately as #19; admin action, not a code change. The fix here lets the workflow run without the token (logs a skip notice) so verification can proceed independently.
- Migration to JSDoc-driven type emission for typed bridges — tracked as #29 for 0.5.3.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run test:smoke` passes
- [x] `npm run test:treeshake` passes
- [ ] CI run on this PR is green (workflow validation must pass on push of PR commits)
- [ ] After merge + tag `v0.5.2`, release workflow run starts (≠ 0s) — proves #28 fix works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)