### PR TITLE
fix: 0.5.4 — placement-change dedup correctness (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-04-25
+
+### Fixed
+- **Placement-change dedup correctness (#6).** `_placementPayloadUnchanged`
+  in `SHARCContainer` previously compared only six geometric fields
+  (`width`, `height`, and the four `position` rect bounds). Any non-geometric
+  placement field — `inline`, `placementType`, `dataspec`, `data` — that
+  changed without geometry changing would be silently suppressed when
+  `_syncPlacementState()` ran on the next ACTIVE transition, so a creative
+  could miss a real placement update. Replaced with a full normalized
+  payload compare (`JSON.stringify` both sides). Tradeoff is one extra
+  potentially-redundant message in the rare property-order-shuffle case;
+  silent suppression of a real update is no longer possible.
+  Behavior unchanged when the payload is genuinely identical or when
+  geometry alone changes.
+- New regression test `test-placement-dedup.js` (run via `npm run test:placement`)
+  covers the bug and the four common non-geometric mutations (`inline`,
+  `dataspec`, `placementType`, `data`).
+
 ### Changed
 - **External-readiness documentation pass (#36).** Repointed the README, the
   new `docs/README.md` curated index, and `docs/current-status.md` toward

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SHARC (Secure HTML Ad Richmedia Container)
 
-![Package status](https://img.shields.io/badge/package-v0.5.3%20(pre--publish)-informational)
+![Package status](https://img.shields.io/badge/package-v0.5.4%20(pre--publish)-informational)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/InteractiveAdvertisingBureau/SHARC/actions/workflows/ci.yml/badge.svg)](https://github.com/InteractiveAdvertisingBureau/SHARC/actions/workflows/ci.yml)
 
@@ -64,9 +64,9 @@ All public entry points build into `dist/` as ESM (`.mjs`) plus browser/IIFE bun
 
 After the package is published, public CDN URL patterns should mirror the current `dist/` filenames:
 
-- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.3/dist/sharc-container.js`
-- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.3/dist/sharc-creative.js`
-- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.3/dist/sharc-protocol.js`
+- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.4/dist/sharc-container.js`
+- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.4/dist/sharc-creative.js`
+- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.4/dist/sharc-protocol.js`
 
 Versioning guidance:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iabtechlab/sharc",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol",
   "type": "module",
   "files": [
@@ -51,6 +51,7 @@
     "test": "npm run build && npm run size",
     "test:smoke": "node test-smoke.js",
     "test:treeshake": "node test-treeshake.js",
+    "test:placement": "node test-placement-dedup.js",
     "test:types": "tsc -p test/types/tsconfig.json",
     "regen:baseline": "node scripts/regen-mraid3-baseline.js",
     "lint": "eslint src/*.js --max-warnings=0",

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -26,7 +26,7 @@
  * container.load();
  * ```
  *
- * @version 0.5.3
+ * @version 0.5.4
  */
 
 'use strict';
@@ -983,8 +983,21 @@ class SHARCContainer {
   }
 
   /**
-   * Returns true when the given placement payload matches the last sent payload
-   * on width/height and position bounds.
+   * Returns true when the given placement payload is structurally identical
+   * to the last payload sent via notifyPlacementChange().
+   *
+   * Compares the full normalized payload, not just geometry. The earlier
+   * geometry-only comparison silently suppressed legitimate updates whenever
+   * a non-geometric placement field (e.g. inline, placementType, dataspec,
+   * data) changed without geometry changing — for example, a publisher
+   * mutating environmentData.currentPlacement mid-preload to swap the
+   * dataspec while keeping slot dimensions identical. See issue #6.
+   *
+   * Tradeoff: deep-equal comparison is stricter than geometry-only and may
+   * occasionally pass a redundant message through when an irrelevant field
+   * differs in serialization. That is recoverable; silent suppression of a
+   * real placement update is not.
+   *
    * @param {Object} payload
    * @returns {boolean}
    * @private
@@ -993,15 +1006,18 @@ class SHARCContainer {
     const last = this._lastSentPlacement;
     if (!last) return false;
 
-    const lastPosition = last.position || {};
-    const nextPosition = payload.position || {};
-
-    return last.width === payload.width &&
-           last.height === payload.height &&
-           lastPosition.x === nextPosition.x &&
-           lastPosition.y === nextPosition.y &&
-           lastPosition.width === nextPosition.width &&
-           lastPosition.height === nextPosition.height;
+    // JSON.stringify is sufficient for the shape that travels over the
+    // MessagePort. Property-order differences would produce false negatives
+    // (sending a redundant message), which is recoverable; the bug we are
+    // fixing is the inverse — silently suppressing a real update.
+    try {
+      return JSON.stringify(last) === JSON.stringify(payload);
+    } catch (e) {
+      // Defensive: if either payload contains a circular reference (should
+      // never happen with the protocol's structured-clone contract), fall
+      // back to "different" to err on the side of sending the update.
+      return false;
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -34,7 +34,7 @@
  * </script>
  * ```
  *
- * @version 0.5.3
+ * @version 0.5.4
  */
 
 'use strict';

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -14,7 +14,7 @@
  *   3. sharc-mraid-bridge.js → window.mraid (this file)
  *   4. <MRAID creative>
  *
- * @version 0.5.3
+ * @version 0.5.4
  * @see mraid-bridge-design.md
  */
 

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -28,7 +28,7 @@
  *   - creativeType and impressionType MUST be set before impressionOccurred()
  *   - AdSession must be started before any events are fired
  *
- * @version 0.5.3
+ * @version 0.5.4
  * @see https://iabtechlab.com/standards/open-measurement-sdk/
  * @see https://github.com/IABTechLab/SHARC
  */

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -13,7 +13,7 @@
  *
  * Both extend SHARCProtocolBase which provides the shared message bus.
  *
- * @version 0.5.3
+ * @version 0.5.4
  * @see https://github.com/IABTechLab/SHARC
  */
 
@@ -27,7 +27,7 @@
 // ---------------------------------------------------------------------------
 
 /** Current SHARC spec version this implementation conforms to. */
-const SHARC_VERSION = '0.5.3';
+const SHARC_VERSION = '0.5.4';
 
 /**
  * Protocol-level message types.

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -19,7 +19,7 @@
  *   - exp-push (push expand) — deferred to v2; fires 'failed' callback
  *   - $sf.ext.cookie() — permanently excluded; fires 'failed' callback
  *
- * @version 0.5.3
+ * @version 0.5.4
  * @see safeframe-bridge-design.md
  */
 

--- a/test-placement-dedup.js
+++ b/test-placement-dedup.js
@@ -1,0 +1,116 @@
+/**
+ * test-placement-dedup.js — issue #6 regression coverage
+ *
+ * Exercises SHARCContainer's placement-change dedup directly. Runs in node
+ * after `npm run build`. No browser, no test framework — just enough harness
+ * to drive the dedup decision and assert the right outcome.
+ *
+ * The bug: prior to 0.5.4, _placementPayloadUnchanged compared only width,
+ * height, and position bounds. If a non-geometric field (inline,
+ * placementType, dataspec, data) changed without geometry changing, the
+ * dedup falsely returned true and the update was silently suppressed.
+ *
+ * The fix: full JSON.stringify compare. Same geometry + same other fields →
+ * still skipped (no regression on the intended dedup). Same geometry + any
+ * other field changed → sent.
+ */
+
+import { SHARCContainer } from './dist/sharc-container.mjs';
+
+let failures = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log('  ✓', message);
+  } else {
+    console.log('  ✗', message);
+    failures++;
+  }
+}
+
+// We exercise _placementPayloadUnchanged directly via the prototype rather
+// than instantiating SHARCContainer, because the constructor pulls in
+// browser-only globals (MessageChannel, document) that don't exist in node.
+// The dedup method only reads this._lastSentPlacement, so a plain object
+// bound to the prototype is enough surface for this test.
+function makeContainer() {
+  return Object.create(SHARCContainer.prototype);
+}
+
+console.log('test-placement-dedup.js — issue #6 regression\n');
+
+// -- Case 1: identical payload should be considered unchanged. ---------------
+{
+  console.log('Case 1: identical payload → unchanged');
+  const c = makeContainer();
+  const payload = { width: 320, height: 50, position: { x: 0, y: 0, width: 320, height: 50 } };
+  c._lastSentPlacement = payload;
+  assert(c._placementPayloadUnchanged(payload) === true,
+    'identical payload returns true (dedup correct)');
+}
+
+// -- Case 2: geometry changes — must NOT be considered unchanged. ------------
+{
+  console.log('\nCase 2: geometry change → changed');
+  const c = makeContainer();
+  c._lastSentPlacement = { width: 320, height: 50, position: { x: 0, y: 0, width: 320, height: 50 } };
+  const next = { width: 728, height: 90, position: { x: 0, y: 0, width: 728, height: 90 } };
+  assert(c._placementPayloadUnchanged(next) === false,
+    'width/height change returns false (no false dedup)');
+}
+
+// -- Case 3: ISSUE #6 — non-geometric field changes, geometry identical. -----
+//          Pre-fix this returned true (bug). Post-fix it returns false.
+{
+  console.log('\nCase 3: non-geometric field change with identical geometry → changed (issue #6)');
+  const c = makeContainer();
+  const baseGeom = { width: 320, height: 50, position: { x: 0, y: 0, width: 320, height: 50 } };
+
+  c._lastSentPlacement = { ...baseGeom, inline: true };
+  const nextInline = { ...baseGeom, inline: false };
+  assert(c._placementPayloadUnchanged(nextInline) === false,
+    'inline true→false (geometry unchanged) returns false');
+
+  c._lastSentPlacement = { ...baseGeom, dataspec: { adcom: 'v1' } };
+  const nextDataspec = { ...baseGeom, dataspec: { adcom: 'v2' } };
+  assert(c._placementPayloadUnchanged(nextDataspec) === false,
+    'dataspec swap (geometry unchanged) returns false');
+
+  c._lastSentPlacement = { ...baseGeom, placementType: 'inline' };
+  const nextPlacementType = { ...baseGeom, placementType: 'interstitial' };
+  assert(c._placementPayloadUnchanged(nextPlacementType) === false,
+    'placementType change (geometry unchanged) returns false');
+
+  c._lastSentPlacement = { ...baseGeom, data: { campaignId: 'A' } };
+  const nextData = { ...baseGeom, data: { campaignId: 'B' } };
+  assert(c._placementPayloadUnchanged(nextData) === false,
+    'data field change (geometry unchanged) returns false');
+}
+
+// -- Case 4: no prior send — must NOT be considered unchanged. ---------------
+{
+  console.log('\nCase 4: no prior send → changed');
+  const c = makeContainer();
+  c._lastSentPlacement = null;
+  const payload = { width: 320, height: 50 };
+  assert(c._placementPayloadUnchanged(payload) === false,
+    'null prior payload returns false');
+}
+
+// -- Case 5: deep equality on nested position object. ------------------------
+{
+  console.log('\nCase 5: nested position field change → changed');
+  const c = makeContainer();
+  c._lastSentPlacement = { width: 320, height: 50, position: { x: 10, y: 20, width: 320, height: 50 } };
+  const next = { width: 320, height: 50, position: { x: 11, y: 20, width: 320, height: 50 } };
+  assert(c._placementPayloadUnchanged(next) === false,
+    'position.x off-by-one returns false');
+}
+
+console.log('');
+if (failures > 0) {
+  console.error(`✗ ${failures} placement-dedup assertion(s) failed.`);
+  process.exit(1);
+} else {
+  console.log('✓ All placement-dedup assertions passed.');
+}


### PR DESCRIPTION
## Summary
Fixes a silent placement-update suppression in `SHARCContainer`. The dedup that decides whether `_syncPlacementState()` sends a `placementChange` message on ACTIVE transitions was comparing only **six geometric fields** — `width`, `height`, and the four `position` rect bounds. Any non-geometric placement field that changed without geometry changing was silently dropped.

Foundational cleanup before 0.6.0 observability — observability surfaces would inherit this gap and produce silent wrong telemetry for placement events.

## The bug

```js
// src/sharc-container.js (pre-fix)
return last.width === payload.width &&
       last.height === payload.height &&
       lastPosition.x === nextPosition.x &&
       lastPosition.y === nextPosition.y &&
       lastPosition.width === nextPosition.width &&
       lastPosition.height === nextPosition.height;
```

Real-world failure scenario: publisher mutates `environmentData.currentPlacement` mid-preload (e.g., swaps `dataspec` while keeping slot dimensions the same). On ACTIVE transition, dedup returns true → message suppressed → creative never sees the update.

## The fix
Full `JSON.stringify` compare of both payloads.

```js
// src/sharc-container.js (post-fix)
return JSON.stringify(last) === JSON.stringify(payload);
```

**Behavior matrix:**

| Scenario | Before | After |
|---|---|---|
| Identical payload | skipped | skipped (correct) |
| Geometry change | sent | sent (correct) |
| `inline` / `placementType` / `dataspec` / `data` change with identical geometry | **skipped (bug)** | **sent (fixed)** |
| Property-order shuffle on same logical payload | skipped | sent (one redundant message; recoverable) |

The only regression risk is the property-order case producing one extra redundant `placementChange` message. That's recoverable; silent suppression of a real update was not.

## Regression coverage
New `test-placement-dedup.js` (run via `npm run test:placement`) exercises the dedup method directly via `Object.create(SHARCContainer.prototype)` (the constructor needs browser globals not available in node) and covers:
1. Identical payload → unchanged
2. Geometry change → changed
3. Four non-geometric field mutations (`inline`, `dataspec`, `placementType`, `data`) → all changed (the bug case)
4. No prior send → changed
5. Nested `position.x` off-by-one → changed

8/8 assertions pass.

## Verification
- [x] `npm run build` — rollup + tsc green
- [x] `npm run test:smoke` — 6/6 imports
- [x] `npm run test:treeshake` — all bundles
- [x] `npm run test:types` — consumer probe clean
- [x] `npm run test:placement` — 8/8 assertions
- [x] `npm run size` — all 6 budgets

## Why now
Issue #6 was filed `2026-04-17` as a non-blocking follow-up. Surfaced again while scoping 0.6.0 observability — instrumenting placement events on top of a known correctness gap would propagate the gap into telemetry. Fixing it now means the observability layer in 0.6.0 builds on a clean placement model.

Closes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)