### PR TITLE
docs: improve external-readiness entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,55 @@
 # SHARC (Secure HTML Ad Richmedia Container)
 
-![Package status](https://img.shields.io/badge/package-v0.5.3%20(publishable--ready%2C%20not%20yet%20published)-informational)
+![Package status](https://img.shields.io/badge/package-v0.5.3%20(pre--publish)-informational)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/InteractiveAdvertisingBureau/SHARC/actions/workflows/ci.yml/badge.svg)](https://github.com/InteractiveAdvertisingBureau/SHARC/actions/workflows/ci.yml)
 
-Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol
+Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol reference implementation.
 
-> 📋 **This is the IAB Tech Lab SHARC reference implementation.**
->
-> For the full specification, API reference, and detailed design documents,
-> see the [documentation](docs/) directory or the [official documentation site](https://iabtechlab.github.io/SHARC/).
+> 📋 This repository is the current SHARC reference implementation and working specification set.
+> It is in active pre-1.0 development at package version `0.5.3` and is not yet published to npm.
+> Start with the curated docs index at [docs/README.md](docs/README.md) and the current state summary at [docs/current-status.md](docs/current-status.md).
 
 ## Overview
 
-SHARC is a secure container API for managed communication between an app webview or webpage and a served ad creative.
+SHARC is a secure container API for managed communication between a publisher-controlled container (iframe or WebView) and a served ad creative.
 
-**Goal**: _Write one ad; serve it anywhere._
+**Goal:** _Write one ad; serve it across supported SHARC environments._
 
-SHARC is built on the same premise as IAB Tech Lab's SafeFrame and MRAID standards. Unlike these two standards, SHARC provides cross-platform interoperability—web, mobile in-app, CTV, and more—with a single API surface.
+The current v1 reference implementation targets web iframes, iOS WKWebView, and Android WebView. Future scope such as CTV is discussed in design material, but is not part of the current supported implementation surface.
 
 ## Quick Start
 
-```bash
-# Available after the first npm publish
-npm install @iabtechlab/sharc
+### Current state
 
-# Use in your project
-import { sharcProtocol } from '@iabtechlab/sharc/sharc-protocol';
-import { SharcContainer } from '@iabtechlab/sharc/sharc-container';
-import { SharcCreative } from '@iabtechlab/sharc/sharc-creative';
+- **Today:** build from this repository and use the `dist/` artifacts locally.
+- **After first npm publish:** install `@iabtechlab/sharc` and use the same subpath entry points shown below.
+
+### ESM / bundler usage
+
+```bash
+npm install @iabtechlab/sharc
 ```
+
+```js
+import { SHARCContainer } from '@iabtechlab/sharc/sharc-container';
+import { SHARC } from '@iabtechlab/sharc/sharc-creative';
+```
+
+All public entry points ship generated `.d.ts` declarations, so TypeScript consumers get full IntelliSense and argument-shape checking on every subpath import — no separate `@types` package required.
+
+### Browser bundle usage
+
+```html
+<script src="./dist/sharc-protocol.js"></script>
+<script src="./dist/sharc-container.js"></script>
+<script src="./dist/sharc-creative.js"></script>
+```
+
+Browser globals:
+
+- `window.SHARC.Container` — container constructor
+- `window.SHARC` — creative API surface (`onReady`, `onStart`, `requestNavigation`, etc.)
 
 ## Distribution and URL Guidance
 
@@ -38,10 +58,11 @@ SHARC is packaged as one npm package with versioned subpath exports:
 - Container: `@iabtechlab/sharc/sharc-container`
 - Creative: `@iabtechlab/sharc/sharc-creative`
 - Protocol: `@iabtechlab/sharc/sharc-protocol`
+- Bridges: `@iabtechlab/sharc/sharc-mraid-bridge`, `@iabtechlab/sharc/sharc-safeframe-bridge`, `@iabtechlab/sharc/sharc-omid-bridge`
 
-**Note:** All modules ship as both IIFE (`.js` for `<script>` tags) and ESM (`.mjs` for bundlers).
+All public entry points build into `dist/` as ESM (`.mjs`) plus browser/IIFE bundles (`.js`).
 
-After the package is published, public CDN URL patterns should mirror those entry points and the current `dist/` filenames:
+After the package is published, public CDN URL patterns should mirror the current `dist/` filenames:
 
 - Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.3/dist/sharc-container.js`
 - Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.3/dist/sharc-creative.js`
@@ -57,36 +78,47 @@ Bridge public CDN URL policy is intentionally deferred for now. Treat bridge bun
 
 ## Documentation
 
-- **[Full Specification](docs/)** — Complete protocol specification and API reference
-- **[Architecture Overview](docs/architecture-overview.md)** — How the reference implementation works
-- **[API Reference](docs/api-reference.md)** — Detailed API documentation
-- **[MRAID Bridge](docs/design/mraid-bridge-design.md)** — MRAID 2.0/3.0 compatibility
-- **[SafeFrame Bridge](docs/design/safeframe-bridge-design.md)** — SafeFrame compatibility
+Start with the curated index, then dive into specifics:
+
+- **[Docs index](docs/README.md)** — curated guide to authoritative, maintainer, and archive material
+- **[Current status](docs/current-status.md)** — what's stable, what's pre-publish, current package version
+- **[API reference](docs/api-reference.md)** — detailed protocol and public API reference
+
+The [docs index](docs/README.md) lists everything else (architecture overview, bridge designs, change log, reviews, proposals).
 
 ## Repository Structure
 
 ```
 SHARC/
-├── dist/              # Built modules (ESM + IIFE)
-├── examples/          # Reference implementations and test harness
-├── docs/              # Full specification and design documents
+├── src/               # Reference implementation source
+├── dist/              # Built modules (ESM + browser/IIFE)
+├── docs/              # Specification, design, review, and research material
+├── test/browser/      # Browser test harness and reference creatives
+├── test/types/        # Type-consumer verification
+├── examples/          # Wrappers, bridge demos, and compliance vectors
 ├── CHANGELOG.md       # Version history
-├── LICENSE            # Apache 2.0
+├── SECURITY.md        # Security reporting and support policy
 └── README.md          # This file
 ```
 
 ## Examples and Test Harness
 
-The repository includes a local test harness for development:
+The repository includes a local browser test harness for development:
 
 ```bash
-# Start the development server
 npm run dev
-
-# Visit http://localhost:8765/test/browser/index.html
+# or: node server.cjs
 ```
 
-Use `?build=dist` to test with the production build:
+Main entry points:
+
+- `http://localhost:8765/test/browser/index.html` — core SHARC harness
+- `http://localhost:8765/test/browser/mraid-test.html` — MRAID bridge harness
+- `http://localhost:8765/test/browser/safeframe-test.html` — SafeFrame bridge harness
+- `http://localhost:8765/examples/omid-integration-test.html` — OMID bridge integration page
+
+Use `?build=dist` on the core harness to exercise built artifacts:
+
 ```http
 http://localhost:8765/test/browser/index.html?build=dist
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,14 @@
 
 ## Supported Versions
 
-SHARC is currently publishable-ready at `0.3.0`, but not yet publicly published to npm. Until the first public release, security fixes should be tracked against the current mainline development state.
+SHARC is currently in pre-1.0 development at package version `0.5.3` and is not yet publicly published to npm.
 
-| Version | Supported |
+Until the first public release, the project supports the current development line on `main` / the latest `0.5.x` source state in this repository. Earlier snapshots are not maintained as supported release lines, and there is no backport commitment yet.
+
+| Version / state | Supported |
 | ------- | --------- |
-| 0.3.x (current package line) | :white_check_mark: |
-| < 0.3.0 | :x: |
+| Current `main` / `0.5.x` development line | :white_check_mark: |
+| Earlier pre-release snapshots | :x: |
 
 ## Reporting a Vulnerability
 
@@ -38,11 +40,11 @@ When using SHARC, please follow these security best practices:
 
 ### Container Implementations
 
-- **Sandbox iframe containers**: Always use `sandbox` attributes with minimal permissions:
+- **Sandbox iframe containers**: Use the narrowest sandbox that still supports the ad experience. The current SHARC reference container uses:
   ```html
-  <iframe sandbox="allow-scripts allow-same-origin allow-forms allow-popups" ...>
+  <iframe sandbox="allow-scripts allow-forms allow-popups" ...>
   ```
-  Avoid `allow-same-origin` unless absolutely necessary, and never use `allow-scripts` without it.
+  `allow-same-origin` is intentionally excluded. In combination with `allow-scripts`, it can let a same-origin creative remove its own sandbox and escape isolation. `allow-popups-to-escape-sandbox` is also intentionally excluded.
 
 - **Content Security Policy (CSP)**: Implement a restrictive CSP that:
   - Only allows connections to known trusted origins
@@ -50,7 +52,7 @@ When using SHARC, please follow these security best practices:
   - Restricts media and script sources
   - Uses `strict-dynamic` where appropriate
 
-- **Origin validation**: Verify the `origin` header in `postMessage` events and only accept messages from expected publishers/ad networks.
+- **Origin and channel validation**: The SHARC reference path uses a transferred `MessageChannel` port after bootstrap; treat that private port as the primary trust boundary. If you implement any fallback `postMessage` path around SHARC, validate expected origins and do not send sensitive payloads to `*`.
 
 ### Creative Implementations
 
@@ -64,7 +66,8 @@ When using SHARC, please follow these security best practices:
 - **Keep dependencies updated**: Regularly review and update npm dependencies.
 - **Monitor for CVEs**: Subscribe to npm audit notifications for your dependencies.
 - **Code review**: Have security-minded peers review code changes before merging.
-- **Security scanning**: Consider integrating automated security scanning tools (e.g., Snyk, Dependabot).
+- **Security scanning**: Consider integrating automated security scanning tools (e.g., Dependabot or equivalent).
+- **Validate URLs**: Only allow approved navigation/tracker URL schemes (`https:` and, if required for legacy environments, `http:`).
 
 ## Security Headers
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,40 @@
+# SHARC Documentation Guide
+
+This directory contains a mix of current design-of-record documents, maintainer notes, and historical research.
+
+## Start Here
+
+- [current-status.md](./current-status.md) — concise project maturity, scope, and external-readiness summary
+- [getting-started.md](./getting-started.md) — practical setup and usage guidance for evaluators
+- [api-reference.md](./api-reference.md) — authoritative protocol and public API reference
+
+## Authoritative / Current Design Docs
+
+These are the best starting points for external readers and implementers:
+
+- [api-reference.md](./api-reference.md)
+- [architecture-design.md](./architecture-design.md)
+- [distribution-design.md](./distribution-design.md)
+- [design/mraid-bridge-design.md](./design/mraid-bridge-design.md)
+- [design/safeframe-bridge-design.md](./design/safeframe-bridge-design.md)
+- [test-creative-specs.md](./test-creative-specs.md)
+- [../CHANGELOG.md](../CHANGELOG.md) — version history (canonical record of what shipped when)
+
+## Maintainer / Contributor Orientation
+
+Useful when working on the reference implementation itself:
+
+- [architecture-overview.md](./architecture-overview.md)
+- [product-scope.md](./product-scope.md)
+- [github-metadata.md](./github-metadata.md)
+
+## Reviews, Proposals, and Research Archive
+
+These documents are valuable context, but many are time-bound or exploratory rather than normative:
+
+- [`reviews/`](./reviews) — audits, review snapshots, and analysis notes
+- [`proposals/`](./proposals) — change proposals and discussion drafts
+- [`research/`](./research) — background research, migration notes, and external references
+- [`strategy/`](./strategy) — planning and positioning material
+
+When in doubt, prefer the **Authoritative / Current Design Docs** list over archive material.

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -17,24 +17,24 @@ SHARC (Secure HTML Ad Rich-media Container) is an IAB Tech Lab ad-container stan
 
 | Path | Purpose |
 |---|---|
-| `README.md` | The current SHARC specification (HTML rendering). |
+| `README.md` | Top-level project overview and repo entry point. |
 | `docs/` | Design documents, API reference, bridge design, research, review artifacts. |
 | `src/sharc-*.js` | The JavaScript reference implementation (protocol core, container, creative API, and the MRAID / SafeFrame / OMID bridges). |
-| `test/browser/` | A browser-based test harness for exercising the container and bridges. |
+| `test/browser/` | Browser-based test harness pages and reference creatives. |
 | `examples/compliance-ads/` | MRAID 3.0 compliance test vectors. |
 | `examples/compliance-ads-safeframe/` | SafeFrame compliance test vectors. |
-| `dist/` | Built IIFE (`.js`) and ESM (`.mjs`) bundles produced by Rollup. |
-| `server.js` | A minimal static dev server for the test harness. Dev-only. |
+| `dist/` | Built browser/IIFE (`.js`) and ESM (`.mjs`) bundles produced by Rollup. |
+| `server.cjs` | Minimal static dev server for the harness. Dev-only. |
 | `CHANGELOG.md` | Keep a Changelog format; the canonical log of externally visible changes. |
 
-Contributors edit source files in `examples/` directly and verify changes by loading the test harness in a browser. A Rollup build step produces IIFE (`.js`) and ESM (`.mjs`) bundles in `dist/`. A smoke test (`node test-smoke.js`) verifies artifacts and ESM importability.
+Contributors edit source files in `src/` and the relevant test assets in `test/browser/` or `examples/`, then verify changes in the browser harness. A Rollup build step produces browser/IIFE (`.js`) and ESM (`.mjs`) bundles in `dist/`. Smoke and type-consumer checks live in `test-smoke.js`, `test-treeshake.js`, and `test/types/`.
 
 ---
 
 ## 2. Running the Test Harness
 
 ```bash
-node server.js
+node server.cjs
 ```
 
 Serves the repo root at `http://localhost:8765` (bound to `127.0.0.1`, CORS `*`). The main entry points:
@@ -49,13 +49,13 @@ Serves the repo root at `http://localhost:8765` (bound to `127.0.0.1`, CORS `*`)
 
 Verification is visual: drive the lifecycle with the UI controls and read the protocol trace in the log pane.
 
-`server.js` is **development-only**. It has an intentional path-traversal guard, binds to `127.0.0.1`, and sets permissive CORS headers — none of which is appropriate for production. Do not add production features to it.
+`server.cjs` is **development-only**. It has an intentional path-traversal guard, binds to `127.0.0.1`, and sets permissive CORS headers — none of which is appropriate for production. Do not add production features to it.
 
 ---
 
 ## 3. The Reference Implementation Stack
 
-The canonical implementation lives in `examples/`. The layering, from bottom up:
+The canonical implementation lives in `src/`, with test harness pages and reference creatives under `test/browser/`. The layering, from bottom up:
 
 ### 3.1 `sharc-protocol.js` — protocol core
 
@@ -211,4 +211,4 @@ Review and audit artifacts (`code-review.md`, `security-audit.md`, dated review 
 - **Feature strings are reverse-DNS namespaced** (e.g. `com.iabtechlab.sharc.audio`). Extensions auto-register them via `getFeatureName()`.
 - **Prefer extensions over core protocol changes.** New capabilities should land as a new feature string and an extension, not as a new core message type.
 - **Semver in `CHANGELOG.md`:** MAJOR for protocol or public API break, MINOR for backwards-compatible feature, PATCH for fix.
-- **Active reference creatives live under `test/browser/`.** The reference implementation is `src/sharc-*.js`.
+- **Active reference creatives live under `test/browser/`.** The reference implementation itself lives in `src/sharc-*.js`.

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -1,0 +1,61 @@
+# SHARC Current Status
+
+## Summary
+
+SHARC is an IAB Tech Lab reference implementation in active **pre-1.0** development.
+
+- Repository package version: `0.5.3`
+- npm publication status: **not yet published**
+- Current implementation scope: **web iframe**, **iOS WKWebView**, **Android WebView**
+- Current repo posture: suitable for technical evaluation and standards review; not yet presented here as a broadly adopted production release line
+
+## What Is Stable Enough to Read as Current
+
+The following are the most reliable descriptions of the present implementation:
+
+- [api-reference.md](./api-reference.md)
+- [architecture-design.md](./architecture-design.md)
+- bridge design docs under [`docs/design/`](./design)
+- the current source and generated `dist/` artifacts
+- [CHANGELOG.md](../CHANGELOG.md) — what shipped in `0.5.3` and earlier
+
+As of `0.5.3`, every public package subpath ships generated TypeScript declaration files (`.d.ts`) alongside its `.mjs` bundle. TypeScript consumers get full IntelliSense and compile-time argument validation when importing any subpath.
+
+## What to Treat Carefully
+
+This repository also includes proposals, research notes, and review snapshots that were kept for context. They are helpful, but they are not all normative or current.
+
+Use extra caution with:
+
+- dated review documents
+- proposal drafts
+- strategy material
+- research notes written before recent security and sandbox hardening
+
+## Using SHARC Today
+
+Until the first npm publish, external evaluators should treat this repo as the source of truth and use local builds.
+
+Supported package entry points are already defined for eventual publication:
+
+- `@iabtechlab/sharc/sharc-container`
+- `@iabtechlab/sharc/sharc-creative`
+- `@iabtechlab/sharc/sharc-protocol`
+- `@iabtechlab/sharc/sharc-mraid-bridge`
+- `@iabtechlab/sharc/sharc-safeframe-bridge`
+- `@iabtechlab/sharc/sharc-omid-bridge`
+
+## Security Model Snapshot
+
+For the web reference implementation, the container uses a sandboxed iframe with `allow-scripts allow-forms allow-popups` and intentionally excludes `allow-same-origin`.
+
+SHARC communication uses a transferred `MessageChannel` port after bootstrap. Navigation and tracker execution are expected to be mediated by the container.
+
+## External Readiness Notes
+
+For external and standards-facing review, the clearest framing today is:
+
+1. SHARC is real, implemented, and testable.
+2. The implementation is still pre-release and should be described that way.
+3. The authoritative documents are concentrated in a small subset of this repo.
+4. Historical review and research material is preserved for transparency, not because every file reflects current policy.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,662 +1,156 @@
-# SHARC Getting Started Guide
+# SHARC Getting Started
 
-**Version:** 1.0  
-**Last Updated:** 2026-04-03  
+**Audience:** container implementers and creative developers evaluating the current SHARC reference implementation.
 
-This guide covers two audiences:
-1. **[Container Implementers](#part-1-container-implementers)** — publishers and SSPs embedding ads
-2. **[Creative Developers](#part-2-creative-developers)** — ad developers building SHARC-enabled creatives
+## Before You Start
 
-Each part is self-contained. Read only what applies to you.
+SHARC is currently in active pre-1.0 development:
 
----
+- Current package version in this repo: `0.5.3`
+- npm package: **not yet published**
+- Current supported implementation scope: **web iframe**, **iOS WKWebView**, **Android WebView**
 
-## Part 1: Container Implementers
+Today, the practical way to evaluate SHARC is to build from this repository and use the generated `dist/` artifacts or the local browser harness.
 
-You are a publisher or SSP. You want to render SHARC-enabled ads in your web page or mobile app. Your job is to create the container — the secure environment that runs the ad.
+## Package Entry Points
 
-### What the Container Does
+The repository builds one package with subpath exports:
 
-- Creates a sandboxed iframe (web) or WebView (mobile)
-- Runs the SHARC handshake with the creative
-- Controls what the ad can and cannot do
-- Provides the close button
-- Handles navigation, placement changes, and state events
+- `@iabtechlab/sharc/sharc-container`
+- `@iabtechlab/sharc/sharc-creative`
+- `@iabtechlab/sharc/sharc-protocol`
+- `@iabtechlab/sharc/sharc-mraid-bridge`
+- `@iabtechlab/sharc/sharc-safeframe-bridge`
+- `@iabtechlab/sharc/sharc-omid-bridge`
 
-### Step 1: Include the Container Library
+When the package is published, those are the supported import paths.
 
-```html
-<script src="sharc-container.js"></script>
+## Local Evaluation Flow
+
+```bash
+npm install
+npm run build
+npm run dev
 ```
 
-Or as an ES module:
+Then open:
 
-```javascript
-import { SHARCContainer } from './sharc-container.js';
-```
+- `http://localhost:8765/test/browser/index.html` — core SHARC harness
+- `http://localhost:8765/test/browser/mraid-test.html` — MRAID bridge harness
+- `http://localhost:8765/test/browser/safeframe-test.html` — SafeFrame bridge harness
+- `http://localhost:8765/examples/omid-integration-test.html` — OMID bridge integration page
 
-### Step 2: Create the Container
+Use `?build=dist` on the core harness to validate the built artifacts.
 
-```javascript
+## TypeScript Support
+
+As of `0.5.3`, every public subpath ships a generated `.d.ts` declaration alongside its `.mjs` bundle. TypeScript consumers get IntelliSense and compile-time argument validation on `new SHARCContainer({...})`, every bridge constructor, and the creative API surface — no `@types/sharc` needed.
+
+## Container Usage
+
+### ESM / bundler
+
+```js
+import { SHARCContainer } from '@iabtechlab/sharc/sharc-container';
+
 const container = new SHARCContainer({
-  // Where to render the ad
-  element: document.getElementById('ad-slot'),
-
-  // The creative URL to load
-  creativeUrl: 'https://ad.example.com/creative.html',
-
-  // Placement information
-  placement: {
-    width: 320,
-    height: 50,
-    inline: true  // anchored in content (vs. overlay)
+  creativeUrl: 'https://ads.example.com/creative.html',
+  containerEl: document.getElementById('ad-slot'),
+  environmentData: {
+    currentPlacement: {
+      width: 320,
+      height: 50,
+      inline: true,
+    },
   },
-
-  // Optional: AdCOM data from your ad server
-  adcom: {
-    ad: adcomAdObject,
-    placement: adcomPlacementObject,
-    context: adcomContextObject
-  },
-
-  // Optional: SHARC version this container implements
-  version: '1.0.0'
-});
-```
-
-### Step 3: Start the Ad
-
-```javascript
-// start() returns a Promise that resolves when the ad is visible
-container.start()
-  .then(() => {
-    console.log('Ad is running');
-  })
-  .catch((error) => {
-    console.error('Ad failed to start:', error.code, error.message);
-    // Load a fallback ad, fill with house ad, etc.
-  });
-```
-
-### Step 4: Handle Events
-
-```javascript
-// State changes (active, passive, hidden, frozen)
-container.on('stateChange', (newState) => {
-  console.log('Container state:', newState);
-  // e.g., pause your video content when state is 'hidden'
+  autoStart: false,
 });
 
-// Ad closed (user clicked close, or creative requested close)
-container.on('close', () => {
-  console.log('Ad closed');
-  // Remove the ad slot, load next ad, etc.
-  container.destroy();
-});
-
-// Fatal error
-container.on('error', (error) => {
-  console.error('Ad error:', error.code, error.message);
-  container.destroy();
-  // Load fallback
-});
-
-// Creative navigation request (useful for click tracking)
-container.on('navigation', (navEvent) => {
-  console.log('Creative navigating to:', navEvent.url, 'type:', navEvent.target);
-  // Container handles the actual navigation; this is the event callback
-});
+container.load();
+// Later, after the creative resolves init:
+container.start();
 ```
 
-### Step 5: Handle Platform Lifecycle (Web)
-
-The container automatically monitors `document.visibilityState` and `window.focus` / `window.blur` events. You don't need to do anything for web. The container transitions state automatically:
-
-- Tab hidden → sends `stateChange: hidden`
-- Tab back in foreground → sends `stateChange: active`
-- Page freeze event → sends `stateChange: frozen`
-
-### Step 6: Handle Platform Lifecycle (Mobile — iOS WKWebView)
-
-Pass app lifecycle events through to the container:
-
-```swift
-// AppDelegate.swift
-
-func applicationWillResignActive(_ application: UIApplication) {
-    sharcContainer.notifyLifecycle(.passive)
-}
-
-func applicationDidEnterBackground(_ application: UIApplication) {
-    sharcContainer.notifyLifecycle(.hidden)
-}
-
-func applicationWillEnterForeground(_ application: UIApplication) {
-    sharcContainer.notifyLifecycle(.passive)  // visible, not yet focused
-}
-
-func applicationDidBecomeActive(_ application: UIApplication) {
-    sharcContainer.notifyLifecycle(.active)
-}
-```
-
-### Step 7: Handle Platform Lifecycle (Mobile — Android WebView)
-
-```kotlin
-// In your Activity:
-
-override fun onResume() {
-    super.onResume()
-    webView.onResume()
-    sharcContainer.notifyLifecycle(ContainerState.ACTIVE)
-}
-
-override fun onPause() {
-    super.onPause()
-    webView.onPause()
-    sharcContainer.notifyLifecycle(ContainerState.PASSIVE)
-}
-
-override fun onStop() {
-    super.onStop()
-    webView.pauseTimers()
-    sharcContainer.notifyLifecycle(ContainerState.HIDDEN)
-}
-
-override fun onStart() {
-    super.onStart()
-    webView.resumeTimers()
-}
-```
-
-### Complete Web Example
+### Browser bundle
 
 ```html
-<!DOCTYPE html>
-<html>
-<head>
-  <title>SHARC Ad Slot</title>
-  <script src="sharc-container.js"></script>
-</head>
-<body>
-
-  <div id="content">
-    <p>Publisher content here.</p>
-    
-    <!-- Ad slot -->
-    <div id="ad-slot-300x250" style="width:300px; height:250px;"></div>
-    
-    <p>More content here.</p>
-  </div>
-
-  <script>
-    const container = new SHARCContainer({
-      element: document.getElementById('ad-slot-300x250'),
-      creativeUrl: 'https://cdn.ad.example.com/ad-123.html',
-      placement: {
-        width: 300,
-        height: 250,
-        inline: true
-      },
-      version: '1.0.0'
-    });
-
-    container.on('close', () => {
-      document.getElementById('ad-slot-300x250').remove();
-      container.destroy();
-    });
-
-    container.on('error', (err) => {
-      console.warn('Ad failed:', err.code);
-      // Optionally request a replacement ad here
-      container.destroy();
-    });
-
-    container.start().catch(err => {
-      console.warn('Ad did not start:', err.code);
-    });
-  </script>
-
-</body>
-</html>
-```
-
-### Container Security Requirements
-
-The container library enforces these security properties by default. You should not disable them.
-
-**Sandboxed iframe:**
-
-```html
-<!-- The container creates this iframe internally -->
-<iframe
-  src="https://creative-origin.example.com/ad.html"
-  sandbox="allow-scripts"
-  style="border:0"
-></iframe>
-```
-
-> **Important:** `allow-same-origin` is intentionally **not** included in the sandbox attribute. Combining `allow-scripts` and `allow-same-origin` on a same-origin iframe allows the embedded document to remove its own `sandbox` attribute entirely — a complete sandbox escape. `MessageChannel` does **not** require `allow-same-origin`; the transferred port works correctly across origins without it.
->
-> Do not add `allow-same-origin` or `allow-popups-to-escape-sandbox` to this sandbox. If you need popups from creative navigation, handle them through `requestNavigation` instead.
-
-**Session ID validation:** The container validates the `sessionId` on `createSession` against UUID v4 format. Malformed IDs are rejected.
-
-**URL validation:** `requestNavigation` and `reportInteraction` tracker URIs are validated to allow only `https:` and `http:` schemes. All other schemes are rejected or dropped before any network request is made.
-
-**Rate limiting:** The container drops incoming messages that exceed 50 per second. Persistent violators receive error `2205`.
-
-**Pending response cap:** No more than 100 in-flight requests are tracked simultaneously. This prevents memory exhaustion from a misbehaving creative.
-
-**Origin validation:** The initial bootstrap `postMessage` uses `targetOrigin: '*'` by design — this message carries only the `MessagePort` and no sensitive data. All subsequent SHARC communication flows through the private `MessageChannel` port, which has no broadcast risk. Third-party scripts on the publisher page cannot intercept these messages.
-
-**No shared globals:** The creative runs in its own sandboxed browsing context. It cannot access `window.parent`, your cookies, localStorage, or any other data on your page.
-
-### Advertising Extensions
-
-If your container supports extensions (optional features), advertise them in the `features` config:
-
-```javascript
-const container = new SHARCContainer({
-  // ...
-  features: [
-    {
-      name: 'com.iabtechlab.sharc.audio',
-      version: '1.0',
-      handler: async (args) => {
-        // Handle audio requests from the creative
-        if (args.action === 'setVolume') {
-          myVideoPlayer.setVolume(args.level);
-        }
-        return { success: true };
-      }
-    }
-  ]
-});
-```
-
----
-
-## Part 2: Creative Developers
-
-You are building an ad. You want to use the SHARC API to resize, track interactions, handle clicks, and close cleanly.
-
-### The Two-Minute Version
-
-```html
-<!DOCTYPE html>
-<html>
-<head>
-  <script src="sharc-creative.js"></script>
-</head>
-<body>
-  <div id="ad">
-    <!-- Your ad content here -->
-    <img src="banner.jpg" id="banner" />
-  </div>
-
-  <script>
-    // 1. onReady fires after Container:init
-    // env = EnvironmentData (size, version, features, etc.)
-    SHARC.onReady(async (env, features) => {
-      // Prepare your ad. Load assets if needed.
-      // Set muted state if env.isMuted is true.
-      console.log('Container size:', env.currentPlacement.initialDefaultSize);
-      console.log('SHARC version:', env.version);
-    });
-
-    // 2. onStart fires after Container:startCreative
-    // Make your ad visible here.
-    SHARC.onStart(async () => {
-      document.getElementById('ad').style.display = 'block';
-    });
-
-    // 3. Handle click
-    document.getElementById('banner').addEventListener('click', async () => {
-      try {
-        await SHARC.requestNavigation({
-          url: 'https://advertiser.example.com/landing',
-          target: 'clickthrough'
-        });
-        // Container handled navigation (mobile). Nothing else to do.
-      } catch (err) {
-        if (err.code === 2105) {
-          // Container can't handle it (web). Open it ourselves.
-          window.open('https://advertiser.example.com/landing', '_blank');
-        }
-      }
-    });
-  </script>
-</body>
-</html>
-```
-
-That's it. The library handles `createSession`, the protocol handshake, message sequencing, and timeouts automatically.
-
-### Understanding the Creative Lifecycle
-
-```
-[Script loads]
-      │
-      ▼
-Creative sends createSession ──► Container resolves
-      │
-      ▼
-Container sends init
-      │
-SHARC.onReady(env, features) is called
-      │
-Your callback runs (load assets, check features, check muted state)
-      │
-Your callback returns / resolves promise
-      │
-Container sends startCreative
-      │
-SHARC.onStart() is called
-      │
-Your callback makes the ad visible
-      │
-      ▼
-[Ad is running]
-      │
-      ▼
-Container sends close
-      │
-Your close handler runs (fire trackers, animate close)
-      │
-      ▼
-[Container terminates the creative]
-```
-
-### Checking Features
-
-Use `SHARC.hasFeature()` (synchronous) to check what the container supports. Feature data is available as soon as `onReady` fires.
-
-```javascript
-SHARC.onReady(async (env, features) => {
-  // Check for audio controls
-  if (SHARC.hasFeature('com.iabtechlab.sharc.audio')) {
-    // Show audio toggle button
-    document.getElementById('audio-btn').style.display = 'block';
-  }
-
-  // Check for location (rare — requires user permission)
-  if (SHARC.hasFeature('com.iabtechlab.sharc.location')) {
-    const location = await SHARC.requestFeature('com.iabtechlab.sharc.location', {});
-    showNearbyOffers(location);
-  }
-});
-```
-
-### Handling Mute State
-
-Many mobile ad environments start muted. Check `env.isMuted` and configure your audio accordingly.
-
-```javascript
-SHARC.onReady(async (env, features) => {
-  const videoEl = document.getElementById('my-video');
-
-  if (env.isMuted) {
-    videoEl.muted = true;
-  } else if (env.volume !== undefined && env.volume >= 0) {
-    videoEl.volume = env.volume;
-  }
-});
-```
-
-### Resize (Expand/Collapse)
-
-```javascript
-// Expand the ad to max size
-document.getElementById('expand-btn').addEventListener('click', async () => {
-  try {
-    const result = await SHARC.requestPlacementChange({
-      intent: 'expand'
-    });
-    console.log('Expanded to:', result.placementUpdate.containerDimensions);
-    showExpandedContent();
-  } catch (err) {
-    console.warn('Expand failed:', err.message);
-    // Container rejected it. Stay at default size.
-  }
-});
-
-// Resize to specific dimensions
-document.getElementById('resize-btn').addEventListener('click', async () => {
-  try {
-    const result = await SHARC.requestPlacementChange({
-      intent: 'resize',
-      targetDimensions: { width: 320, height: 480 }
-    });
-    console.log('Resized to:', result.placementUpdate.containerDimensions);
-  } catch (err) {
-    console.warn('Resize failed:', err.message);
-  }
-});
-
-// Collapse back to default
-document.getElementById('collapse-btn').addEventListener('click', async () => {
-  await SHARC.requestPlacementChange({
-    intent: 'collapse'
-  });
-  showCollapsedContent();
-});
-```
-
-### Handling State Changes
-
-The container sends state updates when the user switches apps, locks the screen, etc. Use these to pause/resume your creative.
-
-Do your real pause and persistence work in `hidden`. Treat `frozen` as a reported outcome, not as a safe work phase, because JavaScript may already be suspended or about to stop.
-
-```javascript
-SHARC.on('stateChange', (state) => {
-  switch (state) {
-    case 'active':
-      resumeAnimations();
-      resumeVideo();
-      break;
-    case 'passive':
-    case 'hidden':
-      // Pause and save state here while JS still runs.
-      pauseAnimations();
-      pauseVideo();
-      saveSessionState();
-      break;
-    case 'frozen':
-      // Informational only. Do not rely on this for work.
-      // You should already have paused and saved in 'hidden'.
-      break;
-  }
-});
-```
-
-### Reporting Interactions
-
-Delegate tracker firing to the container. This is more reliable than firing from the creative (the container can retry, handle redirects, and maintain the log).
-
-```javascript
-// On ad view (for custom viewability or engagement tracking)
-SHARC.reportInteraction([
-  'https://tracking.example.com/view?id=abc123',
-  'https://another-tracker.com/pixel?ev=view'
-])
-.then((results) => {
-  console.log('Trackers fired:', results);
-});
-```
-
-### Requesting Close
-
-The container always shows a close button. If you want to close programmatically (e.g., after a countdown timer or at the end of the ad experience):
-
-```javascript
-// After ad completes:
-const closed = await SHARC.requestClose();
-// If the container rejects, the ad stays open but you can still wind down internally
-```
-
-### Running a Close Sequence
-
-When the user hits close (from the container's close button), you get a brief window to run a close animation or fire final trackers through the `Container:close` flow.
-
-```javascript
-SHARC.on('close', async () => {
-  // You have ~2 seconds. Be fast.
-  await fireClosingTrackers();
-  await playCloseAnimation();
-  // The container will terminate the creative after 2 seconds regardless
-});
-```
-
-### Signaling a Fatal Error
-
-If your creative cannot run (failed to load assets, wrong ad size, incompatible browser), tell the container so it can replace you with a fallback:
-
-```javascript
-SHARC.onReady(async (env, features) => {
-  const { width, height } = env.currentPlacement.initialDefaultSize;
-
-  if (width < 300 || height < 250) {
-    // Container is too small for this creative
-    SHARC.fatalError(2102, 'Need at least 300x250, got ' + width + 'x' + height);
-    return;
-  }
-
-  // ... normal init
-});
-```
-
-### Logging
-
-Use `SHARC.log()` to send debug messages to the container's console. This appears in test harnesses and dev tools.
-
-```javascript
-SHARC.log('Creative loaded. Targeting: ' + targetingLabel);
-SHARC.log('WARNING: Expected 300x250 but got smaller — resizing gracefully');
-```
-
-Messages prefixed with `"WARNING:"` signal spec deviations to container developers.
-
-### Full Example: Expandable Banner
-
-```html
-<!DOCTYPE html>
-<html>
-<head>
-  <title>SHARC Expandable Banner</title>
-  <script src="sharc-creative.js"></script>
-  <style>
-    body { margin: 0; padding: 0; overflow: hidden; }
-    #collapsed { width: 320px; height: 50px; background: #0066cc; color: white;
-                 display: flex; align-items: center; justify-content: space-between;
-                 padding: 0 10px; box-sizing: border-box; cursor: pointer; }
-    #expanded  { width: 320px; height: 480px; background: #fff; display: none; }
-    #expand-btn { font-size: 12px; }
-    #close-btn  { font-size: 12px; cursor: pointer; }
-  </style>
-</head>
-<body>
-
-<div id="collapsed">
-  <span>Tap to Expand</span>
-  <button id="expand-btn">▲ Expand</button>
-</div>
-
-<div id="expanded">
-  <img src="full-ad.jpg" id="ad-image" style="width:320px; height:420px;" />
-  <div style="display:flex; gap:10px; padding:10px;">
-    <button id="cta-btn" style="flex:1;">Shop Now</button>
-    <button id="collapse-btn">▼ Collapse</button>
-  </div>
-</div>
-
+<script src="./dist/sharc-protocol.js"></script>
+<script src="./dist/sharc-container.js"></script>
 <script>
-  let isExpanded = false;
-
-  SHARC.onReady(async (env, features) => {
-    SHARC.log('Expandable banner ready. Size: ' +
-      env.currentPlacement.initialDefaultSize.width + 'x' +
-      env.currentPlacement.initialDefaultSize.height);
-  });
-
-  SHARC.onStart(async () => {
-    document.getElementById('collapsed').style.display = 'flex';
-  });
-
-  SHARC.on('stateChange', (state) => {
-    if (state === 'hidden' && isExpanded) {
-      collapse(); // Auto-collapse while work is still allowed
+  const container = new window.SHARC.Container({
+    creativeUrl: '/creative.html',
+    containerEl: document.getElementById('ad-slot'),
+    environmentData: {
+      currentPlacement: { width: 320, height: 50, inline: true }
     }
   });
 
-  SHARC.on('close', async () => {
-    // Fire close tracker before termination
-    await SHARC.reportInteraction(['https://tracking.example.com/close']);
-  });
-
-  document.getElementById('expand-btn').addEventListener('click', expand);
-  document.getElementById('collapse-btn').addEventListener('click', collapse);
-
-  document.getElementById('cta-btn').addEventListener('click', async () => {
-    try {
-      await SHARC.requestNavigation({
-        url: 'https://advertiser.example.com/sale',
-        target: 'clickthrough'
-      });
-    } catch (err) {
-      if (err.code === 2105) {
-        window.open('https://advertiser.example.com/sale', '_blank');
-      }
-    }
-
-    await SHARC.reportInteraction([
-      'https://tracking.example.com/click?ev=cta'
-    ]);
-  });
-
-  async function expand() {
-    if (isExpanded) return;
-    await SHARC.requestPlacementChange({
-      intent: 'resize',
-      targetDimensions: { width: 320, height: 480 }
-    });
-    document.getElementById('collapsed').style.display = 'none';
-    document.getElementById('expanded').style.display = 'block';
-    isExpanded = true;
-
-    await SHARC.reportInteraction(['https://tracking.example.com/expand']);
-  }
-
-  async function collapse() {
-    if (!isExpanded) return;
-    await SHARC.requestPlacementChange({
-      intent: 'collapse'
-    });
-    document.getElementById('expanded').style.display = 'none';
-    document.getElementById('collapsed').style.display = 'flex';
-    isExpanded = false;
-  }
+  container.load();
 </script>
-
-</body>
-</html>
 ```
 
-### Checklist: Before You Serve
+## Creative Usage
 
-- [ ] Creative calls `SHARC.onReady()` and returns a resolved Promise when ready
-- [ ] Creative calls `SHARC.onStart()` and makes itself visible inside the callback
-- [ ] All navigation calls go through `SHARC.requestNavigation()` before opening a URL
-- [ ] Creative handles `stateChange` events (at minimum: pause on `hidden`, resume on `active`)
-- [ ] Creative handles `close` event (even if just firing trackers)
-- [ ] Creative calls `SHARC.fatalError()` for unrecoverable errors instead of silently breaking
-- [ ] Creative does NOT try to access `window.parent`, `document.cookie`, or page globals
+### ESM / bundler
 
----
+```js
+import { SHARC } from '@iabtechlab/sharc/sharc-creative';
 
-## Next Steps
+SHARC.onReady(async (env, features) => {
+  console.log('Container env:', env);
+  console.log('Supported features:', features);
+});
 
-- **Test your integration:** Use the SHARC test harness (`test/browser/index.html`) to verify the full message protocol.
-- **Check API details:** See [api-reference.md](./api-reference.md) for complete message specs.
-- **Coming from MRAID?** See [mraid-migration.md](./mraid-migration.md) for a direct mapping.
+SHARC.onStart(() => {
+  document.getElementById('ad-root').style.display = 'block';
+});
+```
+
+### Browser bundle
+
+```html
+<script src="./dist/sharc-protocol.js"></script>
+<script src="./dist/sharc-creative.js"></script>
+<script>
+  SHARC.onReady(async (env) => {
+    console.log('Ready with placement:', env.currentPlacement);
+  });
+
+  SHARC.onStart(() => {
+    document.getElementById('ad-root').style.display = 'block';
+  });
+</script>
+```
+
+Common creative APIs:
+
+- `SHARC.onReady(callback)`
+- `SHARC.onStart(callback)`
+- `SHARC.on(event, callback)`
+- `SHARC.requestNavigation({ url, target })`
+- `SHARC.requestPlacementChange({ intent, targetDimensions })`
+- `SHARC.requestClose()`
+- `SHARC.reportInteraction([...uris])`
+- `SHARC.fatalError(code, message)`
+
+## Security Model at a Glance
+
+The reference web container uses a sandboxed iframe with:
+
+```html
+<iframe sandbox="allow-scripts allow-forms allow-popups"></iframe>
+```
+
+Notably:
+
+- `allow-same-origin` is intentionally **not** used
+- SHARC uses a transferred `MessageChannel` port after bootstrap
+- Creatives should route navigation and tracker firing through the SHARC API rather than bypassing the container
+
+## Recommended Next Reading
+
+- [docs/current-status.md](./current-status.md) — project maturity and scope
+- [docs/api-reference.md](./api-reference.md) — authoritative public API and protocol details
+- [docs/architecture-overview.md](./architecture-overview.md) — maintainer orientation
+- [docs/design/mraid-bridge-design.md](./design/mraid-bridge-design.md)
+- [docs/design/safeframe-bridge-design.md](./design/safeframe-bridge-design.md)


### PR DESCRIPTION
## Summary
- tighten SHARC's external-facing docs for pre-1.0 / pre-publish clarity
- fix README quick-start, repo-layout, and test-harness references to match the current implementation
- align SECURITY.md with the actual sandbox model and supported-version reality
- add curated docs entry points via docs/README.md and docs/current-status.md
- refresh getting-started guidance so evaluators land on the current local-build and package-entry-point story

## Why
Recent implementation work made the repo materially more credible, but the top-level docs still had trust-breaking inconsistencies for an external standards audience. This PR is a surgical cleanup to make the current repo state easier to evaluate without overstating maturity.

## Verification
- npm run build

## Notes
- keeps the framing conservative: implemented and testable, but still pre-1.0 / not yet published to npm
- leaves historical research/review documents intact and instead curates the entry points so external readers land on the right material first