### PR TITLE
feat(container): Creative Sources Phase B — renderer iframe build + render protocol (#41)

### DIFF
--- a/docs/proposals/creative-sources.md
+++ b/docs/proposals/creative-sources.md
@@ -874,6 +874,7 @@ New codes added to the SHARC error code table (additive, pre-1.0 — not breakin
 | `2116` | `RENDERER_ORIGIN_MISMATCH` | Post-load origin echo does not match construction-time origin (redirect detected) |
 | `2117` | `RENDERER_PROTOCOL_ERROR` | Malformed renderer message, missing nonce, version mismatch, parent-origin mismatch |
 | `2118` | `RENDERER_UNAUTHORIZED_NAVIGATION` | Iframe navigated outside the SHARC protocol path (in-frame `location.href`, anchor click, form submit, meta refresh that bypassed the renderer shim). Detected via load-event monitoring. |
+| `2119` | `RENDERER_POST_FAILED` | Synchronous `postMessage(SHARC:Renderer:render)` threw (e.g., `DataCloneError`, null `contentWindow`). Distinct from `RENDERER_TIMEOUT` so telemetry can differentiate transport-layer failures from latency failures. |
 
 Code numbers tentative — final assignment during implementation, fitting the existing `21xx` container-error range.
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test:placement": "node test-placement-dedup.js",
     "test:placement-stamping": "node test-placement-stamping.js",
     "test:creative-sources": "node test-creative-sources.js",
+    "test:creative-sources-load": "node test-creative-sources-load.js",
     "test:types": "tsc -p test/types/tsconfig.json",
     "regen:baseline": "node scripts/regen-mraid3-baseline.js",
     "lint": "eslint src/*.js --max-warnings=0",

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -1337,6 +1337,13 @@ class SHARCContainer {
     });
 
     iframe.addEventListener('load', () => {
+      // SRE pass HIGH: drop late `load` after a timeout-induced termination.
+      // _handleFatalError schedules _terminate asynchronously (via
+      // sendFatalError().then(_terminate) plus a 1s force-terminate
+      // setTimeout), so a load racing the timeout window would otherwise
+      // re-enter the protocol on a terminated container — duplicate onError,
+      // leaked window 'message' listener, mutated creativeInjected.
+      if (this._terminated) return;
       this._clearTimeout('rendererLoad');
 
       // 2a. Run injectors synchronously. For Markup, injection runs
@@ -1543,6 +1550,15 @@ class SHARCContainer {
       this._rendererMessageHandler = null;
     }
     this.creativeRendered = true;
+    // Reflect to DOM per spec § DOM stamping additions. Defensive
+    // `if (this._iframe)` guard mirrors the deferred initChannel pattern
+    // below — `_terminate` may run between dispatch and this point and
+    // null `_iframe`. The new `_terminated` early-return at the top of this
+    // method should already cover the typical case; belt-and-suspenders here
+    // matches existing precedent.
+    if (this._iframe) {
+      this._iframe.setAttribute('data-sharc-creative-rendered', 'true');
+    }
 
     // Standard bootstrap — 200ms delay then initChannel.
     //
@@ -3425,6 +3441,16 @@ class SHARCContainer {
     if (this._iframe) {
       this._iframe.classList.add('sharc-creative');
       this._iframe.setAttribute('data-sharc-placement-session-id', this.placementSessionId);
+      // Per spec § DOM stamping additions: both attributes are always
+      // present on the iframe. `data-sharc-creative-source` reflects the
+      // immutable variant choice; `data-sharc-creative-rendered` starts
+      // 'false' and only flips 'true' for the Markup variant when an
+      // envelope-valid SHARC:Renderer:rendered arrives. Symmetric with the
+      // existing `data-sharc-creative-injected` precedent — devtools queries
+      // like `[data-sharc-creative-rendered="false"]` select Creative URL
+      // instances explicitly.
+      this._iframe.setAttribute('data-sharc-creative-source', this.creativeSource);
+      this._iframe.setAttribute('data-sharc-creative-rendered', 'false');
     }
   }
 

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -1394,7 +1394,7 @@ class SHARCContainer {
         // than letting the exception bubble out of the load handler.
         this._emitSecurityEventAndTerminate(
           'renderer_protocol_post_failed',
-          ErrorCodes.RENDERER_TIMEOUT,
+          ErrorCodes.RENDERER_POST_FAILED,
           'Failed to postMessage SHARC:Renderer:render: '
             + (postErr && postErr.message ? postErr.message : 'unknown')
         );
@@ -2613,28 +2613,29 @@ class SHARCContainer {
    * helper). The structured-event channel for renderer events lands in Phase D
    * along with payload validation (Phase C) and load-event monitoring (Phase D).
    *
-   * Logs a console.error with the message before terminating, so dev bundles
-   * see the failure even when `onSecurityEvent` isn't wired (`onError` runs
-   * inside `_handleFatalError`, but the log gives the operator a stable string
-   * to grep prod logs for).
+   * Logs a console.error with the type-tagged message before terminating, so
+   * dev bundles see the failure even when `onSecurityEvent` isn't wired
+   * (`onError` runs inside `_handleFatalError`, but the log gives the operator
+   * a stable string to grep prod logs for, and the bracketed `type` makes the
+   * failure mode immediately classifiable without consulting source).
    *
-   * @param {string} type - Reserved event type identifier (Phase D).
+   * @param {string} type - Event type identifier. Surfaced today in the
+   *   dev-channel `console.error` for grep-ability; Phase D will additionally
+   *   emit it via the structured `onSecurityEvent` callback. Reserved values
+   *   per proposal: 'renderer_origin_mismatch', 'renderer_protocol_error',
+   *   'renderer_failed', 'unauthorized_navigation', 'renderer_protocol_timeout',
+   *   'renderer_protocol_post_failed'. See issue #62.
    * @param {number} errorCode - SHARC error code (e.g. RENDERER_TIMEOUT 2114).
    * @param {string} message - Human-readable description.
    * @private
    */
   _emitSecurityEventAndTerminate(type, errorCode, message) {
-    // Dev-channel log so a bare `console.error` filter still catches the failure.
+    // Dev-channel log so a bare `console.error` filter still catches the
+    // failure. The `[type]` tag makes the failure mode grep-able in prod logs
+    // today; Phase D will additionally fire the structured `onSecurityEvent`
+    // callback for the same type vocabulary.
     // eslint-disable-next-line no-console
-    console.error('[SHARCContainer] ' + message + ' — terminating container.');
-    // Phase D will fire `this._onSecurityEvent({ type, severity: 'error', … })`
-    // here, before _handleFatalError. Reserved Phase D types per proposal:
-    // 'renderer_origin_mismatch', 'renderer_protocol_error', 'renderer_failed',
-    // 'unauthorized_navigation'. Phase B's `type` argument is captured in the
-    // log message above for traceability; the structured-channel emission is
-    // intentionally deferred so Phase B doesn't ship a half-implemented
-    // event-type vocabulary. See issue #62.
-    void type;
+    console.error('[SHARCContainer] [' + type + '] ' + message + ' — terminating container.');
     this._handleFatalError(errorCode, message);
   }
 

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -50,6 +50,7 @@ const {
   ContainerStates,
   ErrorCodes,
   SHARC_VERSION,
+  RENDERER_PROTOCOL_VERSION,
 } = (typeof module !== 'undefined' && module.exports)
   ? require('./sharc-protocol')
   : ((typeof window !== 'undefined' && window.SHARC && window.SHARC.Protocol) || {});
@@ -64,7 +65,52 @@ const DEFAULT_TIMEOUTS = {
   initResolve: 2000,    // 2s for creative to resolve Container:init
   startResolve: 2000,   // 2s for creative to resolve Container:startCreative
   closeSequence: 2000,  // 2s for creative close sequence
+  // Creative Markup renderer protocol (Phase B). See proposal § Timeouts.
+  rendererLoad: 5000,   // 5s for renderer iframe `load` event after src assignment
+  rendererReply: 2000,  // 2s for renderer's SHARC:Renderer:rendered (or :failed) reply
 };
+
+/**
+ * Iframe `allow` attribute (Permissions Policy) for the Creative Markup
+ * renderer iframe. Default-deny across sensors, hardware-access APIs,
+ * payments, identity-federation (FedCM), and UX-intrusive features.
+ *
+ * Ad-tech-relevant Permissions Policy features are deliberately NOT in the
+ * deny list — `private-state-token-issuance` / `private-state-token-redemption`
+ * (Private State Tokens, anti-fraud) remain operative; the policy features for
+ * `browsing-topics`, `attribution-reporting`, `shared-storage` are also
+ * permit-by-default to stay forward-compatible with whatever the W3C PATCG
+ * attribution work produces. See proposal § Iframe-level CSP / DD-24.
+ *
+ * Stronger than `sandbox` for the denied features — `sandbox` doesn't cover
+ * most of them.
+ */
+const RENDERER_PERMISSIONS_POLICY = [
+  "geolocation 'none'",
+  "camera 'none'",
+  "microphone 'none'",
+  "payment 'none'",
+  "usb 'none'",
+  "serial 'none'",
+  "clipboard-write 'none'",
+  "screen-wake-lock 'none'",
+  "accelerometer 'none'",
+  "gyroscope 'none'",
+  "magnetometer 'none'",
+  "web-share 'none'",
+  "idle-detection 'none'",
+  "xr-spatial-tracking 'none'",
+  "identity-credentials-get 'none'",
+].join('; ');
+
+/**
+ * Iframe `csp` attribute (Chromium-only CSP Embedded Enforcement) for the
+ * renderer iframe. Defense-in-depth against `<base href>` redirection and
+ * plugin-content (`<object>`/`<embed>`) injection. The portable enforcement
+ * layer is the renderer's HTTP-response CSP — see proposal §
+ * "CSP enforcement: HTTP response is the portable layer".
+ */
+const RENDERER_IFRAME_CSP = "object-src 'none'; base-uri 'none'";
 
 // SHARC_VERSION imported from sharc-protocol.js
 
@@ -137,26 +183,22 @@ class SHARCContainer {
    *   `allow-popups-to-escape-sandbox`. When `false`, both tokens are omitted; creative
    *   `window.open()` calls fail at the browser level. `SHARC.requestNavigation()` works
    *   regardless. The `allow-popups-to-escape-sandbox` token is bound to this option
-   *   (DD-21); not exposed separately. Phase A: option is stored; sandbox application
-   *   ships in Phase B.
+   *   (DD-21); not exposed separately.
    * @param {boolean} [options.allowTopNavigationByUserActivation=true] - When `true`
    *   (default), the renderer iframe sandbox includes `allow-top-navigation-by-user-activation`,
    *   permitting user-gesture-initiated `<a target="_top">` clicks. When `false`, the
    *   token is omitted. The unsafe `allow-top-navigation` token (no-gesture variant) is
-   *   never exposed. See DD-20. Phase A: option stored; sandbox application in Phase B.
+   *   never exposed. See DD-20.
    * @param {boolean} [options.allowStorageAccessByUserActivation=true] - When `true`
    *   (default), the renderer iframe sandbox includes
    *   `allow-storage-access-by-user-activation`, permitting `document.requestStorageAccess()`
    *   on user gesture. When `false`, the token is omitted and SAA calls fail. See DD-22.
-   *   Phase A: option stored; sandbox application in Phase B.
    * @param {boolean} [options.allowModals=false] - When `true`, the renderer iframe
    *   sandbox includes `allow-modals`. Default `false` — modals are an opt-in operator
-   *   control, not a baseline capability. See DD-23. Phase A: option stored; sandbox
-   *   application in Phase B.
+   *   control, not a baseline capability. See DD-23.
    * @param {boolean} [options.allowDownloads=false] - When `true`, the renderer iframe
    *   sandbox includes `allow-downloads`. Default `false` — direct iframe downloads are
-   *   an opt-in operator control. See DD-25. Phase A: option stored; sandbox application
-   *   in Phase B.
+   *   an opt-in operator control. See DD-25.
    * @param {'warn'|'block'} [options.wrapperPolicy='warn'] - Controls container behavior
    *   when validation rule 7's wrapper-cross-origin carve-out applies (cross-origin top
    *   frame inaccessible at construction). `'warn'` (default) emits `console.warn` +
@@ -494,10 +536,46 @@ class SHARCContainer {
     /**
      * HTTPS URL of the operator-hosted renderer page in Creative Markup variant.
      * `null` when running in Creative URL variant. Validated at construction
-     * (rules 4–7); the actual iframe load and origin echo land in Phase B.
+     * (rules 4–7); the actual iframe load lands in Phase B; post-load origin
+     * echo lands in Phase C.
      * @type {string|null}
      */
     this.creativeRendererUrl = hasRendererUrl ? creativeRendererUrl : null;
+
+    /**
+     * Construction-time-derived renderer origin (`parsedRendererUrl.origin`,
+     * sans fragment). Used as `targetOrigin` for the `SHARC:Renderer:render`
+     * postMessage and as the envelope-validation origin on the renderer's
+     * `:rendered` reply. `null` in Creative URL variant. Frozen at construction
+     * so a post-load redirect cannot retroactively widen the trust boundary —
+     * Phase C will additionally validate the renderer-supplied `rendererOrigin`
+     * field on the `:rendered` reply against this value (post-load origin echo).
+     * @type {string|null}
+     * @private
+     */
+    this._rendererOrigin = parsedRendererUrl ? parsedRendererUrl.origin : null;
+
+    /**
+     * CSPRNG fragment nonce, assembled lazily by {@link _resolvedIframeSrc}
+     * for the Markup variant and persisted here for renderer-side validation
+     * (the renderer reads `sharcNonce` from `location.hash` and matches it
+     * against the value it receives in the `SHARC:Renderer:render` payload).
+     * `null` in Creative URL variant. Calling {@link _resolvedIframeSrc}
+     * twice for a Markup container generates two different nonces — by design;
+     * the iframe `src` is assigned exactly once per `_createIframe()` call.
+     * @type {string|null}
+     * @private
+     */
+    this._sharcNonce = null;
+
+    /**
+     * `window.message` listener for renderer protocol replies, attached during
+     * the Markup-variant load path and detached on `:rendered` receipt or in
+     * `_terminate()`. `null` outside the Markup load window.
+     * @type {((event: MessageEvent) => void) | null}
+     * @private
+     */
+    this._rendererMessageHandler = null;
 
     /**
      * Active payload variant: `'url'` for Creative URL, `'html'` for Creative Markup.
@@ -516,11 +594,10 @@ class SHARCContainer {
     /**
      * `true` once the Creative Markup renderer protocol has successfully
      * delivered the creative to the renderer iframe (i.e. the renderer's
-     * `SHARC:Renderer:rendered` reply has been validated by the container).
+     * envelope-validated `SHARC:Renderer:rendered` reply has arrived).
      * `false` for Creative URL in all states; `false` for Creative Markup
-     * until the renderer protocol completes — set by Phase B. Initialized
-     * `false` at construction; the variant in use is reflected by
-     * `creativeSource`, not by this flag.
+     * until the renderer protocol completes. The variant in use is reflected
+     * by `creativeSource`, not by this flag.
      * @type {boolean}
      */
     this.creativeRendered = false;
@@ -589,17 +666,18 @@ class SHARCContainer {
     /** @private */ this._onInteraction = onInteraction || null;
     /** @private */ this._onMessage = onMessage || null;
     /**
-     * Structured-event observability hook (Phase A: option stored, fired only for
-     * the construction-time `wrapper_top_frame_inaccessible` carve-out; Phase B
-     * adds the renderer-protocol event types).
+     * Structured-event observability hook. Phase A wires the construction-time
+     * `wrapper_top_frame_inaccessible` carve-out; Phase B does not add new
+     * event types (Phase D wires renderer_origin_mismatch, renderer_failed,
+     * renderer_protocol_error, unauthorized_navigation).
      * @private
      */
     this._onSecurityEvent = (typeof onSecurityEvent === 'function') ? onSecurityEvent : null;
 
     /**
-     * Sandbox / policy configuration captured at construction. Phase A stores these
-     * for downstream use by the Phase B renderer-iframe builder; the constructor
-     * itself does not yet build the sandbox attribute. See proposal § Iframe sandbox.
+     * Sandbox / policy configuration captured at construction. Consumed by
+     * `_buildSandboxAttribute()` during Markup-variant iframe construction.
+     * See proposal § Iframe sandbox.
      * @type {{
      *   allowPopups: boolean,
      *   allowTopNavigationByUserActivation: boolean,
@@ -932,55 +1010,89 @@ class SHARCContainer {
   /**
    * Creates and inserts the secure iframe for the creative.
    *
-   * Default path (Option 2 — recommended): sets iframe.src directly. OM SDK loads
-   * on the publisher page as a regular <script> tag; the container-side bridge
-   * manages the Session Client from the page context. Zero CORS dependency.
+   * Two variants:
    *
-   * Alternative path (Option 3 — opt-in via useMarkupInjection=true): fetches the
-   * creative HTML, pipes it through each extension's injectIntoMarkup(), and loads
-   * via srcdoc. Same-origin creative URLs only. Falls back to direct src if fetch
-   * fails, logging a warning. Useful for test environments and same-origin deployments.
+   * **Creative URL** (`creativeSource === 'url'`):
+   *   - Default path (Option 2 — recommended): sets `iframe.src` directly. OM SDK
+   *     loads on the publisher page as a regular `<script>` tag; the container-side
+   *     bridge manages the Session Client from the page context. Zero CORS dependency.
+   *   - Alternative path (Option 3 — opt-in via `useMarkupInjection=true`): fetches
+   *     the creative HTML, pipes it through each extension's `injectIntoMarkup()`,
+   *     and loads via `srcdoc`. Same-origin creative URLs only. Falls back to direct
+   *     `src` if fetch fails, logging a warning. Useful for test environments and
+   *     same-origin deployments.
+   *   - Sandbox: `allow-scripts allow-forms allow-popups` (no `allow-same-origin`,
+   *     SEC-001).
+   *
+   * **Creative Markup** (`creativeSource === 'html'`, Phase B):
+   *   - `iframe.src` = `creativeRendererUrl + '#sharcNonce=' + crypto.randomUUID()`.
+   *   - Sandbox is granted `allow-same-origin` (safe — the renderer is cross-origin
+   *     to the publisher, validated by construction-time rules 4–7) plus the
+   *     SafeFrame-baseline tokens governed by the constructor `allowPopups` /
+   *     `allowTopNavigationByUserActivation` / `allowStorageAccessByUserActivation` /
+   *     `allowModals` / `allowDownloads` options. The unsafe `allow-top-navigation`
+   *     token is never present.
+   *   - Iframe `csp` (Chromium-only) and `allow` (Permissions Policy) attributes
+   *     pin a default-deny baseline; the portable enforcement layer is the
+   *     renderer's HTTP-response CSP.
+   *   - On iframe `load`, posts `SHARC:Renderer:render` to the renderer (with
+   *     pre-injected creative HTML), waits for `SHARC:Renderer:rendered` (envelope
+   *     checks: source, origin, placementSessionId), then proceeds with the
+   *     standard 200ms-delay → `initChannel` bootstrap.
+   *
+   * Phase B does NOT yet implement: `:failed` receipt + RENDERER_FAILED, post-load
+   * origin echo + RENDERER_ORIGIN_MISMATCH, malformed-payload handling +
+   * RENDERER_PROTOCOL_ERROR, close() mid-render cleanup, load-event monitoring +
+   * RENDERER_UNAUTHORIZED_NAVIGATION, navigation bridge, reference renderer.
    *
    * @private
    */
   _createIframe() {
-    // Phase A guardrail (primary): Creative Markup load is not supported until
-    // the renderer protocol lands. Throw early — before any iframe creation,
-    // placement attach, or fetch — so a Markup container that calls .load()
-    // fails cleanly. Without this, the useMarkupInjection branch below would
-    // run `fetch(null)` (stringified to `fetch("null")`) and emit a stray
-    // `GET <publisher-origin>/null` to the publisher's access logs before the
-    // _resolvedIframeSrc() throw fires in the .catch() fallback. The throw in
-    // _resolvedIframeSrc() remains as defense-in-depth for direct callers.
-    if (this.creativeSource === 'html') {
-      throw new Error(
-        '[SHARCContainer] Creative Markup load is not supported in this build. '
-        + 'The renderer protocol that loads creativeRendererUrl with a fragment '
-        + 'nonce is implemented in a later phase. Use the Creative URL variant '
-        + '(creativeUrl) until Creative Markup ships.'
-      );
-    }
-
     const iframe = document.createElement('iframe');
 
-    // Secure sandbox attributes.
-    // SEC-001: `allow-same-origin` is intentionally ABSENT.
-    // Combining `allow-scripts` + `allow-same-origin` on a same-origin iframe
-    // allows the embedded document to remove the sandbox attribute entirely
-    // (complete sandbox escape). MessageChannel does NOT require same-origin
-    // — the port is transferred and works across origins.
-    iframe.setAttribute('sandbox', [
-      'allow-scripts',
-      // 'allow-same-origin' — REMOVED: defeats sandbox isolation (SEC-001)
-      'allow-forms',
-      'allow-popups',
-      // 'allow-popups-to-escape-sandbox' — REMOVED: grants unsandboxed popup access (SEC-010)
-    ].join(' '));
+    if (this.creativeSource === 'html') {
+      // ── Creative Markup variant (Phase B). ──
+      // Full sandbox per proposal § Iframe sandbox: allow-same-origin grants
+      // the renderer's origin (cross-origin to publisher per rules 4-7) so the
+      // creative gets a real origin — measurement vendors need this. The unsafe
+      // `allow-top-navigation` token (no-gesture variant) is NEVER present;
+      // only the user-activation variant is exposed via the constructor option.
+      iframe.setAttribute('sandbox', this._buildSandboxAttribute());
 
-    // Minimal allow policies
-    iframe.setAttribute('allow', 'autoplay; fullscreen');
+      // Iframe-level CSP — Chromium-only defense-in-depth. Portable enforcement
+      // is the renderer's HTTP response CSP (operator obligation; see proposal
+      // § Renderer implementation contract).
+      iframe.setAttribute('csp', RENDERER_IFRAME_CSP);
 
-    // Scrolling and styling
+      // Permissions Policy default-deny across sensors / hardware / payment /
+      // FedCM / UX-intrusive features. Ad-tech-relevant features
+      // (private-state-tokens, browsing-topics, attribution-reporting,
+      // shared-storage) deliberately remain operative — see DD-24.
+      iframe.setAttribute('allow', RENDERER_PERMISSIONS_POLICY);
+
+      // Prevent the renderer's network requests from leaking the publisher
+      // page URL.
+      iframe.setAttribute('referrerpolicy', 'no-referrer');
+    } else {
+      // ── Creative URL variant (existing behavior). ──
+      // SEC-001: `allow-same-origin` is intentionally ABSENT.
+      // Combining `allow-scripts` + `allow-same-origin` on a same-origin iframe
+      // allows the embedded document to remove the sandbox attribute entirely
+      // (complete sandbox escape). MessageChannel does NOT require same-origin
+      // — the port is transferred and works across origins.
+      iframe.setAttribute('sandbox', [
+        'allow-scripts',
+        // 'allow-same-origin' — REMOVED: defeats sandbox isolation (SEC-001)
+        'allow-forms',
+        'allow-popups',
+        // 'allow-popups-to-escape-sandbox' — REMOVED: grants unsandboxed popup access (SEC-010)
+      ].join(' '));
+
+      // Minimal allow policies
+      iframe.setAttribute('allow', 'autoplay; fullscreen');
+    }
+
+    // Scrolling and styling (shared)
     iframe.style.cssText = [
       'border: none',
       'width: 100%',
@@ -1001,20 +1113,18 @@ class SHARCContainer {
     // Attach to DOM now so contentWindow is available when we wire the channel
     this.placementElement.appendChild(iframe);
 
-    // -----------------------------------------------------------------------
-    // Default (Option 2): load creative via src directly.
-    // OM SDK is managed on the publisher page; no fetch or srcdoc needed.
-    //
-    // Alternative (Option 3): if useMarkupInjection=true, fetch the creative
-    // HTML, pipe through injectors, and load via srcdoc.
-    // Same-origin creative URLs only — cross-origin fetches will fail and
-    // fall back to direct src with a warning.
-    //
-    // NOTE: srcdoc gives the iframe an effective origin of the parent document
-    // (or 'null' with sandbox). Injected scripts must use absolute URLs.
-    // -----------------------------------------------------------------------
+    if (this.creativeSource === 'html') {
+      // Markup variant uses the renderer protocol — initChannel fires after
+      // the renderer's :rendered reply, NOT directly on iframe load.
+      this._wireRendererProtocol(iframe);
+      const src = this._resolvedIframeSrc();
+      this._assertResolvedIframeSrcAllowed(src);
+      iframe.src = src;
+      return;
+    }
 
-    // Wire MessageChannel on load regardless of path.
+    // ── Creative URL variant (existing behavior). ──
+    // Wire MessageChannel directly on iframe load.
     iframe.addEventListener('load', () => {
       setTimeout(
         () => this._protocol.initChannel(iframe.contentWindow, '*', this.placementSessionId),
@@ -1024,7 +1134,9 @@ class SHARCContainer {
 
     if (!this._useMarkupInjection) {
       // Default path (Option 2 — recommended): publisher-page OM SDK loading.
-      iframe.src = this._resolvedIframeSrc();
+      const src = this._resolvedIframeSrc();
+      this._assertResolvedIframeSrcAllowed(src);
+      iframe.src = src;
       return;
     }
 
@@ -1035,7 +1147,9 @@ class SHARCContainer {
 
     if (injectors.length === 0) {
       // No injectors registered — fall straight through to src.
-      iframe.src = this._resolvedIframeSrc();
+      const src = this._resolvedIframeSrc();
+      this._assertResolvedIframeSrcAllowed(src);
+      iframe.src = src;
       return;
     }
 
@@ -1049,40 +1163,411 @@ class SHARCContainer {
         'OM SDK loading pattern (useMarkupInjection=false).',
         err && (err.message || err)
       );
-      iframe.src = this._resolvedIframeSrc();
+      const src = this._resolvedIframeSrc();
+      this._assertResolvedIframeSrcAllowed(src);
+      iframe.src = src;
     });
   }
 
   /**
+   * Builds the `sandbox` attribute string for the Creative Markup renderer
+   * iframe. Tokens follow proposal § Iframe sandbox; conditional tokens are
+   * governed by `_sandboxConfig` (captured at construction). The unsafe
+   * `allow-top-navigation` token is never emitted — only the user-activation
+   * variant is exposed.
+   *
+   * @returns {string}
+   * @private
+   */
+  _buildSandboxAttribute() {
+    const tokens = [
+      'allow-scripts',
+      // `allow-same-origin` is REQUIRED for Creative Markup — the renderer is
+      // cross-origin to the publisher (rules 4-7), so this grants the renderer's
+      // own origin to the iframe rather than collapsing to the publisher's.
+      // See proposal § Iframe sandbox table.
+      'allow-same-origin',
+      'allow-forms',
+    ];
+    if (this._sandboxConfig.allowPopups) {
+      tokens.push('allow-popups');
+      // `allow-popups-to-escape-sandbox` is bound to `allowPopups` per DD-21.
+      tokens.push('allow-popups-to-escape-sandbox');
+    }
+    if (this._sandboxConfig.allowTopNavigationByUserActivation) {
+      tokens.push('allow-top-navigation-by-user-activation');
+    }
+    if (this._sandboxConfig.allowStorageAccessByUserActivation) {
+      tokens.push('allow-storage-access-by-user-activation');
+    }
+    if (this._sandboxConfig.allowModals) {
+      tokens.push('allow-modals');
+    }
+    if (this._sandboxConfig.allowDownloads) {
+      tokens.push('allow-downloads');
+    }
+    return tokens.join(' ');
+  }
+
+  /**
    * Returns the URL to assign to `iframe.src` for the active creative-source
-   * variant. Phase A returns `this.creativeUrl` for Creative URL and throws
-   * for Creative Markup — the renderer protocol that consumes
-   * `creativeRendererUrl + '#sharcNonce=' + nonce` lands in a later phase.
+   * variant.
    *
-   * The Markup-variant throw here is defense-in-depth: `_createIframe()`
-   * already throws earlier in `.load()` (before any DOM creation or fetch)
-   * for the Markup variant, so this method should not normally be reached
-   * for Markup callers. This throw covers the case where extensions or
-   * tests call `_resolvedIframeSrc()` directly.
+   * - Creative URL: returns `this.creativeUrl`.
+   * - Creative Markup: generates a fresh CSPRNG nonce via `crypto.randomUUID()`,
+   *   stores it on `this._sharcNonce`, and returns
+   *   `creativeRendererUrl + '#sharcNonce=' + nonce`. Calling this method twice
+   *   for a Markup container produces two different nonces — by design; the
+   *   iframe `src` is assigned exactly once per `_createIframe()` call.
+   *   `Math.random`-based UUIDs are explicitly rejected (CSPRNG required per
+   *   proposal § Load sequence).
    *
-   * Phase B replaces both throws with the renderer-URL + CSPRNG nonce
-   * assembly; the call sites in `_createIframe` stay unchanged.
+   * Defended by `_assertResolvedIframeSrcAllowed()` at every call site —
+   * extensions / subclasses cannot override this method to defeat the rule
+   * 4–7 origin guarantee. See issue #65.
    *
    * @returns {string} Resolved iframe src URL.
-   * @throws {Error} If invoked for Creative Markup before the renderer
-   *   protocol implementation lands.
+   * @throws {Error} If invoked for Creative Markup in an environment without
+   *   `crypto.randomUUID()` (CSPRNG fallback rejected by spec).
    * @private
    */
   _resolvedIframeSrc() {
     if (this.creativeSource === 'html') {
-      throw new Error(
-        '[SHARCContainer] Creative Markup load is not supported in this build. '
-        + 'The renderer protocol that loads creativeRendererUrl with a fragment '
-        + 'nonce is implemented in a later phase. Use the Creative URL variant '
-        + '(creativeUrl) until Creative Markup ships.'
-      );
+      // CSPRNG required — Math.random()-based UUIDs are unsafe and the spec
+      // explicitly rejects them. crypto.randomUUID() is universally available
+      // in SHARC's lowest-supported targets (iOS WKWebView 15.4+, WebView 92+).
+      if (typeof crypto === 'undefined' || typeof crypto.randomUUID !== 'function') {
+        throw new Error(
+          '[SHARCContainer] crypto.randomUUID() is unavailable in this environment; '
+          + 'cannot assemble Creative Markup renderer URL. Math.random fallback is '
+          + 'unsafe and rejected by spec. See proposal § Load sequence.'
+        );
+      }
+      this._sharcNonce = crypto.randomUUID();
+      return /** @type {string} */ (this.creativeRendererUrl) + '#sharcNonce=' + this._sharcNonce;
     }
     return /** @type {string} */ (this.creativeUrl);
+  }
+
+  /**
+   * Runtime guard that asserts `_resolvedIframeSrc()`'s return value matches
+   * the URL that the construction-time validation (rules 4–7) actually
+   * approved. Defends against extensions or subclasses overriding
+   * `_resolvedIframeSrc()` to return an arbitrary URL after rule 4–7 already
+   * cleared a different URL — which would defeat the cross-origin / HTTPS /
+   * no-userinfo guarantees the sandbox model relies on. See issue #65.
+   *
+   * Throws synchronously (before `iframe.src = ...`) so the iframe never
+   * navigates to an unapproved URL.
+   *
+   * @param {string} resolvedSrc - Value returned by `_resolvedIframeSrc()`.
+   * @throws {Error} If `resolvedSrc` does not match the expected URL.
+   * @private
+   */
+  _assertResolvedIframeSrcAllowed(resolvedSrc) {
+    if (this.creativeSource === 'url') {
+      if (resolvedSrc !== this.creativeUrl) {
+        throw new Error(
+          '[SHARCContainer] _resolvedIframeSrc() returned a URL that does not match '
+          + 'this.creativeUrl. Refusing to load. An extension or subclass appears to '
+          + 'have overridden _resolvedIframeSrc() — the SEC-001 sandbox isolation '
+          + 'depends on this method returning exactly this.creativeUrl.'
+        );
+      }
+      return;
+    }
+    // Markup variant — must be exactly creativeRendererUrl + '#sharcNonce=<nonce>'.
+    if (!this._sharcNonce) {
+      throw new Error(
+        '[SHARCContainer] _resolvedIframeSrc() did not populate this._sharcNonce. '
+        + 'Refusing to load — extension override suspected.'
+      );
+    }
+    const expected = this.creativeRendererUrl + '#sharcNonce=' + this._sharcNonce;
+    if (resolvedSrc !== expected) {
+      throw new Error(
+        '[SHARCContainer] _resolvedIframeSrc() returned a URL that does not match '
+        + 'creativeRendererUrl + "#sharcNonce=<nonce>". Refusing to load. An extension '
+        + 'or subclass appears to have overridden _resolvedIframeSrc() — the rule-4..7 '
+        + 'cross-origin guarantee relies on this method returning the exact renderer URL.'
+      );
+    }
+  }
+
+  /**
+   * Wires the renderer-protocol message exchange for the Creative Markup
+   * variant (Phase B). Attaches:
+   *
+   * 1. A 5s `rendererLoad` timeout (cleared on iframe `load` event).
+   * 2. An iframe `load` listener that:
+   *    a. Runs registered extensions' `injectIntoMarkup(creativeHtml)` in
+   *       order (synchronously). Sets `creativeInjected = true` if any
+   *       injector returned a non-empty modified string.
+   *    b. Attaches a `window` `message` listener for `SHARC:Renderer:rendered`
+   *       envelope-validated against `event.source`, `event.origin`, and
+   *       `event.data.placementSessionId`. Phase B silently ignores messages
+   *       failing envelope checks (any frame on the page can postMessage;
+   *       mismatches are noise, not errors).
+   *    c. Arms a 2s `rendererReply` timeout (cleared on `:rendered` receipt).
+   *    d. Posts `SHARC:Renderer:render` to `iframe.contentWindow` with
+   *       `targetOrigin = this._rendererOrigin`.
+   * 3. On envelope-validated `:rendered`: sets `this.creativeRendered = true`,
+   *    detaches the message listener, clears the reply timeout, and proceeds
+   *    with the standard SHARC bootstrap (200ms delay → `initChannel`).
+   *
+   * Both timeouts terminate via `_handleFatalError(RENDERER_TIMEOUT)`. Phase
+   * B does NOT yet implement payload validation, post-load origin echo, or
+   * `:failed` receipt — those land in Phase C.
+   *
+   * @param {HTMLIFrameElement} iframe
+   * @private
+   */
+  _wireRendererProtocol(iframe) {
+    // 1. Iframe-load timeout. Per spec § Load sequence step 3:
+    // "Iframe-load 'error' events and never-resolving loads are caught by the
+    // same timeout." We don't attach a separate 'error' listener — the timeout
+    // covers both cases.
+    this._startTimeout('rendererLoad', () => {
+      this._emitSecurityEventAndTerminate(
+        'renderer_protocol_timeout',
+        ErrorCodes.RENDERER_TIMEOUT,
+        'Renderer iframe `load` event did not fire within '
+          + this.timeouts.rendererLoad + 'ms'
+      );
+    });
+
+    iframe.addEventListener('load', () => {
+      this._clearTimeout('rendererLoad');
+
+      // 2a. Run injectors synchronously. For Markup, injection runs
+      // regardless of `useMarkupInjection` (the flag only governs Creative
+      // URL's fetch behavior). See proposal § Injection Across Variants.
+      const html = this._runMarkupInjection();
+
+      // Resolve container origin for the renderer to validate against.
+      const containerOrigin = (typeof window !== 'undefined' && window.location)
+        ? window.location.origin
+        : '';
+
+      // 2b. Attach `:rendered` listener — split into envelope validation and
+      // type-dispatch helpers so Phase C can plug in `:failed` (RENDERER_FAILED)
+      // and payload-shape validation (RENDERER_PROTOCOL_ERROR) by extending
+      // `_dispatchRendererMessage`, NOT by rewriting the closure. (Architect
+      // pass 1 HIGH.)
+      // Capture `iframe` in the closure — `this._iframe` may be cleared by
+      // _terminate() before a stale message arrives.
+      const handler = (event) => {
+        if (!this._isValidRendererEnvelope(event, iframe)) return;
+        this._dispatchRendererMessage(event.data);
+      };
+      this._rendererMessageHandler = handler;
+      window.addEventListener('message', handler, false);
+
+      // 2c. Post the render request BEFORE arming the reply timeout.
+      // targetOrigin is the construction-time-derived rendererOrigin — defends
+      // against the iframe being navigated to a different origin between
+      // construction and load. (Post-load origin echo lands in Phase C as a
+      // second layer.)
+      const renderMsg = {
+        type: 'SHARC:Renderer:render',
+        creativeHtml: html,
+        placementSessionId: this.placementSessionId,
+        sharcNonce: this._sharcNonce,
+        sharcVersion: SHARC_VERSION,
+        rendererProtocolVersion: RENDERER_PROTOCOL_VERSION,
+        containerOrigin: containerOrigin,
+      };
+      try {
+        iframe.contentWindow.postMessage(renderMsg, this._rendererOrigin);
+      } catch (postErr) {
+        // postMessage throws synchronously on, e.g., DataCloneError or a null
+        // contentWindow — neither should happen on a freshly-loaded iframe,
+        // but if the operator's environment is broken in an unanticipated
+        // way, surface it cleanly via the standard fatal-error path rather
+        // than letting the exception bubble out of the load handler.
+        this._emitSecurityEventAndTerminate(
+          'renderer_protocol_post_failed',
+          ErrorCodes.RENDERER_TIMEOUT,
+          'Failed to postMessage SHARC:Renderer:render: '
+            + (postErr && postErr.message ? postErr.message : 'unknown')
+        );
+        // Do NOT arm the reply timeout — _terminate has already been requested.
+        // (Code-review pass-2 LOW: arming the reply timeout before postMessage
+        // could double-fire onError if postMessage threw, since _handleFatalError
+        // resolves async.)
+        return;
+      }
+
+      // 2d. Reply timeout — armed only after postMessage succeeded.
+      this._startTimeout('rendererReply', () => {
+        this._emitSecurityEventAndTerminate(
+          'renderer_protocol_timeout',
+          ErrorCodes.RENDERER_TIMEOUT,
+          'SHARC:Renderer:rendered reply not received within '
+            + this.timeouts.rendererReply + 'ms'
+        );
+      });
+    });
+  }
+
+  /**
+   * Validates the envelope of a `message` event against the renderer-protocol
+   * trust anchors:
+   *
+   *   - `event.source === iframe.contentWindow`
+   *   - `event.origin === this._rendererOrigin` (construction-time-derived)
+   *   - `event.data` is a non-null object with a string `type`
+   *
+   * Per proposal § Container-side message validation (lines 466–476), envelope
+   * failures are SILENTLY ignored — any frame on the page can postMessage; a
+   * mismatch is noise, not an error. Payload-shape failures (Phase C scope)
+   * terminate; envelope failures do not.
+   *
+   * @param {MessageEvent} event
+   * @param {HTMLIFrameElement} iframe
+   * @returns {boolean} true if the envelope is valid and the message warrants
+   *   dispatch.
+   * @private
+   */
+  _isValidRendererEnvelope(event, iframe) {
+    if (!event) return false;
+    // Security pass-2 INFO-1 hardening: guard against primitive `event.data`
+    // (a sender posting a string/number). `typeof null === 'object'`, so the
+    // null check is explicit. Auto-boxing on primitives would make
+    // `event.data.type` evaluate to `undefined` and the type-string check
+    // would still bail — but explicit object validation is the durable shape.
+    if (typeof event.data !== 'object' || event.data === null) return false;
+    if (event.source !== iframe.contentWindow) return false;
+    if (event.origin !== this._rendererOrigin) return false;
+    if (typeof event.data.type !== 'string') return false;
+    return true;
+  }
+
+  /**
+   * Dispatches an envelope-validated renderer message to the appropriate
+   * handler based on `data.type`.
+   *
+   * Phase B handles only `SHARC:Renderer:rendered`, with the
+   * `placementSessionId` envelope check inline. Phase C extends this dispatch
+   * to handle `SHARC:Renderer:failed` (terminate with RENDERER_FAILED), the
+   * post-load origin echo (terminate with RENDERER_ORIGIN_MISMATCH on
+   * `data.rendererOrigin` mismatch), and malformed-payload detection
+   * (terminate with RENDERER_PROTOCOL_ERROR).
+   *
+   * @param {{type: string, placementSessionId?: string}} data
+   * @private
+   */
+  _dispatchRendererMessage(data) {
+    if (data.type !== 'SHARC:Renderer:rendered') {
+      // Phase B: silently ignore non-`:rendered` types. Phase C plugs `:failed`
+      // and the malformed-payload terminate path here.
+      return;
+    }
+    if (data.placementSessionId !== this.placementSessionId) {
+      // Session-correlation mismatch — silent ignore (per proposal § Container-
+      // side message validation, line 471). The check lives in dispatch rather
+      // than `_isValidRendererEnvelope` because the envelope helper is purely
+      // event-shape (source/origin/type) and doesn't carry the container's
+      // expected session id.
+      return;
+    }
+    this._onRendererRendered();
+  }
+
+  /**
+   * Pipes `this._creativeHtml` through every registered extension's
+   * `injectIntoMarkup()` in registration order. Mirrors the same loop used by
+   * Creative URL's `_fetchAndInjectCreative()` so observable behavior
+   * (`creativeInjected` flag, throw-tolerance, fall-through on non-string
+   * results) is identical across variants. Markup variant runs injection
+   * regardless of `useMarkupInjection` per proposal § Injection Across Variants.
+   *
+   * @returns {string} The (possibly injected) HTML to post to the renderer.
+   * @private
+   */
+  _runMarkupInjection() {
+    let html = /** @type {string} */ (this._creativeHtml);
+    const injectors = this._extensions.filter(
+      (ext) => typeof ext.injectIntoMarkup === 'function'
+    );
+    if (injectors.length === 0) return html;
+
+    let injected = false;
+    for (const injector of injectors) {
+      try {
+        const result = injector.injectIntoMarkup(html);
+        if (typeof result === 'string' && result.length > 0) {
+          html = result;
+          injected = true;
+        }
+      } catch (injectErr) {
+        console.warn(
+          '[SHARCContainer] Extension injectIntoMarkup threw; continuing with prior HTML.',
+          injectErr && (injectErr.message || injectErr)
+        );
+      }
+    }
+    if (injected) {
+      this.creativeInjected = true;
+    }
+    return html;
+  }
+
+  /**
+   * Handler invoked when the renderer's envelope-validated
+   * `SHARC:Renderer:rendered` message arrives. Clears the reply timeout,
+   * detaches the message listener, sets `creativeRendered`, and schedules
+   * the standard 200ms-delay → `initChannel` bootstrap.
+   *
+   * Reviewer fix (security pass 1 / code pass 1 HIGH): drop late `:rendered`
+   * arrivals that race a fatal-error termination. `_handleFatalError` calls
+   * `_terminate` asynchronously (after `sendFatalError` resolves), so a
+   * `:rendered` racing the timeout-induced termination would otherwise flip
+   * `creativeRendered` true on a container that fataled — confusing
+   * observability state.
+   *
+   * @private
+   */
+  _onRendererRendered() {
+    // Drop after fatal termination. The handler may still be on `window` until
+    // _terminate's listener-detach runs.
+    if (this._terminated) return;
+    // Idempotency: duplicate :rendered (stray reply, double-dispatch, etc.).
+    if (this.creativeRendered) return;
+
+    this._clearTimeout('rendererReply');
+    if (this._rendererMessageHandler) {
+      try {
+        window.removeEventListener('message', this._rendererMessageHandler, false);
+      } catch (_) { /* ignore */ }
+      this._rendererMessageHandler = null;
+    }
+    this.creativeRendered = true;
+
+    // Standard bootstrap — 200ms delay then initChannel.
+    //
+    // The 200ms is conservative parity with the Creative URL post-load wiring,
+    // where the OM SDK script tag needs a tick to register its message listener.
+    // The Markup variant doesn't strictly need the same headroom — the renderer
+    // sends `:rendered` only after `DOMContentLoaded` on its inner document
+    // (proposal § Renderer implementation contract item 7), so the creative SDK
+    // is already listening. Tightening the delay is a future Phase optimization;
+    // for now Phase B keeps parity with URL.
+    //
+    // Reviewer fix (security pass 1 HIGH): targetOrigin is the construction-time
+    // `_rendererOrigin`, NOT '*'. The Markup variant has a stable trust anchor
+    // (the renderer URL was rule-4..7-validated at construction); using '*'
+    // would leak the MessagePort and placementSessionId to whatever document
+    // happens to occupy the iframe at this instant — including a renderer that
+    // self-navigated between `:rendered` and the deferred bootstrap.
+    setTimeout(() => {
+      if (this._terminated || !this._iframe) return;
+      this._protocol.initChannel(
+        this._iframe.contentWindow,
+        /** @type {string} */ (this._rendererOrigin),
+        this.placementSessionId
+      );
+    }, 200);
   }
 
   /**
@@ -2037,6 +2522,16 @@ class SHARCContainer {
     // Clear all pending timeouts
     Object.keys(this._timeouts).forEach((key) => this._clearTimeout(key));
 
+    // Detach the renderer-protocol `message` listener if it's still attached
+    // (Markup variant terminating mid-render). Phase B partial — full close()
+    // mid-render cleanup contract lands in Phase C.
+    if (this._rendererMessageHandler) {
+      try {
+        window.removeEventListener('message', this._rendererMessageHandler, false);
+      } catch (_) { /* ignore */ }
+      this._rendererMessageHandler = null;
+    }
+
     // Transition to terminated
     this._stateMachine.transition(ContainerStates.TERMINATED);
 
@@ -2086,6 +2581,45 @@ class SHARCContainer {
       .catch(() => this._terminate());
     // Force terminate after 1s regardless
     setTimeout(() => this._terminate(), 1000);
+  }
+
+  /**
+   * Emits a structured `onSecurityEvent` (when Phase D wires renderer event
+   * types) and terminates via `_handleFatalError`. Phase B uses this helper
+   * as a single chokepoint for renderer-protocol terminations so Phase D can
+   * enrich the `onSecurityEvent` emission in one place rather than refactoring
+   * every call site. (Architect pass 1 HIGH — forward-compat with proposal
+   * § Security Model `onSecurityEvent` table for `renderer_origin_mismatch`,
+   * `renderer_failed`, `renderer_protocol_error`, `unauthorized_navigation`.)
+   *
+   * Phase B does NOT emit renderer event types yet — only the wrapper carve-out
+   * at construction (which fires inline in the constructor, not through this
+   * helper). The structured-event channel for renderer events lands in Phase D
+   * along with payload validation (Phase C) and load-event monitoring (Phase D).
+   *
+   * Logs a console.error with the message before terminating, so dev bundles
+   * see the failure even when `onSecurityEvent` isn't wired (`onError` runs
+   * inside `_handleFatalError`, but the log gives the operator a stable string
+   * to grep prod logs for).
+   *
+   * @param {string} type - Reserved event type identifier (Phase D).
+   * @param {number} errorCode - SHARC error code (e.g. RENDERER_TIMEOUT 2114).
+   * @param {string} message - Human-readable description.
+   * @private
+   */
+  _emitSecurityEventAndTerminate(type, errorCode, message) {
+    // Dev-channel log so a bare `console.error` filter still catches the failure.
+    // eslint-disable-next-line no-console
+    console.error('[SHARCContainer] ' + message + ' — terminating container.');
+    // Phase D will fire `this._onSecurityEvent({ type, severity: 'error', … })`
+    // here, before _handleFatalError. Reserved Phase D types per proposal:
+    // 'renderer_origin_mismatch', 'renderer_protocol_error', 'renderer_failed',
+    // 'unauthorized_navigation'. Phase B's `type` argument is captured in the
+    // log message above for traceability; the structured-channel emission is
+    // intentionally deferred so Phase B doesn't ship a half-implemented
+    // event-type vocabulary. See issue #62.
+    void type;
+    this._handleFatalError(errorCode, message);
   }
 
   // -------------------------------------------------------------------------

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -174,6 +174,10 @@ const ErrorCodes = Object.freeze({
   RENDERER_ORIGIN_MISMATCH: 2116,
   RENDERER_PROTOCOL_ERROR: 2117,
   RENDERER_UNAUTHORIZED_NAVIGATION: 2118,
+  // 2119: synchronous postMessage(SHARC:Renderer:render) threw — DataCloneError,
+  // null contentWindow, etc. Distinct from 2114 (timeout) for telemetry/alerting
+  // accuracy: a transport-layer send failure is not a latency failure.
+  RENDERER_POST_FAILED: 2119,
   UNSPECIFIED_CONTAINER: 2200,
   WRONG_SHARC_VERSION_CONTAINER: 2201,
   UNSUPPORTED_FEATURE: 2203,

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -30,6 +30,18 @@
 const SHARC_VERSION = '0.6.2';
 
 /**
+ * Renderer protocol version — bumps independently of {@link SHARC_VERSION}.
+ *
+ * Sent in `SHARC:Renderer:render` so the renderer page can reject containers
+ * that speak a renderer protocol it does not implement. See proposal
+ * docs/proposals/creative-sources.md § Renderer protocol messages and
+ * § Container and renderer must upgrade together. Initial value `'1'` for
+ * 0.7.0. Bumped only when the on-the-wire renderer protocol shape changes
+ * (additive fields do not warrant a bump).
+ */
+const RENDERER_PROTOCOL_VERSION = '1';
+
+/**
  * Protocol-level message types.
  * @enum {string}
  */
@@ -1352,6 +1364,7 @@ const SHARCProtocol = {
   STATE_TRANSITIONS,
   MESSAGES_REQUIRING_RESPONSE,
   SHARC_VERSION,
+  RENDERER_PROTOCOL_VERSION,
 };
 
 if (typeof globalThis !== 'undefined') {
@@ -1380,4 +1393,5 @@ export {
   STATE_TRANSITIONS,
   MESSAGES_REQUIRING_RESPONSE,
   SHARC_VERSION,
+  RENDERER_PROTOCOL_VERSION,
 };

--- a/test-creative-sources-load.js
+++ b/test-creative-sources-load.js
@@ -719,6 +719,46 @@ console.log('test-creative-sources-load.js — issue #41 Phase B regression\n');
     assert(c.creativeRendered === true,
       'happy path: creativeRendered === true');
   }
+
+  // 9d — postMessage throws synchronously (DataCloneError, null contentWindow):
+  // fires onError(RENDERER_POST_FAILED, …) (code 2119), NOT RENDERER_TIMEOUT.
+  // Locks in the OpenClaw-flagged semantic distinction: a synchronous send
+  // failure is not a timeout. Also locks in the pass-2 LOW fix that the
+  // rendererReply timeout is NOT armed when postMessage fails.
+  {
+    const errors = [];
+    const slot = freshSlot();
+    const c = new SHARCContainer({
+      creativeHtml: CREATIVE_HTML,
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: slot,
+      timeouts: { rendererLoad: 5000, rendererReply: 5000 },
+      onError: (code, msg) => errors.push({ code, msg }),
+    });
+    const originalError = console.error;
+    const errorOutput = [];
+    console.error = (...args) => { errorOutput.push(args.join(' ')); };
+    try {
+      c.load();
+      // Stub postMessage to throw a DataCloneError-shaped error.
+      c._iframe.contentWindow.postMessage = () => {
+        throw new dom.window.DOMException('Failed to clone', 'DataCloneError');
+      };
+      c._iframe.dispatchEvent(new dom.window.Event('load'));
+      // Allow the async _handleFatalError → _terminate chain to settle.
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      console.error = originalError;
+    }
+    assert(errors.length >= 1 && errors[0].code === ErrorCodes.RENDERER_POST_FAILED,
+      'postMessage failure fires onError(RENDERER_POST_FAILED, …) (code 2119, NOT 2114)');
+    assert(c._terminated === true,
+      'postMessage failure terminates the container');
+    assert(errorOutput.some((s) => /renderer_protocol_post_failed/.test(s)),
+      'console.error includes the [renderer_protocol_post_failed] type tag (Part 3 grep-ability)');
+    assert(c._timeouts['rendererReply'] === undefined,
+      'postMessage failure short-circuits BEFORE arming rendererReply timeout (pass-2 LOW fix preserved)');
+  }
 }
 
 // -- 10. Creative URL variant — Phase B does NOT regress the URL load path

--- a/test-creative-sources-load.js
+++ b/test-creative-sources-load.js
@@ -1,0 +1,680 @@
+/**
+ * test-creative-sources-load.js — issue #41 Phase B regression coverage
+ *
+ * Load-path tests for the Creative Markup variant. Phase B scope:
+ *   1. Renderer-iframe build — sandbox tokens, csp, allow, referrerpolicy.
+ *   2. CSPRNG fragment-nonce URL assembly + `_assertResolvedIframeSrcAllowed`
+ *      runtime guard (issue #65).
+ *   3. Synchronous injection of `creativeHtml` via extension `injectIntoMarkup`
+ *      hooks (regardless of `useMarkupInjection`).
+ *   4. SHARC:Renderer:render postMessage shape + targetOrigin.
+ *   5. SHARC:Renderer:rendered envelope validation (source / origin /
+ *      placementSessionId) + standard 200ms-delay → initChannel bootstrap.
+ *   6. RENDERER_TIMEOUT (2114) on iframe-load and rendered-reply timeouts.
+ *
+ * NOT in Phase B (defer to Phase C/D):
+ *   :failed receipt + RENDERER_FAILED (2115)
+ *   Post-load origin echo + RENDERER_ORIGIN_MISMATCH (2116)
+ *   Malformed-payload handling + RENDERER_PROTOCOL_ERROR (2117)
+ *   close() mid-render cleanup contract
+ *   Load-event navigation backstop + RENDERER_UNAUTHORIZED_NAVIGATION (2118)
+ *   Reference renderer + service-worker detection
+ *
+ * Uses jsdom (no browser harness) — mirrors the test-creative-sources.js
+ * pattern. Stubs `iframe.contentWindow.postMessage` to capture the render
+ * message and dispatches synthetic `MessageEvent`s on `window` to simulate
+ * the renderer's `:rendered` reply.
+ *
+ * Runs in Node after `npm run build`.
+ */
+
+import { JSDOM } from 'jsdom';
+
+// ── DOM globals BEFORE importing SHARCContainer. ──────────────────────────
+const PUBLISHER_ORIGIN = 'https://publisher.example';
+const RENDERER_URL = 'https://renderer.operator.example/0.7.0/';
+const RENDERER_ORIGIN = 'https://renderer.operator.example';
+const dom = new JSDOM(
+  '<!DOCTYPE html><html><body></body></html>',
+  { url: PUBLISHER_ORIGIN + '/page.html' },
+);
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.HTMLIFrameElement = dom.window.HTMLIFrameElement;
+global.MessageChannel = dom.window.MessageChannel;
+global.MessagePort = dom.window.MessagePort;
+global.MessageEvent = dom.window.MessageEvent;
+// crypto.randomUUID is required by Phase B's CSPRNG nonce. Node 19+ exposes
+// it as a global; fall back to webcrypto on Node 18.
+if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.randomUUID !== 'function') {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const nodeCrypto = await import('node:crypto');
+  globalThis.crypto = nodeCrypto.webcrypto || nodeCrypto;
+}
+
+// Pre-load protocol exports onto window.SHARC.Protocol (matches Phase A test).
+const protoMod = await import('./dist/sharc-protocol.mjs');
+window.SHARC = window.SHARC || {};
+window.SHARC.Protocol = protoMod;
+
+const { SHARCContainer } = await import('./dist/sharc-container.mjs');
+const { ErrorCodes, SHARC_VERSION, RENDERER_PROTOCOL_VERSION } = protoMod;
+
+// ── Tiny assertion harness ────────────────────────────────────────────────
+let failures = 0;
+function assert(condition, message) {
+  if (condition) {
+    console.log('  ✓', message);
+  } else {
+    console.error('  ✗', message);
+    failures++;
+  }
+}
+function assertThrows(fn, msgPattern, message) {
+  try {
+    fn();
+    console.error('  ✗', message, '(no throw)');
+    failures++;
+  } catch (e) {
+    if (msgPattern && !String(e.message).match(msgPattern)) {
+      console.error('  ✗', message, `(threw, wrong message: ${e.message})`);
+      failures++;
+      return;
+    }
+    console.log('  ✓', message);
+  }
+}
+
+// ── Test fixtures ─────────────────────────────────────────────────────────
+function freshSlot() {
+  document.body.innerHTML = '';
+  const el = document.createElement('div');
+  el.id = 'ad-slot';
+  document.body.appendChild(el);
+  return el;
+}
+const CREATIVE_HTML = '<html><body>creative goes here</body></html>';
+function markupOptions(overrides) {
+  return {
+    creativeHtml: CREATIVE_HTML,
+    creativeRendererUrl: RENDERER_URL,
+    placementElement: freshSlot(),
+    ...overrides,
+  };
+}
+
+/**
+ * Builds a Markup container, calls .load(), captures the SHARC:Renderer:render
+ * postMessage on the iframe.contentWindow, and (optionally) dispatches a
+ * synthetic SHARC:Renderer:rendered reply on window. Returns helpers and the
+ * captured state for assertions.
+ *
+ * `respond: false` skips the rendered reply so callers can probe timeout
+ * behavior. `tweakRendered` mutates the rendered payload before dispatch
+ * (used to probe envelope-mismatch silent-ignore behavior).
+ */
+function buildAndLoad(options = {}, opts = {}) {
+  const {
+    respond = true,
+    rendererOrigin = RENDERER_ORIGIN,
+    tweakRendered = null,
+    timeouts = { rendererLoad: 50, rendererReply: 50 },
+  } = opts;
+
+  const container = new SHARCContainer({ ...markupOptions(options), timeouts });
+  container.load();
+  const iframe = container._iframe;
+
+  // Stub postMessage on the iframe.contentWindow so we can capture the
+  // SHARC:Renderer:render payload + targetOrigin without a real cross-origin
+  // postMessage round-trip.
+  const captured = { posts: [] };
+  // jsdom gives us a contentWindow; replace its postMessage with a spy.
+  const cw = iframe.contentWindow;
+  cw.postMessage = (data, targetOrigin) => {
+    captured.posts.push({ data, targetOrigin });
+  };
+
+  // Manually fire the iframe 'load' event — jsdom won't actually navigate
+  // the iframe to the cross-origin renderer URL, but our load handler is
+  // registered and `iframe.contentWindow` is non-null, which is all the
+  // protocol path needs.
+  iframe.dispatchEvent(new dom.window.Event('load'));
+
+  if (respond) {
+    // Default rendered reply payload — pass envelope checks.
+    let payload = {
+      type: 'SHARC:Renderer:rendered',
+      placementSessionId: container.placementSessionId,
+      rendererOrigin: rendererOrigin,
+    };
+    if (typeof tweakRendered === 'function') payload = tweakRendered(payload);
+    // Use MessageEvent so event.source / event.origin are settable.
+    const evt = new dom.window.MessageEvent('message', {
+      data: payload,
+      origin: rendererOrigin,
+      source: cw,
+    });
+    window.dispatchEvent(evt);
+  }
+
+  return { container, iframe, captured };
+}
+
+console.log('test-creative-sources-load.js — issue #41 Phase B regression\n');
+
+// -- 1. Renderer iframe attributes — sandbox / csp / allow / referrerpolicy
+{
+  console.log('1. Renderer iframe attributes — sandbox + csp + allow + referrerpolicy');
+  const { iframe } = buildAndLoad();
+
+  // 1a — sandbox: SafeFrame-baseline tokens with conditionals defaulting on
+  // for click-through-or-measurement; off for UX-disruption surfaces.
+  const sandbox = iframe.getAttribute('sandbox');
+  assert(typeof sandbox === 'string' && sandbox.length > 0,
+    'sandbox attribute is set');
+  assert(sandbox.includes('allow-scripts'),
+    'sandbox includes allow-scripts (always present)');
+  assert(sandbox.includes('allow-same-origin'),
+    'sandbox includes allow-same-origin (Markup variant — required for renderer origin)');
+  assert(sandbox.includes('allow-forms'),
+    'sandbox includes allow-forms (always present)');
+  assert(sandbox.includes('allow-popups'),
+    'sandbox includes allow-popups (allowPopups defaults true)');
+  assert(sandbox.includes('allow-popups-to-escape-sandbox'),
+    'sandbox includes allow-popups-to-escape-sandbox (bound to allowPopups, DD-21)');
+  assert(sandbox.includes('allow-top-navigation-by-user-activation'),
+    'sandbox includes allow-top-navigation-by-user-activation (DD-20 default)');
+  assert(sandbox.includes('allow-storage-access-by-user-activation'),
+    'sandbox includes allow-storage-access-by-user-activation (DD-22 default)');
+  assert(!sandbox.includes('allow-modals'),
+    'sandbox EXCLUDES allow-modals (DD-23 default off)');
+  assert(!sandbox.includes('allow-downloads'),
+    'sandbox EXCLUDES allow-downloads (DD-25 default off)');
+  // The unsafe no-gesture top-nav token must NEVER appear, regardless of options.
+  assert(!/\ballow-top-navigation\b(?!-by-)/.test(sandbox),
+    'sandbox NEVER includes the unsafe `allow-top-navigation` token');
+
+  // 1b — csp attribute: object-src + base-uri none (Chromium-only DiD).
+  const csp = iframe.getAttribute('csp');
+  assert(csp === "object-src 'none'; base-uri 'none'",
+    'csp attribute exactly matches the proposal baseline (object-src + base-uri none)');
+
+  // 1c — Permissions Policy `allow` deny-list.
+  const allow = iframe.getAttribute('allow');
+  for (const denied of [
+    'geolocation', 'camera', 'microphone', 'payment', 'usb', 'serial',
+    'clipboard-write', 'screen-wake-lock', 'accelerometer', 'gyroscope',
+    'magnetometer', 'web-share', 'idle-detection', 'xr-spatial-tracking',
+    'identity-credentials-get',
+  ]) {
+    assert(allow.includes(denied + " 'none'"),
+      `allow Permissions Policy denies ${denied}`);
+  }
+  // DD-24: ad-tech features deliberately NOT denied.
+  for (const adTechFeature of [
+    'private-state-token-issuance', 'private-state-token-redemption',
+    'browsing-topics', 'attribution-reporting', 'shared-storage',
+  ]) {
+    assert(!allow.includes(adTechFeature),
+      `allow Permissions Policy does NOT deny ${adTechFeature} (DD-24)`);
+  }
+
+  // 1d — referrerpolicy.
+  assert(iframe.getAttribute('referrerpolicy') === 'no-referrer',
+    'referrerpolicy is no-referrer (prevents publisher URL leak to renderer)');
+}
+
+// -- 2. Conditional sandbox tokens — overrides flow through to the attribute
+{
+  console.log('\n2. Conditional sandbox tokens — overrides flow through');
+
+  // allowPopups: false → both popup tokens absent.
+  const a = buildAndLoad({ allowPopups: false }).iframe.getAttribute('sandbox');
+  assert(!a.includes('allow-popups'),
+    'allowPopups: false strips `allow-popups`');
+  assert(!a.includes('allow-popups-to-escape-sandbox'),
+    'allowPopups: false also strips `allow-popups-to-escape-sandbox` (bound by DD-21)');
+
+  // allowTopNavigationByUserActivation: false → token absent.
+  const b = buildAndLoad({ allowTopNavigationByUserActivation: false }).iframe.getAttribute('sandbox');
+  assert(!b.includes('allow-top-navigation-by-user-activation'),
+    'allowTopNavigationByUserActivation: false strips token');
+
+  // allowStorageAccessByUserActivation: false → token absent.
+  const c = buildAndLoad({ allowStorageAccessByUserActivation: false }).iframe.getAttribute('sandbox');
+  assert(!c.includes('allow-storage-access-by-user-activation'),
+    'allowStorageAccessByUserActivation: false strips token');
+
+  // allowModals: true → token present.
+  const d = buildAndLoad({ allowModals: true }).iframe.getAttribute('sandbox');
+  assert(d.includes('allow-modals'),
+    'allowModals: true adds `allow-modals` token');
+
+  // allowDownloads: true → token present.
+  const e = buildAndLoad({ allowDownloads: true }).iframe.getAttribute('sandbox');
+  assert(e.includes('allow-downloads'),
+    'allowDownloads: true adds `allow-downloads` token');
+}
+
+// -- 3. Iframe src — CSPRNG nonce + creativeRendererUrl assembly
+{
+  console.log('\n3. Iframe src — CSPRNG nonce + creativeRendererUrl assembly');
+  const { container, iframe } = buildAndLoad();
+  const src = iframe.getAttribute('src');
+  assert(src.startsWith(RENDERER_URL + '#sharcNonce='),
+    'iframe.src is creativeRendererUrl + "#sharcNonce=<uuid>"');
+  const nonce = src.split('#sharcNonce=')[1];
+  const noncePattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  assert(noncePattern.test(nonce),
+    'fragment nonce is UUID v4 shape (CSPRNG, NOT Math.random)');
+  assert(container._sharcNonce === nonce,
+    'container._sharcNonce equals the URL fragment nonce (used in render payload)');
+}
+
+// -- 4. _resolvedIframeSrc runtime guard (#65) — extension override is rejected
+{
+  console.log('\n4. _resolvedIframeSrc runtime guard (#65) — extension override aborts load');
+
+  // 4a — URL variant: extension overrides _resolvedIframeSrc to return an
+  // attacker-controlled URL. The runtime guard MUST throw before iframe.src
+  // assignment, defending the rule-4..7 origin guarantee.
+  {
+    const slot = freshSlot();
+    const c = new SHARCContainer({
+      creativeUrl: 'https://ads.example/creative.html',
+      placementElement: slot,
+    });
+    c._resolvedIframeSrc = function () { return 'https://attacker.example/evil.html'; };
+    assertThrows(
+      () => c.load(),
+      /Refusing to load/,
+      'URL: extension override of _resolvedIframeSrc aborts load with clear error');
+    // No iframe should be navigated to the attacker URL.
+    const iframe = c._iframe;
+    assert(!iframe || iframe.getAttribute('src') !== 'https://attacker.example/evil.html',
+      'URL: iframe.src is NOT assigned the attacker-controlled URL');
+  }
+
+  // 4b — Markup variant: extension overrides to return a non-renderer URL.
+  {
+    const slot = freshSlot();
+    const c = new SHARCContainer({
+      creativeHtml: CREATIVE_HTML,
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: slot,
+    });
+    c._resolvedIframeSrc = function () { return 'https://attacker.example/evil.html'; };
+    assertThrows(
+      () => c.load(),
+      /Refusing to load/,
+      'Markup: extension override of _resolvedIframeSrc aborts load with clear error');
+    const iframe = c._iframe;
+    assert(!iframe || iframe.getAttribute('src') !== 'https://attacker.example/evil.html',
+      'Markup: iframe.src is NOT assigned the attacker-controlled URL');
+  }
+
+  // 4c — Markup variant: extension overrides to return the renderer URL but
+  // with a forged nonce. Guard catches the mismatch.
+  {
+    const slot = freshSlot();
+    const c = new SHARCContainer({
+      creativeHtml: CREATIVE_HTML,
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: slot,
+    });
+    c._resolvedIframeSrc = function () {
+      // Set _sharcNonce too, so the "no nonce populated" branch doesn't
+      // mask the mismatch. This simulates a sloppy attacker who knows the
+      // guard checks _sharcNonce.
+      this._sharcNonce = 'attacker-controlled-nonce';
+      return RENDERER_URL + '#sharcNonce=different-nonce-than-stored';
+    };
+    assertThrows(
+      () => c.load(),
+      /Refusing to load/,
+      'Markup: extension override returning forged nonce mismatch is rejected');
+  }
+}
+
+// -- 5. Pre-injection of creativeHtml — synchronous, regardless of useMarkupInjection
+{
+  console.log('\n5. Pre-injection — synchronous, regardless of useMarkupInjection');
+
+  // 5a — No injectors registered: posted creativeHtml is the original.
+  {
+    const { container, captured } = buildAndLoad();
+    assert(captured.posts.length === 1,
+      'exactly one postMessage was fired (SHARC:Renderer:render)');
+    assert(captured.posts[0].data.creativeHtml === CREATIVE_HTML,
+      'no injectors → creativeHtml passed through unchanged');
+    assert(container.creativeInjected === false,
+      'creativeInjected stays false when no injector returned a non-empty result');
+  }
+
+  // 5b — With injectors: each runs in registration order; final HTML is posted.
+  {
+    const order = [];
+    const ext1 = {
+      injectIntoMarkup(html) { order.push('ext1'); return html + '<!-- ext1 -->'; },
+    };
+    const ext2 = {
+      injectIntoMarkup(html) { order.push('ext2'); return html + '<!-- ext2 -->'; },
+    };
+    const { container, captured } = buildAndLoad({ extensions: [ext1, ext2] });
+    assert(JSON.stringify(order) === JSON.stringify(['ext1', 'ext2']),
+      'injectors run in registration order');
+    assert(captured.posts[0].data.creativeHtml.endsWith('<!-- ext1 --><!-- ext2 -->'),
+      'final injected HTML reflects all injectors');
+    assert(container.creativeInjected === true,
+      'creativeInjected is true when at least one injector returned a non-empty modification');
+  }
+
+  // 5c — Injector throws: container logs warn and continues with prior HTML.
+  {
+    const ext = {
+      injectIntoMarkup() { throw new Error('boom'); },
+    };
+    const originalWarn = console.warn;
+    let warnFired = false;
+    console.warn = (...args) => {
+      if (args.some((a) => /injectIntoMarkup threw/.test(String(a)))) warnFired = true;
+    };
+    try {
+      const { container, captured } = buildAndLoad({ extensions: [ext] });
+      assert(captured.posts[0].data.creativeHtml === CREATIVE_HTML,
+        'throwing injector → original creativeHtml is posted');
+      assert(container.creativeInjected === false,
+        'throwing injector → creativeInjected stays false');
+    } finally {
+      console.warn = originalWarn;
+    }
+    // Console.warn capture is dev-only signalling; permit silent-prod bundles.
+    if (warnFired) {
+      assert(true, 'console.warn fired for throwing injector (dev bundle)');
+    }
+  }
+
+  // 5d — Markup variant ignores `useMarkupInjection`: injection runs whether
+  // the flag is true or false. (Per proposal § Injection Across Variants.)
+  {
+    const ext = { injectIntoMarkup(html) { return html + '<!-- forced -->'; } };
+    const aOff = buildAndLoad({ extensions: [ext], useMarkupInjection: false });
+    assert(aOff.captured.posts[0].data.creativeHtml.endsWith('<!-- forced -->'),
+      'Markup: injection runs even when useMarkupInjection=false');
+    const aOn = buildAndLoad({ extensions: [ext], useMarkupInjection: true });
+    assert(aOn.captured.posts[0].data.creativeHtml.endsWith('<!-- forced -->'),
+      'Markup: injection runs when useMarkupInjection=true');
+  }
+}
+
+// -- 6. SHARC:Renderer:render postMessage shape + targetOrigin
+{
+  console.log('\n6. SHARC:Renderer:render postMessage payload + targetOrigin');
+  const { container, captured } = buildAndLoad();
+  assert(captured.posts.length === 1, 'exactly one render postMessage was fired');
+  const post = captured.posts[0];
+  assert(post.targetOrigin === RENDERER_ORIGIN,
+    `targetOrigin === construction-time rendererOrigin (${RENDERER_ORIGIN})`);
+  const data = post.data;
+  assert(data.type === 'SHARC:Renderer:render',
+    'render payload type === "SHARC:Renderer:render"');
+  assert(typeof data.creativeHtml === 'string',
+    'render payload includes creativeHtml');
+  assert(data.placementSessionId === container.placementSessionId,
+    'render payload placementSessionId matches container');
+  assert(data.sharcNonce === container._sharcNonce,
+    'render payload sharcNonce matches container._sharcNonce (and URL fragment)');
+  assert(data.sharcVersion === SHARC_VERSION,
+    'render payload sharcVersion matches SHARC_VERSION');
+  assert(data.rendererProtocolVersion === RENDERER_PROTOCOL_VERSION,
+    'render payload rendererProtocolVersion matches RENDERER_PROTOCOL_VERSION');
+  assert(data.containerOrigin === PUBLISHER_ORIGIN,
+    'render payload containerOrigin equals window.location.origin');
+}
+
+// -- 7. SHARC:Renderer:rendered envelope validation + bootstrap
+{
+  console.log('\n7. SHARC:Renderer:rendered envelope validation + bootstrap');
+
+  // 7a — Happy path: container.creativeRendered flips to true.
+  {
+    const { container } = buildAndLoad();
+    assert(container.creativeRendered === true,
+      'envelope-valid :rendered → container.creativeRendered === true');
+  }
+
+  // 7b — Wrong event.origin: silently ignored, container stays unrendered.
+  {
+    const { container } = buildAndLoad({}, {
+      respond: true,
+      rendererOrigin: 'https://impostor.example',
+    });
+    assert(container.creativeRendered === false,
+      'wrong event.origin → :rendered SILENTLY ignored, creativeRendered stays false');
+  }
+
+  // 7c — Wrong placementSessionId: silently ignored.
+  {
+    const { container } = buildAndLoad({}, {
+      respond: true,
+      tweakRendered: (p) => ({ ...p, placementSessionId: 'forged-id' }),
+    });
+    assert(container.creativeRendered === false,
+      'wrong placementSessionId → :rendered SILENTLY ignored');
+  }
+
+  // 7d — Wrong type: silently ignored.
+  {
+    const { container } = buildAndLoad({}, {
+      respond: true,
+      tweakRendered: (p) => ({ ...p, type: 'SHARC:Renderer:notARealType' }),
+    });
+    assert(container.creativeRendered === false,
+      'wrong message type → :rendered SILENTLY ignored');
+  }
+
+  // 7e — initChannel scheduled after :rendered, with the standard 200ms
+  // delay. Probe by spying on protocol.initChannel.
+  {
+    const { container } = buildAndLoad({}, { respond: false });
+    let initCalled = false;
+    let initArgs = null;
+    container._protocol.initChannel = (...args) => {
+      initCalled = true;
+      initArgs = args;
+    };
+    // Fire envelope-valid :rendered.
+    const cw = container._iframe.contentWindow;
+    const evt = new dom.window.MessageEvent('message', {
+      data: {
+        type: 'SHARC:Renderer:rendered',
+        placementSessionId: container.placementSessionId,
+        rendererOrigin: RENDERER_ORIGIN,
+      },
+      origin: RENDERER_ORIGIN,
+      source: cw,
+    });
+    window.dispatchEvent(evt);
+    assert(initCalled === false,
+      'initChannel does NOT fire synchronously on :rendered (must respect 200ms bootstrap delay)');
+    // 350ms — 150ms slack over the 200ms bootstrap delay so CI under load
+    // doesn't flake (code-review pass-1 LOW).
+    await new Promise((r) => setTimeout(r, 350));
+    assert(initCalled === true,
+      'initChannel fires after the 200ms bootstrap delay');
+    assert(Array.isArray(initArgs) && initArgs[2] === container.placementSessionId,
+      'initChannel called with placementSessionId');
+    // Reviewer fix (security pass 1 HIGH): targetOrigin must be the
+    // construction-time-derived rendererOrigin, NOT '*' — otherwise the
+    // MessagePort + placementSessionId leak to whatever document occupies
+    // the iframe at the bootstrap instant.
+    assert(initArgs && initArgs[1] === RENDERER_ORIGIN,
+      "initChannel targetOrigin === construction-time _rendererOrigin (not '*')");
+  }
+}
+
+// -- 8. Renderer message listener cleanup — _terminate detaches the handler
+{
+  console.log('\n8. Renderer message listener cleanup on _terminate');
+  const { container } = buildAndLoad({}, { respond: false });
+  assert(typeof container._rendererMessageHandler === 'function',
+    'message listener is attached during the load window');
+  container._terminate();
+  assert(container._rendererMessageHandler === null,
+    'message listener is detached on _terminate');
+  // After terminate, a stale :rendered must not flip creativeRendered.
+  const cw = container._iframe;
+  // _iframe is null after terminate; just dispatch on window to confirm no-op.
+  const evt = new dom.window.MessageEvent('message', {
+    data: {
+      type: 'SHARC:Renderer:rendered',
+      placementSessionId: container.placementSessionId,
+      rendererOrigin: RENDERER_ORIGIN,
+    },
+    origin: RENDERER_ORIGIN,
+    source: cw,
+  });
+  window.dispatchEvent(evt);
+  assert(container.creativeRendered === false,
+    'stale :rendered after _terminate is ignored (listener was detached)');
+}
+
+// -- 9. RENDERER_TIMEOUT — iframe-load and rendered-reply timeouts terminate
+{
+  console.log('\n9. RENDERER_TIMEOUT — iframe-load + rendered-reply termination');
+
+  // 9a — iframe never fires 'load': rendererLoad timeout terminates with 2114.
+  // We rely on jsdom NOT performing cross-origin iframe navigation (so a
+  // synthetic 'load' never fires for our renderer URL). To lock in that the
+  // rendererLoad timeout fired (and not, say, the rendererReply timeout that
+  // would only arm if 'load' did fire), set rendererReply to a much larger
+  // value than rendererLoad — only the load timeout can win the race here.
+  // (Code-review pass-1 HIGH.)
+  {
+    const errors = [];
+    const slot = freshSlot();
+    const c = new SHARCContainer({
+      creativeHtml: CREATIVE_HTML,
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: slot,
+      timeouts: { rendererLoad: 30, rendererReply: 5000 },
+      onError: (code, msg) => errors.push({ code, msg }),
+    });
+    // Suppress noisy console.error from _emitSecurityEventAndTerminate.
+    const originalError = console.error;
+    const errorOutput = [];
+    console.error = (...args) => { errorOutput.push(args.join(' ')); };
+    try {
+      c.load();
+      // Do NOT dispatch the iframe 'load' event — let the timeout fire.
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      console.error = originalError;
+    }
+    assert(errors.length >= 1 && errors[0].code === ErrorCodes.RENDERER_TIMEOUT,
+      'iframe-load timeout fires onError(RENDERER_TIMEOUT, …) (code 2114)');
+    assert(c._terminated === true,
+      'iframe-load timeout terminates the container');
+    // Lock in that this was the rendererLoad timeout, not rendererReply.
+    assert(errorOutput.some((s) => /Renderer iframe `load` event did not fire/.test(s)),
+      'iframe-load timeout (NOT rendered-reply timeout) is the one that fired');
+  }
+
+  // 9b — rendered reply never arrives: rendererReply timeout terminates.
+  {
+    const errors = [];
+    const slot = freshSlot();
+    const c = new SHARCContainer({
+      creativeHtml: CREATIVE_HTML,
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: slot,
+      timeouts: { rendererLoad: 5000, rendererReply: 30 },
+      onError: (code, msg) => errors.push({ code, msg }),
+    });
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      c.load();
+      // Stub postMessage so the load handler doesn't blow up.
+      c._iframe.contentWindow.postMessage = () => {};
+      // Fire iframe 'load' to enter the rendered-reply waiting window;
+      // do NOT dispatch :rendered.
+      c._iframe.dispatchEvent(new dom.window.Event('load'));
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      console.error = originalError;
+    }
+    assert(errors.length >= 1 && errors[0].code === ErrorCodes.RENDERER_TIMEOUT,
+      'rendered-reply timeout fires onError(RENDERER_TIMEOUT, …) (code 2114)');
+    assert(c._terminated === true,
+      'rendered-reply timeout terminates the container');
+  }
+
+  // 9c — happy-path rendered before timeout: timeouts cleared, no termination.
+  {
+    const errors = [];
+    const slot = freshSlot();
+    const c = new SHARCContainer({
+      creativeHtml: CREATIVE_HTML,
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: slot,
+      timeouts: { rendererLoad: 5000, rendererReply: 5000 },
+      onError: (code, msg) => errors.push({ code, msg }),
+    });
+    c.load();
+    c._iframe.contentWindow.postMessage = () => {};
+    c._iframe.dispatchEvent(new dom.window.Event('load'));
+    const evt = new dom.window.MessageEvent('message', {
+      data: {
+        type: 'SHARC:Renderer:rendered',
+        placementSessionId: c.placementSessionId,
+        rendererOrigin: RENDERER_ORIGIN,
+      },
+      origin: RENDERER_ORIGIN,
+      source: c._iframe.contentWindow,
+    });
+    window.dispatchEvent(evt);
+    // Wait past the bootstrap delay so any race surfaces.
+    await new Promise((r) => setTimeout(r, 250));
+    assert(errors.length === 0,
+      'happy path: no onError fired');
+    assert(c._terminated === false,
+      'happy path: container is NOT terminated');
+    assert(c.creativeRendered === true,
+      'happy path: creativeRendered === true');
+  }
+}
+
+// -- 10. Creative URL variant — Phase B does NOT regress the URL load path
+{
+  console.log('\n10. Creative URL variant — Phase B does NOT regress URL load path');
+  const slot = freshSlot();
+  const c = new SHARCContainer({
+    creativeUrl: 'https://ads.example/creative.html',
+    placementElement: slot,
+  });
+  c.load();
+  const iframe = c._iframe;
+  assert(iframe.getAttribute('src') === 'https://ads.example/creative.html',
+    'URL: iframe.src equals this.creativeUrl');
+  assert(!iframe.hasAttribute('csp'),
+    'URL: iframe csp attribute is NOT set (Markup-only)');
+  assert(iframe.getAttribute('referrerpolicy') === null,
+    'URL: iframe referrerpolicy is NOT set (Markup-only)');
+  const sandbox = iframe.getAttribute('sandbox');
+  assert(!sandbox.includes('allow-same-origin'),
+    'URL: sandbox does NOT include allow-same-origin (SEC-001 holds)');
+  assert(c.creativeRendered === false,
+    'URL: creativeRendered remains false (renderer protocol is Markup-only)');
+}
+
+// ── Summary ───────────────────────────────────────────────────────────────
+console.log('');
+if (failures > 0) {
+  console.error(`✗ ${failures} creative-sources-load assertion(s) failed.`);
+  process.exit(1);
+} else {
+  console.log('✓ All creative-sources-load assertions passed.');
+}

--- a/test-creative-sources-load.js
+++ b/test-creative-sources-load.js
@@ -224,6 +224,33 @@ console.log('test-creative-sources-load.js — issue #41 Phase B regression\n');
   // 1d — referrerpolicy.
   assert(iframe.getAttribute('referrerpolicy') === 'no-referrer',
     'referrerpolicy is no-referrer (prevents publisher URL leak to renderer)');
+
+  // 1e — DOM stamping: data-sharc-creative-source + data-sharc-creative-rendered
+  // per spec § DOM stamping additions. Both attributes are always present.
+  // Markup variant: source='html'; rendered='false' at attach time, flips
+  // to 'true' on envelope-valid :rendered.
+  {
+    const { container, iframe: f } = buildAndLoad({}, { respond: false });
+    assert(f.getAttribute('data-sharc-creative-source') === 'html',
+      'Markup: iframe stamped with data-sharc-creative-source="html" at attach time');
+    assert(f.getAttribute('data-sharc-creative-rendered') === 'false',
+      'Markup: iframe stamped with data-sharc-creative-rendered="false" before :rendered');
+    // Drive a happy-path :rendered.
+    const evt = new dom.window.MessageEvent('message', {
+      data: {
+        type: 'SHARC:Renderer:rendered',
+        placementSessionId: container.placementSessionId,
+        rendererOrigin: RENDERER_ORIGIN,
+      },
+      origin: RENDERER_ORIGIN,
+      source: f.contentWindow,
+    });
+    window.dispatchEvent(evt);
+    assert(container.creativeRendered === true,
+      'Markup: :rendered flips creativeRendered=true (sanity)');
+    assert(f.getAttribute('data-sharc-creative-rendered') === 'true',
+      'Markup: iframe data-sharc-creative-rendered flips to "true" on envelope-valid :rendered');
+  }
 }
 
 // -- 2. Conditional sandbox tokens — overrides flow through to the attribute
@@ -475,6 +502,53 @@ console.log('test-creative-sources-load.js — issue #41 Phase B regression\n');
       'wrong message type → :rendered SILENTLY ignored');
   }
 
+  // 7d2 — Wrong event.source: silently ignored. The primary
+  // neighbor-frame-forgery defense — any other frame on the publisher
+  // page can postMessage to window; only the source-equality check
+  // against iframe.contentWindow rejects them.
+  {
+    const { container } = buildAndLoad({}, { respond: false });
+    // Use the publisher window (which is `global.window` here) as the
+    // forged source. Envelope check should reject.
+    const evt = new dom.window.MessageEvent('message', {
+      data: {
+        type: 'SHARC:Renderer:rendered',
+        placementSessionId: container.placementSessionId,
+        rendererOrigin: RENDERER_ORIGIN,
+      },
+      origin: RENDERER_ORIGIN,
+      source: window, // forged — NOT iframe.contentWindow
+    });
+    window.dispatchEvent(evt);
+    assert(container.creativeRendered === false,
+      'forged event.source (publisher window) → :rendered SILENTLY ignored — neighbor-frame defense holds');
+  }
+
+  // 7d3 — Non-object event.data (primitive/null/undefined): silently
+  // ignored. Defense against `typeof event.data !== 'object'` regression
+  // — a refactor to `data && data.type` would silently weaken (primitives
+  // auto-box and let `data.type` evaluate to undefined, then the type-string
+  // check would still bail, but the explicit object check is the durable
+  // shape).
+  for (const badData of [null, undefined, 'string-payload', 42, true]) {
+    const { container } = buildAndLoad({}, { respond: false });
+    const evt = new dom.window.MessageEvent('message', {
+      data: badData,
+      origin: RENDERER_ORIGIN,
+      source: container._iframe.contentWindow,
+    });
+    let threw = false;
+    try {
+      window.dispatchEvent(evt);
+    } catch (_) {
+      threw = true;
+    }
+    assert(!threw,
+      `primitive event.data (${typeof badData} ${String(badData)}) does NOT throw inside the listener`);
+    assert(container.creativeRendered === false,
+      `primitive event.data (${typeof badData} ${String(badData)}) → :rendered SILENTLY ignored`);
+  }
+
   // 7e — initChannel scheduled after :rendered, with the standard 200ms
   // delay. Probe by spying on protocol.initChannel.
   {
@@ -668,6 +742,12 @@ console.log('test-creative-sources-load.js — issue #41 Phase B regression\n');
     'URL: sandbox does NOT include allow-same-origin (SEC-001 holds)');
   assert(c.creativeRendered === false,
     'URL: creativeRendered remains false (renderer protocol is Markup-only)');
+  // DOM stamping per spec § DOM stamping additions. URL variant: source='url';
+  // rendered='false' (URL never flips this true — only Markup's :rendered does).
+  assert(iframe.getAttribute('data-sharc-creative-source') === 'url',
+    'URL: iframe stamped with data-sharc-creative-source="url"');
+  assert(iframe.getAttribute('data-sharc-creative-rendered') === 'false',
+    'URL: iframe stamped with data-sharc-creative-rendered="false" (URL variant never flips this true)');
 }
 
 // ── Summary ───────────────────────────────────────────────────────────────

--- a/test-creative-sources.js
+++ b/test-creative-sources.js
@@ -2,10 +2,11 @@
  * test-creative-sources.js — issue #41 Phase A regression coverage
  *
  * Constructor-level tests for the Creative Markup payload variant.
- * Phase A scope: constructor option additions + 8 sequenced validation rules
- * + error codes 2114-2118 + new instance properties (creativeSource,
- * creativeInjected, creativeRendered, creativeRendererUrl). No iframe creation,
- * no renderer protocol behavior, no MessageChannel — those land in Phase B-D.
+ * Scope: constructor option additions + 8 sequenced validation rules + error
+ * codes 2114-2118 + new instance properties (creativeSource, creativeInjected,
+ * creativeRendered, creativeRendererUrl) + the post-Phase-B return shape of
+ * `_resolvedIframeSrc()`. Iframe build, postMessage protocol, and timeouts
+ * are exercised in `test-creative-sources-load.js`.
  *
  * Uses jsdom to provide window/document so each test calls
  * `new SHARCContainer({...})` for real — not via Object.create stubs.
@@ -495,11 +496,11 @@ console.log('test-creative-sources.js — issue #41 Phase A regression\n');
   assert(c.creativeSource === 'html',
     "creativeSource === 'html' in Markup variant");
   // creativeRendered is a load-time fact: true only after the renderer
-  // protocol's ':rendered' reply is validated (Phase B). At construction
+  // protocol's ':rendered' reply is envelope-validated. At construction
   // it is FALSE for both variants; the variant in use is reflected by
   // creativeSource, not by this flag. (Architect review fix.)
   assert(c.creativeRendered === false,
-    'creativeRendered === false at construction in Markup variant (Phase B sets true on :rendered)');
+    'creativeRendered === false at construction in Markup variant (set true on :rendered)');
   assert(c.creativeInjected === false,
     'creativeInjected === false at construction (load-time concern)');
   assert(typeof c.placementSessionId === 'string' && c.placementSessionId.length > 0,
@@ -586,26 +587,18 @@ console.log('test-creative-sources.js — issue #41 Phase A regression\n');
     'Creative URL: creativeSource defaults to "url"');
 }
 
-// -- 17. Markup-variant load-path guardrails (Phase A) ────────────────────
+// -- 17. _resolvedIframeSrc shape — both variants ────────────────────────
 //
-// Two guards close the Phase A "Markup load not supported" boundary:
-//   - `_createIframe()` throws at the very top of .load() — primary, runs
-//     before any DOM creation, placement attach, or fetch. This is the
-//     production scenario gate.
-//   - `_resolvedIframeSrc()` throws as defense-in-depth — covers direct
-//     callers (extensions, tests) that bypass `_createIframe`.
-//
-// Without the `_createIframe()` early-throw, Markup + `useMarkupInjection`
-// + an injector extension would emit a stray `GET <publisher-origin>/null`
-// via `fetch(this.creativeUrl)` (where creativeUrl is null) before the
-// `_resolvedIframeSrc()` throw fires in the fetch's `.catch()`. The early
-// throw closes that leak.
-//
-// Phase B replaces both throws with the renderer-protocol assembly.
+// Phase A guarded "Markup not supported" with two throws (in `_createIframe`
+// and `_resolvedIframeSrc`). Phase B replaces both with the renderer-URL
+// assembly: `creativeRendererUrl + '#sharcNonce=' + crypto.randomUUID()`.
+// This block locks in the post-Phase-B return shape; the deeper load-path
+// behavior (sandbox, postMessage protocol, timeouts) lives in
+// `test-creative-sources-load.js`.
 {
-  console.log('\n17. Markup-variant load-path guardrails');
+  console.log('\n17. _resolvedIframeSrc shape — Creative URL + Creative Markup');
 
-  // 17a — _resolvedIframeSrc unit-level: URL passes through, Markup throws.
+  // 17a — Creative URL: returns this.creativeUrl unchanged.
   const urlContainer = new SHARCContainer(urlOptions());
   let urlResolved;
   try {
@@ -616,74 +609,24 @@ console.log('test-creative-sources.js — issue #41 Phase A regression\n');
   assert(urlResolved === 'https://ads.example/creative.html',
     'Creative URL: _resolvedIframeSrc returns this.creativeUrl');
 
+  // 17b — Creative Markup: returns creativeRendererUrl + '#sharcNonce=' + uuid;
+  // calling twice produces two different nonces (each call generates a fresh
+  // CSPRNG nonce — by design; iframe.src is assigned exactly once per
+  // `_createIframe()` call).
   const markupContainer = new SHARCContainer(markupOptions());
-  assertThrows(
-    () => markupContainer._resolvedIframeSrc(),
-    /Creative Markup load is not supported/,
-    'Creative Markup: _resolvedIframeSrc throws "not supported in Phase A"',
-    Error,
-  );
-
-  // 17b — load() on a plain Markup container throws cleanly with no DOM
-  // mutation. The throw originates from `_createIframe()`'s early guard.
-  {
-    const slot = freshSlot();
-    const c = new SHARCContainer({
-      creativeHtml: '<html><body>ad</body></html>',
-      creativeRendererUrl: RENDERER_URL,
-      placementElement: slot,
-    });
-    assertThrows(
-      () => c.load(),
-      /Creative Markup load is not supported/,
-      'Creative Markup: .load() throws via _createIframe early-throw',
-      Error,
-    );
-    assert(slot.children.length === 0,
-      'Creative Markup: .load() throws BEFORE any iframe is appended to placement');
-  }
-
-  // 17c — Markup + useMarkupInjection + injector extension: the historical
-  // fetch-leak scenario. `_createIframe()`'s early throw must fire BEFORE the
-  // useMarkupInjection branch reaches `fetch(this.creativeUrl)` — otherwise
-  // a `fetch("null")` would emit a stray request to publisher-origin/null.
-  // Stub global.fetch so a leak would be observable; assert it was NEVER
-  // called.
-  {
-    const originalFetch = global.fetch;
-    let fetchCallCount = 0;
-    global.fetch = (...args) => {
-      fetchCallCount++;
-      // Return a rejected promise to simulate the 404; if this code path
-      // were reached the test would still surface the leak via the count.
-      return Promise.reject(new Error('fetch should not have been called'));
-    };
-    try {
-      const slot = freshSlot();
-      const c = new SHARCContainer({
-        creativeHtml: '<html><body>ad</body></html>',
-        creativeRendererUrl: RENDERER_URL,
-        placementElement: slot,
-        useMarkupInjection: true,
-        extensions: [{
-          getFeatureName() { return 'fake-injector'; },
-          injectIntoMarkup(html) { return html + '<!-- injected -->'; },
-        }],
-      });
-      assertThrows(
-        () => c.load(),
-        /Creative Markup load is not supported/,
-        'Markup + useMarkupInjection + injector: .load() throws cleanly',
-        Error,
-      );
-      assert(fetchCallCount === 0,
-        'Markup + useMarkupInjection + injector: NO stray fetch leak (was the security pass-3 finding)');
-      assert(slot.children.length === 0,
-        'Markup + useMarkupInjection + injector: placement remains empty after throw');
-    } finally {
-      global.fetch = originalFetch;
-    }
-  }
+  const first = markupContainer._resolvedIframeSrc();
+  const second = markupContainer._resolvedIframeSrc();
+  assert(typeof first === 'string' && first.startsWith(RENDERER_URL + '#sharcNonce='),
+    'Creative Markup: _resolvedIframeSrc returns creativeRendererUrl + "#sharcNonce=<uuid>"');
+  // UUID v4 shape after the prefix.
+  const noncePattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  const firstNonce = first.split('#sharcNonce=')[1];
+  assert(noncePattern.test(firstNonce),
+    'Creative Markup: assembled nonce is a UUID-shaped string (CSPRNG, no Math.random)');
+  assert(typeof second === 'string' && second !== first,
+    'Creative Markup: _resolvedIframeSrc generates a fresh nonce on each call');
+  assert(markupContainer._sharcNonce && markupContainer._sharcNonce === second.split('#sharcNonce=')[1],
+    'Creative Markup: this._sharcNonce reflects the most recent _resolvedIframeSrc() call');
 }
 
 // -- 18. Input-shape edge cases — lock in URL parser + coercion behavior ──

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -136,6 +136,7 @@ declare global {
       SHARC_VERSION?: string;
       Protocol?: {
         SHARC_VERSION?: string;
+        RENDERER_PROTOCOL_VERSION?: string;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         SHARCProtocolBase: any;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

Iframe build + happy-path renderer protocol for the **Creative Markup** variant of issue #41. Phase A (#66) shipped constructor validation + types; Phase B replaces the \"Creative Markup not supported\" throws in `_createIframe` and `_resolvedIframeSrc` with the renderer-protocol assembly per [docs/proposals/creative-sources.md](docs/proposals/creative-sources.md).

## What ships

**Iframe attributes** (Markup variant only):
- Sandbox tokens assembled from `_sandboxConfig` via `_buildSandboxAttribute`. Always: `allow-scripts allow-same-origin allow-forms`. Conditional, governed by constructor options: `allow-popups` + `allow-popups-to-escape-sandbox` (bound, DD-21), `allow-top-navigation-by-user-activation` (DD-20), `allow-storage-access-by-user-activation` (DD-22), `allow-modals` (DD-23), `allow-downloads` (DD-25). Unsafe `allow-top-navigation` (no-gesture) **never** emitted.
- `csp=\"object-src 'none'; base-uri 'none'\"` — Chromium-only defense-in-depth.
- `allow=` Permissions Policy default-denies sensors / hardware / payment / FedCM / UX-intrusive features. Ad-tech-relevant features (Private State Tokens, Topics, Attribution Reporting, Shared Storage) **not** denied per DD-24.
- `referrerpolicy=\"no-referrer\"`.

**Iframe src**:
- `_resolvedIframeSrc` for Markup returns `creativeRendererUrl + '#sharcNonce=' + crypto.randomUUID()`. CSPRNG-only — `Math.random` fallback throws.
- `_assertResolvedIframeSrcAllowed` runtime guard (#65) called at every `iframe.src = …` site. Aborts load with a clear error if extension/subclass override returns an unapproved URL.

**Renderer protocol** (Markup variant):
- After iframe `load` (5s timeout → `RENDERER_TIMEOUT` 2114), runs registered extensions' `injectIntoMarkup(creativeHtml)` synchronously (regardless of `useMarkupInjection`, per § Injection Across Variants), then posts `SHARC:Renderer:render` to `iframe.contentWindow` with `targetOrigin = this._rendererOrigin` (construction-time-derived, **never** `'*'`).
- Listens for `SHARC:Renderer:rendered`. Envelope checks (silent-ignore on mismatch, per § Container-side message validation): `event.source === iframe.contentWindow`, `event.origin === _rendererOrigin`, `data.type` is a string, `data.placementSessionId` matches. Reply timeout 2s → `RENDERER_TIMEOUT`.
- On envelope-valid `:rendered`: sets `creativeRendered = true`, schedules the standard 200ms-delay → `initChannel(_rendererOrigin)`. Bootstrap `targetOrigin` is the construction-time origin, **not** `'*'` — defends the MessagePort hand-off.

## NOT in Phase B (deferred to Phase C/D)

- `:failed` receipt + `RENDERER_FAILED` (2115)
- Post-load origin echo + `RENDERER_ORIGIN_MISMATCH` (2116)
- Malformed-payload validation + `RENDERER_PROTOCOL_ERROR` (2117) — Phase B is envelope-only
- `close()` mid-render cleanup contract (Phase B does partial: detaches message listener + clears timeouts)
- Load-event monitoring backstop + `RENDERER_UNAUTHORIZED_NAVIGATION` (2118)
- Reference renderer (`examples/renderer/index.html`) + service-worker detection
- Navigation bridge (`sharc-navigation-bridge.js`)
- `onSecurityEvent` emissions for renderer event types — Phase B preserves the structured-event channel for the construction-time wrapper carve-out only

## Architecture notes (forward-compat with Phase C/D)

- Message handler split into `_isValidRendererEnvelope` (envelope-only, silent-ignore semantics) + `_dispatchRendererMessage` (type-switch). Phase C plugs `:failed` and the `RENDERER_PROTOCOL_ERROR` terminate path into `_dispatchRendererMessage` without rewriting the closure.
- All renderer-protocol terminations route through `_emitSecurityEventAndTerminate(type, errorCode, message)` — single chokepoint Phase D enriches with structured `onSecurityEvent` emissions.
- `_runMarkupInjection` mirrors the URL-variant injector loop from `_fetchAndInjectCreative`. Duplication is intentional pre-Phase-C; the paths are semantically distinct (Markup sync, URL async with fetch).
- #64 (`_validateCreativeSources` static extraction) **deferred** — Phase B's added LoC landed in `_createIframe`/`_buildSandboxAttribute`/`_wireRendererProtocol`, not the constructor. The trigger condition for #64 (\"constructor scan length\") didn't materialize. Won't-fix candidate.

## Backward compatibility

- Creative URL load path unchanged. SEC-001 sandbox isolation (no `allow-same-origin` on URL variant) preserved — verified by test 10 in test-creative-sources-load.js.
- Test 17 in test-creative-sources.js updated: was \"Markup load throws (Phase A)\", now locks in the Phase B `_resolvedIframeSrc` return shape (UUID-shaped nonce, fresh-per-call).

## Tests

- **New:** `test-creative-sources-load.js` — jsdom-based, 78 assertions across 10 blocks. Stubs `iframe.contentWindow.postMessage` to capture render payloads; dispatches synthetic `MessageEvent`s on `window` to drive the `:rendered` path. Probes envelope-mismatch silent-ignore on three independent axes (origin, sessionId, type), the `_resolvedIframeSrc` runtime guard, and both timeout paths with explicit load-vs-reply differentiation.
- **Updated:** `test-creative-sources.js` — section 17 reshaped from Phase A throw-guards to Phase B `_resolvedIframeSrc` return-shape locks. All 37 Phase A regression assertions still pass.
- All other suites (`test:smoke`, `test:treeshake`, `test:placement`, `test:placement-stamping`, `test:types`) pass. `npm run size` clean (sharc-container 10.15 kB / 25 kB budget).

## Reviewers

Two passes through three Claude reviewers (security, code, architect). Pass-1 raised:
- **Security HIGH:** `initChannel` post-`:rendered` was `targetOrigin = '*'` — fixed to `_rendererOrigin`.
- **Code HIGH:** race on late `:rendered` after fatal-termination flipping `creativeRendered=true` — fixed with `_terminated` guard at top of `_onRendererRendered`.
- **Code HIGH:** test 9a couldn't distinguish load-timeout from reply-timeout — fixed with asymmetric timeouts + console.error capture.
- **Architect HIGH:** message handler closure wouldn't generalize for Phase C — split into `_isValidRendererEnvelope` + `_dispatchRendererMessage`.
- **Architect HIGH:** direct `_handleFatalError` call sites would force Phase D refactor — introduced `_emitSecurityEventAndTerminate` chokepoint.

Pass-2 verdicts: **SHIP** (code), **GREENLIT** (security), **SHIP** (architect). Pass-2 polish landed: `rendererReply` armed only after successful `postMessage`, envelope object-type hardened, session-correlation comment rephrased.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run test:creative-sources` — 37 assertions pass
- [x] `npm run test:creative-sources-load` — 78 assertions pass
- [x] `npm run test:smoke` / `test:treeshake` / `test:placement` / `test:placement-stamping` / `test:types` — clean
- [x] `npm run size` — within budgets
- [ ] OpenClaw review pass
- [ ] Manual smoke against the existing browser harness (post-Phase-C, once a reference renderer exists)

## Related

- Closes the Phase B portion of #41
- Implements #65 (`_resolvedIframeSrc` runtime guard + nonce assembly)
- Defers #64 (validation static-extraction) — recommend close as won't-fix