### PR TITLE
Creative Sources Phase A — constructor validation + types (#41)

### DIFF
--- a/docs/proposals/creative-sources.md
+++ b/docs/proposals/creative-sources.md
@@ -1,4 +1,4 @@
-# Proposal: Creative Payload Polymorphism (Creative Markup — Renderer Protocol)
+# Proposal: Creative Sources (Creative URL and Creative Markup)
 
 **Author:** Jeffrey Carlson  
 **Date:** 2026-04-27  

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:treeshake": "node test-treeshake.js",
     "test:placement": "node test-placement-dedup.js",
     "test:placement-stamping": "node test-placement-stamping.js",
+    "test:creative-sources": "node test-creative-sources.js",
     "test:types": "tsc -p test/types/tsconfig.json",
     "regen:baseline": "node scripts/regen-mraid3-baseline.js",
     "lint": "eslint src/*.js --max-warnings=0",

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -86,10 +86,83 @@ const DEFAULT_TIMEOUTS = {
  * Each SHARCContainer instance manages exactly one ad. To show a new ad,
  * create a new SHARCContainer instance.
  */
+/**
+ * @typedef {object} SHARCSecurityEvent
+ * @property {string} type - Event type identifier. Phase A reserves
+ *   `'wrapper_top_frame_inaccessible'`. Phase B-D adds `'renderer_origin_mismatch'`,
+ *   `'renderer_protocol_error'`, `'renderer_failed'`, `'unauthorized_navigation'`.
+ * @property {'warning'|'error'} severity - `'warning'` for non-terminating events;
+ *   `'error'` for terminating events (which fire `onSecurityEvent` before `onError`).
+ * @property {number} timestamp - `Date.now()` at the time the event fired.
+ * @property {string} placementSessionId - Same UUID exposed as `container.placementSessionId`.
+ *   Use it to correlate this event to the container instance.
+ * @property {string} message - Human-readable description.
+ * @property {Object<string, unknown>} details - Event-type-specific context.
+ *   For `wrapper_top_frame_inaccessible`: `{ wrapperOrigin, creativeRendererUrl }`.
+ *   Phase B-D event types add their own keys.
+ */
+
+/**
+ * @callback SHARCSecurityEventCallback
+ * @param {SHARCSecurityEvent} event
+ * @returns {void}
+ */
+
 class SHARCContainer {
   /**
    * @param {Object} [options={}]
-   * @param {string} [options.creativeUrl] - URL of the SHARC-enabled creative HTML.
+   * @param {string} [options.creativeUrl] - URL of the SHARC-enabled creative HTML
+   *   (Creative URL variant). Mutually exclusive with `creativeHtml`. Exactly one
+   *   of `creativeUrl` or `creativeHtml` MUST be provided. Empty string (`''`) is
+   *   treated as "not provided" — same as `undefined`/`null`.
+   * @param {string} [options.creativeHtml] - Raw HTML markup for the creative
+   *   (Creative Markup variant — added in 0.7.0). Mutually exclusive with
+   *   `creativeUrl`. Requires `creativeRendererUrl`. Posted to the operator-hosted
+   *   renderer page via the renderer protocol. Capped at 256 KiB at construction
+   *   (pre-injection); see proposal § Validation Rules. Empty string (`''`) is
+   *   treated as "not provided" — same as `undefined`/`null`.
+   * @param {string} [options.creativeRendererUrl] - HTTPS URL of an operator-hosted
+   *   renderer page. Required when `creativeHtml` is provided; forbidden alongside
+   *   `creativeUrl`. Must parse via `new URL(...)`, use the `https:` scheme, contain
+   *   no userinfo, and be cross-origin to both `window.location` and (when accessible)
+   *   `window.top.location`. See proposal § Validation Rules. Empty string (`''`)
+   *   is treated as "not provided."
+   * @param {SHARCSecurityEventCallback} [options.onSecurityEvent] - Callback fired
+   *   with a {@link SHARCSecurityEvent} for security-relevant events (wrapper carve-out,
+   *   origin mismatch, renderer protocol failure, etc.). Production observability hook.
+   *   Synchronous; throws are caught and logged. Console output continues regardless
+   *   of whether the callback is provided. See proposal § Security Model.
+   * @param {boolean} [options.allowPopups=true] - When `true` (default), the Creative
+   *   Markup renderer iframe sandbox includes both `allow-popups` AND
+   *   `allow-popups-to-escape-sandbox`. When `false`, both tokens are omitted; creative
+   *   `window.open()` calls fail at the browser level. `SHARC.requestNavigation()` works
+   *   regardless. The `allow-popups-to-escape-sandbox` token is bound to this option
+   *   (DD-21); not exposed separately. Phase A: option is stored; sandbox application
+   *   ships in Phase B.
+   * @param {boolean} [options.allowTopNavigationByUserActivation=true] - When `true`
+   *   (default), the renderer iframe sandbox includes `allow-top-navigation-by-user-activation`,
+   *   permitting user-gesture-initiated `<a target="_top">` clicks. When `false`, the
+   *   token is omitted. The unsafe `allow-top-navigation` token (no-gesture variant) is
+   *   never exposed. See DD-20. Phase A: option stored; sandbox application in Phase B.
+   * @param {boolean} [options.allowStorageAccessByUserActivation=true] - When `true`
+   *   (default), the renderer iframe sandbox includes
+   *   `allow-storage-access-by-user-activation`, permitting `document.requestStorageAccess()`
+   *   on user gesture. When `false`, the token is omitted and SAA calls fail. See DD-22.
+   *   Phase A: option stored; sandbox application in Phase B.
+   * @param {boolean} [options.allowModals=false] - When `true`, the renderer iframe
+   *   sandbox includes `allow-modals`. Default `false` — modals are an opt-in operator
+   *   control, not a baseline capability. See DD-23. Phase A: option stored; sandbox
+   *   application in Phase B.
+   * @param {boolean} [options.allowDownloads=false] - When `true`, the renderer iframe
+   *   sandbox includes `allow-downloads`. Default `false` — direct iframe downloads are
+   *   an opt-in operator control. See DD-25. Phase A: option stored; sandbox application
+   *   in Phase B.
+   * @param {'warn'|'block'} [options.wrapperPolicy='warn'] - Controls container behavior
+   *   when validation rule 7's wrapper-cross-origin carve-out applies (cross-origin top
+   *   frame inaccessible at construction). `'warn'` (default) emits `console.warn` +
+   *   `onSecurityEvent` and proceeds. `'block'` emits `console.error` + `onSecurityEvent`
+   *   and throws synchronously at construction. See DD-19 and proposal § Security Model
+   *   § wrapper-cross-origin.
    * @param {HTMLElement} [options.placementElement] - The DOM element to insert the iframe into.
    *   (Previously named `containerEl` — `containerEl` is no longer accepted. Use `placementElement` instead.)
    * @param {string|null} [options.placementId] - Publisher-supplied placement identifier.
@@ -149,6 +222,15 @@ class SHARCContainer {
   constructor(options = {}) {
     const {
       creativeUrl,
+      creativeHtml,
+      creativeRendererUrl,
+      onSecurityEvent,
+      allowPopups = true,
+      allowTopNavigationByUserActivation = true,
+      allowStorageAccessByUserActivation = true,
+      allowModals = false,
+      allowDownloads = false,
+      wrapperPolicy = 'warn',
       placementElement,
       placementId = null,
       placementName = null,
@@ -178,8 +260,205 @@ class SHARCContainer {
       );
     }
 
-    if (!creativeUrl) throw new Error('[SHARCContainer] creativeUrl is required');
+    // Generate the placementSessionId up-front so any structured event fired
+    // during construction (e.g. the wrapper-cross-origin carve-out below)
+    // carries the SAME UUID that the constructed instance will expose. The
+    // assignment to `this.placementSessionId` happens later, but the value is
+    // captured here so observability pipelines can correlate construction-time
+    // security events to the running container.
+    const placementSessionId = SHARCContainer._generateUUID();
+
+    // ── Creative Sources — 8 sequenced validation rules. ──
+    // Evaluated in order; first violation throws. Shape errors (rules 1–3,
+    // TypeError) precede value errors (rules 4–8, Error). See proposal:
+    // docs/proposals/creative-sources.md § Validation Rules.
+    //
+    // Note on `''` (empty string) handling: empty strings for `creativeUrl`,
+    // `creativeHtml`, and `creativeRendererUrl` are intentionally treated as
+    // "not provided" — same as `null`/`undefined`. Operators passing an empty
+    // string have nothing to load; conflating that with absent makes rule 1
+    // fire with the more useful "got neither" message instead of "got empty
+    // string."
+    const hasCreativeUrl = creativeUrl != null && creativeUrl !== '';
+    const hasCreativeHtml = creativeHtml != null && creativeHtml !== '';
+    const hasRendererUrl = creativeRendererUrl != null && creativeRendererUrl !== '';
+
+    // Rule 1: exactly one of `creativeUrl` or `creativeHtml`. Neither or both → TypeError.
+    if (!hasCreativeUrl && !hasCreativeHtml) {
+      throw new TypeError(
+        '[SHARCContainer] creativeUrl is required (or pass creativeHtml + creativeRendererUrl '
+        + 'for inline-markup Creative Markup variant). Got neither.'
+      );
+    }
+    if (hasCreativeUrl && hasCreativeHtml) {
+      throw new TypeError(
+        '[SHARCContainer] creativeUrl and creativeHtml are mutually exclusive — '
+        + 'exactly one must be provided. Got both.'
+      );
+    }
+
+    // Rule 2: `creativeHtml` requires `creativeRendererUrl`.
+    if (hasCreativeHtml && !hasRendererUrl) {
+      throw new TypeError(
+        '[SHARCContainer] creativeHtml requires creativeRendererUrl '
+        + '(operator-hosted renderer page). Bare srcdoc is not supported — '
+        + 'see proposal § Bare srcdoc breaks silently.'
+      );
+    }
+
+    // Rule 3: `creativeRendererUrl` is only valid alongside `creativeHtml`.
+    if (hasCreativeUrl && hasRendererUrl) {
+      throw new TypeError(
+        '[SHARCContainer] creativeRendererUrl is only valid alongside creativeHtml '
+        + '(Creative Markup variant). Remove creativeRendererUrl when using creativeUrl.'
+      );
+    }
+
     if (!placementElement) throw new Error('[SHARCContainer] placementElement is required');
+
+    // Rules 4–7 only apply when the Markup variant is in use (renderer URL present).
+    /** @type {URL|null} */
+    let parsedRendererUrl = null;
+    if (hasRendererUrl) {
+      // Rule 4: `creativeRendererUrl` must parse via `new URL(...)`.
+      try {
+        parsedRendererUrl = new URL(creativeRendererUrl);
+      } catch (_) {
+        throw new Error(
+          '[SHARCContainer] creativeRendererUrl is not a parseable URL: '
+          + JSON.stringify(creativeRendererUrl)
+        );
+      }
+
+      // Rule 5: must use exactly the `https:` scheme.
+      if (parsedRendererUrl.protocol !== 'https:') {
+        throw new Error(
+          '[SHARCContainer] creativeRendererUrl must use the https: scheme '
+          + '(got "' + parsedRendererUrl.protocol + '"). '
+          + 'http:, javascript:, data:, blob:, file:, about:, and other schemes are rejected — '
+          + 'they collapse the cross-origin sandbox guarantee.'
+        );
+      }
+
+      // Rule 6: must not contain userinfo.
+      if (parsedRendererUrl.username !== '' || parsedRendererUrl.password !== '') {
+        throw new Error(
+          '[SHARCContainer] creativeRendererUrl must not contain userinfo '
+          + '(username or password). Strip credentials from the URL before passing it.'
+        );
+      }
+
+      // Rule 7: must be cross-origin to `window.location` and `window.top.location`.
+      // When `window.top.location` access throws (cross-origin top frame), the
+      // wrapper carve-out applies — `wrapperPolicy` governs warn-vs-block behavior.
+      const rendererOrigin = parsedRendererUrl.origin;
+      const windowOrigin = (typeof window !== 'undefined' && window.location)
+        ? window.location.origin
+        : null;
+      if (windowOrigin !== null && rendererOrigin === windowOrigin) {
+        throw new Error(
+          '[SHARCContainer] creativeRendererUrl must be cross-origin to window.location '
+          + '(got same-origin: "' + rendererOrigin + '"). Same-origin renderer collapses '
+          + 'the sandbox isolation that makes Creative Markup safe.'
+        );
+      }
+      let topOrigin = null;
+      let topAccessThrew = false;
+      try {
+        // Reading window.top.location.origin throws on cross-origin top frame.
+        topOrigin = (typeof window !== 'undefined' && window.top && window.top.location)
+          ? window.top.location.origin
+          : null;
+      } catch (err) {
+        // Only treat true cross-origin SecurityError as the wrapper carve-out
+        // signal. A bare `catch (_)` would silently swallow unrelated TypeErrors
+        // (e.g. window.top poisoned by userland Object.defineProperty, detached
+        // frame edge cases) and fail-open under default wrapperPolicy='warn'.
+        // SecurityError DOMException is what every major browser throws for
+        // cross-origin top.location reads.
+        if (err && err.name === 'SecurityError') {
+          topAccessThrew = true;
+        } else {
+          // Unknown failure mode — re-throw so the operator sees the real
+          // problem instead of silently routing into the carve-out path.
+          throw err;
+        }
+      }
+      if (!topAccessThrew && topOrigin !== null && rendererOrigin === topOrigin) {
+        throw new Error(
+          '[SHARCContainer] creativeRendererUrl must be cross-origin to window.top.location '
+          + '(got same-origin: "' + rendererOrigin + '"). Same-origin to publisher top '
+          + 'collapses the sandbox isolation that makes Creative Markup safe.'
+        );
+      }
+      if (topAccessThrew) {
+        // Wrapper carve-out: cross-origin top frame inaccessible. Behavior governed
+        // by wrapperPolicy (default 'warn'). See proposal § Security Model
+        // § wrapper-cross-origin and DD-19.
+        const severity = wrapperPolicy === 'block' ? 'error' : 'warning';
+        const message = 'Validation rule 7 carve-out applied — cross-origin top frame '
+          + 'detected; cannot verify creativeRendererUrl is cross-origin to the '
+          + "publisher's top-level page. This is an unsupported deployment unless "
+          + 'the operator has independently guaranteed creativeRendererUrl is not '
+          + 'same-origin with any publisher top this wrapper is embedded into.';
+        const consoleMethod = wrapperPolicy === 'block' ? 'error' : 'warn';
+        // eslint-disable-next-line no-console
+        console[consoleMethod]('[SHARCContainer] ' + message);
+        if (typeof onSecurityEvent === 'function') {
+          try {
+            onSecurityEvent({
+              type: 'wrapper_top_frame_inaccessible',
+              severity: severity,
+              timestamp: Date.now(),
+              // The same UUID the constructed instance will expose as
+              // `this.placementSessionId` — captured up-front for correlation.
+              placementSessionId: placementSessionId,
+              message: message,
+              details: {
+                wrapperOrigin: windowOrigin,
+                creativeRendererUrl: creativeRendererUrl,
+                // publisher top origin intentionally omitted — we cannot read it.
+              },
+            });
+          } catch (cbErr) {
+            // eslint-disable-next-line no-console
+            console.error('[SHARCContainer] onSecurityEvent callback threw; continuing.', cbErr);
+          }
+        }
+        if (wrapperPolicy === 'block') {
+          throw new Error('[SHARCContainer] ' + message);
+        }
+      }
+    }
+
+    // Rule 8: `creativeHtml` size must not exceed 256 KiB at construction (pre-injection).
+    if (hasCreativeHtml) {
+      // String.length is UTF-16 code units; the cap is UTF-8 bytes. TextEncoder
+      // is universally available in SHARC's target environments (modern browsers
+      // + Node 18+) and gives an exact UTF-8 byte count. Buffer.byteLength is
+      // a Node-only secondary path. If neither is reachable, throw — better to
+      // surface the environment problem than silently inflate by a worst-case
+      // 4× factor and false-reject near-cap markup.
+      let byteLength;
+      if (typeof TextEncoder !== 'undefined') {
+        byteLength = new TextEncoder().encode(creativeHtml).length;
+      } else if (typeof Buffer !== 'undefined') {
+        byteLength = Buffer.byteLength(creativeHtml, 'utf8');
+      } else {
+        throw new Error(
+          '[SHARCContainer] Cannot measure creativeHtml byte size: neither '
+          + 'TextEncoder nor Buffer is available in this environment.'
+        );
+      }
+      const MAX_BYTES = 256 * 1024;
+      if (byteLength > MAX_BYTES) {
+        throw new Error(
+          '[SHARCContainer] creativeHtml exceeds 256 KiB at construction '
+          + '(' + byteLength + ' bytes; cap is ' + MAX_BYTES + '). RTB markup norms '
+          + 'are well below this — payloads this large almost always indicate a bug.'
+        );
+      }
+    }
 
     // ── Synchronous isolation guard (proposal Part 7) ──
     // Throws at construction — before any iframe, MessageChannel, or page
@@ -194,8 +473,57 @@ class SHARCContainer {
       );
     }
 
-    /** @type {string} */
-    this.creativeUrl = creativeUrl;
+    /**
+     * URL of the SHARC-enabled creative HTML when running in Creative URL variant.
+     * `null` when running in Creative Markup variant — see `creativeSource`.
+     * @type {string|null}
+     */
+    this.creativeUrl = hasCreativeUrl ? creativeUrl : null;
+
+    /**
+     * Inline HTML markup when running in Creative Markup variant.
+     * `null` when running in Creative URL variant. Pre-injection markup as supplied
+     * by the operator (extension `injectIntoMarkup` hooks run later, in the load
+     * path). Not surfaced as a public field per DD-1 — exposed here as a private
+     * field for the renderer-protocol implementation in Phase B.
+     * @type {string|null}
+     * @private
+     */
+    this._creativeHtml = hasCreativeHtml ? creativeHtml : null;
+
+    /**
+     * HTTPS URL of the operator-hosted renderer page in Creative Markup variant.
+     * `null` when running in Creative URL variant. Validated at construction
+     * (rules 4–7); the actual iframe load and origin echo land in Phase B.
+     * @type {string|null}
+     */
+    this.creativeRendererUrl = hasRendererUrl ? creativeRendererUrl : null;
+
+    /**
+     * Active payload variant: `'url'` for Creative URL, `'html'` for Creative Markup.
+     * Stable across the container's lifetime. See proposal § Metadata and Observability.
+     * @type {'url'|'html'}
+     */
+    this.creativeSource = hasCreativeHtml ? 'html' : 'url';
+
+    /**
+     * `true` if injection ran and at least one injector returned a non-empty
+     * modified string. Set by the load path; initialized `false` at construction.
+     * @type {boolean}
+     */
+    this.creativeInjected = false;
+
+    /**
+     * `true` once the Creative Markup renderer protocol has successfully
+     * delivered the creative to the renderer iframe (i.e. the renderer's
+     * `SHARC:Renderer:rendered` reply has been validated by the container).
+     * `false` for Creative URL in all states; `false` for Creative Markup
+     * until the renderer protocol completes — set by Phase B. Initialized
+     * `false` at construction; the variant in use is reflected by
+     * `creativeSource`, not by this flag.
+     * @type {boolean}
+     */
+    this.creativeRendered = false;
 
     /** @type {HTMLElement} */
     this.placementElement = placementElement;
@@ -216,9 +544,12 @@ class SHARCContainer {
     /**
      * UUID v4 generated at construction time. Unique per SHARCContainer instance.
      * Used for DOM stamping, iframe identification, and diagnostics.
+     * Generated above the validation block so any construction-time security
+     * event (e.g. wrapper-cross-origin carve-out) carries the same correlation
+     * ID as the running container.
      * @type {string}
      */
-    this.placementSessionId = SHARCContainer._generateUUID();
+    this.placementSessionId = placementSessionId;
 
     /** @type {Object} */
     this.environmentData = environmentData;
@@ -257,6 +588,43 @@ class SHARCContainer {
     /** @private */ this._onNavigation = onNavigation || null;
     /** @private */ this._onInteraction = onInteraction || null;
     /** @private */ this._onMessage = onMessage || null;
+    /**
+     * Structured-event observability hook (Phase A: option stored, fired only for
+     * the construction-time `wrapper_top_frame_inaccessible` carve-out; Phase B
+     * adds the renderer-protocol event types).
+     * @private
+     */
+    this._onSecurityEvent = (typeof onSecurityEvent === 'function') ? onSecurityEvent : null;
+
+    /**
+     * Sandbox / policy configuration captured at construction. Phase A stores these
+     * for downstream use by the Phase B renderer-iframe builder; the constructor
+     * itself does not yet build the sandbox attribute. See proposal § Iframe sandbox.
+     * @type {{
+     *   allowPopups: boolean,
+     *   allowTopNavigationByUserActivation: boolean,
+     *   allowStorageAccessByUserActivation: boolean,
+     *   allowModals: boolean,
+     *   allowDownloads: boolean,
+     *   wrapperPolicy: 'warn'|'block'
+     * }}
+     * @private
+     */
+    // Asymmetric coercion intentional, mirrors the configuration philosophy in
+    // the proposal (DD-19/20/22 vs DD-23/25): click-through-or-measurement
+    // load-bearing tokens default permissive — only literal `false` opts out
+    // (`!== false`); UX-disruption-surface tokens default strict — only literal
+    // `true` opts in (`=== true`). Documented contract types these as boolean;
+    // operators passing other values (0, null, '') get the documented default,
+    // not a nuanced coercion.
+    this._sandboxConfig = {
+      allowPopups: allowPopups !== false,
+      allowTopNavigationByUserActivation: allowTopNavigationByUserActivation !== false,
+      allowStorageAccessByUserActivation: allowStorageAccessByUserActivation !== false,
+      allowModals: allowModals === true,
+      allowDownloads: allowDownloads === true,
+      wrapperPolicy: wrapperPolicy === 'block' ? 'block' : 'warn',
+    };
 
     /** @type {HTMLIFrameElement|null} @private */
     this._iframe = null;
@@ -576,6 +944,23 @@ class SHARCContainer {
    * @private
    */
   _createIframe() {
+    // Phase A guardrail (primary): Creative Markup load is not supported until
+    // the renderer protocol lands. Throw early — before any iframe creation,
+    // placement attach, or fetch — so a Markup container that calls .load()
+    // fails cleanly. Without this, the useMarkupInjection branch below would
+    // run `fetch(null)` (stringified to `fetch("null")`) and emit a stray
+    // `GET <publisher-origin>/null` to the publisher's access logs before the
+    // _resolvedIframeSrc() throw fires in the .catch() fallback. The throw in
+    // _resolvedIframeSrc() remains as defense-in-depth for direct callers.
+    if (this.creativeSource === 'html') {
+      throw new Error(
+        '[SHARCContainer] Creative Markup load is not supported in this build. '
+        + 'The renderer protocol that loads creativeRendererUrl with a fragment '
+        + 'nonce is implemented in a later phase. Use the Creative URL variant '
+        + '(creativeUrl) until Creative Markup ships.'
+      );
+    }
+
     const iframe = document.createElement('iframe');
 
     // Secure sandbox attributes.
@@ -639,7 +1024,7 @@ class SHARCContainer {
 
     if (!this._useMarkupInjection) {
       // Default path (Option 2 — recommended): publisher-page OM SDK loading.
-      iframe.src = this.creativeUrl;
+      iframe.src = this._resolvedIframeSrc();
       return;
     }
 
@@ -650,7 +1035,7 @@ class SHARCContainer {
 
     if (injectors.length === 0) {
       // No injectors registered — fall straight through to src.
-      iframe.src = this.creativeUrl;
+      iframe.src = this._resolvedIframeSrc();
       return;
     }
 
@@ -664,8 +1049,40 @@ class SHARCContainer {
         'OM SDK loading pattern (useMarkupInjection=false).',
         err && (err.message || err)
       );
-      iframe.src = this.creativeUrl;
+      iframe.src = this._resolvedIframeSrc();
     });
+  }
+
+  /**
+   * Returns the URL to assign to `iframe.src` for the active creative-source
+   * variant. Phase A returns `this.creativeUrl` for Creative URL and throws
+   * for Creative Markup — the renderer protocol that consumes
+   * `creativeRendererUrl + '#sharcNonce=' + nonce` lands in a later phase.
+   *
+   * The Markup-variant throw here is defense-in-depth: `_createIframe()`
+   * already throws earlier in `.load()` (before any DOM creation or fetch)
+   * for the Markup variant, so this method should not normally be reached
+   * for Markup callers. This throw covers the case where extensions or
+   * tests call `_resolvedIframeSrc()` directly.
+   *
+   * Phase B replaces both throws with the renderer-URL + CSPRNG nonce
+   * assembly; the call sites in `_createIframe` stay unchanged.
+   *
+   * @returns {string} Resolved iframe src URL.
+   * @throws {Error} If invoked for Creative Markup before the renderer
+   *   protocol implementation lands.
+   * @private
+   */
+  _resolvedIframeSrc() {
+    if (this.creativeSource === 'html') {
+      throw new Error(
+        '[SHARCContainer] Creative Markup load is not supported in this build. '
+        + 'The renderer protocol that loads creativeRendererUrl with a fragment '
+        + 'nonce is implemented in a later phase. Use the Creative URL variant '
+        + '(creativeUrl) until Creative Markup ships.'
+      );
+    }
+    return /** @type {string} */ (this.creativeUrl);
   }
 
   /**
@@ -700,11 +1117,15 @@ class SHARCContainer {
 
     // Pipe through each injector in registration order.
     // Each injector receives the HTML string and returns the modified string.
+    // Track whether any injector returned a non-empty modified string so the
+    // observable `creativeInjected` flag reflects what actually happened.
+    let injected = false;
     for (const injector of injectors) {
       try {
         const result = injector.injectIntoMarkup(html);
         if (typeof result === 'string' && result.length > 0) {
           html = result;
+          injected = true;
         }
       } catch (injectErr) {
         console.warn(
@@ -712,6 +1133,9 @@ class SHARCContainer {
           injectErr && (injectErr.message || injectErr)
         );
       }
+    }
+    if (injected) {
+      this.creativeInjected = true;
     }
 
     // Load the injected markup via srcdoc.

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -152,6 +152,16 @@ const ErrorCodes = Object.freeze({
   DEVICE_NOT_SUPPORTED: 2109,
   CONTAINER_NOT_SENDING: 2110,
   CONTAINER_NOT_RESPONDING: 2111,
+  // 2112 and 2113 are intentionally unassigned — reserved for future creative-side
+  // error codes that may emerge as the spec evolves. Renderer-protocol codes
+  // start at 2114 to keep them grouped.
+  // Renderer protocol errors (Creative Markup variant) — added in 0.7.0.
+  // See proposal: docs/proposals/creative-sources.md § Error Codes.
+  RENDERER_TIMEOUT: 2114,
+  RENDERER_FAILED: 2115,
+  RENDERER_ORIGIN_MISMATCH: 2116,
+  RENDERER_PROTOCOL_ERROR: 2117,
+  RENDERER_UNAUTHORIZED_NAVIGATION: 2118,
   UNSPECIFIED_CONTAINER: 2200,
   WRONG_SHARC_VERSION_CONTAINER: 2201,
   UNSUPPORTED_FEATURE: 2203,

--- a/test-creative-sources.js
+++ b/test-creative-sources.js
@@ -1,0 +1,765 @@
+/**
+ * test-creative-sources.js — issue #41 Phase A regression coverage
+ *
+ * Constructor-level tests for the Creative Markup payload variant.
+ * Phase A scope: constructor option additions + 8 sequenced validation rules
+ * + error codes 2114-2118 + new instance properties (creativeSource,
+ * creativeInjected, creativeRendered, creativeRendererUrl). No iframe creation,
+ * no renderer protocol behavior, no MessageChannel — those land in Phase B-D.
+ *
+ * Uses jsdom to provide window/document so each test calls
+ * `new SHARCContainer({...})` for real — not via Object.create stubs.
+ *
+ * Mirror of test-placement-stamping.js structure.
+ *
+ * Spec: docs/proposals/creative-sources.md § Validation Rules
+ *       and § Metadata and Observability.
+ *
+ * Runs in Node after `npm run build`. No browser, no test framework.
+ */
+
+import { JSDOM } from 'jsdom';
+
+// ── Set up DOM globals BEFORE importing SHARCContainer. ───────────────────
+// Constructor reads window.location for rule 7 (cross-origin check). The test
+// origin is the "publisher origin" — the renderer URL must be cross-origin
+// to it for rule 7 to pass.
+const PUBLISHER_ORIGIN = 'https://publisher.example';
+const dom = new JSDOM(
+  '<!DOCTYPE html><html><body></body></html>',
+  { url: PUBLISHER_ORIGIN + '/page.html', referrer: 'https://search.example/' },
+);
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.MessageChannel = dom.window.MessageChannel;
+global.MessagePort = dom.window.MessagePort;
+// TextEncoder is needed by validation rule 8 for accurate byte counting; jsdom
+// exposes it on the window, but Node 18+ also has it as a global. Either is fine.
+
+// Pre-load protocol exports onto window.SHARC.Protocol so the bundled
+// container module can resolve them (matches test-placement-stamping.js).
+const protoMod = await import('./dist/sharc-protocol.mjs');
+window.SHARC = window.SHARC || {};
+window.SHARC.Protocol = protoMod;
+
+const { SHARCContainer } = await import('./dist/sharc-container.mjs');
+const { ErrorCodes } = protoMod;
+
+// ── Tiny assertion harness ────────────────────────────────────────────────
+let failures = 0;
+function assert(condition, message) {
+  if (condition) {
+    console.log('  ✓', message);
+  } else {
+    console.error('  ✗', message);
+    failures++;
+  }
+}
+function assertThrows(fn, msgPattern, message, ErrorCtor) {
+  try {
+    fn();
+    console.error('  ✗', message, '(no throw)');
+    failures++;
+  } catch (e) {
+    if (ErrorCtor && !(e instanceof ErrorCtor)) {
+      console.error('  ✗', message, `(threw, wrong type: ${e.constructor.name}, expected ${ErrorCtor.name})`);
+      failures++;
+      return;
+    }
+    if (msgPattern && !String(e.message).match(msgPattern)) {
+      console.error('  ✗', message, `(threw, wrong message: ${e.message})`);
+      failures++;
+      return;
+    }
+    console.log('  ✓', message);
+  }
+}
+
+// ── Test fixtures ─────────────────────────────────────────────────────────
+const RENDERER_URL = 'https://renderer.operator.example/0.7.0/';
+function freshSlot() {
+  document.body.innerHTML = '';
+  const el = document.createElement('div');
+  el.id = 'ad-slot';
+  document.body.appendChild(el);
+  return el;
+}
+function urlOptions(overrides) {
+  return {
+    creativeUrl: 'https://ads.example/creative.html',
+    placementElement: freshSlot(),
+    ...overrides,
+  };
+}
+function markupOptions(overrides) {
+  return {
+    creativeHtml: '<html><body>ad</body></html>',
+    creativeRendererUrl: RENDERER_URL,
+    placementElement: freshSlot(),
+    ...overrides,
+  };
+}
+
+console.log('test-creative-sources.js — issue #41 Phase A regression\n');
+
+// -- 1. Error codes 2114-2118 are exposed on the protocol module ───────────
+{
+  console.log('1. Error codes 2114-2118 exposed on ErrorCodes');
+  assert(ErrorCodes.RENDERER_TIMEOUT === 2114,
+    'RENDERER_TIMEOUT === 2114');
+  assert(ErrorCodes.RENDERER_FAILED === 2115,
+    'RENDERER_FAILED === 2115');
+  assert(ErrorCodes.RENDERER_ORIGIN_MISMATCH === 2116,
+    'RENDERER_ORIGIN_MISMATCH === 2116');
+  assert(ErrorCodes.RENDERER_PROTOCOL_ERROR === 2117,
+    'RENDERER_PROTOCOL_ERROR === 2117');
+  assert(ErrorCodes.RENDERER_UNAUTHORIZED_NAVIGATION === 2118,
+    'RENDERER_UNAUTHORIZED_NAVIGATION === 2118');
+}
+
+// -- 2. Rule 1 — exactly one of creativeUrl or creativeHtml ────────────────
+{
+  console.log('\n2. Rule 1 — exactly one of creativeUrl or creativeHtml');
+  // Neither → TypeError
+  assertThrows(
+    () => new SHARCContainer({ placementElement: freshSlot() }),
+    /creativeUrl is required/,
+    'neither creativeUrl nor creativeHtml throws TypeError',
+    TypeError,
+  );
+  // Both → TypeError
+  assertThrows(
+    () => new SHARCContainer({
+      creativeUrl: 'https://ads.example/c.html',
+      creativeHtml: '<html></html>',
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: freshSlot(),
+    }),
+    /mutually exclusive/i,
+    'both creativeUrl and creativeHtml throws TypeError',
+    TypeError,
+  );
+}
+
+// -- 3. Rule 2 — creativeHtml requires creativeRendererUrl ─────────────────
+{
+  console.log('\n3. Rule 2 — creativeHtml requires creativeRendererUrl');
+  assertThrows(
+    () => new SHARCContainer({
+      creativeHtml: '<html></html>',
+      placementElement: freshSlot(),
+    }),
+    /creativeHtml requires creativeRendererUrl/,
+    'creativeHtml without creativeRendererUrl throws TypeError',
+    TypeError,
+  );
+}
+
+// -- 4. Rule 3 — creativeRendererUrl forbidden alongside creativeUrl ───────
+{
+  console.log('\n4. Rule 3 — creativeRendererUrl is only valid with creativeHtml');
+  assertThrows(
+    () => new SHARCContainer({
+      creativeUrl: 'https://ads.example/c.html',
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: freshSlot(),
+    }),
+    /only valid alongside creativeHtml/,
+    'creativeUrl + creativeRendererUrl throws TypeError',
+    TypeError,
+  );
+}
+
+// -- 5. Rule 4 — creativeRendererUrl must parse via new URL(...) ───────────
+{
+  console.log('\n5. Rule 4 — creativeRendererUrl must parse via new URL()');
+  assertThrows(
+    () => new SHARCContainer(markupOptions({ creativeRendererUrl: 'not-a-url' })),
+    /not a parseable URL/,
+    'unparseable creativeRendererUrl throws Error',
+    Error,
+  );
+}
+
+// -- 6. Rule 5 — creativeRendererUrl must use https: scheme ────────────────
+{
+  console.log('\n6. Rule 5 — creativeRendererUrl must use https: scheme');
+  const badSchemes = [
+    ['http://renderer.operator.example/', 'http:'],
+    ['javascript:alert(1)', 'javascript:'],
+    ['data:text/html,hello', 'data:'],
+    ['blob:https://x/abcd', 'blob:'],
+    ['file:///tmp/renderer.html', 'file:'],
+    ['about:blank', 'about:'],
+  ];
+  for (const [bad, scheme] of badSchemes) {
+    assertThrows(
+      () => new SHARCContainer(markupOptions({ creativeRendererUrl: bad })),
+      /must use the https: scheme/,
+      `${scheme} creativeRendererUrl throws Error`,
+      Error,
+    );
+  }
+}
+
+// -- 7. Rule 6 — creativeRendererUrl must not contain userinfo ─────────────
+{
+  console.log('\n7. Rule 6 — creativeRendererUrl must not contain userinfo');
+  assertThrows(
+    () => new SHARCContainer(markupOptions({
+      creativeRendererUrl: 'https://user@renderer.operator.example/',
+    })),
+    /must not contain userinfo/,
+    'creativeRendererUrl with username throws Error',
+    Error,
+  );
+  assertThrows(
+    () => new SHARCContainer(markupOptions({
+      creativeRendererUrl: 'https://user:pass@renderer.operator.example/',
+    })),
+    /must not contain userinfo/,
+    'creativeRendererUrl with username:password throws Error',
+    Error,
+  );
+  // Percent-encoded credentials (`%75` decodes to `u`) — the URL parser
+  // decodes during construction, so `username` is `'user'` by the time we
+  // check. Locks in that the rule can't be bypassed via encoding.
+  assertThrows(
+    () => new SHARCContainer(markupOptions({
+      creativeRendererUrl: 'https://%75ser@renderer.operator.example/',
+    })),
+    /must not contain userinfo/,
+    'creativeRendererUrl with percent-encoded username throws Error',
+    Error,
+  );
+}
+
+// -- 8. Rule 7 — creativeRendererUrl must be cross-origin to window ────────
+{
+  console.log('\n8. Rule 7 — creativeRendererUrl must be cross-origin to window');
+  assertThrows(
+    () => new SHARCContainer(markupOptions({
+      creativeRendererUrl: PUBLISHER_ORIGIN + '/renderer.html',
+    })),
+    /must be cross-origin to window\.location/,
+    'same-origin creativeRendererUrl (vs window.location) throws Error',
+    Error,
+  );
+  // Cross-port is a different origin in HTML's origin model — explicit + safe.
+  let crossPortOk = false;
+  try {
+    const c = new SHARCContainer(markupOptions({
+      creativeRendererUrl: 'https://publisher.example:8443/renderer.html',
+    }));
+    crossPortOk = c.creativeRendererUrl === 'https://publisher.example:8443/renderer.html';
+  } catch (_) { /* swallow */ }
+  assert(crossPortOk,
+    'cross-port renderer URL is treated as cross-origin (per HTML origin model)');
+}
+
+// -- 9. Rule 7 carve-out — wrapper-cross-origin top frame inaccessible ────
+{
+  console.log('\n9. Rule 7 carve-out — wrapper-cross-origin top frame inaccessible');
+
+  // Simulate cross-origin top by swapping `global.window` for a Proxy that
+  // intercepts `.top` and returns an object whose `.location.origin` access
+  // throws — mirroring how browsers block cross-origin top.location reads from
+  // inside a wrapper iframe. The container reads `window` as a free global,
+  // so reassigning `global.window` for the duration of the test is sufficient.
+  // jsdom's `window.top` getter is non-configurable, so we cannot stub it
+  // in place — wrap the whole window instead.
+  const originalWindow = global.window;
+  function installCrossOriginTopStub() {
+    const throwingTop = new Proxy({}, {
+      get() {
+        throw new DOMException(
+          'Blocked a frame with origin "' + PUBLISHER_ORIGIN + '" from accessing a cross-origin frame.',
+          'SecurityError',
+        );
+      },
+    });
+    global.window = new Proxy(originalWindow, {
+      get(target, prop, receiver) {
+        if (prop === 'top') return throwingTop;
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+  }
+  function restoreTop() {
+    global.window = originalWindow;
+  }
+
+  // 9a — default 'warn' policy: emits console.warn + onSecurityEvent, proceeds.
+  installCrossOriginTopStub();
+  try {
+    const events = [];
+    const warned = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => { warned.push(args.join(' ')); };
+    let constructed = null;
+    try {
+      constructed = new SHARCContainer(markupOptions({
+        onSecurityEvent: (ev) => events.push(ev),
+      }));
+    } finally {
+      console.warn = originalWarn;
+    }
+    assert(constructed instanceof SHARCContainer,
+      "default wrapperPolicy='warn' proceeds with construction");
+    // Console output is dev-channel signalling only; prod bundles
+    // (`NODE_ENV=production`) strip it via terser `drop_console: true`. The
+    // structured-event channel below is the durable contract. Skip the console
+    // probe when no output was captured (signature of a prod bundle).
+    if (warned.length > 0) {
+      assert(warned.some((w) => /Validation rule 7 carve-out/.test(w)),
+        'console.warn fires once with carve-out message (dev bundle)');
+    }
+    assert(events.length === 1 && events[0].type === 'wrapper_top_frame_inaccessible',
+      'onSecurityEvent fires with type=wrapper_top_frame_inaccessible');
+    assert(events[0] && events[0].severity === 'warning',
+      'onSecurityEvent severity === "warning" under wrapperPolicy="warn"');
+    assert(events[0] && typeof events[0].timestamp === 'number',
+      'onSecurityEvent payload includes numeric timestamp');
+    assert(events[0] && typeof events[0].placementSessionId === 'string'
+      && events[0].placementSessionId.length > 0,
+      'onSecurityEvent payload includes placementSessionId');
+    // Correlation guarantee: the event's placementSessionId MUST equal the
+    // constructed instance's placementSessionId. Reviewers (security, code,
+    // architect) all flagged that an earlier draft generated a throwaway UUID
+    // here; this regression probe locks the fix in place.
+    assert(events[0] && constructed
+      && events[0].placementSessionId === constructed.placementSessionId,
+      'onSecurityEvent.placementSessionId === instance.placementSessionId (correlation)');
+    assert(events[0] && events[0].details
+      && events[0].details.wrapperOrigin === PUBLISHER_ORIGIN,
+      'onSecurityEvent details.wrapperOrigin === window.location.origin');
+    assert(events[0] && events[0].details
+      && events[0].details.creativeRendererUrl === RENDERER_URL,
+      'onSecurityEvent details.creativeRendererUrl matches input');
+  } finally {
+    restoreTop();
+  }
+
+  // 9b — wrapperPolicy='block': console.error + onSecurityEvent + throws.
+  installCrossOriginTopStub();
+  try {
+    const events = [];
+    const errored = [];
+    const originalError = console.error;
+    console.error = (...args) => { errored.push(args.join(' ')); };
+    let threw = false;
+    try {
+      new SHARCContainer(markupOptions({
+        wrapperPolicy: 'block',
+        onSecurityEvent: (ev) => events.push(ev),
+      }));
+    } catch (e) {
+      threw = /Validation rule 7 carve-out/.test(e.message);
+    } finally {
+      console.error = originalError;
+    }
+    assert(threw, "wrapperPolicy='block' throws synchronously at construction");
+    // Same dev-vs-prod console caveat as 9a above.
+    if (errored.length > 0) {
+      assert(errored.some((e) => /Validation rule 7 carve-out/.test(e)),
+        'console.error fires with carve-out message (dev bundle)');
+    }
+    assert(events.length === 1 && events[0].severity === 'error',
+      "onSecurityEvent fires with severity='error' before throw");
+  } finally {
+    restoreTop();
+  }
+
+  // 9c — onSecurityEvent throwing inside callback does NOT propagate.
+  installCrossOriginTopStub();
+  try {
+    const originalWarn = console.warn;
+    const originalError = console.error;
+    console.warn = () => {};
+    console.error = () => {};
+    let constructed = false;
+    try {
+      const c = new SHARCContainer(markupOptions({
+        onSecurityEvent: () => { throw new Error('callback boom'); },
+      }));
+      constructed = c instanceof SHARCContainer;
+    } catch (_) { /* should not happen */ }
+    console.warn = originalWarn;
+    console.error = originalError;
+    assert(constructed,
+      "throwing onSecurityEvent does NOT propagate under wrapperPolicy='warn'");
+  } finally {
+    restoreTop();
+  }
+
+  // 9d — non-SecurityError throws on `window.top` access MUST propagate
+  // (narrowed catch — security review medium finding). Earlier drafts used
+  // a bare `catch (_)` that silently routed any throw into the carve-out
+  // path, fail-open under default 'warn'. Wrap window so `.top` access
+  // throws a plain TypeError; expect the constructor to re-throw, NOT
+  // silently apply the carve-out.
+  {
+    const throwingTopWindow = new Proxy(originalWindow, {
+      get(target, prop, receiver) {
+        if (prop === 'top') {
+          throw new TypeError('window.top is poisoned (not a SecurityError)');
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    global.window = throwingTopWindow;
+    let propagatedError = null;
+    try {
+      new SHARCContainer(markupOptions());
+    } catch (e) { propagatedError = e; }
+    global.window = originalWindow;
+    assert(propagatedError instanceof TypeError
+      && /poisoned/.test(propagatedError.message),
+      'non-SecurityError on window.top access propagates (does NOT fall into carve-out)');
+  }
+}
+
+// -- 10. Rule 8 — creativeHtml size cap (256 KiB at construction) ──────────
+{
+  console.log('\n10. Rule 8 — creativeHtml size cap (256 KiB)');
+  const MAX = 256 * 1024;
+  // Just under the cap is fine.
+  const justUnder = 'a'.repeat(MAX - 1);
+  let underOk = false;
+  try {
+    const c = new SHARCContainer(markupOptions({ creativeHtml: justUnder }));
+    underOk = c.creativeSource === 'html';
+  } catch (_) { /* swallow */ }
+  assert(underOk, 'creativeHtml at MAX-1 bytes constructs successfully');
+
+  // Over the cap throws.
+  const justOver = 'a'.repeat(MAX + 1);
+  assertThrows(
+    () => new SHARCContainer(markupOptions({ creativeHtml: justOver })),
+    /exceeds 256 KiB/,
+    'creativeHtml > 256 KiB throws Error',
+    Error,
+  );
+}
+
+// -- 11. Validation rule ordering — shape errors precede value errors ─────
+{
+  console.log('\n11. Validation rule ordering — TypeError (shape) before Error (value)');
+  // Both shape (rule 3) and value (rule 5) violations present;
+  // rule 3 fires first with TypeError, never reaches the http: scheme check.
+  assertThrows(
+    () => new SHARCContainer({
+      creativeUrl: 'https://ads.example/c.html',
+      creativeRendererUrl: 'http://insecure.renderer.example/',
+      placementElement: freshSlot(),
+    }),
+    /only valid alongside creativeHtml/,
+    'shape error (rule 3) thrown before value error (rule 5)',
+    TypeError,
+  );
+
+  // Rule 4 (parseable) precedes rule 5 (https:); unparseable URL hits rule 4.
+  assertThrows(
+    () => new SHARCContainer(markupOptions({ creativeRendererUrl: '!!!' })),
+    /not a parseable URL/,
+    'rule 4 (parseable) thrown before rule 5 (https:)',
+    Error,
+  );
+}
+
+// -- 12. Creative URL variant — instance properties ────────────────────────
+{
+  console.log('\n12. Creative URL variant — instance properties');
+  const c = new SHARCContainer(urlOptions());
+  assert(c.creativeUrl === 'https://ads.example/creative.html',
+    'creativeUrl is preserved on the instance');
+  assert(c.creativeRendererUrl === null,
+    'creativeRendererUrl is null in URL variant');
+  assert(c.creativeSource === 'url',
+    "creativeSource === 'url' in URL variant");
+  assert(c.creativeRendered === false,
+    'creativeRendered === false at construction in URL variant (load-time concern)');
+  assert(c.creativeInjected === false,
+    'creativeInjected === false at construction (load-time concern)');
+}
+
+// -- 13. Creative Markup variant — instance properties ────────────────────
+{
+  console.log('\n13. Creative Markup variant — instance properties');
+  const c = new SHARCContainer(markupOptions());
+  assert(c.creativeUrl === null,
+    'creativeUrl is null in Markup variant');
+  assert(c.creativeRendererUrl === RENDERER_URL,
+    'creativeRendererUrl is preserved on the instance');
+  assert(c.creativeSource === 'html',
+    "creativeSource === 'html' in Markup variant");
+  // creativeRendered is a load-time fact: true only after the renderer
+  // protocol's ':rendered' reply is validated (Phase B). At construction
+  // it is FALSE for both variants; the variant in use is reflected by
+  // creativeSource, not by this flag. (Architect review fix.)
+  assert(c.creativeRendered === false,
+    'creativeRendered === false at construction in Markup variant (Phase B sets true on :rendered)');
+  assert(c.creativeInjected === false,
+    'creativeInjected === false at construction (load-time concern)');
+  assert(typeof c.placementSessionId === 'string' && c.placementSessionId.length > 0,
+    'placementSessionId is generated for Markup variant (parity with URL)');
+}
+
+// -- 14. Sandbox / policy options — defaults and overrides ────────────────
+{
+  console.log('\n14. Sandbox / policy options — defaults match spec');
+  const c = new SHARCContainer(markupOptions());
+  assert(c._sandboxConfig.allowPopups === true,
+    'allowPopups defaults to true (DD-12, DD-17)');
+  assert(c._sandboxConfig.allowTopNavigationByUserActivation === true,
+    'allowTopNavigationByUserActivation defaults to true (DD-20)');
+  assert(c._sandboxConfig.allowStorageAccessByUserActivation === true,
+    'allowStorageAccessByUserActivation defaults to true (DD-22)');
+  assert(c._sandboxConfig.allowModals === false,
+    'allowModals defaults to false (DD-23 — UX-disruption surface)');
+  assert(c._sandboxConfig.allowDownloads === false,
+    'allowDownloads defaults to false (DD-25 — UX-disruption surface)');
+  assert(c._sandboxConfig.wrapperPolicy === 'warn',
+    "wrapperPolicy defaults to 'warn' (DD-19)");
+
+  const overridden = new SHARCContainer(markupOptions({
+    allowPopups: false,
+    allowTopNavigationByUserActivation: false,
+    allowStorageAccessByUserActivation: false,
+    allowModals: true,
+    allowDownloads: true,
+    wrapperPolicy: 'block',
+  }));
+  assert(overridden._sandboxConfig.allowPopups === false,
+    'allowPopups: false flows through');
+  assert(overridden._sandboxConfig.allowTopNavigationByUserActivation === false,
+    'allowTopNavigationByUserActivation: false flows through');
+  assert(overridden._sandboxConfig.allowStorageAccessByUserActivation === false,
+    'allowStorageAccessByUserActivation: false flows through');
+  assert(overridden._sandboxConfig.allowModals === true,
+    'allowModals: true flows through');
+  assert(overridden._sandboxConfig.allowDownloads === true,
+    'allowDownloads: true flows through');
+  assert(overridden._sandboxConfig.wrapperPolicy === 'block',
+    "wrapperPolicy: 'block' flows through");
+
+  // Unknown wrapperPolicy values fall back to 'warn' (defensive default).
+  const fallback = new SHARCContainer(markupOptions({ wrapperPolicy: 'lenient' }));
+  assert(fallback._sandboxConfig.wrapperPolicy === 'warn',
+    "unknown wrapperPolicy falls back to 'warn'");
+}
+
+// -- 15. Constructor is side-effect-free on success path ───────────────────
+//
+// Construction must NOT mutate the placement element or attach to the DOM —
+// load() owns those mutations. Same invariant as Creative URL.
+{
+  console.log('\n15. Markup constructor does not mutate placement element');
+  const slot = freshSlot();
+  const before = slot.outerHTML;
+  new SHARCContainer({
+    creativeHtml: '<html><body>ad</body></html>',
+    creativeRendererUrl: RENDERER_URL,
+    placementElement: slot,
+  });
+  assert(slot.outerHTML === before,
+    'placementElement.outerHTML unchanged after Markup construction');
+}
+
+// -- 16. Backward compatibility — Creative URL construction unchanged ─────
+{
+  console.log('\n16. Backward compatibility — Creative URL behavior preserved');
+  const c = new SHARCContainer({
+    creativeUrl: 'https://ads.example/creative.html',
+    placementElement: freshSlot(),
+    placementId: 'slot-001',
+    placementName: 'sidebar',
+  });
+  assert(c.creativeUrl === 'https://ads.example/creative.html',
+    'Creative URL: creativeUrl preserved');
+  assert(c.placementId === 'slot-001',
+    'Creative URL: placementId round-trip preserved');
+  assert(c.placementName === 'sidebar',
+    'Creative URL: placementName round-trip preserved');
+  assert(c.creativeSource === 'url',
+    'Creative URL: creativeSource defaults to "url"');
+}
+
+// -- 17. Markup-variant load-path guardrails (Phase A) ────────────────────
+//
+// Two guards close the Phase A "Markup load not supported" boundary:
+//   - `_createIframe()` throws at the very top of .load() — primary, runs
+//     before any DOM creation, placement attach, or fetch. This is the
+//     production scenario gate.
+//   - `_resolvedIframeSrc()` throws as defense-in-depth — covers direct
+//     callers (extensions, tests) that bypass `_createIframe`.
+//
+// Without the `_createIframe()` early-throw, Markup + `useMarkupInjection`
+// + an injector extension would emit a stray `GET <publisher-origin>/null`
+// via `fetch(this.creativeUrl)` (where creativeUrl is null) before the
+// `_resolvedIframeSrc()` throw fires in the fetch's `.catch()`. The early
+// throw closes that leak.
+//
+// Phase B replaces both throws with the renderer-protocol assembly.
+{
+  console.log('\n17. Markup-variant load-path guardrails');
+
+  // 17a — _resolvedIframeSrc unit-level: URL passes through, Markup throws.
+  const urlContainer = new SHARCContainer(urlOptions());
+  let urlResolved;
+  try {
+    urlResolved = urlContainer._resolvedIframeSrc();
+  } catch (_) {
+    urlResolved = null;
+  }
+  assert(urlResolved === 'https://ads.example/creative.html',
+    'Creative URL: _resolvedIframeSrc returns this.creativeUrl');
+
+  const markupContainer = new SHARCContainer(markupOptions());
+  assertThrows(
+    () => markupContainer._resolvedIframeSrc(),
+    /Creative Markup load is not supported/,
+    'Creative Markup: _resolvedIframeSrc throws "not supported in Phase A"',
+    Error,
+  );
+
+  // 17b — load() on a plain Markup container throws cleanly with no DOM
+  // mutation. The throw originates from `_createIframe()`'s early guard.
+  {
+    const slot = freshSlot();
+    const c = new SHARCContainer({
+      creativeHtml: '<html><body>ad</body></html>',
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: slot,
+    });
+    assertThrows(
+      () => c.load(),
+      /Creative Markup load is not supported/,
+      'Creative Markup: .load() throws via _createIframe early-throw',
+      Error,
+    );
+    assert(slot.children.length === 0,
+      'Creative Markup: .load() throws BEFORE any iframe is appended to placement');
+  }
+
+  // 17c — Markup + useMarkupInjection + injector extension: the historical
+  // fetch-leak scenario. `_createIframe()`'s early throw must fire BEFORE the
+  // useMarkupInjection branch reaches `fetch(this.creativeUrl)` — otherwise
+  // a `fetch("null")` would emit a stray request to publisher-origin/null.
+  // Stub global.fetch so a leak would be observable; assert it was NEVER
+  // called.
+  {
+    const originalFetch = global.fetch;
+    let fetchCallCount = 0;
+    global.fetch = (...args) => {
+      fetchCallCount++;
+      // Return a rejected promise to simulate the 404; if this code path
+      // were reached the test would still surface the leak via the count.
+      return Promise.reject(new Error('fetch should not have been called'));
+    };
+    try {
+      const slot = freshSlot();
+      const c = new SHARCContainer({
+        creativeHtml: '<html><body>ad</body></html>',
+        creativeRendererUrl: RENDERER_URL,
+        placementElement: slot,
+        useMarkupInjection: true,
+        extensions: [{
+          getFeatureName() { return 'fake-injector'; },
+          injectIntoMarkup(html) { return html + '<!-- injected -->'; },
+        }],
+      });
+      assertThrows(
+        () => c.load(),
+        /Creative Markup load is not supported/,
+        'Markup + useMarkupInjection + injector: .load() throws cleanly',
+        Error,
+      );
+      assert(fetchCallCount === 0,
+        'Markup + useMarkupInjection + injector: NO stray fetch leak (was the security pass-3 finding)');
+      assert(slot.children.length === 0,
+        'Markup + useMarkupInjection + injector: placement remains empty after throw');
+    } finally {
+      global.fetch = originalFetch;
+    }
+  }
+}
+
+// -- 18. Input-shape edge cases — lock in URL parser + coercion behavior ──
+//
+// Code-review pass-1 LOW finding: several real-world input shapes weren't
+// probed. These assertions lock in current parser behavior so a future
+// change can't silently break them.
+{
+  console.log('\n18. Input-shape edge cases');
+
+  // 18a — `creativeRendererUrl` accepts a `URL` object (real-world DSP code
+  // routinely passes parsed URLs). `new URL(URL)` constructs from the
+  // stringified form, so this should round-trip cleanly.
+  const urlObject = new URL(RENDERER_URL);
+  let urlObjectOk = false;
+  try {
+    const c = new SHARCContainer(markupOptions({ creativeRendererUrl: urlObject }));
+    urlObjectOk = c.creativeRendererUrl === urlObject;
+  } catch (_) { /* swallow */ }
+  assert(urlObjectOk,
+    'creativeRendererUrl accepts a URL object input');
+
+  // 18b — Trailing-whitespace creativeRendererUrl: per the WHATWG URL spec
+  // the parser silently strips leading/trailing C0-control + ASCII-space
+  // characters before parsing, so rule 4 does NOT throw. Lock in the
+  // pass-through behavior so a future stricter-input check can't regress it
+  // without a deliberate code change. (Code-review pass-1 expected a throw;
+  // probe corrected to match documented spec behavior.)
+  let trailingOk = false;
+  try {
+    const c = new SHARCContainer(markupOptions({
+      creativeRendererUrl: 'https://renderer.operator.example/   ',
+    }));
+    trailingOk = c.creativeSource === 'html';
+  } catch (_) { /* swallow */ }
+  assert(trailingOk,
+    'trailing-whitespace creativeRendererUrl is normalized by URL parser (no rule 4 throw)');
+
+  // 18c — Uppercase scheme `'HTTPS://'`: URL parser normalizes `protocol` to
+  // lowercase, so rule 5's `=== 'https:'` check passes. Lock this in so a
+  // future strict-equal-on-the-input-string check can't regress it.
+  let httpsUppercaseOk = false;
+  try {
+    const c = new SHARCContainer(markupOptions({
+      creativeRendererUrl: 'HTTPS://renderer.operator.example/0.7.0/',
+    }));
+    httpsUppercaseOk = c.creativeSource === 'html';
+  } catch (_) { /* swallow */ }
+  assert(httpsUppercaseOk,
+    'uppercase HTTPS scheme is normalized and accepted (rule 5)');
+
+  // 18d — `wrapperPolicy: undefined` (explicit) behaves identically to a
+  // missing key; destructuring default applies in both cases.
+  const explicitUndefined = new SHARCContainer(markupOptions({ wrapperPolicy: undefined }));
+  assert(explicitUndefined._sandboxConfig.wrapperPolicy === 'warn',
+    "explicit wrapperPolicy: undefined → defaults to 'warn'");
+
+  // 18e — Non-string `creativeHtml`: the documented contract is `string`.
+  // Passing a number coerces inside TextEncoder.encode (which calls toString
+  // internally), so byte counting works and validation proceeds. Documented
+  // contract violated, but no crash. Operators relying on this behavior
+  // are off-spec; the test locks in "doesn't blow up" not "is supported."
+  let numericHtmlOk = false;
+  try {
+    const c = new SHARCContainer(markupOptions({ creativeHtml: 42 }));
+    numericHtmlOk = c.creativeSource === 'html';
+  } catch (_) { /* swallow */ }
+  assert(numericHtmlOk,
+    'non-string creativeHtml (number) constructs without crash (off-spec but stable)');
+}
+
+// ── Summary ───────────────────────────────────────────────────────────────
+console.log('');
+if (failures > 0) {
+  console.error(`✗ ${failures} creative-sources assertion(s) failed.`);
+  process.exit(1);
+} else {
+  console.log('✓ All creative-sources assertions passed.');
+}

--- a/test/types/consumer.ts
+++ b/test/types/consumer.ts
@@ -17,7 +17,7 @@
  *     arguments, so that argument-shape regressions surface as compile errors.
  */
 
-import { SHARCContainer } from '../../dist/sharc-container';
+import { SHARCContainer, type SHARCSecurityEvent, type SHARCSecurityEventCallback } from '../../dist/sharc-container';
 import { SHARCCreative } from '../../dist/sharc-creative';
 import { MRAIDCompatBridge } from '../../dist/sharc-mraid-bridge';
 import { SafeFrameCompatBridge } from '../../dist/sharc-safeframe-bridge';
@@ -39,18 +39,51 @@ const container = new SHARCContainer({
 });
 
 // ── SHARCContainer instance shape ──
-const url: string = container.creativeUrl;
+const url: string | null = container.creativeUrl;
+const rendererUrl: string | null = container.creativeRendererUrl;
+const source: 'url' | 'html' = container.creativeSource;
+const injected: boolean = container.creativeInjected;
+const rendered: boolean = container.creativeRendered;
 const el: HTMLElement = container.placementElement;
 const pid: string | null = container.placementId;
 const pname: string | null = container.placementName;
 const psid: string = container.placementSessionId;
 const sid: string | null = container.sessionId;
 void url;
+void rendererUrl;
+void source;
+void injected;
+void rendered;
 void el;
 void pid;
 void pname;
 void psid;
 void sid;
+
+// ── Creative Markup constructor surface (Phase A — option shape only) ──
+const markupContainer = new SHARCContainer({
+  creativeHtml: '<html><body>inline ad markup</body></html>',
+  creativeRendererUrl: 'https://renderer.operator.example/0.7.0/',
+  placementElement: slot,
+  allowPopups: true,
+  allowTopNavigationByUserActivation: true,
+  allowStorageAccessByUserActivation: true,
+  allowModals: false,
+  allowDownloads: false,
+  wrapperPolicy: 'warn',
+  onSecurityEvent: (event: SHARCSecurityEvent) => {
+    void event.type;
+    void event.severity;
+    void event.placementSessionId;
+  },
+});
+void markupContainer;
+
+// ── Verify the exported callback type is reusable as a standalone alias ──
+const _securityHandler: SHARCSecurityEventCallback = (event) => {
+  void event.details;
+};
+void _securityHandler;
 
 // ── Bridge constructor variants ──
 const mraid = new MRAIDCompatBridge({ baseUrl: '/sharc' });


### PR DESCRIPTION
## Summary

- **Phase A of #41** — constructor surface for the Creative Sources work (Creative URL + Creative Markup variants). Just constructor + validation + types + test; no iframe, sandbox, or renderer protocol behavior yet (Phase B-D ship as follow-up PRs against #65 and beyond).
- 8 sequenced validation rules at construction (`TypeError` for shape rules 1–3, `Error` for value rules 4–8), 5 new error codes (2114-2118), 9 new constructor options, 4 new instance properties.
- Renames the proposal `creative-payload-polymorphism.md` → `creative-sources.md` to match the `creativeSource` instance property the constructor adds.

## What's NOT in this PR

- Iframe creation / sandbox token application / Permissions Policy / CSP attribute (`_createIframe()` and `_resolvedIframeSrc()` throw cleanly for the Markup variant in this build)
- Fragment nonce + `SHARC:Renderer:render` / `:rendered` / `:failed` exchange
- Container-side message validation + post-load origin echo
- Load-event monitoring backstop for unauthorized navigation
- Reference renderer (`examples/renderer/index.html`)

These ship as follow-up PRs against #65 and beyond.

## Review

Three Claude review passes (security / code / architect) plus two OpenClaw passes — all final verdicts ship. Highlights of what got fixed along the way:

- Pass 1: `placementSessionId` correlation bug — wrapper-cross-origin carve-out event payload was generating a throwaway UUID instead of the eventual instance's session ID. Fixed by hoisting UUID generation above the validation block. (Flagged independently by all three reviewers.)
- Pass 1: `creativeRendered` semantics — was set `true` at construction for the Markup variant, but the spec defines it as a post-load fact. Now initialized `false`; Phase B sets `true` after `:rendered` reply.
- Pass 2: `topAccessErrorName` fingerprinting channel removed (security MED) — a poisoned `window.top` Proxy could plant arbitrary strings into operator observability for zero diagnostic value.
- OpenClaw 1: `_resolvedIframeSrc()` Markup-variant silent-bad-navigation (HIGH) — `iframe.src = null` was resolving to `<publisher>/null` instead of failing cleanly.
- Pass 3: `_createIframe()` early-throw closes the `.load()` + `useMarkupInjection` stray-`fetch(null)` leak (security LOW) — without this, a Markup container with `useMarkupInjection: true` and an injector extension would emit a `GET <publisher>/null` to publisher access logs before the throw fires.

Four follow-up tickets filed for properly-deferred items: #62 (discriminated `SHARCSecurityEvent.type`), #63 (build-mode-aware test infra), #64 (static `_validateCreativeSources`), #65 (Phase B `_resolvedIframeSrc` nonce assembly + runtime guard).

## Test plan

- [x] `npm run build` — rollup + tsc types emission clean
- [x] `npm run test:creative-sources` — 80 assertions across 18 sections, all pass
- [x] `npm run test:placement-stamping` — no regression
- [x] `npm run test:placement` — no regression
- [x] `npm run test:smoke` — all artifacts importable
- [x] `npm run test:treeshake` — bundles tree-shake; container 9.13 kB / 25 kB budget
- [x] `npm run test:types` — `consumer.ts` typechecks against generated `.d.ts`; verifies `SHARCSecurityEvent` + `SHARCSecurityEventCallback` exports
- [x] Verified `dist/sharc-container.d.ts` carries every new option + property
- [x] Verified `dist/sharc-protocol.d.ts` carries new error code constants + 2112-2113 reserved-gap comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)