### PR TITLE
fix: 0.6.1 — source polish (#48, #34, #35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-04-27
+
+### Fixed
+- **Stale JSDoc on `_applyAnimatedDimensions` (#48).** Method comment previously
+  described a `transform: scale()` / GPU compositor approach that was replaced
+  with direct CSS `width`/`height` transitions. JSDoc updated to match the
+  implementation.
+- **Typed constructor default (#34).** Removed `/** @type {any} */ ({})` cast
+  on the `SHARCContainer` constructor default argument — unnecessary suppression
+  of type checking on an already-typed parameter shape.
+- **`@private` annotation pass on `SHARCProtocolBase` internals (#35).** Internal
+  members missing `@private` JSDoc tags were leaking into the generated
+  `dist/sharc-protocol.d.ts`. Tags added; `dist/` regenerated.
+
 ## [0.6.0] - 2026-04-26
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iabtechlab/sharc",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol",
   "type": "module",
   "files": [

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -99,7 +99,7 @@ class SHARCContainer {
    *   Round-trips through the constructor so the instance exposes `container.placementName`.
    *   Omitting the option or passing `''` both result in `null`.
    * @param {Object} [options.environmentData] - Environment data to pass in Container:init.
-   *   @param {Object} options.environmentData.currentPlacement - Placement dimensions.
+   *   @param {Object} [options.environmentData.currentPlacement] - Placement dimensions.
    *   @param {Object} [options.environmentData.dataspec] - AdCOM or custom dataspec info.
    *   @param {Object} [options.environmentData.data] - Data from the dataspec.
    *   @param {Object} [options.environmentData.containerNavigation] - Navigation capabilities.

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -26,7 +26,7 @@
  * container.load();
  * ```
  *
- * @version 0.6.0
+ * @version 0.6.1
  */
 
 'use strict';
@@ -88,9 +88,9 @@ const DEFAULT_TIMEOUTS = {
  */
 class SHARCContainer {
   /**
-   * @param {Object} options
-   * @param {string} options.creativeUrl - URL of the SHARC-enabled creative HTML.
-   * @param {HTMLElement} options.placementElement - The DOM element to insert the iframe into.
+   * @param {Object} [options={}]
+   * @param {string} [options.creativeUrl] - URL of the SHARC-enabled creative HTML.
+   * @param {HTMLElement} [options.placementElement] - The DOM element to insert the iframe into.
    *   (Previously named `containerEl` — `containerEl` is no longer accepted. Use `placementElement` instead.)
    * @param {string|null} [options.placementId] - Publisher-supplied placement identifier.
    *   Round-trips through the constructor so the instance exposes `container.placementId`.
@@ -98,7 +98,7 @@ class SHARCContainer {
    * @param {string|null} [options.placementName] - Human-readable placement name.
    *   Round-trips through the constructor so the instance exposes `container.placementName`.
    *   Omitting the option or passing `''` both result in `null`.
-   * @param {Object} options.environmentData - Environment data to pass in Container:init.
+   * @param {Object} [options.environmentData] - Environment data to pass in Container:init.
    *   @param {Object} options.environmentData.currentPlacement - Placement dimensions.
    *   @param {Object} [options.environmentData.dataspec] - AdCOM or custom dataspec info.
    *   @param {Object} [options.environmentData.data] - Data from the dataspec.
@@ -146,7 +146,7 @@ class SHARCContainer {
    * @param {Object} [options.closeButtonStyles] - CSS overrides for the auto-rendered close button.
    *   Keys map to the close button element's style properties (e.g. `top`, `right`, `width`).
    */
-  constructor(options = /** @type {any} */ ({})) {
+  constructor(options = {}) {
     const {
       creativeUrl,
       placementElement,
@@ -2176,9 +2176,10 @@ class SHARCContainer {
   }
 
   /**
-   * Applies an animated dimension change using transform: scale().
-   * The visual transition runs on the GPU compositor. On completion,
-   * snaps to final width/height and removes the transform.
+   * Applies an animated dimension change using direct CSS `width`/`height` transitions.
+   * Sets the transition property on both the placement element and iframe, applies
+   * the target dimensions, then cleans up the transition property on `transitionend`
+   * (or a safety timeout). Sends `PLACEMENT_TRANSITION_END` to the creative on completion.
    *
    * @param {Object} fromDims - { width, height } current dimensions
    * @param {Object} toDims - { width, height } target dimensions

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -34,7 +34,7 @@
  * </script>
  * ```
  *
- * @version 0.6.0
+ * @version 0.6.1
  */
 
 'use strict';

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -13,7 +13,7 @@
  *
  * Both extend SHARCProtocolBase which provides the shared message bus.
  *
- * @version 0.6.0
+ * @version 0.6.1
  * @see https://github.com/IABTechLab/SHARC
  */
 
@@ -27,7 +27,7 @@
 // ---------------------------------------------------------------------------
 
 /** Current SHARC spec version this implementation conforms to. */
-const SHARC_VERSION = '0.6.0';
+const SHARC_VERSION = '0.6.1';
 
 /**
  * Protocol-level message types.
@@ -221,18 +221,24 @@ class SHARCProtocolBase {
      */
     this.sessionId = '';
 
-    /** @type {number} Next message ID to send. */
+    /**
+     * Next message ID to send.
+     * @type {number}
+     * @protected
+     */
     this._nextMessageId = 0;
 
     /**
      * Listeners keyed by message type.
      * @type {Object.<string, Array<(data: Object) => void>>}
+     * @private
      */
     this._listeners = {};
 
     /**
      * Pending resolve/reject callbacks keyed by outgoing messageId.
      * @type {Object.<number, (responseData: Object) => void>}
+     * @protected
      */
     this._pendingResponses = {};
 
@@ -240,12 +246,14 @@ class SHARCProtocolBase {
      * The MessagePort we use to send/receive messages.
      * Set by subclass after transport setup.
      * @type {MessagePort|null}
+     * @protected
      */
     this._port = null;
 
     /**
      * Whether the protocol is in a terminated state.
      * @type {boolean}
+     * @protected
      */
     this._terminated = false;
 
@@ -266,6 +274,7 @@ class SHARCProtocolBase {
    * Attaches the MessagePort and starts listening for incoming messages.
    * Called by subclasses after the port is established.
    * @param {MessagePort} port - The port to use for communication.
+   * @protected
    */
   _attachPort(port) {
     this._port = port;
@@ -291,6 +300,7 @@ class SHARCProtocolBase {
    * @param {*} [args] - The message args payload (Structured Clone compatible).
    * @returns {Promise<*>} Resolves with the value from the resolve message,
    *   or rejects with the error from the reject message.
+   * @protected
    */
   _sendMessage(type, args = {}) {
     if (this._terminated) {
@@ -337,6 +347,7 @@ class SHARCProtocolBase {
    * Sends a resolve response for a received message.
    * @param {Object} incomingMessage - The message being resolved.
    * @param {*} [value] - The resolve payload.
+   * @protected
    */
   _resolve(incomingMessage, value = {}) {
     if (this._terminated || !this._port) return;
@@ -357,6 +368,7 @@ class SHARCProtocolBase {
    * @param {Object} incomingMessage - The message being rejected.
    * @param {number} errorCode - The error code.
    * @param {string} [errorMessage] - Additional error information.
+   * @protected
    */
   _reject(incomingMessage, errorCode, errorMessage = '') {
     if (this._terminated || !this._port) return;
@@ -398,6 +410,7 @@ class SHARCProtocolBase {
   /**
    * Handles incoming MessagePort messages.
    * @param {MessageEvent} event
+   * @protected
    */
   _onPortMessage(event) {
     const data = event.data;
@@ -432,6 +445,7 @@ class SHARCProtocolBase {
   /**
    * Routes resolve/reject messages to their pending promise callbacks.
    * @param {Object} data - The resolve/reject message data.
+   * @private
    */
   _handleResponse(data) {
     const respondingToId = data.args && data.args.messageId;
@@ -448,6 +462,7 @@ class SHARCProtocolBase {
    * Dispatches a received message to all registered listeners for its type.
    * @param {string} type - The message type.
    * @param {Object} data - The full message data.
+   * @private
    */
   _dispatchToListeners(type, data) {
     const listeners = this._listeners[type];
@@ -565,24 +580,28 @@ class SHARCContainerProtocol extends SHARCProtocolBase {
      * The MessageChannel used for communication.
      * Container owns both ports; port2 is transferred to the creative.
      * @type {MessageChannel|null}
+     * @private
      */
     this._channel = null;
 
     /**
      * Whether we're using the MessageChannel transport (vs. fallback postMessage).
      * @type {boolean}
+     * @private
      */
     this._usingMessageChannel = false;
 
     /**
      * The target window for the fallback postMessage transport.
      * @type {Window|null}
+     * @private
      */
     this._fallbackTarget = null;
 
     /**
      * Bound fallback message handler (for cleanup).
      * @type {(event: MessageEvent) => void|null}
+     * @private
      */
     this._fallbackHandler = null;
   }
@@ -882,6 +901,7 @@ class SHARCCreativeProtocol extends SHARCProtocolBase {
     /**
      * Optional origin pin for the bootstrap handshake (SEC-003).
      * @type {string|null}
+     * @private
      */
     this._trustedOrigin = (options && typeof options.trustedOrigin === 'string')
       ? options.trustedOrigin
@@ -890,6 +910,7 @@ class SHARCCreativeProtocol extends SHARCProtocolBase {
     /**
      * Whether the MessagePort bootstrap message has been received.
      * @type {boolean}
+     * @private
      */
     this._portReceived = false;
 
@@ -897,6 +918,7 @@ class SHARCCreativeProtocol extends SHARCProtocolBase {
      * Promise that resolves when the MessagePort is received from the container.
      * createSession() waits on this before sending.
      * @type {Promise<void>}
+     * @private
      */
     this._portReadyPromise = new Promise((resolve) => {
       this._portReadyResolve = resolve;
@@ -905,12 +927,14 @@ class SHARCCreativeProtocol extends SHARCProtocolBase {
     /**
      * Bound handler for the bootstrap window message (for cleanup).
      * @type {(event: MessageEvent) => void}
+     * @private
      */
     this._bootstrapHandler = null;
 
     /**
      * Whether we're using the MessageChannel transport.
      * @type {boolean}
+     * @private
      */
     this._usingMessageChannel = false;
   }

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -895,6 +895,7 @@ class SHARCCreativeProtocol extends SHARCProtocolBase {
      * Placement type declared by the creative ('inline' or 'interstitial').
      * Sent to the container in createSession.
      * @type {string}
+     * @private
      */
     this._placementType = 'inline';
 


### PR DESCRIPTION
## Summary

- **#48** — `_applyAnimatedDimensions` JSDoc was describing a `transform: scale()` / GPU compositor two-phase approach that had been replaced with direct CSS `width`/`height` transitions. Comment updated to match the implementation; no code touched.
- **#34** — Removed `/** @type {any} */ ({})` cast on `SHARCContainer` constructor default. Changed to `constructor(options = {})` and updated the `@param` to `{Object} [options={}]`, marking `creativeUrl`, `placementElement`, and `environmentData` sub-params as optional so tsc accepts the typed empty-object default without suppressing type checking via `any`. Runtime guards for required fields are unchanged.
- **#35** — `@private`/`@protected` annotation pass on `SHARCProtocolBase`, `SHARCContainerProtocol`, and `SHARCCreativeProtocol`. All `_`-prefixed members that were leaking into `dist/sharc-protocol.d.ts` as public fields now carry the correct access modifier tag. Members accessed by subclasses are `@protected`; members used only internally are `@private`. `dist/` regenerated.

Closes #48, #34, #35.

## Build verification

- [x] `npm run build` — clean (rollup + tsc --emitDeclarationOnly)
- [x] `npm run test:smoke` — all artifacts importable
- [x] `npm run test:types` — no tsc errors
- [x] `npm run test:placement-stamping` — all assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)