### PR TITLE
0.6.0 polish: null-safety, sessionId, aria-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-26
+
+### Changed
+- **`placementId` / `placementName` null-safety (breaking).** Both fields on
+  `SHARCContainer` now type as `string|null` instead of `string|undefined`.
+  When the constructor option is omitted the field is `null`; passing an empty
+  string `''` also normalizes to `null`. Downstream TypeScript consumers must
+  update their type annotations from `string | undefined` to `string | null`.
+- **`sessionId` getter returns `null` before handshake (breaking).** Previously
+  returned `''`. Callers that tested `if (!container.sessionId)` are unaffected
+  since both `''` and `null` are falsy; strict-equality checks `=== ''` must
+  be updated to `=== null`.
+- **Close-button `aria-label` updated.** `'Collapse advertisement'` →
+  `'Close ad'` — shorter, plain-language label per accessibility proposal
+  Part 4. Matches the function (user-initiated close) rather than the
+  mechanical action (collapse).
+
 ## [0.5.4] - 2026-04-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iabtechlab/sharc",
-      "version": "0.5.4",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol",
   "type": "module",
   "files": [

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -26,7 +26,7 @@
  * container.load();
  * ```
  *
- * @version 0.5.4
+ * @version 0.6.0
  */
 
 'use strict';
@@ -92,10 +92,12 @@ class SHARCContainer {
    * @param {string} options.creativeUrl - URL of the SHARC-enabled creative HTML.
    * @param {HTMLElement} options.placementElement - The DOM element to insert the iframe into.
    *   (Previously named `containerEl` — `containerEl` is no longer accepted. Use `placementElement` instead.)
-   * @param {string} [options.placementId] - Publisher-supplied placement identifier.
+   * @param {string|null} [options.placementId] - Publisher-supplied placement identifier.
    *   Round-trips through the constructor so the instance exposes `container.placementId`.
-   * @param {string} [options.placementName] - Human-readable placement name.
+   *   Omitting the option or passing `''` both result in `null`.
+   * @param {string|null} [options.placementName] - Human-readable placement name.
    *   Round-trips through the constructor so the instance exposes `container.placementName`.
+   *   Omitting the option or passing `''` both result in `null`.
    * @param {Object} options.environmentData - Environment data to pass in Container:init.
    *   @param {Object} options.environmentData.currentPlacement - Placement dimensions.
    *   @param {Object} [options.environmentData.dataspec] - AdCOM or custom dataspec info.
@@ -148,8 +150,8 @@ class SHARCContainer {
     const {
       creativeUrl,
       placementElement,
-      placementId,
-      placementName,
+      placementId = null,
+      placementName = null,
       environmentData = {},
       supportedFeatures = [],
       extensions = [],
@@ -199,17 +201,17 @@ class SHARCContainer {
     this.placementElement = placementElement;
 
     /**
-     * Publisher-supplied placement identifier (optional — may be undefined).
+     * Publisher-supplied placement identifier (optional — null when not provided).
      * Distinct from the runtime-generated {@link placementSessionId}.
-     * @type {string|undefined}
+     * @type {string|null}
      */
-    this.placementId = placementId;
+    this.placementId = placementId === '' ? null : placementId;
 
     /**
-     * Human-readable placement name (optional — may be undefined).
-     * @type {string|undefined}
+     * Human-readable placement name (optional — null when not provided).
+     * @type {string|null}
      */
-    this.placementName = placementName;
+    this.placementName = placementName === '' ? null : placementName;
 
     /**
      * UUID v4 generated at construction time. Unique per SHARCContainer instance.
@@ -438,11 +440,11 @@ class SHARCContainer {
 
   /**
    * Returns the creative session ID (set during the createSession handshake).
-   * Empty string before the handshake completes.
-   * @returns {string}
+   * Null before the handshake completes.
+   * @returns {string|null}
    */
   get sessionId() {
-    return this._protocol.sessionId || '';
+    return this._protocol.sessionId || null;
   }
 
   /**
@@ -1941,7 +1943,7 @@ class SHARCContainer {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'sharc-close-button';
-    btn.setAttribute('aria-label', 'Collapse advertisement');
+    btn.setAttribute('aria-label', 'Close ad');
 
     // 50×50 tap target (MRAID minimum), 30×30 visible close icon centered inside.
     btn.style.cssText = [

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -34,7 +34,7 @@
  * </script>
  * ```
  *
- * @version 0.5.4
+ * @version 0.6.0
  */
 
 'use strict';

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -13,7 +13,7 @@
  *
  * Both extend SHARCProtocolBase which provides the shared message bus.
  *
- * @version 0.5.4
+ * @version 0.6.0
  * @see https://github.com/IABTechLab/SHARC
  */
 
@@ -27,7 +27,7 @@
 // ---------------------------------------------------------------------------
 
 /** Current SHARC spec version this implementation conforms to. */
-const SHARC_VERSION = '0.5.4';
+const SHARC_VERSION = '0.6.0';
 
 /**
  * Protocol-level message types.

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -210,7 +210,15 @@ function isMessageChannelAvailable() {
  */
 class SHARCProtocolBase {
   constructor() {
-    /** @type {string} Current session ID. */
+    /**
+     * Current session ID. Intentionally `''` (not `null`) as the internal sentinel
+     * for "no session yet" — the message routing check in `_onPortMessage` compares
+     * incoming `sessionId` against this value, and the wire protocol uses empty
+     * string as its uninitialized state. The public-facing `SHARCContainer.sessionId`
+     * getter normalizes `''` → `null` at the API boundary; internal code should
+     * never need to distinguish the two.
+     * @type {string}
+     */
     this.sessionId = '';
 
     /** @type {number} Next message ID to send. */

--- a/test-placement-stamping.js
+++ b/test-placement-stamping.js
@@ -10,7 +10,7 @@
  *   - Required-args validation (creativeUrl, placementElement)
  *   - placementSessionId is a UUID v4 and unique per instance
  *   - placementId / placementName round-trip from constructor → instance
- *   - sessionId getter is empty string until handshake (existing field)
+ *   - sessionId getter is null until handshake completes
  *   - Isolation guard fires synchronously at construction (Part 7)
  *   - _attachToPlacement stamps placement element + iframe per Part 4
  *   - _stampState writes data-sharc-state on the placement element
@@ -150,18 +150,18 @@ console.log('test-placement-stamping.js — issue #40 regression\n');
     'placementName round-trips constructor → instance');
 
   const cNone = new SHARCContainer(baseOptions());
-  assert(cNone.placementId === undefined,
-    'placementId defaults to undefined when option omitted');
-  assert(cNone.placementName === undefined,
-    'placementName defaults to undefined when option omitted');
+  assert(cNone.placementId === null,
+    'placementId defaults to null when option omitted');
+  assert(cNone.placementName === null,
+    'placementName defaults to null when option omitted');
 }
 
 // -- 5. sessionId getter ───────────────────────────────────────────────────
 {
   console.log('\n5. sessionId getter');
   const c = new SHARCContainer(baseOptions());
-  assert(c.sessionId === '',
-    'sessionId is empty string before handshake completes');
+  assert(c.sessionId === null,
+    'sessionId is null before handshake completes');
 
   // Mutate the protocol's sessionId and confirm the getter passes through.
   c._protocol.sessionId = 'creative-uuid-123';

--- a/test/types/consumer.ts
+++ b/test/types/consumer.ts
@@ -41,10 +41,10 @@ const container = new SHARCContainer({
 // ── SHARCContainer instance shape ──
 const url: string = container.creativeUrl;
 const el: HTMLElement = container.placementElement;
-const pid: string | undefined = container.placementId;
-const pname: string | undefined = container.placementName;
+const pid: string | null = container.placementId;
+const pname: string | null = container.placementName;
 const psid: string = container.placementSessionId;
-const sid: string = container.sessionId;
+const sid: string | null = container.sessionId;
 void url;
 void el;
 void pid;


### PR DESCRIPTION
## Summary

Pre-1.0 breaking-change polish commit for the 0.6.0 release.

- **`placementId` / `placementName` → `string|null`** — omitting the option or passing `''` both produce `null` (was `undefined` / unchecked empty string). JSDoc, field types, test assertions, and TypeScript consumer probe all updated.
- **`sessionId` getter → `null` before handshake** — was returning `''`. Callers using `!container.sessionId` are unaffected (both falsy); strict `=== ''` checks need updating.
- **Close-button `aria-label` → `'Close ad'`** — was `'Collapse advertisement'`. Shorter, plain-language label per accessibility proposal Part 4.
- **Version bump to 0.6.0** — `SHARC_VERSION` constant, all three `@version` JSDoc tags, `package.json`, `package-lock.json`, and `CHANGELOG.md` (`[Unreleased]` → `[0.6.0] - 2026-04-26`).

## Test plan

- [ ] `npm run build` — dist rebuild with new version
- [ ] `node test-placement-stamping.js` — verify null assertions pass (sections 4 and 5)
- [ ] `npm run test:types` — TypeScript consumer probe compiles clean with `string|null` types
- [ ] Manual: confirm `data-sharc-version="0.6.0"` in browser harness after build
- [ ] Manual: confirm close button reads "Close ad" in screen reader / accessibility inspector

🤖 Generated with [Claude Code](https://claude.com/claude-code)