### PR TITLE
chore(types): tighten OMID ambients + @private internal fields (post-#31 polish)

### DIFF
--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -181,6 +181,7 @@ class SHARCContainer {
      * Extension plugin instances.
      * Each may contribute a feature name, inject markup, and/or require cleanup.
      * @type {Array}
+     * @private
      */
     this._extensions = extensions;
 
@@ -189,6 +190,7 @@ class SHARCContainer {
      * Accepts either plain feature name strings or descriptor objects.
      * Extension-contributed features are merged in at session time, but only as feature names.
      * @type {Array<string | {name: string, version?: string}>}
+     * @private
      */
     this._explicitSupportedFeatures = supportedFeatures;
 
@@ -198,30 +200,29 @@ class SHARCContainer {
     /** @type {boolean} */
     this.autoStart = autoStart;
 
-    /** Callbacks */
-    this._onStateChange = onStateChange || null;
-    this._onClose = onClose || null;
-    this._onError = onError || null;
-    this._onNavigation = onNavigation || null;
-    this._onInteraction = onInteraction || null;
-    this._onMessage = onMessage || null;
+    /** @private */ this._onStateChange = onStateChange || null;
+    /** @private */ this._onClose = onClose || null;
+    /** @private */ this._onError = onError || null;
+    /** @private */ this._onNavigation = onNavigation || null;
+    /** @private */ this._onInteraction = onInteraction || null;
+    /** @private */ this._onMessage = onMessage || null;
 
-    /** @type {HTMLIFrameElement|null} */
+    /** @type {HTMLIFrameElement|null} @private */
     this._iframe = null;
 
-    /** @type {SHARCContainerProtocol} */
+    /** @type {SHARCContainerProtocol} @private */
     this._protocol = new SHARCContainerProtocol();
 
-    /** @type {SHARCStateMachine} */
+    /** @type {SHARCStateMachine} @private */
     this._stateMachine = new SHARCStateMachine(ContainerStates.LOADING);
 
-    /** Active timeout handles (for cleanup). @type {Object.<string,number>} */
+    /** Active timeout handles (for cleanup). @type {Object.<string,number>} @private */
     this._timeouts = {};
 
-    /** Whether a close has been requested. @type {boolean} */
+    /** Whether a close has been requested. @type {boolean} @private */
     this._closeRequested = false;
 
-    /** Whether _terminate() has already been called. @type {boolean} */
+    /** Whether _terminate() has already been called. @type {boolean} @private */
     this._terminated = false;
 
     // Wire up state machine → callback
@@ -230,23 +231,24 @@ class SHARCContainer {
     });
 
     // Wire up page lifecycle listeners (for web browser state tracking)
-    this._pageFocusHandler = this._onPageFocus.bind(this);
-    this._pageBlurHandler = this._onPageBlur.bind(this);
-    this._visibilityHandler = this._onVisibilityChange.bind(this);
-    this._freezeHandler = this._onFreeze.bind(this);
-    this._resumeHandler = this._onResume.bind(this);
+    /** @private */ this._pageFocusHandler = this._onPageFocus.bind(this);
+    /** @private */ this._pageBlurHandler = this._onPageBlur.bind(this);
+    /** @private */ this._visibilityHandler = this._onVisibilityChange.bind(this);
+    /** @private */ this._freezeHandler = this._onFreeze.bind(this);
+    /** @private */ this._resumeHandler = this._onResume.bind(this);
 
-    this._initiallyVisible = visible;
+    /** @private */ this._initiallyVisible = visible;
 
     // Debounced handler for viewport changes that may affect placement constraints
-    this._constraintsDebounceTimer = null;
-    this._constraintsResizeHandler = this._onConstraintsRelevantResize.bind(this);
-    this._constraintsOrientationHandler = this._onConstraintsRelevantOrientation.bind(this);
+    /** @private */ this._constraintsDebounceTimer = null;
+    /** @private */ this._constraintsResizeHandler = this._onConstraintsRelevantResize.bind(this);
+    /** @private */ this._constraintsOrientationHandler = this._onConstraintsRelevantOrientation.bind(this);
 
     /**
      * Last placement payload sent via notifyPlacementChange().
      * Used by _syncPlacementState() to skip redundant sends.
      * @type {Object|null}
+     * @private
      */
     this._lastSentPlacement = null;
 
@@ -255,6 +257,7 @@ class SHARCContainer {
      * before loading via srcdoc. Opt-in only — see options.useMarkupInjection JSDoc.
      * Default: false (publisher-page OM SDK loading, Option 2).
      * @type {boolean}
+     * @private
      */
     this._useMarkupInjection = useMarkupInjection;
 
@@ -262,6 +265,7 @@ class SHARCContainer {
      * Placement policy — container-local enforcement layer.
      * Never sent over the wire. When undefined, no policy enforcement occurs.
      * @type {Object|undefined}
+     * @private
      */
     this._placementPolicy = placementPolicy || undefined;
 
@@ -269,12 +273,14 @@ class SHARCContainer {
      * Publisher customization for the container-rendered close button.
      * Applied via Object.assign over defaults; minimum 50 DIP enforced.
      * @type {Object|null}
+     * @private
      */
     this._closeButtonStyles = closeButtonStyles || null;
 
     /**
      * The container-rendered close button DOM element (sibling to iframe).
      * @type {HTMLElement|null}
+     * @private
      */
     this._closeButton = null;
 
@@ -282,6 +288,7 @@ class SHARCContainer {
      * Placement type declared by the creative in createSession.
      * 'inline' (default) or 'interstitial'.
      * @type {string}
+     * @private
      */
     this._placementType = 'inline';
 
@@ -289,6 +296,7 @@ class SHARCContainer {
      * Tracks the current placement intent ('resize', 'expand', 'fullscreen', or null).
      * Used by close button click handler to determine restore vs close behavior.
      * @type {string|null}
+     * @private
      */
     this._currentIntent = null;
 
@@ -297,6 +305,7 @@ class SHARCContainer {
      * Used by restore to return to the original state, independent of
      * mutations that _handleRequestPlacementChange applies to environmentData.
      * @type {Object}
+     * @private
      */
     this._originalPlacement = { ...(this.environmentData.currentPlacement || {}) };
 
@@ -304,6 +313,7 @@ class SHARCContainer {
      * Snapshot of the iframe's CSS state before the first resize.
      * Restored on collapse to fix position reset bug.
      * @type {Object|null}
+     * @private
      */
     this._preResizeCSSState = null;
   }
@@ -758,7 +768,7 @@ class SHARCContainer {
     this._placementType = (pt === 'interstitial') ? 'interstitial' : 'inline';
 
     // Store the creative's SHARC version for diagnostics/compatibility logging
-    this._creativeVersion = (msg.args && msg.args.version) || null;
+    /** @private */ this._creativeVersion = (msg.args && msg.args.version) || null;
 
     // Build the merged supportedFeatures list:
     //   1. Explicit features passed via options.supportedFeatures
@@ -787,7 +797,7 @@ class SHARCContainer {
     ];
 
     // Cache for subsequent getFeatures() queries from the creative
-    this._mergedSupportedFeatures = mergedFeatures;
+    /** @private */ this._mergedSupportedFeatures = mergedFeatures;
 
     // Build the full init payload
     // Priority 2: Include iframe's absolute position so bridges can use it for resize/expand

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -107,42 +107,43 @@ class SHARCCreative {
       ? { trustedOrigin: cfg.trustedOrigin }
       : undefined;
 
-    /** @type {SHARCCreativeProtocol} */
+    /** @type {SHARCCreativeProtocol} @private */
     this._proto = new SHARCCreativeProtocol(protocolOptions);
 
-    /** Cached environment data from Container:init. @type {Object|null} */
+    /** Cached environment data from Container:init. @type {Object|null} @private */
     this._env = null;
 
-    /** Cached features from Container:init. @type {Array<string | {name: string, version?: string}>} */
+    /** Cached features from Container:init. @type {Array<string | {name: string, version?: string}>} @private */
     this._features = [];
 
-    /** Feature set for O(1) hasFeature lookup. @type {Set<string>} */
+    /** Feature set for O(1) hasFeature lookup. @type {Set<string>} @private */
     this._featureSet = new Set();
 
-    /** Cached placement constraints from last query or constraintsChange event. @type {Object|null} */
+    /** Cached placement constraints from last query or constraintsChange event. @type {Object|null} @private */
     this._cachedConstraints = null;
 
-    /** The onReady callback registered by the creative. @type {Function|null} */
+    /** The onReady callback registered by the creative. @type {Function|null} @private */
     this._onReadyCallback = null;
 
-    /** The onStart callback registered by the creative. @type {Function|null} */
+    /** The onStart callback registered by the creative. @type {Function|null} @private */
     this._onStartCallback = null;
 
     /**
      * User-registered event listeners (including 'close' handlers).
      * ALL close handlers participate in the watchdog (see _handleClose).
      * @type {Object.<string, Function[]>}
+     * @private
      */
     // Note: _closeHandler field removed. 'close' listeners live in _eventListeners['close']
     // so all registered handlers (not just the last) receive the watchdog guarantee.
 
-    /** User-registered event listeners. @type {Object.<string, Function[]>} */
+    /** User-registered event listeners. @type {Object.<string, Function[]>} @private */
     this._eventListeners = {};
 
-    /** Whether the creative has been initialized. @type {boolean} */
+    /** Whether the creative has been initialized. @type {boolean} @private */
     this._initialized = false;
 
-    /** Whether the creative has reached its internal terminated bookend. @type {boolean} */
+    /** Whether the creative has reached its internal terminated bookend. @type {boolean} @private */
     this._terminated = false;
 
     /** Placement type: 'inline' or 'interstitial'. Defaults to 'inline'. @type {string} */

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -20,22 +20,72 @@
 
 /**
  * OMID Session Client namespace — provided externally by the IAB OM SDK
- * service script. Declared loosely because the SDK is loaded at runtime
- * from a CDN URL and its surface is not authored in this repo.
+ * service script. Surface mirrors the IAB OM Web SDK 1.5+ public API.
+ * Used by the SHARC OMID bridge for viewability measurement.
  */
 declare namespace OmidSessionClient {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  type AdSession = any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  type Context = any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  type Partner = any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  type VastProperties = any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  type AdEvents = any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  type MediaEvents = any;
+  interface SessionEvent {
+    type: 'sessionStart' | 'sessionError' | 'sessionFinish';
+    data?: unknown;
+    timestamp?: number;
+  }
+
+  interface AdSession {
+    registerSessionObserver(observer: (event: SessionEvent) => void): void;
+    setCreativeType(creativeType: string): void;
+    setImpressionType(impressionType: string): void;
+    start(): void;
+    finish(): void;
+    addFriendlyObstruction(element: HTMLElement, purpose: string, reason: string): void;
+    removeFriendlyObstruction(element: HTMLElement): void;
+  }
+
+  interface VerificationScriptResource {
+    resourceUrl: string;
+    vendorKey?: string;
+    verificationParameters?: string;
+  }
+
+  class Partner {
+    constructor(name: string, version: string);
+    name: string;
+    version: string;
+  }
+
+  class Context {
+    constructor(partner: Partner, verificationScripts?: VerificationScriptResource[]);
+    setServiceScriptUrl(url: string): void;
+    setContentUrl(url: string): void;
+  }
+
+  class VastProperties {
+    constructor(isSkippable: boolean, skipOffset: number, isAutoPlay: boolean, placement: string);
+  }
+
+  const AdSession: { new (context: Context): AdSession };
+  const AdEvents: {
+    new (session: AdSession): {
+      loaded(vastProperties?: VastProperties): void;
+      impressionOccurred(): void;
+      skipped(): void;
+    };
+  };
+  const MediaEvents: {
+    new (session: AdSession): {
+      start(duration: number, volume: number): void;
+      pause(): void;
+      resume(): void;
+      complete(): void;
+      firstQuartile(): void;
+      midpoint(): void;
+      thirdQuartile(): void;
+      bufferStart(): void;
+      bufferFinish(): void;
+      playerStateChange(state: number | string): void;
+      volumeChange(volume: number): void;
+    };
+  };
+  const PlayerState: { readonly [stateName: string]: number };
 }
 
 /**
@@ -149,11 +199,11 @@ declare global {
 
     /**
      * OMID Session Client namespace, loaded from the OM SDK service script.
-     * Surface is opaque (loaded externally from a CDN); typed consumers should
-     * interact via the SHARC OMID bridge, not directly.
+     * Typed consumers should normally interact via the SHARC OMID bridge,
+     * but the namespace is exposed here for advanced integrations that need
+     * to inspect session state directly.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    OmidSessionClient?: any;
+    OmidSessionClient?: typeof OmidSessionClient;
 
     /** Set to true once installOmidBridge() has been called. */
     __sharcOmidInstalled?: boolean;


### PR DESCRIPTION
## Summary
Reviewer-approved follow-up to PR #31 (typed bridges). Two small polish items that materially improve the consumer-facing `.d.ts` surface that 0.5.3 just shipped.

This is the same `e118b8d` commit Jeffrey's reviewer already verified locally on the original branch — re-landed against `main` cleanly so it can ship under the `v0.5.3` tag.

## Changes

**#B — Tighten OMID ambient types** (`types/globals.d.ts`, internal-only)
Restored typed interfaces for `OmidSessionClient.{AdSession, Context, Partner, VastProperties, AdEvents, MediaEvents, PlayerState, SessionEvent, VerificationScriptResource}` that had been collapsed to `any` during the original PR. `Window.OmidSessionClient` is now `typeof OmidSessionClient` again.

**#C — `@private` JSDoc on internal fields** (Container + Creative)
Internal `_*` fields no longer leak into the consumer-facing IntelliSense surface:

| File | Before | After |
|---|---|---|
| `sharc-container.d.ts` | 34 internal members | **0** |
| `sharc-creative.d.ts` | 10 internal members | **0** |
| `sharc-mraid-bridge.d.ts` | 0 | 0 |
| `sharc-safeframe-bridge.d.ts` | 0 | 0 |
| `sharc-omid-bridge.d.ts` | 0 | 0 |
| `sharc-protocol.d.ts` | 24 | 24 *(deferred)* |

## Out of scope (deferred to follow-up issue)
`sharc-protocol.d.ts` retains its 24 internal members. The protocol is the shared base class with cross-class access patterns (`SHARCProtocolBase ↔ SHARCContainerProtocol ↔ SHARCCreativeProtocol`); cleanly partitioning `@private` vs `@protected` requires careful work that's not worth bundling here. Bridge implementers who subclass the protocol can deal with seeing internal members; standard consumers don't import `sharc-protocol` directly.

Reviewer's **#A** (ES6 class refactor of MRAID/SafeFrame) and **#D** (replace `({})` constructor cast) also remain deferred per the original scope discussion.

## Verification
- [x] `npm run build` — rollup + tsc green
- [x] `npm run test:smoke` — 6/6 imports
- [x] `npm run test:types` — consumer probe compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)