### PR TITLE
fix(0.6.2): add setPlacementType accessor to fix TS2341 build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-04-27
+
+### Fixed
+- **TypeScript build failure on `_placementType` cross-class access.**
+  The `@private` annotation pass in 0.6.1 (PR #49) tightened the typing
+  of `SHARCCreativeProtocol._placementType`, but `sharc-creative.js`
+  was still assigning to it directly across class boundaries
+  (`this._proto._placementType = this.placementType` at line 189),
+  which `tsc` correctly flagged as a TS2341 error. Added a typed
+  `setPlacementType(type)` accessor on `SHARCCreativeProtocol`; the
+  Creative SDK now goes through the accessor instead of touching the
+  private field. Build is green.
+
 ## [0.6.1] - 2026-04-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SHARC (Secure HTML Ad Richmedia Container)
 
-![Package status](https://img.shields.io/badge/package-v0.5.4%20(pre--publish)-informational)
+![Package status](https://img.shields.io/badge/package-v0.6.2%20(pre--publish)-informational)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/InteractiveAdvertisingBureau/SHARC/actions/workflows/ci.yml/badge.svg)](https://github.com/InteractiveAdvertisingBureau/SHARC/actions/workflows/ci.yml)
 
@@ -64,9 +64,9 @@ All public entry points build into `dist/` as ESM (`.mjs`) plus browser/IIFE bun
 
 After the package is published, public CDN URL patterns should mirror the current `dist/` filenames:
 
-- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.4/dist/sharc-container.js`
-- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.4/dist/sharc-creative.js`
-- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.5.4/dist/sharc-protocol.js`
+- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.6.2/dist/sharc-container.js`
+- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.6.2/dist/sharc-creative.js`
+- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.6.2/dist/sharc-protocol.js`
 
 Versioning guidance:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iabtechlab/sharc",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol",
   "type": "module",
   "files": [

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -26,7 +26,7 @@
  * container.load();
  * ```
  *
- * @version 0.6.1
+ * @version 0.6.2
  */
 
 'use strict';

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -34,7 +34,7 @@
  * </script>
  * ```
  *
- * @version 0.6.1
+ * @version 0.6.2
  */
 
 'use strict';
@@ -186,7 +186,7 @@ class SHARCCreative {
    */
   _startSession() {
     if (this._terminated) return;
-    this._proto._placementType = this.placementType;
+    this._proto.setPlacementType(this.placementType);
     this._proto.createSession()
       .then(() => {
         // Session established — wait for Container:init (handled in listener)

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -14,7 +14,7 @@
  *   3. sharc-mraid-bridge.js → window.mraid (this file)
  *   4. <MRAID creative>
  *
- * @version 0.5.4
+ * @version 0.6.2
  * @see mraid-bridge-design.md
  */
 

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -28,7 +28,7 @@
  *   - creativeType and impressionType MUST be set before impressionOccurred()
  *   - AdSession must be started before any events are fired
  *
- * @version 0.5.4
+ * @version 0.6.2
  * @see https://iabtechlab.com/standards/open-measurement-sdk/
  * @see https://github.com/IABTechLab/SHARC
  */

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -13,7 +13,7 @@
  *
  * Both extend SHARCProtocolBase which provides the shared message bus.
  *
- * @version 0.6.1
+ * @version 0.6.2
  * @see https://github.com/IABTechLab/SHARC
  */
 
@@ -27,7 +27,7 @@
 // ---------------------------------------------------------------------------
 
 /** Current SHARC spec version this implementation conforms to. */
-const SHARC_VERSION = '0.6.1';
+const SHARC_VERSION = '0.6.2';
 
 /**
  * Protocol-level message types.
@@ -1095,6 +1095,16 @@ class SHARCCreativeProtocol extends SHARCProtocolBase {
   // -------------------------------------------------------------------------
   // Creative protocol API
   // -------------------------------------------------------------------------
+
+  /**
+   * Sets the placement type to be sent in the next createSession message.
+   * Provides a typed accessor for the public Creative SDK so it can configure
+   * placement type without reaching into the protocol's private field.
+   * @param {string} type - 'inline' or 'interstitial'.
+   */
+  setPlacementType(type) {
+    this._placementType = type;
+  }
 
   /**
    * Sends createSession, establishing this creative's session with the container.

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -19,7 +19,7 @@
  *   - exp-push (push expand) — deferred to v2; fires 'failed' callback
  *   - $sf.ext.cookie() — permanently excluded; fires 'failed' callback
  *
- * @version 0.5.4
+ * @version 0.6.2
  * @see safeframe-bridge-design.md
  */
 


### PR DESCRIPTION
## What

The \`@private\` annotation pass in 0.6.1 (PR #49) correctly tightened \`SHARCCreativeProtocol._placementType\` to private, but \`sharc-creative.js\` was still assigning to it directly across class boundaries:

\`\`\`javascript
this._proto._placementType = this.placementType;  // line 189
\`\`\`

\`tsc\` correctly flagged this as **TS2341** (private field accessed from outside class). The annotation pass should have caught the access at the call site as well; it missed.

## Fix

Added a typed accessor on \`SHARCCreativeProtocol\`:

\`\`\`javascript
setPlacementType(type) {
  this._placementType = type;
}
\`\`\`

The Creative SDK now goes through the accessor:

\`\`\`javascript
this._proto.setPlacementType(this.placementType);
\`\`\`

Pre-1.0, additive, non-breaking. The private field stays private; the protocol class exposes a typed seam for the Creative SDK.

## Why this matters

CI is currently red on \`main\` because of this. Blocks PR #54 (creative payload polymorphism proposal) from merging until fixed.

## Verification

- \`npm run build\` — rollup ✅
- \`npm run build:types\` — tsc ✅
- All existing tests pass

## Version bump

0.6.1 → 0.6.2 (patch).

\`npm version patch\` ran the lifecycle hook (\`scripts/sync-version.js\`) which propagated the version to:
- \`package.json\`, \`package-lock.json\`
- \`SHARC_VERSION\` constant in \`sharc-protocol.js\`
- \`@version\` JSDoc tags across all entry points
- \`README.md\` badge and CDN URLs

## CHANGELOG

Added 0.6.2 entry under Fixed.