### PR TITLE
feat(container): Creative Sources Phase C — renderer message validation + close-mid-render (#41)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Build all modules
         run: npm run build
 
-      - name: Enforce size budgets
-        run: npm run size
-
       - name: Test treeshaking
         run: npm run test:treeshake
 
@@ -51,6 +48,15 @@ jobs:
 
       - name: Placement-stamping + cleanup invariant (issue #40)
         run: npm run test:placement-stamping
+
+      - name: Creative Sources construction validation (issue #41)
+        run: npm run test:creative-sources
+
+      - name: Creative Sources load + renderer protocol (issue #41)
+        run: npm run test:creative-sources-load
+
+      - name: Enforce size budgets
+        run: npm run size
 
       - name: Inspect publish tarball
         run: |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1219,6 +1219,12 @@ environmentData.supportedFeatures = [
 | 2109 | Device not supported | Creative cannot render or execute on this device. |
 | 2110 | Container sending messages incorrectly | Container messages are malformed, mislabeled, or out-of-spec. |
 | 2111 | Container not responding adequately | Container responses are delayed or missing expected data. |
+| 2114 | Renderer timeout | Renderer iframe `load` event did not fire within `timeouts.rendererLoad` (default 5s), OR renderer `:rendered`/`:failed` reply did not arrive within `timeouts.rendererReply` (default 5s). Markup variant only. See [creative-sources spec](proposals/creative-sources.md#container-side-message-validation). |
+| 2115 | Renderer failed | Renderer reported failure via `SHARC:Renderer:failed` with a non-empty `reason` string. The `reason` is included in the `onError` message (sanitized + truncated to 200 UTF-16 code units). Markup variant only. See [creative-sources spec](proposals/creative-sources.md#container-side-message-validation). |
+| 2116 | Renderer origin mismatch | The renderer's reported `rendererOrigin` did not match the construction-time-derived `_rendererOrigin` (parsed from `creativeRendererUrl`). Indicates a redirect collapsed the cross-origin sandbox guarantee. Configure `creativeRendererUrl` to the post-redirect canonical URL. Markup variant only. See [creative-sources spec](proposals/creative-sources.md#container-side-message-validation). |
+| 2117 | Renderer protocol error | Renderer message had an envelope-valid type (`SHARC:Renderer:rendered` or `SHARC:Renderer:failed`) but malformed payload — `rendererOrigin` (rendered) or `reason` (failed) is missing, not a string, or empty. Markup variant only. See [creative-sources spec](proposals/creative-sources.md#container-side-message-validation). |
+| 2118 | Renderer unauthorized navigation | Reserved (Phase D). Markup variant only. |
+| 2119 | Renderer post failed | `iframe.contentWindow.postMessage(SHARC:Renderer:render, ...)` threw synchronously (e.g. `DataCloneError`, null `contentWindow`). Distinct from 2114 (timeout) — a transport-layer send failure is not a latency failure. Markup variant only. See [creative-sources spec](proposals/creative-sources.md#container-side-message-validation). |
 
 ### Container Errors (22xx)
 

--- a/docs/proposals/creative-sources.md
+++ b/docs/proposals/creative-sources.md
@@ -481,13 +481,14 @@ For `rendered` specifically, the container additionally verifies:
 If `event.data.rendererOrigin` does not match (because the renderer was redirected to a different origin), the container terminates with `RENDERER_ORIGIN_MISMATCH` and emits a `console.error`:
 
 ```
-[SHARCContainer] Renderer origin mismatch — refusing to load.
+[SHARCContainer] [renderer_origin_mismatch] Renderer origin mismatch — refusing to load.
   Expected origin: https://renderer.operator.com (from creativeRendererUrl)
   Actual origin:   https://cdn.example.com (after redirect)
 Redirects on creativeRendererUrl are not permitted — they can collapse the
 cross-origin sandbox guarantee. Configure creativeRendererUrl to the
 post-redirect canonical URL.
-See: https://github.com/IABTechLab/SHARC/blob/main/docs/api-reference.md#renderer-protocol
+See: https://github.com/IABTechLab/SHARC/blob/main/docs/proposals/creative-sources.md#container-side-message-validation
+ — terminating container.
 ```
 
 ### `close()` mid-render cleanup

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -1466,6 +1466,12 @@ class SHARCContainer {
    * defense-in-depth rather than an adversary mitigation — but it closes the
    * log-deception channel cheaply.
    *
+   * The 200-char limit operates on UTF-16 code units, not user-perceived
+   * characters; for non-BMP content (emoji, supplementary-plane CJK), this is
+   * fewer than 200 user-perceived characters. The trailing-high-surrogate
+   * strip prevents malformed output but not boundary truncation of multi-
+   * codepoint glyphs (combining sequences, ZWJ-joined emoji).
+   *
    * @param {string} s
    * @returns {string}
    * @private
@@ -1519,6 +1525,15 @@ class SHARCContainer {
    * @private
    */
   _dispatchRendererMessage(data) {
+    if (this._rendererOrigin == null) {
+      // Defense-in-depth: dispatcher should only be reachable on the Markup
+      // variant where _rendererOrigin is set at construction. A null check
+      // here future-proofs against refactors that might wire the dispatcher
+      // into the URL variant or other code paths where _rendererOrigin would
+      // be null.
+      return;
+    }
+
     // Type-routing. Two recognized renderer-protocol message types; everything
     // else is silently ignored. (A frame on the page can postMessage anything;
     // the envelope helper has already verified source/origin, so this branch
@@ -1566,6 +1581,13 @@ class SHARCContainer {
       //    `[SHARCContainer] [renderer_origin_mismatch] Renderer origin
       //    mismatch — refusing to load. …` log line.
       if (data.rendererOrigin !== this._rendererOrigin) {
+        // Trust boundary: `this._rendererOrigin` is parsed from the
+        // operator-supplied `creativeRendererUrl` at construction (URL.origin
+        // canonicalization) — trusted input, concatenated raw. `data.rendererOrigin`
+        // is renderer-supplied via postMessage — sanitized before logging
+        // because the renderer is partially-trusted (operator-deployed,
+        // cross-origin) and could craft control-char sequences for log
+        // deception.
         this._emitSecurityEventAndTerminate(
           'renderer_origin_mismatch',
           ErrorCodes.RENDERER_ORIGIN_MISMATCH,
@@ -1573,7 +1595,7 @@ class SHARCContainer {
             + '  Expected origin: ' + this._rendererOrigin + ' (from creativeRendererUrl)\n'
             + '  Actual origin:   ' + this._sanitizeForLog(data.rendererOrigin) + ' (after redirect)\n'
             + 'Redirects on creativeRendererUrl are not permitted — they can collapse the cross-origin sandbox guarantee. Configure creativeRendererUrl to the post-redirect canonical URL.\n'
-            + 'See: https://github.com/IABTechLab/SHARC/blob/main/docs/api-reference.md#renderer-protocol'
+            + 'See: https://github.com/IABTechLab/SHARC/blob/main/docs/proposals/creative-sources.md#container-side-message-validation'
         );
         return;
       }

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -1451,6 +1451,26 @@ class SHARCContainer {
   }
 
   /**
+   * Sanitizes a renderer-supplied string for safe inclusion in operator-facing
+   * dev-channel logs. Strips ASCII control characters (C0 0x00–0x1f and DEL
+   * 0x7f) that could deceive log readers via CR/LF splitting, ANSI escape
+   * sequences, or terminal cursor manipulation, and truncates to 200 chars to
+   * bound the log line length. Phase C, security pass-1 MEDIUM-2.
+   *
+   * The renderer is operator-deployed and partially trusted, so this is
+   * defense-in-depth rather than an adversary mitigation — but it closes the
+   * log-deception channel cheaply.
+   *
+   * @param {string} s
+   * @returns {string}
+   * @private
+   */
+  _sanitizeForLog(s) {
+    // eslint-disable-next-line no-control-regex
+    return String(s).replace(/[\x00-\x1f\x7f]/g, '?').slice(0, 200);
+  }
+
+  /**
    * Dispatches an envelope-validated renderer message to the appropriate
    * handler based on `data.type`.
    *
@@ -1544,7 +1564,7 @@ class SHARCContainer {
           ErrorCodes.RENDERER_ORIGIN_MISMATCH,
           'Renderer origin mismatch — refusing to load.\n'
             + '  Expected origin: ' + this._rendererOrigin + ' (from creativeRendererUrl)\n'
-            + '  Actual origin:   ' + data.rendererOrigin + ' (after redirect)\n'
+            + '  Actual origin:   ' + this._sanitizeForLog(data.rendererOrigin) + ' (after redirect)\n'
             + 'Redirects on creativeRendererUrl are not permitted — they can collapse the cross-origin sandbox guarantee. Configure creativeRendererUrl to the post-redirect canonical URL.\n'
             + 'See: https://github.com/IABTechLab/SHARC/blob/main/docs/api-reference.md#renderer-protocol'
         );
@@ -1574,7 +1594,7 @@ class SHARCContainer {
     this._emitSecurityEventAndTerminate(
       'renderer_failed',
       ErrorCodes.RENDERER_FAILED,
-      'Renderer reported failure: ' + data.reason
+      'Renderer reported failure: ' + this._sanitizeForLog(data.reason)
     );
   }
 
@@ -2635,9 +2655,9 @@ class SHARCContainer {
     // Clear all pending timeouts
     Object.keys(this._timeouts).forEach((key) => this._clearTimeout(key));
 
-    // Detach the renderer-protocol `message` listener if it's still attached
-    // (Markup variant terminating mid-render). Phase B partial — full close()
-    // mid-render cleanup contract lands in Phase C.
+    // Detach the renderer-protocol `message` listener if still attached
+    // (Markup variant terminating mid-render, after a fatal error, or via
+    // close()-during-loading).
     if (this._rendererMessageHandler) {
       try {
         window.removeEventListener('message', this._rendererMessageHandler, false);
@@ -2727,6 +2747,16 @@ class SHARCContainer {
    * @private
    */
   _emitSecurityEventAndTerminate(type, errorCode, message) {
+    // Re-entrancy guard: this helper is reachable from the message-listener
+    // dispatch (Phase C: :failed, origin-mismatch, protocol-error) and from
+    // the renderer-load/reply timeouts (Phase B). _handleFatalError is async
+    // — between this call and _terminate actually detaching the listener and
+    // setting _terminated, another inbound message could route here a second
+    // time. Mirror the _onRendererRendered guard at the chokepoint so all
+    // renderer-protocol terminate paths (and Phase D's onSecurityEvent
+    // emissions, when wired) are idempotent at the source.
+    if (this._terminated) return;
+
     // Dev-channel log so a bare `console.error` filter still catches the
     // failure. The `[type]` tag makes the failure mode grep-able in prod logs
     // today; Phase D will additionally fire the structured `onSecurityEvent`

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -1455,7 +1455,12 @@ class SHARCContainer {
    * dev-channel logs. Strips ASCII control characters (C0 0x00–0x1f and DEL
    * 0x7f) that could deceive log readers via CR/LF splitting, ANSI escape
    * sequences, or terminal cursor manipulation, and truncates to 200 chars to
-   * bound the log line length. Phase C, security pass-1 MEDIUM-2.
+   * bound the log line length.
+   *
+   * C1 (0x80–0x9f) is intentionally not stripped — it would corrupt legitimate
+   * UTF-8 multi-byte sequences in non-ASCII reason strings, and the named
+   * log-deception threats (ANSI escape via 0x1B, CR/LF splitting via 0x0A/0x0D)
+   * are all in C0.
    *
    * The renderer is operator-deployed and partially trusted, so this is
    * defense-in-depth rather than an adversary mitigation — but it closes the
@@ -1466,8 +1471,10 @@ class SHARCContainer {
    * @private
    */
   _sanitizeForLog(s) {
+    // slice on UTF-16 code units, then drop a trailing lone high surrogate to
+    // avoid emitting a malformed pair when the cut lands inside a surrogate.
     // eslint-disable-next-line no-control-regex
-    return String(s).replace(/[\x00-\x1f\x7f]/g, '?').slice(0, 200);
+    return String(s).replace(/[\x00-\x1f\x7f]/g, '?').slice(0, 200).replace(/[\uD800-\uDBFF]$/, '');
   }
 
   /**
@@ -2747,14 +2754,22 @@ class SHARCContainer {
    * @private
    */
   _emitSecurityEventAndTerminate(type, errorCode, message) {
-    // Re-entrancy guard: this helper is reachable from the message-listener
-    // dispatch (Phase C: :failed, origin-mismatch, protocol-error) and from
-    // the renderer-load/reply timeouts (Phase B). _handleFatalError is async
-    // — between this call and _terminate actually detaching the listener and
-    // setting _terminated, another inbound message could route here a second
-    // time. Mirror the _onRendererRendered guard at the chokepoint so all
-    // renderer-protocol terminate paths (and Phase D's onSecurityEvent
-    // emissions, when wired) are idempotent at the source.
+    // Re-entrancy guard (post-microtask idempotency). _handleFatalError is
+    // async — between this call and _terminate actually detaching the listener
+    // and setting _terminated, microtasks drain. A second terminating message
+    // delivered AFTER that microtask boundary would otherwise dispatch through
+    // here a second time, double-firing _onError and console.error.
+    //
+    // Scope: this guard protects against post-microtask re-entry (the realistic
+    // browser scenario, where cross-origin postMessage queues messages as
+    // separate tasks with microtasks draining between). It does NOT claim
+    // protection against synchronous double-dispatch — cross-origin postMessage
+    // cannot deliver two messages synchronously, so that case doesn't occur
+    // outside of test code.
+    //
+    // Mirror of _onRendererRendered's _terminated guard at the chokepoint, so
+    // all renderer-protocol terminate paths (and Phase D's onSecurityEvent
+    // emissions, when wired here) are idempotent at a single source.
     if (this._terminated) return;
 
     // Dev-channel log so a bare `console.error` filter still catches the

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -1454,31 +1454,128 @@ class SHARCContainer {
    * Dispatches an envelope-validated renderer message to the appropriate
    * handler based on `data.type`.
    *
-   * Phase B handles only `SHARC:Renderer:rendered`, with the
-   * `placementSessionId` envelope check inline. Phase C extends this dispatch
-   * to handle `SHARC:Renderer:failed` (terminate with RENDERER_FAILED), the
-   * post-load origin echo (terminate with RENDERER_ORIGIN_MISMATCH on
-   * `data.rendererOrigin` mismatch), and malformed-payload detection
-   * (terminate with RENDERER_PROTOCOL_ERROR).
+   * Phase C dispatch surface:
+   *   - `SHARC:Renderer:rendered` — payload-shape check on `rendererOrigin`,
+   *     then post-load origin echo. On payload-shape failure terminates with
+   *     RENDERER_PROTOCOL_ERROR (2117). On origin echo mismatch terminates
+   *     with RENDERER_ORIGIN_MISMATCH (2116). On all-pass invokes
+   *     `_onRendererRendered()`.
+   *   - `SHARC:Renderer:failed` — payload-shape check on `reason`. On
+   *     payload-shape failure terminates with RENDERER_PROTOCOL_ERROR (2117).
+   *     On all-pass terminates with RENDERER_FAILED (2115) carrying the
+   *     renderer-supplied reason.
+   *   - All other `data.type` values — silently ignored (a frame on the page
+   *     can postMessage anything).
    *
-   * @param {{type: string, placementSessionId?: string}} data
+   * Session-correlation (`placementSessionId === this.placementSessionId`) is
+   * checked AFTER type-routing but BEFORE any payload validation: a message
+   * for the wrong session is treated as noise (silent ignore, per proposal
+   * § Container-side message validation line 471), not as a protocol error.
+   * That keeps the helper composable with future renderer-message types
+   * without tying every payload-validation rule to the session check.
+   *
+   * Order-of-checks for `:rendered`:
+   *   1. session-id (silent ignore on mismatch)
+   *   2. payload shape (rendererOrigin presence/type/non-empty) → 2117
+   *   3. origin echo (rendererOrigin === this._rendererOrigin) → 2116
+   *   4. accept → `_onRendererRendered()`
+   *
+   * The shape check precedes the origin echo because if `data.rendererOrigin`
+   * is missing or non-string, the comparison `data.rendererOrigin !==
+   * this._rendererOrigin` would still fire RENDERER_ORIGIN_MISMATCH on a
+   * malformed payload — but the actual failure is protocol-shape, not a
+   * post-redirect origin mismatch. The two error codes carry distinct
+   * semantics for operators reading logs.
+   *
+   * @param {{type: string, placementSessionId?: string,
+   *          rendererOrigin?: string, reason?: string}} data
    * @private
    */
   _dispatchRendererMessage(data) {
-    if (data.type !== 'SHARC:Renderer:rendered') {
-      // Phase B: silently ignore non-`:rendered` types. Phase C plugs `:failed`
-      // and the malformed-payload terminate path here.
+    // Type-routing. Two recognized renderer-protocol message types; everything
+    // else is silently ignored. (A frame on the page can postMessage anything;
+    // the envelope helper has already verified source/origin, so this branch
+    // is reached only on legitimate-but-unknown types — likely a future
+    // protocol version this container doesn't speak.)
+    if (data.type !== 'SHARC:Renderer:rendered'
+        && data.type !== 'SHARC:Renderer:failed') {
       return;
     }
+
+    // Session-correlation: silent ignore on mismatch. The check lives in
+    // dispatch rather than `_isValidRendererEnvelope` because the envelope
+    // helper is purely event-shape (source/origin/type) and doesn't carry
+    // the container's expected session id.
     if (data.placementSessionId !== this.placementSessionId) {
-      // Session-correlation mismatch — silent ignore (per proposal § Container-
-      // side message validation, line 471). The check lives in dispatch rather
-      // than `_isValidRendererEnvelope` because the envelope helper is purely
-      // event-shape (source/origin/type) and doesn't carry the container's
-      // expected session id.
       return;
     }
-    this._onRendererRendered();
+
+    if (data.type === 'SHARC:Renderer:rendered') {
+      // 1. Payload shape: rendererOrigin is required, must be a non-empty
+      //    string. Empty-string is treated as malformed (an empty origin
+      //    can't equal `this._rendererOrigin` either, but the protocol-shape
+      //    failure is the more accurate diagnosis for an operator).
+      if (typeof data.rendererOrigin !== 'string' || data.rendererOrigin.length === 0) {
+        this._emitSecurityEventAndTerminate(
+          'renderer_protocol_error',
+          ErrorCodes.RENDERER_PROTOCOL_ERROR,
+          'Malformed SHARC:Renderer:rendered — `rendererOrigin` is missing, '
+            + 'not a string, or empty.'
+        );
+        return;
+      }
+
+      // 2. Post-load origin echo. The renderer reports the origin it actually
+      //    loaded from; if it differs from the construction-time
+      //    `_rendererOrigin`, a redirect collapsed the cross-origin sandbox
+      //    guarantee and we refuse to proceed. Per proposal lines 484–491,
+      //    the operator-facing log line names both origins so the redirect
+      //    misconfiguration is diagnosable from a single console.error.
+      //
+      //    Note: `_emitSecurityEventAndTerminate` prefixes its console.error
+      //    with `[SHARCContainer] [<type>]`, so the message we pass omits
+      //    the `[SHARCContainer]` prefix shown in the spec snippet — the
+      //    helper adds the bracket-tag prefix to produce the spec-intended
+      //    `[SHARCContainer] [renderer_origin_mismatch] Renderer origin
+      //    mismatch — refusing to load. …` log line.
+      if (data.rendererOrigin !== this._rendererOrigin) {
+        this._emitSecurityEventAndTerminate(
+          'renderer_origin_mismatch',
+          ErrorCodes.RENDERER_ORIGIN_MISMATCH,
+          'Renderer origin mismatch — refusing to load.\n'
+            + '  Expected origin: ' + this._rendererOrigin + ' (from creativeRendererUrl)\n'
+            + '  Actual origin:   ' + data.rendererOrigin + ' (after redirect)\n'
+            + 'Redirects on creativeRendererUrl are not permitted — they can collapse the cross-origin sandbox guarantee. Configure creativeRendererUrl to the post-redirect canonical URL.\n'
+            + 'See: https://github.com/IABTechLab/SHARC/blob/main/docs/api-reference.md#renderer-protocol'
+        );
+        return;
+      }
+
+      // 3. Accept.
+      this._onRendererRendered();
+      return;
+    }
+
+    // data.type === 'SHARC:Renderer:failed'.
+    //
+    // Payload shape: `reason` is required, must be a non-empty string. Per
+    // proposal § Renderer protocol messages, `reason` is the renderer's
+    // human-readable explanation of why it could not render.
+    if (typeof data.reason !== 'string' || data.reason.length === 0) {
+      this._emitSecurityEventAndTerminate(
+        'renderer_protocol_error',
+        ErrorCodes.RENDERER_PROTOCOL_ERROR,
+        'Malformed SHARC:Renderer:failed — `reason` is missing, '
+          + 'not a string, or empty.'
+      );
+      return;
+    }
+
+    this._emitSecurityEventAndTerminate(
+      'renderer_failed',
+      ErrorCodes.RENDERER_FAILED,
+      'Renderer reported failure: ' + data.reason
+    );
   }
 
   /**

--- a/test-creative-sources-load.js
+++ b/test-creative-sources-load.js
@@ -66,6 +66,45 @@ window.SHARC.Protocol = protoMod;
 const { SHARCContainer } = await import('./dist/sharc-container.mjs');
 const { ErrorCodes, SHARC_VERSION, RENDERER_PROTOCOL_VERSION } = protoMod;
 
+// ── Build-mode guard ──────────────────────────────────────────────────────
+// Prod builds use terser `drop_console: true` which strips every
+// `console.error`. Several Phase C log-assertion tests would vacuously pass
+// against the prod bundle because `errorOutput.some(...)` returns false on an
+// empty array, and a few negative-shape assertions (`!/X/.test('')`) would
+// silently pass. Fail fast with a clear message instead. Issue #63 will
+// replace this with a build-time-injected constant once the broader
+// test-infra work lands.
+{
+  const fs = await import('node:fs');
+  const distSrc = fs.readFileSync('./dist/sharc-container.mjs', 'utf8');
+  if (!/console\.error/.test(distSrc)) {
+    console.error(
+      'FATAL: dist/sharc-container.mjs has zero console.error calls — '
+      + 'this is a production build (terser drop_console=true). Phase C log '
+      + 'assertions would vacuously pass. Re-run `npm run build` (dev mode) '
+      + 'and try again.'
+    );
+    process.exit(1);
+  }
+}
+
+// ── Cross-test timer hygiene ──────────────────────────────────────────────
+// Track every SHARCContainer the test file creates so we can flush leaked
+// timers between sections. Without this, the 1s `_handleFatalError` force-
+// terminate and the 5s `createSession` timeout leak across blocks and
+// occasionally pollute downstream `errorOutput.some(...)` assertions when
+// their console.error lands during a silenced window. Test Results Analyzer
+// depth-pass observed ~5% flake rate without this hygiene.
+const _liveContainers = [];
+function track(c) { _liveContainers.push(c); return c; }
+function flushContainers() {
+  while (_liveContainers.length) {
+    const c = _liveContainers.pop();
+    try { if (!c._terminated) c._terminate(); } catch (_) { /* ignore */ }
+  }
+}
+process.on('beforeExit', flushContainers);
+
 // ── Tiny assertion harness ────────────────────────────────────────────────
 let failures = 0;
 function assert(condition, message) {
@@ -127,7 +166,7 @@ function buildAndLoad(options = {}, opts = {}) {
     timeouts = { rendererLoad: 50, rendererReply: 50 },
   } = opts;
 
-  const container = new SHARCContainer({ ...markupOptions(options), timeouts });
+  const container = track(new SHARCContainer({ ...markupOptions(options), timeouts }));
   container.load();
   const iframe = container._iframe;
 
@@ -256,6 +295,7 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
     assert(f.getAttribute('data-sharc-creative-rendered') === 'true',
       'Markup: iframe data-sharc-creative-rendered flips to "true" on envelope-valid :rendered');
   }
+  flushContainers();
 }
 
 // -- 2. Conditional sandbox tokens — overrides flow through to the attribute
@@ -288,6 +328,7 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   const e = buildAndLoad({ allowDownloads: true }).iframe.getAttribute('sandbox');
   assert(e.includes('allow-downloads'),
     'allowDownloads: true adds `allow-downloads` token');
+  flushContainers();
 }
 
 // -- 3. Iframe src — CSPRNG nonce + creativeRendererUrl assembly
@@ -303,6 +344,7 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
     'fragment nonce is UUID v4 shape (CSPRNG, NOT Math.random)');
   assert(container._sharcNonce === nonce,
     'container._sharcNonce equals the URL fragment nonce (used in render payload)');
+  flushContainers();
 }
 
 // -- 4. _resolvedIframeSrc runtime guard (#65) — extension override is rejected
@@ -314,10 +356,10 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   // assignment, defending the rule-4..7 origin guarantee.
   {
     const slot = freshSlot();
-    const c = new SHARCContainer({
+    const c = track(new SHARCContainer({
       creativeUrl: 'https://ads.example/creative.html',
       placementElement: slot,
-    });
+    }));
     c._resolvedIframeSrc = function () { return 'https://attacker.example/evil.html'; };
     assertThrows(
       () => c.load(),
@@ -332,11 +374,11 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   // 4b — Markup variant: extension overrides to return a non-renderer URL.
   {
     const slot = freshSlot();
-    const c = new SHARCContainer({
+    const c = track(new SHARCContainer({
       creativeHtml: CREATIVE_HTML,
       creativeRendererUrl: RENDERER_URL,
       placementElement: slot,
-    });
+    }));
     c._resolvedIframeSrc = function () { return 'https://attacker.example/evil.html'; };
     assertThrows(
       () => c.load(),
@@ -351,11 +393,11 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   // with a forged nonce. Guard catches the mismatch.
   {
     const slot = freshSlot();
-    const c = new SHARCContainer({
+    const c = track(new SHARCContainer({
       creativeHtml: CREATIVE_HTML,
       creativeRendererUrl: RENDERER_URL,
       placementElement: slot,
-    });
+    }));
     c._resolvedIframeSrc = function () {
       // Set _sharcNonce too, so the "no nonce populated" branch doesn't
       // mask the mismatch. This simulates a sloppy attacker who knows the
@@ -368,6 +410,7 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       /Refusing to load/,
       'Markup: extension override returning forged nonce mismatch is rejected');
   }
+  flushContainers();
 }
 
 // -- 5. Pre-injection of creativeHtml — synchronous, regardless of useMarkupInjection
@@ -439,6 +482,7 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
     assert(aOn.captured.posts[0].data.creativeHtml.endsWith('<!-- forced -->'),
       'Markup: injection runs when useMarkupInjection=true');
   }
+  flushContainers();
 }
 
 // -- 6. SHARC:Renderer:render postMessage shape + targetOrigin
@@ -464,6 +508,7 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
     'render payload rendererProtocolVersion matches RENDERER_PROTOCOL_VERSION');
   assert(data.containerOrigin === PUBLISHER_ORIGIN,
     'render payload containerOrigin equals window.location.origin');
+  flushContainers();
 }
 
 // -- 7. SHARC:Renderer:rendered envelope validation + bootstrap
@@ -592,6 +637,7 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
     assert(initArgs && initArgs[1] === RENDERER_ORIGIN,
       "initChannel targetOrigin === construction-time _rendererOrigin (not '*')");
   }
+  flushContainers();
 }
 
 // -- 8. Renderer message listener cleanup — _terminate detaches the handler
@@ -618,6 +664,7 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   window.dispatchEvent(evt);
   assert(container.creativeRendered === false,
     'stale :rendered after _terminate is ignored (listener was detached)');
+  flushContainers();
 }
 
 // -- 9. RENDERER_TIMEOUT — iframe-load and rendered-reply timeouts terminate
@@ -634,13 +681,13 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   {
     const errors = [];
     const slot = freshSlot();
-    const c = new SHARCContainer({
+    const c = track(new SHARCContainer({
       creativeHtml: CREATIVE_HTML,
       creativeRendererUrl: RENDERER_URL,
       placementElement: slot,
       timeouts: { rendererLoad: 30, rendererReply: 5000 },
       onError: (code, msg) => errors.push({ code, msg }),
-    });
+    }));
     // Suppress noisy console.error from _emitSecurityEventAndTerminate.
     const originalError = console.error;
     const errorOutput = [];
@@ -665,13 +712,13 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   {
     const errors = [];
     const slot = freshSlot();
-    const c = new SHARCContainer({
+    const c = track(new SHARCContainer({
       creativeHtml: CREATIVE_HTML,
       creativeRendererUrl: RENDERER_URL,
       placementElement: slot,
       timeouts: { rendererLoad: 5000, rendererReply: 30 },
       onError: (code, msg) => errors.push({ code, msg }),
-    });
+    }));
     const originalError = console.error;
     console.error = () => {};
     try {
@@ -695,13 +742,13 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   {
     const errors = [];
     const slot = freshSlot();
-    const c = new SHARCContainer({
+    const c = track(new SHARCContainer({
       creativeHtml: CREATIVE_HTML,
       creativeRendererUrl: RENDERER_URL,
       placementElement: slot,
       timeouts: { rendererLoad: 5000, rendererReply: 5000 },
       onError: (code, msg) => errors.push({ code, msg }),
-    });
+    }));
     c.load();
     c._iframe.contentWindow.postMessage = () => {};
     c._iframe.dispatchEvent(new dom.window.Event('load'));
@@ -733,13 +780,13 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   {
     const errors = [];
     const slot = freshSlot();
-    const c = new SHARCContainer({
+    const c = track(new SHARCContainer({
       creativeHtml: CREATIVE_HTML,
       creativeRendererUrl: RENDERER_URL,
       placementElement: slot,
       timeouts: { rendererLoad: 5000, rendererReply: 5000 },
       onError: (code, msg) => errors.push({ code, msg }),
-    });
+    }));
     const originalError = console.error;
     const errorOutput = [];
     console.error = (...args) => { errorOutput.push(args.join(' ')); };
@@ -764,16 +811,17 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
     assert(c._timeouts['rendererReply'] === undefined,
       'postMessage failure short-circuits BEFORE arming rendererReply timeout (pass-2 LOW fix preserved)');
   }
+  flushContainers();
 }
 
 // -- 10. Creative URL variant — Phase B does NOT regress the URL load path
 {
   console.log('\n10. Creative URL variant — Phase B does NOT regress URL load path');
   const slot = freshSlot();
-  const c = new SHARCContainer({
+  const c = track(new SHARCContainer({
     creativeUrl: 'https://ads.example/creative.html',
     placementElement: slot,
-  });
+  }));
   c.load();
   const iframe = c._iframe;
   assert(iframe.getAttribute('src') === 'https://ads.example/creative.html',
@@ -793,6 +841,7 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
     'URL: iframe stamped with data-sharc-creative-source="url"');
   assert(iframe.getAttribute('data-sharc-creative-rendered') === 'false',
     'URL: iframe stamped with data-sharc-creative-rendered="false" (URL variant never flips this true)');
+  flushContainers();
 }
 
 // =========================================================================
@@ -808,13 +857,13 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   function buildForFailedTest(opts = {}) {
     const errors = [];
     const slot = freshSlot();
-    const c = new SHARCContainer({
+    const c = track(new SHARCContainer({
       creativeHtml: CREATIVE_HTML,
       creativeRendererUrl: RENDERER_URL,
       placementElement: slot,
       timeouts: { rendererLoad: 5000, rendererReply: 5000, ...(opts.timeouts || {}) },
       onError: (code, msg) => errors.push({ code, msg }),
-    });
+    }));
     c.load();
     c._iframe.contentWindow.postMessage = () => {};
     c._iframe.dispatchEvent(new dom.window.Event('load'));
@@ -846,6 +895,8 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
     }
     assert(errors.length >= 1 && errors[0].code === ErrorCodes.RENDERER_FAILED,
       ':failed → onError(RENDERER_FAILED, …) (code 2115)');
+    assert(errors[0].code !== ErrorCodes.RENDERER_PROTOCOL_ERROR,
+      ':failed with valid reason → 2115 (NOT 2117 — payload shape passed)');
     assert(/creative HTML parse error/.test(errors[0].msg),
       ':failed → onError message includes the renderer-supplied reason');
     assert(container._terminated === true,
@@ -922,32 +973,12 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       ':failed with wrong placementSessionId → container NOT terminated');
   }
 
-  // 11e — :failed clears the rendererReply timeout (no double-terminate from
-  //       the timeout firing after the :failed-induced termination).
-  //
-  // Timing dependency note (pass-1 code review M2): this assertion relies on
-  // _terminate running before the rendererReply timeout fires. The chain is:
-  // :failed → _emitSecurityEventAndTerminate → _handleFatalError →
-  // sendFatalError() rejects synchronously (no MessagePort mid-render) →
-  // .catch(_terminate) on next microtask → listener-detach + clear-all
-  // timeouts + _terminated=true. All of that completes within microtasks of
-  // the dispatch, well before the 60ms rendererReply timeout. The 120ms
-  // await then proves the timeout did NOT fire (errors.length stays at 1).
-  //
-  // If sendFatalError's rejection were ever made async (e.g. queued on a
-  // macrotask), this test would race — the rendererReply timeout could
-  // fire at 60ms before the terminate-induced clearTimeout ran. Either
-  // restore the microtask-rejection invariant or rewrite this test to drive
-  // both the :failed dispatch and the timeout assertion inside the same
-  // sync block.
-  //
-  // Note: with Fix 1 (re-entrancy guard at _emitSecurityEventAndTerminate),
-  // this test is now ROBUST against the race even if the listener weren't
-  // detached in time — the second terminate path (the timeout) would
-  // short-circuit on the _terminated guard at the chokepoint. The comment
-  // above documents the path future readers should expect; Fix 1 hardens
-  // it, but the documented invariant (microtask-sync rejection) is still
-  // the cleaner contract to preserve.
+  // 11e — :failed clears the rendererReply timeout: the re-entrancy guard
+  // prevents a follow-up RENDERER_TIMEOUT from firing after a :failed,
+  // regardless of whether _terminate races the timeout-clear. Even if the
+  // rendererReply timeout fires before clear-all-timeouts has run, its
+  // terminate path short-circuits on the _terminated guard at the
+  // chokepoint helper. errors.length must stay at 1.
   {
     const { container, iframe, errors } = buildForFailedTest({
       timeouts: { rendererLoad: 5000, rendererReply: 60 },
@@ -1079,22 +1110,25 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       '11h: each control char is replaced with "?" (ANSI escape neutralized)');
   }
 
-  // 11i — Re-entrancy guard at _emitSecurityEventAndTerminate.
-  // The guard is post-microtask-idempotent: it protects against the realistic
-  // case where the browser delivers a second terminating renderer message
-  // AFTER microtasks have drained (which is when _terminate's listener-detach
-  // and `_terminated = true` would have run). It does NOT claim coverage for
-  // synchronous double-dispatch — cross-origin postMessage cannot deliver
-  // two messages synchronously, so that scenario doesn't occur in real
-  // browser environments.
+  // 11i — Listener-detach idempotency (and indirect coverage of the
+  // re-entrancy guard at _emitSecurityEventAndTerminate).
   //
-  // Without this guard: the second :failed would fire `_onError` a second
-  // time before the listener was detached. With it: the second message is
-  // short-circuited at the chokepoint helper, exactly one `_onError` fires,
-  // and Phase D's structured `onSecurityEvent` emission (when wired here)
-  // inherits the idempotency contract for free.
+  // Honest scope: what this test actually exercises is the listener-detach
+  // contract — after the first `:failed` triggers `_terminate`, the renderer
+  // message listener is removed; a second `:failed` dispatched on `window`
+  // never reaches `_dispatchRendererMessage`. The chokepoint guard
+  // (`if (this._terminated) return;` at the top of
+  // `_emitSecurityEventAndTerminate`) is forward-compat for Phase D, where
+  // non-listener paths (e.g. load-event monitoring) may call the chokepoint
+  // after `_terminated=true`. Today it isn't reached because the listener-
+  // detach already short-circuits the only path. Precondition assertions
+  // below pin those facts so the test doesn't silently morph into something
+  // weaker if the chain ever changes (e.g. listener-detach moves later in
+  // `_terminate`, or `sendFatalError` becomes 2-microtask-async).
+  //
+  // A direct test of the chokepoint guard belongs with Phase D's load-event
+  // monitoring work — file an issue for it then.
   {
-    console.log('\n11i. Re-entrancy guard at _emitSecurityEventAndTerminate (post-microtask idempotency)');
     const { container, iframe, errors } = buildForFailedTest();
     const originalError = console.error;
     const errorOutput = [];
@@ -1117,6 +1151,15 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       // this `await`, _terminated === true and the listener is detached.
       await Promise.resolve();
       await Promise.resolve();
+
+      // Lock in the precondition the rest of the test depends on. Without
+      // this, if the chain ever changes the second-dispatch assertion below
+      // would silently become a no-op test of envelope rejection rather than
+      // a test of the listener-detach / re-entrancy guard contract.
+      assert(container._terminated === true,
+        'guard precondition: _terminated is true after microtask drain');
+      assert(container._rendererMessageHandler === null,
+        'guard precondition: renderer message listener detached after microtask drain');
 
       // Second :failed in the next tick. Real browsers would deliver this as
       // a separate task; we simulate that by `await`ing first.
@@ -1184,6 +1227,7 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
     assert(/A{199}$/.test(payload),
       '11j: payload ends with the 199 As preceding the cut surrogate (high surrogate stripped)');
   }
+  flushContainers();
 }
 
 // -- 12. Origin echo + payload-shape validation on :rendered/:failed
@@ -1199,15 +1243,16 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
     const errorOutput = [];
     console.error = (...args) => { errorOutput.push(args.join(' ')); };
     let errors;
+    let c;
     try {
       const slot = freshSlot();
-      const c = new SHARCContainer({
+      c = track(new SHARCContainer({
         creativeHtml: CREATIVE_HTML,
         creativeRendererUrl: RENDERER_URL,
         placementElement: slot,
         timeouts: { rendererLoad: 5000, rendererReply: 5000 },
         onError: (code, msg) => (errors = errors || []).push({ code, msg }),
-      });
+      }));
       errors = [];
       c.load();
       c._iframe.contentWindow.postMessage = () => {};
@@ -1228,34 +1273,39 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       });
       window.dispatchEvent(evt);
       await new Promise((r) => setTimeout(r, 60));
-
-      assert(errors.length >= 1 && errors[0].code === ErrorCodes.RENDERER_ORIGIN_MISMATCH,
-        'origin echo mismatch on :rendered → onError(RENDERER_ORIGIN_MISMATCH, …) (code 2116)');
-      assert(c._terminated === true,
-        'origin echo mismatch terminates the container');
-      assert(c.creativeRendered === false,
-        'origin echo mismatch does NOT flip creativeRendered=true');
-
-      // Operator-facing log: per spec § Container-side message validation
-      // lines 484–491. The helper prefixes `[SHARCContainer] [<type>]`, so the
-      // rendered log line is the spec-intended:
-      //   [SHARCContainer] [renderer_origin_mismatch] Renderer origin mismatch — refusing to load. …
-      const joined = errorOutput.join('\n');
-      assert(/\[renderer_origin_mismatch\]/.test(joined),
-        'console.error includes the [renderer_origin_mismatch] type tag');
-      assert(/Renderer origin mismatch — refusing to load\./.test(joined),
-        'console.error includes the spec wording "Renderer origin mismatch — refusing to load."');
-      assert(joined.includes('Expected origin: ' + RENDERER_ORIGIN),
-        'console.error names the expected origin (from creativeRendererUrl)');
-      assert(/Actual origin:\s+https:\/\/cdn\.example\.com/.test(joined),
-        'console.error names the actual (post-redirect) origin');
-      assert(/Redirects on creativeRendererUrl are not permitted/.test(joined),
-        'console.error explains why redirects are refused (spec wording)');
-      assert(/api-reference\.md#renderer-protocol/.test(joined),
-        'console.error includes the api-reference link to the renderer-protocol section');
     } finally {
       console.error = originalError;
     }
+
+    // Assertions live OUTSIDE the try/finally so any failure indicator (`✗`
+    // line) is written to the real terminal, not into the captured
+    // `errorOutput` array (which would silently mask the failure).
+    assert(errors.length >= 1 && errors[0].code === ErrorCodes.RENDERER_ORIGIN_MISMATCH,
+      'origin echo mismatch on :rendered → onError(RENDERER_ORIGIN_MISMATCH, …) (code 2116)');
+    assert(errors[0].code !== ErrorCodes.RENDERER_PROTOCOL_ERROR,
+      'origin echo mismatch with valid shape → 2116 (NOT 2117 — payload shape passed)');
+    assert(c._terminated === true,
+      'origin echo mismatch terminates the container');
+    assert(c.creativeRendered === false,
+      'origin echo mismatch does NOT flip creativeRendered=true');
+
+    // Operator-facing log: per spec § Container-side message validation
+    // lines 484–491. The helper prefixes `[SHARCContainer] [<type>]`, so the
+    // rendered log line is the spec-intended:
+    //   [SHARCContainer] [renderer_origin_mismatch] Renderer origin mismatch — refusing to load. …
+    const joined = errorOutput.join('\n');
+    assert(/\[renderer_origin_mismatch\]/.test(joined),
+      'console.error includes the [renderer_origin_mismatch] type tag');
+    assert(/Renderer origin mismatch — refusing to load\./.test(joined),
+      'console.error includes the spec wording "Renderer origin mismatch — refusing to load."');
+    assert(joined.includes('Expected origin: ' + RENDERER_ORIGIN),
+      'console.error names the expected origin (from creativeRendererUrl)');
+    assert(/Actual origin:\s+https:\/\/cdn\.example\.com/.test(joined),
+      'console.error names the actual (post-redirect) origin');
+    assert(/Redirects on creativeRendererUrl are not permitted/.test(joined),
+      'console.error explains why redirects are refused (spec wording)');
+    assert(/creative-sources\.md#container-side-message-validation/.test(joined),
+      'console.error includes the link to the creative-sources spec § container-side-message-validation');
   }
 
   // 12b — Malformed :rendered payload: missing / non-string / empty
@@ -1283,13 +1333,13 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   ]) {
     const errors = [];
     const slot = freshSlot();
-    const c = new SHARCContainer({
+    const c = track(new SHARCContainer({
       creativeHtml: CREATIVE_HTML,
       creativeRendererUrl: RENDERER_URL,
       placementElement: slot,
       timeouts: { rendererLoad: 5000, rendererReply: 5000 },
       onError: (code, msg) => errors.push({ code, msg }),
-    });
+    }));
     c.load();
     c._iframe.contentWindow.postMessage = () => {};
     c._iframe.dispatchEvent(new dom.window.Event('load'));
@@ -1346,13 +1396,13 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   ]) {
     const errors = [];
     const slot = freshSlot();
-    const c = new SHARCContainer({
+    const c = track(new SHARCContainer({
       creativeHtml: CREATIVE_HTML,
       creativeRendererUrl: RENDERER_URL,
       placementElement: slot,
       timeouts: { rendererLoad: 5000, rendererReply: 5000 },
       onError: (code, msg) => errors.push({ code, msg }),
-    });
+    }));
     c.load();
     c._iframe.contentWindow.postMessage = () => {};
     c._iframe.dispatchEvent(new dom.window.Event('load'));
@@ -1390,13 +1440,13 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   {
     const errors = [];
     const slot = freshSlot();
-    const c = new SHARCContainer({
+    const c = track(new SHARCContainer({
       creativeHtml: CREATIVE_HTML,
       creativeRendererUrl: RENDERER_URL,
       placementElement: slot,
       timeouts: { rendererLoad: 5000, rendererReply: 5000 },
       onError: (code, msg) => errors.push({ code, msg }),
-    });
+    }));
     c.load();
     c._iframe.contentWindow.postMessage = () => {};
     c._iframe.dispatchEvent(new dom.window.Event('load'));
@@ -1430,13 +1480,13 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   {
     const errors = [];
     const slot = freshSlot();
-    const c = new SHARCContainer({
+    const c = track(new SHARCContainer({
       creativeHtml: CREATIVE_HTML,
       creativeRendererUrl: RENDERER_URL,
       placementElement: slot,
       timeouts: { rendererLoad: 5000, rendererReply: 5000 },
       onError: (code, msg) => errors.push({ code, msg }),
-    });
+    }));
     c.load();
     c._iframe.contentWindow.postMessage = () => {};
     c._iframe.dispatchEvent(new dom.window.Event('load'));
@@ -1468,6 +1518,7 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
     assert(errors.length >= 1 && /Actual origin:   https:\/\/impostor\.example\?\[SHARCContainer\] \[audit\] forged/.test(errors[0].msg),
       '12e: onError receives the same sanitized rendererOrigin the log saw');
   }
+  flushContainers();
 }
 
 // -- 13. close() mid-render cleanup contract
@@ -1481,9 +1532,9 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   // through the .catch() → _terminate path because no port exists yet)
   // doesn't slow the test even if some future change re-routes it through
   // the closeSequence timeout.
-  function buildMidRender() {
+  function buildMidRender(opts = {}) {
     const slot = freshSlot();
-    const c = new SHARCContainer({
+    const c = track(new SHARCContainer({
       creativeHtml: CREATIVE_HTML,
       creativeRendererUrl: RENDERER_URL,
       placementElement: slot,
@@ -1492,7 +1543,8 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
         rendererReply: 5000,
         closeSequence: 50, // belt-and-suspenders — see comment above
       },
-    });
+      ...opts,
+    }));
     c.load();
     c._iframe.contentWindow.postMessage = () => {};
     c._iframe.dispatchEvent(new dom.window.Event('load'));
@@ -1545,13 +1597,20 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
 
   // 13b — Placement element restored to pre-load state (sub-bullet d).
   //       _detachFromPlacement is the existing implementation. Test checks
-  //       the SHARC-stamped attributes are gone after close.
+  //       the SHARC-stamped attributes are gone after close. Pass an explicit
+  //       placementId so the data-sharc-placement-id round-trip (set → cleared)
+  //       is locked in — without it the post-close === null check is vacuous
+  //       (TRA depth-pass BLOCKER-2).
   {
-    const { container, slot } = buildMidRender();
+    const { container, slot } = buildMidRender({ placementId: 'pid-test-13b' });
     // Pre-close: slot carries SHARC placement stamps (the placement-stamping
     // proposal already lands `data-sharc-placement-session-id` on the slot).
     assert(slot.getAttribute('data-sharc-placement-session-id') === container.placementSessionId,
       'pre-close: placement element carries data-sharc-placement-session-id');
+    assert(slot.getAttribute('data-sharc-placement-id') === 'pid-test-13b',
+      'pre-close: placement element carries data-sharc-placement-id (set from constructor option)');
+    assert(slot.getAttribute('data-sharc-state') !== null,
+      'pre-close: placement element carries data-sharc-state');
 
     container.close();
     await new Promise((r) => setTimeout(r, 80));
@@ -1606,13 +1665,13 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   {
     const errors = [];
     const slot = freshSlot();
-    const c = new SHARCContainer({
+    const c = track(new SHARCContainer({
       creativeHtml: CREATIVE_HTML,
       creativeRendererUrl: RENDERER_URL,
       placementElement: slot,
       timeouts: { rendererLoad: 5000, rendererReply: 5000, closeSequence: 50 },
       onError: (code, msg) => errors.push({ code, msg }),
-    });
+    }));
     c.load();
     c._iframe.contentWindow.postMessage = () => {};
     c._iframe.dispatchEvent(new dom.window.Event('load'));
@@ -1640,19 +1699,32 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
 
   // 13e — Idempotency: close() called twice during mid-render is a no-op on
   //       the second call. (Already covered by `_closeRequested` guard at
-  //       sharc-container.js:866; locking it in.)
+  //       sharc-container.js:866; locking it in via an `onClose` spy so the
+  //       observable side effect — the publisher callback firing — is
+  //       counted exactly once.)
   {
-    const { container } = buildMidRender();
-    container.close();
+    let closeCalls = 0;
+    const slot = freshSlot();
+    const c = track(new SHARCContainer({
+      creativeHtml: CREATIVE_HTML,
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: slot,
+      timeouts: { rendererLoad: 5000, rendererReply: 5000, closeSequence: 50 },
+      onClose: () => { closeCalls++; },
+    }));
+    c.load();
+    c._iframe.contentWindow.postMessage = () => {};
+    c._iframe.dispatchEvent(new dom.window.Event('load'));
+    c.close();
     await new Promise((r) => setTimeout(r, 80));
-    const terminatedAfterFirst = container._terminated;
     // Second close — no throw, no double-terminate side effects.
     let threw = false;
-    try { container.close(); } catch (_) { threw = true; }
+    try { c.close(); } catch (_) { threw = true; }
+    await new Promise((r) => setTimeout(r, 20));
     assert(!threw,
       'mid-render close() called twice does not throw');
-    assert(container._terminated === terminatedAfterFirst,
-      'mid-render close() called twice does not re-run terminate side effects');
+    assert(closeCalls === 1,
+      'mid-render close() called twice fires onClose exactly once (idempotency)');
   }
 }
 
@@ -1663,4 +1735,5 @@ if (failures > 0) {
   process.exit(1);
 } else {
   console.log('✓ All creative-sources-load assertions passed.');
+  flushContainers();
 }

--- a/test-creative-sources-load.js
+++ b/test-creative-sources-load.js
@@ -924,6 +924,30 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
 
   // 11e — :failed clears the rendererReply timeout (no double-terminate from
   //       the timeout firing after the :failed-induced termination).
+  //
+  // Timing dependency note (pass-1 code review M2): this assertion relies on
+  // _terminate running before the rendererReply timeout fires. The chain is:
+  // :failed → _emitSecurityEventAndTerminate → _handleFatalError →
+  // sendFatalError() rejects synchronously (no MessagePort mid-render) →
+  // .catch(_terminate) on next microtask → listener-detach + clear-all
+  // timeouts + _terminated=true. All of that completes within microtasks of
+  // the dispatch, well before the 60ms rendererReply timeout. The 120ms
+  // await then proves the timeout did NOT fire (errors.length stays at 1).
+  //
+  // If sendFatalError's rejection were ever made async (e.g. queued on a
+  // macrotask), this test would race — the rendererReply timeout could
+  // fire at 60ms before the terminate-induced clearTimeout ran. Either
+  // restore the microtask-rejection invariant or rewrite this test to drive
+  // both the :failed dispatch and the timeout assertion inside the same
+  // sync block.
+  //
+  // Note: with Fix 1 (re-entrancy guard at _emitSecurityEventAndTerminate),
+  // this test is now ROBUST against the race even if the listener weren't
+  // detached in time — the second terminate path (the timeout) would
+  // short-circuit on the _terminated guard at the chokepoint. The comment
+  // above documents the path future readers should expect; Fix 1 hardens
+  // it, but the documented invariant (microtask-sync rejection) is still
+  // the cleaner contract to preserve.
   {
     const { container, iframe, errors } = buildForFailedTest({
       timeouts: { rendererLoad: 5000, rendererReply: 60 },
@@ -952,6 +976,107 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       ':failed clears rendererReply — only one onError fires (no follow-up RENDERER_TIMEOUT)');
     assert(errors[0].code === ErrorCodes.RENDERER_FAILED,
       'first (and only) onError is RENDERER_FAILED, not RENDERER_TIMEOUT');
+  }
+
+  // 11f — Log-injection hardening on data.reason (security pass-1 MEDIUM-2):
+  //       a :failed reason carrying CR/LF + a forged log-line prefix must be
+  //       sanitized (control chars replaced with '?') before being spliced
+  //       into console.error. Long reasons must be truncated to 200 chars to
+  //       bound log-line length. The sanitized form is what flows through to
+  //       both console.error and the onError callback (consistent surface).
+  {
+    const { container, iframe, errors } = buildForFailedTest();
+    const originalError = console.error;
+    const errorOutput = [];
+    console.error = (...args) => { errorOutput.push(args.join(' ')); };
+    try {
+      const evt = new dom.window.MessageEvent('message', {
+        data: {
+          type: 'SHARC:Renderer:failed',
+          placementSessionId: container.placementSessionId,
+          reason: 'fake_error\n[SHARCContainer] [audit] forged log line',
+        },
+        origin: RENDERER_ORIGIN,
+        source: iframe.contentWindow,
+      });
+      window.dispatchEvent(evt);
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      console.error = originalError;
+    }
+    const failureLog = errorOutput.find((s) => /\[renderer_failed\]/.test(s)) || '';
+    assert(/Renderer reported failure: fake_error\?\[SHARCContainer\] \[audit\] forged log line/.test(failureLog),
+      '11f: console.error sanitizes data.reason — LF replaced with "?"');
+    assert(!/fake_error\n\[SHARCContainer\] \[audit\]/.test(failureLog),
+      '11f: console.error does NOT contain a literal newline followed by a forged [SHARCContainer] prefix (log-splitting blocked)');
+    assert(errors.length >= 1 && /Renderer reported failure: fake_error\?\[SHARCContainer\] \[audit\] forged log line/.test(errors[0].msg),
+      '11f: onError receives the same sanitized message the log saw (consistent surface)');
+  }
+
+  // 11g — Truncation hardening on data.reason (security pass-1 MEDIUM-2):
+  //       reasons longer than 200 chars are sliced to 200 to bound the log
+  //       line length. The truncation cut is exact — exactly 200 chars of
+  //       payload appear after the "Renderer reported failure: " prefix.
+  {
+    const { container, iframe, errors } = buildForFailedTest();
+    const originalError = console.error;
+    const errorOutput = [];
+    console.error = (...args) => { errorOutput.push(args.join(' ')); };
+    const longReason = 'A'.repeat(500);
+    try {
+      const evt = new dom.window.MessageEvent('message', {
+        data: {
+          type: 'SHARC:Renderer:failed',
+          placementSessionId: container.placementSessionId,
+          reason: longReason,
+        },
+        origin: RENDERER_ORIGIN,
+        source: iframe.contentWindow,
+      });
+      window.dispatchEvent(evt);
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      console.error = originalError;
+    }
+    assert(errors.length >= 1,
+      '11g: long reason still routes to onError');
+    const m = /Renderer reported failure: (A+)/.exec(errors[0].msg);
+    assert(m && m[1].length === 200,
+      '11g: data.reason is truncated to exactly 200 chars in the operator-facing message');
+    assert(!/A{201}/.test(errors[0].msg),
+      '11g: no run of 201+ A chars survives the truncation');
+  }
+
+  // 11h — Other C0/DEL control chars in data.reason are stripped (CR, NUL,
+  //       ESC for ANSI sequences, DEL 0x7f). Spot-check the full range
+  //       behavior, not just LF.
+  {
+    const { container, iframe, errors } = buildForFailedTest();
+    const originalError = console.error;
+    const errorOutput = [];
+    console.error = (...args) => { errorOutput.push(args.join(' ')); };
+    try {
+      const evt = new dom.window.MessageEvent('message', {
+        data: {
+          type: 'SHARC:Renderer:failed',
+          placementSessionId: container.placementSessionId,
+          // CR + NUL + ESC[31m (ANSI red) + DEL — none should survive.
+          reason: 'cr\rnul\x00esc\x1b[31mred\x1b[0mdel\x7fend',
+        },
+        origin: RENDERER_ORIGIN,
+        source: iframe.contentWindow,
+      });
+      window.dispatchEvent(evt);
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      console.error = originalError;
+    }
+    assert(errors.length >= 1,
+      '11h: reason with mixed control chars still routes to onError');
+    assert(!/[\x00-\x1f\x7f]/.test(errors[0].msg.split('Renderer reported failure: ')[1] || ''),
+      '11h: no C0 or DEL control char survives in the post-prefix payload');
+    assert(/cr\?nul\?esc\?\[31mred\?\[0mdel\?end/.test(errors[0].msg),
+      '11h: each control char is replaced with "?" (ANSI escape neutralized)');
   }
 }
 
@@ -1188,6 +1313,54 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
     }
     assert(errors.length >= 1 && errors[0].code === ErrorCodes.RENDERER_PROTOCOL_ERROR,
       'order-of-checks: empty rendererOrigin → 2117 (shape) takes precedence over 2116 (echo)');
+  }
+
+  // 12e — Log-injection hardening on data.rendererOrigin (security pass-1
+  //       MEDIUM-2): a :rendered carrying a CR + forged log-line in
+  //       rendererOrigin must be sanitized before being spliced into the
+  //       multi-line origin-mismatch console.error. Reaches the sanitization
+  //       site because the string is non-empty (passes shape) but does not
+  //       equal `_rendererOrigin` (fails echo → routes to mismatch log).
+  {
+    const errors = [];
+    const slot = freshSlot();
+    const c = new SHARCContainer({
+      creativeHtml: CREATIVE_HTML,
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: slot,
+      timeouts: { rendererLoad: 5000, rendererReply: 5000 },
+      onError: (code, msg) => errors.push({ code, msg }),
+    });
+    c.load();
+    c._iframe.contentWindow.postMessage = () => {};
+    c._iframe.dispatchEvent(new dom.window.Event('load'));
+    const originalError = console.error;
+    const errorOutput = [];
+    console.error = (...args) => { errorOutput.push(args.join(' ')); };
+    try {
+      const evt = new dom.window.MessageEvent('message', {
+        data: {
+          type: 'SHARC:Renderer:rendered',
+          placementSessionId: c.placementSessionId,
+          // CR splice attempt — non-empty (passes shape), differs from
+          // _rendererOrigin (fails echo → reaches the mismatch log).
+          rendererOrigin: 'https://impostor.example\r[SHARCContainer] [audit] forged',
+        },
+        origin: RENDERER_ORIGIN,
+        source: c._iframe.contentWindow,
+      });
+      window.dispatchEvent(evt);
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      console.error = originalError;
+    }
+    const mismatchLog = errorOutput.find((s) => /\[renderer_origin_mismatch\]/.test(s)) || '';
+    assert(/Actual origin:   https:\/\/impostor\.example\?\[SHARCContainer\] \[audit\] forged/.test(mismatchLog),
+      '12e: console.error sanitizes data.rendererOrigin — CR replaced with "?"');
+    assert(!/impostor\.example\r\[SHARCContainer\] \[audit\]/.test(mismatchLog),
+      '12e: console.error does NOT contain a literal CR followed by a forged [SHARCContainer] prefix');
+    assert(errors.length >= 1 && /Actual origin:   https:\/\/impostor\.example\?\[SHARCContainer\] \[audit\] forged/.test(errors[0].msg),
+      '12e: onError receives the same sanitized rendererOrigin the log saw');
   }
 }
 

--- a/test-creative-sources-load.js
+++ b/test-creative-sources-load.js
@@ -1,5 +1,5 @@
 /**
- * test-creative-sources-load.js — issue #41 Phase B regression coverage
+ * test-creative-sources-load.js — issue #41 Phase B+C regression coverage
  *
  * Load-path tests for the Creative Markup variant. Phase B scope:
  *   1. Renderer-iframe build — sandbox tokens, csp, allow, referrerpolicy.
@@ -12,18 +12,23 @@
  *      placementSessionId) + standard 200ms-delay → initChannel bootstrap.
  *   6. RENDERER_TIMEOUT (2114) on iframe-load and rendered-reply timeouts.
  *
- * NOT in Phase B (defer to Phase C/D):
- *   :failed receipt + RENDERER_FAILED (2115)
- *   Post-load origin echo + RENDERER_ORIGIN_MISMATCH (2116)
- *   Malformed-payload handling + RENDERER_PROTOCOL_ERROR (2117)
- *   close() mid-render cleanup contract
+ * Phase C scope (sections 11/12/13):
+ *  11. SHARC:Renderer:failed receipt → RENDERER_FAILED (2115).
+ *  12. Post-load origin echo on :rendered → RENDERER_ORIGIN_MISMATCH (2116);
+ *      malformed-payload validation on both :rendered and :failed →
+ *      RENDERER_PROTOCOL_ERROR (2117).
+ *  13. close() mid-render cleanup contract — timeouts, listener detach, iframe
+ *      removal, placement restoration, late-message silent-ignore.
+ *
+ * NOT in Phase B+C (defer to Phase D):
  *   Load-event navigation backstop + RENDERER_UNAUTHORIZED_NAVIGATION (2118)
  *   Reference renderer + service-worker detection
+ *   Structured `onSecurityEvent` payloads (#62)
  *
  * Uses jsdom (no browser harness) — mirrors the test-creative-sources.js
  * pattern. Stubs `iframe.contentWindow.postMessage` to capture the render
  * message and dispatches synthetic `MessageEvent`s on `window` to simulate
- * the renderer's `:rendered` reply.
+ * the renderer's `:rendered` / `:failed` replies.
  *
  * Runs in Node after `npm run build`.
  */
@@ -162,7 +167,7 @@ function buildAndLoad(options = {}, opts = {}) {
   return { container, iframe, captured };
 }
 
-console.log('test-creative-sources-load.js — issue #41 Phase B regression\n');
+console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n');
 
 // -- 1. Renderer iframe attributes — sandbox / csp / allow / referrerpolicy
 {
@@ -788,6 +793,588 @@ console.log('test-creative-sources-load.js — issue #41 Phase B regression\n');
     'URL: iframe stamped with data-sharc-creative-source="url"');
   assert(iframe.getAttribute('data-sharc-creative-rendered') === 'false',
     'URL: iframe stamped with data-sharc-creative-rendered="false" (URL variant never flips this true)');
+}
+
+// =========================================================================
+// Phase C — sections 11/12/13
+// =========================================================================
+
+// -- 11. SHARC:Renderer:failed receipt → RENDERER_FAILED (2115)
+{
+  console.log('\n11. SHARC:Renderer:failed receipt → RENDERER_FAILED (2115)');
+
+  // Helper: build + load a Markup container, stub postMessage, fire iframe
+  // 'load', and return primitives the test cases below need.
+  function buildForFailedTest(opts = {}) {
+    const errors = [];
+    const slot = freshSlot();
+    const c = new SHARCContainer({
+      creativeHtml: CREATIVE_HTML,
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: slot,
+      timeouts: { rendererLoad: 5000, rendererReply: 5000, ...(opts.timeouts || {}) },
+      onError: (code, msg) => errors.push({ code, msg }),
+    });
+    c.load();
+    c._iframe.contentWindow.postMessage = () => {};
+    c._iframe.dispatchEvent(new dom.window.Event('load'));
+    return { container: c, iframe: c._iframe, errors };
+  }
+
+  // 11a — Happy-path :failed: terminates with RENDERER_FAILED (2115) and the
+  // operator-facing message echoes the renderer-supplied reason.
+  {
+    const { container, iframe, errors } = buildForFailedTest();
+    const originalError = console.error;
+    const errorOutput = [];
+    console.error = (...args) => { errorOutput.push(args.join(' ')); };
+    try {
+      const evt = new dom.window.MessageEvent('message', {
+        data: {
+          type: 'SHARC:Renderer:failed',
+          placementSessionId: container.placementSessionId,
+          reason: 'creative HTML parse error: unterminated <script>',
+        },
+        origin: RENDERER_ORIGIN,
+        source: iframe.contentWindow,
+      });
+      window.dispatchEvent(evt);
+      // Allow async _handleFatalError → _terminate chain to settle.
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      console.error = originalError;
+    }
+    assert(errors.length >= 1 && errors[0].code === ErrorCodes.RENDERER_FAILED,
+      ':failed → onError(RENDERER_FAILED, …) (code 2115)');
+    assert(/creative HTML parse error/.test(errors[0].msg),
+      ':failed → onError message includes the renderer-supplied reason');
+    assert(container._terminated === true,
+      ':failed terminates the container');
+    assert(errorOutput.some((s) => /\[renderer_failed\]/.test(s)),
+      'console.error includes the [renderer_failed] type tag');
+    assert(errorOutput.some((s) => /Renderer reported failure: creative HTML parse error/.test(s)),
+      'console.error includes the "Renderer reported failure: <reason>" wording');
+    assert(container.creativeRendered === false,
+      ':failed does NOT flip creativeRendered=true (renderer never rendered)');
+  }
+
+  // 11b — Envelope source/origin mismatch on :failed: silently ignored
+  //       (envelope helper is symmetric across :rendered and :failed).
+  {
+    const { container, iframe, errors } = buildForFailedTest();
+    // Wrong event.origin — envelope check fails, silent ignore.
+    const evt = new dom.window.MessageEvent('message', {
+      data: {
+        type: 'SHARC:Renderer:failed',
+        placementSessionId: container.placementSessionId,
+        reason: 'should be ignored',
+      },
+      origin: 'https://impostor.example',
+      source: iframe.contentWindow,
+    });
+    window.dispatchEvent(evt);
+    await new Promise((r) => setTimeout(r, 20));
+    assert(errors.length === 0,
+      ':failed with wrong event.origin → SILENTLY ignored (envelope reject), no onError fired');
+    assert(container._terminated === false,
+      ':failed with wrong event.origin → container NOT terminated');
+  }
+
+  // 11c — Wrong event.source on :failed: silently ignored — neighbor-frame
+  //       defense (a sibling iframe forging :failed must not terminate us).
+  {
+    const { container, errors } = buildForFailedTest();
+    const evt = new dom.window.MessageEvent('message', {
+      data: {
+        type: 'SHARC:Renderer:failed',
+        placementSessionId: container.placementSessionId,
+        reason: 'forged from neighbor frame',
+      },
+      origin: RENDERER_ORIGIN,
+      source: window, // forged — NOT iframe.contentWindow
+    });
+    window.dispatchEvent(evt);
+    await new Promise((r) => setTimeout(r, 20));
+    assert(errors.length === 0,
+      ':failed with forged event.source → SILENTLY ignored, no onError fired');
+    assert(container._terminated === false,
+      ':failed with forged event.source → container NOT terminated');
+  }
+
+  // 11d — Wrong placementSessionId on :failed: silently ignored (session
+  //       correlation is symmetric across :rendered and :failed).
+  {
+    const { container, iframe, errors } = buildForFailedTest();
+    const evt = new dom.window.MessageEvent('message', {
+      data: {
+        type: 'SHARC:Renderer:failed',
+        placementSessionId: 'forged-id-not-mine',
+        reason: 'wrong session',
+      },
+      origin: RENDERER_ORIGIN,
+      source: iframe.contentWindow,
+    });
+    window.dispatchEvent(evt);
+    await new Promise((r) => setTimeout(r, 20));
+    assert(errors.length === 0,
+      ':failed with wrong placementSessionId → SILENTLY ignored');
+    assert(container._terminated === false,
+      ':failed with wrong placementSessionId → container NOT terminated');
+  }
+
+  // 11e — :failed clears the rendererReply timeout (no double-terminate from
+  //       the timeout firing after the :failed-induced termination).
+  {
+    const { container, iframe, errors } = buildForFailedTest({
+      timeouts: { rendererLoad: 5000, rendererReply: 60 },
+    });
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      const evt = new dom.window.MessageEvent('message', {
+        data: {
+          type: 'SHARC:Renderer:failed',
+          placementSessionId: container.placementSessionId,
+          reason: 'fail-fast for timeout-clear test',
+        },
+        origin: RENDERER_ORIGIN,
+        source: iframe.contentWindow,
+      });
+      window.dispatchEvent(evt);
+      // Wait past the rendererReply window so the timeout would fire if not
+      // cleared. Errors array must contain exactly one entry — the
+      // RENDERER_FAILED — not a follow-up RENDERER_TIMEOUT.
+      await new Promise((r) => setTimeout(r, 120));
+    } finally {
+      console.error = originalError;
+    }
+    assert(errors.length === 1,
+      ':failed clears rendererReply — only one onError fires (no follow-up RENDERER_TIMEOUT)');
+    assert(errors[0].code === ErrorCodes.RENDERER_FAILED,
+      'first (and only) onError is RENDERER_FAILED, not RENDERER_TIMEOUT');
+  }
+}
+
+// -- 12. Origin echo + payload-shape validation on :rendered/:failed
+{
+  console.log('\n12. Post-load origin echo + payload-shape validation');
+
+  // 12a — Post-load origin echo: :rendered with a different rendererOrigin
+  //       than the construction-time `_rendererOrigin` →
+  //       RENDERER_ORIGIN_MISMATCH (2116). Multi-line operator log includes
+  //       both expected and actual origins.
+  {
+    const originalError = console.error;
+    const errorOutput = [];
+    console.error = (...args) => { errorOutput.push(args.join(' ')); };
+    let errors;
+    try {
+      const slot = freshSlot();
+      const c = new SHARCContainer({
+        creativeHtml: CREATIVE_HTML,
+        creativeRendererUrl: RENDERER_URL,
+        placementElement: slot,
+        timeouts: { rendererLoad: 5000, rendererReply: 5000 },
+        onError: (code, msg) => (errors = errors || []).push({ code, msg }),
+      });
+      errors = [];
+      c.load();
+      c._iframe.contentWindow.postMessage = () => {};
+      c._iframe.dispatchEvent(new dom.window.Event('load'));
+      // Envelope `event.origin` MUST match `_rendererOrigin` for the message
+      // to even reach the dispatch — origin echo failures by definition come
+      // from a redirect that the renderer notices server-side and reports
+      // back. So `event.origin` stays the construction-time origin, but
+      // `data.rendererOrigin` carries the post-redirect origin.
+      const evt = new dom.window.MessageEvent('message', {
+        data: {
+          type: 'SHARC:Renderer:rendered',
+          placementSessionId: c.placementSessionId,
+          rendererOrigin: 'https://cdn.example.com',
+        },
+        origin: RENDERER_ORIGIN,
+        source: c._iframe.contentWindow,
+      });
+      window.dispatchEvent(evt);
+      await new Promise((r) => setTimeout(r, 60));
+
+      assert(errors.length >= 1 && errors[0].code === ErrorCodes.RENDERER_ORIGIN_MISMATCH,
+        'origin echo mismatch on :rendered → onError(RENDERER_ORIGIN_MISMATCH, …) (code 2116)');
+      assert(c._terminated === true,
+        'origin echo mismatch terminates the container');
+      assert(c.creativeRendered === false,
+        'origin echo mismatch does NOT flip creativeRendered=true');
+
+      // Operator-facing log: per spec § Container-side message validation
+      // lines 484–491. The helper prefixes `[SHARCContainer] [<type>]`, so the
+      // rendered log line is the spec-intended:
+      //   [SHARCContainer] [renderer_origin_mismatch] Renderer origin mismatch — refusing to load. …
+      const joined = errorOutput.join('\n');
+      assert(/\[renderer_origin_mismatch\]/.test(joined),
+        'console.error includes the [renderer_origin_mismatch] type tag');
+      assert(/Renderer origin mismatch — refusing to load\./.test(joined),
+        'console.error includes the spec wording "Renderer origin mismatch — refusing to load."');
+      assert(joined.includes('Expected origin: ' + RENDERER_ORIGIN),
+        'console.error names the expected origin (from creativeRendererUrl)');
+      assert(/Actual origin:\s+https:\/\/cdn\.example\.com/.test(joined),
+        'console.error names the actual (post-redirect) origin');
+      assert(/Redirects on creativeRendererUrl are not permitted/.test(joined),
+        'console.error explains why redirects are refused (spec wording)');
+      assert(/api-reference\.md#renderer-protocol/.test(joined),
+        'console.error includes the api-reference link to the renderer-protocol section');
+    } finally {
+      console.error = originalError;
+    }
+  }
+
+  // 12b — Malformed :rendered payload: missing / non-string / empty
+  //       `rendererOrigin` → RENDERER_PROTOCOL_ERROR (2117). Payload shape
+  //       check FIRST, before origin echo (a missing field can't meaningfully
+  //       fail an origin comparison; protocol-shape is the more accurate
+  //       diagnosis for the operator).
+  for (const probe of [
+    {
+      label: 'missing rendererOrigin',
+      mutate: (p) => { delete p.rendererOrigin; return p; },
+    },
+    {
+      label: 'rendererOrigin not a string (number)',
+      mutate: (p) => { p.rendererOrigin = 42; return p; },
+    },
+    {
+      label: 'rendererOrigin not a string (null)',
+      mutate: (p) => { p.rendererOrigin = null; return p; },
+    },
+    {
+      label: 'rendererOrigin empty string',
+      mutate: (p) => { p.rendererOrigin = ''; return p; },
+    },
+  ]) {
+    const errors = [];
+    const slot = freshSlot();
+    const c = new SHARCContainer({
+      creativeHtml: CREATIVE_HTML,
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: slot,
+      timeouts: { rendererLoad: 5000, rendererReply: 5000 },
+      onError: (code, msg) => errors.push({ code, msg }),
+    });
+    c.load();
+    c._iframe.contentWindow.postMessage = () => {};
+    c._iframe.dispatchEvent(new dom.window.Event('load'));
+    const originalError = console.error;
+    const errorOutput = [];
+    console.error = (...args) => { errorOutput.push(args.join(' ')); };
+    try {
+      const payload = probe.mutate({
+        type: 'SHARC:Renderer:rendered',
+        placementSessionId: c.placementSessionId,
+        rendererOrigin: RENDERER_ORIGIN,
+      });
+      const evt = new dom.window.MessageEvent('message', {
+        data: payload,
+        origin: RENDERER_ORIGIN,
+        source: c._iframe.contentWindow,
+      });
+      window.dispatchEvent(evt);
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      console.error = originalError;
+    }
+    assert(errors.length >= 1 && errors[0].code === ErrorCodes.RENDERER_PROTOCOL_ERROR,
+      `:rendered with ${probe.label} → onError(RENDERER_PROTOCOL_ERROR, …) (code 2117)`);
+    assert(c._terminated === true,
+      `:rendered with ${probe.label} → container terminated`);
+    assert(errorOutput.some((s) => /\[renderer_protocol_error\]/.test(s)),
+      `:rendered with ${probe.label} → console.error tagged [renderer_protocol_error]`);
+    assert(errorOutput.some((s) => /Malformed SHARC:Renderer:rendered/.test(s)),
+      `:rendered with ${probe.label} → console.error names the malformed message type`);
+    assert(c.creativeRendered === false,
+      `:rendered with ${probe.label} → creativeRendered NOT flipped`);
+  }
+
+  // 12c — Malformed :failed payload: reason missing / non-string / empty →
+  //       RENDERER_PROTOCOL_ERROR (2117), distinct from RENDERER_FAILED.
+  for (const probe of [
+    {
+      label: 'missing reason',
+      mutate: (p) => { delete p.reason; return p; },
+    },
+    {
+      label: 'reason not a string (number)',
+      mutate: (p) => { p.reason = 0; return p; },
+    },
+    {
+      label: 'reason not a string (object)',
+      mutate: (p) => { p.reason = { message: 'wrong type' }; return p; },
+    },
+    {
+      label: 'reason empty string',
+      mutate: (p) => { p.reason = ''; return p; },
+    },
+  ]) {
+    const errors = [];
+    const slot = freshSlot();
+    const c = new SHARCContainer({
+      creativeHtml: CREATIVE_HTML,
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: slot,
+      timeouts: { rendererLoad: 5000, rendererReply: 5000 },
+      onError: (code, msg) => errors.push({ code, msg }),
+    });
+    c.load();
+    c._iframe.contentWindow.postMessage = () => {};
+    c._iframe.dispatchEvent(new dom.window.Event('load'));
+    const originalError = console.error;
+    const errorOutput = [];
+    console.error = (...args) => { errorOutput.push(args.join(' ')); };
+    try {
+      const payload = probe.mutate({
+        type: 'SHARC:Renderer:failed',
+        placementSessionId: c.placementSessionId,
+        reason: 'placeholder',
+      });
+      const evt = new dom.window.MessageEvent('message', {
+        data: payload,
+        origin: RENDERER_ORIGIN,
+        source: c._iframe.contentWindow,
+      });
+      window.dispatchEvent(evt);
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      console.error = originalError;
+    }
+    assert(errors.length >= 1 && errors[0].code === ErrorCodes.RENDERER_PROTOCOL_ERROR,
+      `:failed with ${probe.label} → onError(RENDERER_PROTOCOL_ERROR, …) (code 2117 — NOT 2115)`);
+    assert(c._terminated === true,
+      `:failed with ${probe.label} → container terminated`);
+    assert(errorOutput.some((s) => /Malformed SHARC:Renderer:failed/.test(s)),
+      `:failed with ${probe.label} → console.error names the malformed message type`);
+  }
+
+  // 12d — Order-of-checks: a :rendered with BOTH a malformed rendererOrigin
+  //       (empty string) AND that doesn't match `_rendererOrigin` must take
+  //       the RENDERER_PROTOCOL_ERROR path, not RENDERER_ORIGIN_MISMATCH.
+  //       Locks in the spec-required precedence (shape before echo).
+  {
+    const errors = [];
+    const slot = freshSlot();
+    const c = new SHARCContainer({
+      creativeHtml: CREATIVE_HTML,
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: slot,
+      timeouts: { rendererLoad: 5000, rendererReply: 5000 },
+      onError: (code, msg) => errors.push({ code, msg }),
+    });
+    c.load();
+    c._iframe.contentWindow.postMessage = () => {};
+    c._iframe.dispatchEvent(new dom.window.Event('load'));
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      const evt = new dom.window.MessageEvent('message', {
+        data: {
+          type: 'SHARC:Renderer:rendered',
+          placementSessionId: c.placementSessionId,
+          rendererOrigin: '', // empty — fails shape AND fails echo comparison
+        },
+        origin: RENDERER_ORIGIN,
+        source: c._iframe.contentWindow,
+      });
+      window.dispatchEvent(evt);
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      console.error = originalError;
+    }
+    assert(errors.length >= 1 && errors[0].code === ErrorCodes.RENDERER_PROTOCOL_ERROR,
+      'order-of-checks: empty rendererOrigin → 2117 (shape) takes precedence over 2116 (echo)');
+  }
+}
+
+// -- 13. close() mid-render cleanup contract
+{
+  console.log('\n13. close() mid-render cleanup contract');
+
+  // Helper: build, load, fire iframe 'load' (so the render postMessage goes
+  // out and the message listener is attached) — but do NOT dispatch any
+  // :rendered/:failed reply. Container is now in the mid-render window.
+  // closeSequence is set short so the close-induced terminate (which goes
+  // through the .catch() → _terminate path because no port exists yet)
+  // doesn't slow the test even if some future change re-routes it through
+  // the closeSequence timeout.
+  function buildMidRender() {
+    const slot = freshSlot();
+    const c = new SHARCContainer({
+      creativeHtml: CREATIVE_HTML,
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: slot,
+      timeouts: {
+        rendererLoad: 5000,
+        rendererReply: 5000,
+        closeSequence: 50, // belt-and-suspenders — see comment above
+      },
+    });
+    c.load();
+    c._iframe.contentWindow.postMessage = () => {};
+    c._iframe.dispatchEvent(new dom.window.Event('load'));
+    return { container: c, iframe: c._iframe, slot };
+  }
+
+  // 13a — close() during mid-render reaches _terminate. Per `_initiateClose`
+  //       at sharc-container.js:2509–2526: `_protocol.sendClose()` rejects
+  //       synchronously with "No MessagePort available" because no
+  //       MessageChannel handshake has happened yet, the .catch branch fires,
+  //       and _terminate runs. (closeSequence is the 2s backstop only.)
+  {
+    const { container, iframe } = buildMidRender();
+    // Snapshot pre-close state — listener is attached, iframe is in the DOM,
+    // rendererReply timeout is armed, placement carries the SHARC stamps.
+    assert(typeof container._rendererMessageHandler === 'function',
+      'pre-close: renderer message listener IS attached during mid-render window');
+    assert(container._timeouts['rendererReply'] != null,
+      'pre-close: rendererReply timeout IS armed during mid-render window');
+    assert(iframe.parentNode != null,
+      'pre-close: iframe IS attached to the DOM during mid-render window');
+    assert(iframe.getAttribute('data-sharc-creative-source') === 'html',
+      'pre-close: iframe carries data-sharc-creative-source="html"');
+    assert(iframe.getAttribute('data-sharc-creative-rendered') === 'false',
+      'pre-close: iframe carries data-sharc-creative-rendered="false"');
+
+    container.close();
+    // _initiateClose's .catch fires on the next microtask; allow it to settle.
+    await new Promise((r) => setTimeout(r, 80));
+
+    assert(container._terminated === true,
+      'mid-render close → _terminate runs (sendClose rejects, .catch path fires)');
+
+    // 13a.i — rendererReply timeout cancelled (sub-bullet a of the spec
+    // contract). _terminate's `Object.keys(this._timeouts).forEach(_clearTimeout)`
+    // covers this; locking it in here.
+    assert(container._timeouts['rendererReply'] === undefined,
+      'mid-render close: rendererReply timeout cancelled (spec sub-bullet a)');
+
+    // 13a.ii — renderer message listener removed (sub-bullet b).
+    assert(container._rendererMessageHandler === null,
+      'mid-render close: renderer message listener detached (spec sub-bullet b)');
+
+    // 13a.iii — iframe removed from DOM (sub-bullet c).
+    assert(container._iframe === null,
+      'mid-render close: container._iframe is nulled (spec sub-bullet c)');
+    assert(iframe.parentNode === null,
+      'mid-render close: iframe is detached from the DOM (spec sub-bullet c)');
+  }
+
+  // 13b — Placement element restored to pre-load state (sub-bullet d).
+  //       _detachFromPlacement is the existing implementation. Test checks
+  //       the SHARC-stamped attributes are gone after close.
+  {
+    const { container, slot } = buildMidRender();
+    // Pre-close: slot carries SHARC placement stamps (the placement-stamping
+    // proposal already lands `data-sharc-placement-session-id` on the slot).
+    assert(slot.getAttribute('data-sharc-placement-session-id') === container.placementSessionId,
+      'pre-close: placement element carries data-sharc-placement-session-id');
+
+    container.close();
+    await new Promise((r) => setTimeout(r, 80));
+
+    assert(slot.getAttribute('data-sharc-placement-session-id') === null,
+      'mid-render close: data-sharc-placement-session-id removed from placement (spec sub-bullet d)');
+    assert(slot.getAttribute('data-sharc-placement-id') === null,
+      'mid-render close: data-sharc-placement-id removed from placement');
+    assert(slot.getAttribute('data-sharc-state') === null,
+      'mid-render close: data-sharc-state removed from placement');
+    // The iframe (which carried the data-sharc-creative-source/rendered stamps)
+    // is detached entirely; the placement no longer contains a SHARC iframe.
+    assert(slot.querySelector('iframe.sharc-creative') === null,
+      'mid-render close: placement no longer contains a SHARC creative iframe');
+  }
+
+  // 13c — Late :rendered after close-mid-render: silently ignored. The
+  //       message listener has been detached, so dispatching a synthetic
+  //       :rendered on window is a no-op for this container.
+  {
+    const { container, iframe } = buildMidRender();
+    container.close();
+    await new Promise((r) => setTimeout(r, 80));
+
+    // Fabricate a :rendered that *would* have been envelope-valid pre-close.
+    // The listener is gone; container.creativeRendered must stay false.
+    // (We need a `source` reference; `iframe.contentWindow` is still around
+    //  because we captured it pre-close.)
+    const evt = new dom.window.MessageEvent('message', {
+      data: {
+        type: 'SHARC:Renderer:rendered',
+        placementSessionId: container.placementSessionId,
+        rendererOrigin: RENDERER_ORIGIN,
+      },
+      origin: RENDERER_ORIGIN,
+      source: iframe.contentWindow,
+    });
+    window.dispatchEvent(evt);
+    await new Promise((r) => setTimeout(r, 20));
+
+    assert(container.creativeRendered === false,
+      'late :rendered after close-mid-render → SILENTLY ignored (listener detached, spec line 501)');
+    assert(container._terminated === true,
+      'late :rendered after close-mid-render → container stays terminated');
+  }
+
+  // 13d — Late :failed after close-mid-render: silently ignored (same path
+  //       as 13c — listener detach is symmetric across :rendered and :failed).
+  //       Locks in that Phase B's listener-detach in _terminate covers
+  //       :failed too, as the proposal § close() mid-render cleanup line 501
+  //       implies ("Late `rendered` or `failed` messages…").
+  {
+    const errors = [];
+    const slot = freshSlot();
+    const c = new SHARCContainer({
+      creativeHtml: CREATIVE_HTML,
+      creativeRendererUrl: RENDERER_URL,
+      placementElement: slot,
+      timeouts: { rendererLoad: 5000, rendererReply: 5000, closeSequence: 50 },
+      onError: (code, msg) => errors.push({ code, msg }),
+    });
+    c.load();
+    c._iframe.contentWindow.postMessage = () => {};
+    c._iframe.dispatchEvent(new dom.window.Event('load'));
+    const cwSnapshot = c._iframe.contentWindow;
+    c.close();
+    await new Promise((r) => setTimeout(r, 80));
+
+    const evt = new dom.window.MessageEvent('message', {
+      data: {
+        type: 'SHARC:Renderer:failed',
+        placementSessionId: c.placementSessionId,
+        reason: 'late failure after close',
+      },
+      origin: RENDERER_ORIGIN,
+      source: cwSnapshot,
+    });
+    window.dispatchEvent(evt);
+    await new Promise((r) => setTimeout(r, 20));
+
+    assert(errors.length === 0,
+      'late :failed after close-mid-render → SILENTLY ignored (no onError fires)');
+    assert(c._terminated === true,
+      'late :failed after close-mid-render → container stays terminated');
+  }
+
+  // 13e — Idempotency: close() called twice during mid-render is a no-op on
+  //       the second call. (Already covered by `_closeRequested` guard at
+  //       sharc-container.js:866; locking it in.)
+  {
+    const { container } = buildMidRender();
+    container.close();
+    await new Promise((r) => setTimeout(r, 80));
+    const terminatedAfterFirst = container._terminated;
+    // Second close — no throw, no double-terminate side effects.
+    let threw = false;
+    try { container.close(); } catch (_) { threw = true; }
+    assert(!threw,
+      'mid-render close() called twice does not throw');
+    assert(container._terminated === terminatedAfterFirst,
+      'mid-render close() called twice does not re-run terminate side effects');
+  }
 }
 
 // ── Summary ───────────────────────────────────────────────────────────────

--- a/test-creative-sources-load.js
+++ b/test-creative-sources-load.js
@@ -1078,6 +1078,112 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
     assert(/cr\?nul\?esc\?\[31mred\?\[0mdel\?end/.test(errors[0].msg),
       '11h: each control char is replaced with "?" (ANSI escape neutralized)');
   }
+
+  // 11i — Re-entrancy guard at _emitSecurityEventAndTerminate.
+  // The guard is post-microtask-idempotent: it protects against the realistic
+  // case where the browser delivers a second terminating renderer message
+  // AFTER microtasks have drained (which is when _terminate's listener-detach
+  // and `_terminated = true` would have run). It does NOT claim coverage for
+  // synchronous double-dispatch — cross-origin postMessage cannot deliver
+  // two messages synchronously, so that scenario doesn't occur in real
+  // browser environments.
+  //
+  // Without this guard: the second :failed would fire `_onError` a second
+  // time before the listener was detached. With it: the second message is
+  // short-circuited at the chokepoint helper, exactly one `_onError` fires,
+  // and Phase D's structured `onSecurityEvent` emission (when wired here)
+  // inherits the idempotency contract for free.
+  {
+    console.log('\n11i. Re-entrancy guard at _emitSecurityEventAndTerminate (post-microtask idempotency)');
+    const { container, iframe, errors } = buildForFailedTest();
+    const originalError = console.error;
+    const errorOutput = [];
+    console.error = (...args) => { errorOutput.push(args.join(' ')); };
+    try {
+      // First :failed — should fire onError once and schedule async _terminate.
+      const evt1 = new dom.window.MessageEvent('message', {
+        data: {
+          type: 'SHARC:Renderer:failed',
+          placementSessionId: container.placementSessionId,
+          reason: 'first failure',
+        },
+        origin: RENDERER_ORIGIN,
+        source: iframe.contentWindow,
+      });
+      window.dispatchEvent(evt1);
+
+      // Drain microtasks — `_terminate` schedules via .catch(_terminate) on
+      // the sendFatalError-rejected promise, which is microtask-ordered. After
+      // this `await`, _terminated === true and the listener is detached.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Second :failed in the next tick. Real browsers would deliver this as
+      // a separate task; we simulate that by `await`ing first.
+      const evt2 = new dom.window.MessageEvent('message', {
+        data: {
+          type: 'SHARC:Renderer:failed',
+          placementSessionId: container.placementSessionId,
+          reason: 'second failure',
+        },
+        origin: RENDERER_ORIGIN,
+        source: iframe.contentWindow,
+      });
+      window.dispatchEvent(evt2);
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      console.error = originalError;
+    }
+
+    assert(errors.length === 1,
+      'guard: post-microtask second :failed does NOT fire a second onError (exactly one)');
+    assert(errors[0].code === ErrorCodes.RENDERER_FAILED,
+      'guard: the single onError carries RENDERER_FAILED (2115), from the first :failed');
+    assert(/first failure/.test(errors[0].msg) && !/second failure/.test(errors[0].msg),
+      'guard: the surviving onError carries the FIRST reason (second was short-circuited)');
+    assert(errorOutput.filter((s) => /\[renderer_failed\]/.test(s)).length === 1,
+      'guard: exactly one [renderer_failed] console.error line was emitted');
+  }
+
+  // 11j — Surrogate-pair-safe truncation: `_sanitizeForLog` slices on UTF-16
+  // code units. If the renderer's `reason` puts a supplementary-plane
+  // character (here: an emoji) straddling positions 199–200, slice(0, 200)
+  // would emit a lone high surrogate. The trailing-high-surrogate strip
+  // ensures the output never ends with a malformed UTF-16 sequence.
+  {
+    const { container, iframe, errors } = buildForFailedTest();
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      // Build a reason that places a surrogate pair across the 200-boundary.
+      // 199 'A's + '😀' (a 2-code-unit surrogate pair, U+1F600) + tail. The
+      // slice(0, 200) cuts mid-pair (keeps the high surrogate at index 199,
+      // drops the low surrogate at 200). The trailing strip removes the high
+      // surrogate, so the post-prefix payload ends in 'A' (199 As), not in a
+      // lone high surrogate.
+      const reason = 'A'.repeat(199) + '😀' + 'tail';
+      const evt = new dom.window.MessageEvent('message', {
+        data: {
+          type: 'SHARC:Renderer:failed',
+          placementSessionId: container.placementSessionId,
+          reason,
+        },
+        origin: RENDERER_ORIGIN,
+        source: iframe.contentWindow,
+      });
+      window.dispatchEvent(evt);
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      console.error = originalError;
+    }
+    assert(errors.length >= 1,
+      '11j: surrogate-boundary reason still routes to onError');
+    const payload = errors[0].msg.split('Renderer reported failure: ')[1] || '';
+    assert(!/[\uD800-\uDBFF]$/.test(payload),
+      '11j: post-prefix payload does NOT end with a lone high surrogate (malformed UTF-16 stripped)');
+    assert(/A{199}$/.test(payload),
+      '11j: payload ends with the 199 As preceding the cut surrogate (high surrogate stripped)');
+  }
 }
 
 // -- 12. Origin echo + payload-shape validation on :rendered/:failed


### PR DESCRIPTION
## Summary

Phase C of issue #41 — wires renderer-side message validation and the `close()` mid-render cleanup contract on top of Phase B's renderer iframe build.

- **`SHARC:Renderer:failed` receipt** → terminate with `RENDERER_FAILED` (2115)
- **Post-load origin echo** on `:rendered` → terminate with `RENDERER_ORIGIN_MISMATCH` (2116)
- **Malformed payload validation** → terminate with `RENDERER_PROTOCOL_ERROR` (2117)
- **`close()` mid-render cleanup** — cancel reply timeout, detach listener, remove iframe, restore placement, silently ignore late messages

## Architecture

Phase C plugs into the three Phase B extension points without rewriting them:
- `_isValidRendererEnvelope(event, iframe)` — envelope-only, silent-ignore on failure
- `_dispatchRendererMessage(data)` — type-routes `:rendered` and `:failed`
- `_emitSecurityEventAndTerminate(type, errorCode, message)` — single chokepoint for renderer-protocol terminations (now idempotent via `_terminated` guard, forward-compat for Phase D's `onSecurityEvent` emission)

## Defense-in-depth additions

- **`_sanitizeForLog`** strips C0/DEL control chars and truncates to 200 UTF-16 code units (with trailing-surrogate strip) before splicing renderer-supplied `data.reason` and `data.rendererOrigin` into operator-facing log lines. Prevents log-injection by malicious or buggy renderers.
- **Re-entrancy guard** at `_emitSecurityEventAndTerminate` provides post-microtask idempotency so all renderer-protocol terminate paths (and Phase D's structured `onSecurityEvent` emission) are single-fire at the chokepoint.
- **Defensive null-check** on `_rendererOrigin` in dispatcher for Phase D refactor safety.
- **Build-mode guard** in test file fails fast on prod-stripped bundles instead of letting console-output assertions vacuously pass.

## Test plan

- [x] 214 jsdom assertions in `test-creative-sources-load.js` (Phase B baseline 113 → Phase C 208 → polish 214); all passing
- [x] 15-run stress test, 15/15 deterministic passes, **zero** leaked timer log lines (was ~5% flake before track-and-flush container cleanup)
- [x] `npm run test:creative-sources` — 37 Phase A constructor assertions still pass
- [x] `npm test` — full build + size-limit suite clean; `sharc-container` 10.58 kB / 25 kB budget
- [x] Phase A/B/C tests now **gated in CI** (`.github/workflows/ci.yml` runs `test:creative-sources` and `test:creative-sources-load` before `npm run size`)

## Review trail

Implementation reviewed in two passes (security/code/architect, all cleared no-HIGH), one depth pass (Compliance/Reality Checker/SRE/Test Results Analyzer), and OpenClaw approval. Four commits walk the review trail:

1. `9044411` — Phase C implementation
2. `314f059` — pass-1 fixes (re-entrancy guard, log sanitization, comment cleanup)
3. `eee0e8d` — pass-2 fixes (guard test, JSDoc polish, surrogate-safe truncation)
4. `f0cb737` — depth-pass + OpenClaw consolidation (CI gating, flake fix, dead link repointed, vacuous test fixed, build-mode guard, test 11i precondition assertions, spec format alignment, error codes 2114–2119 documented in api-reference.md, plus 9 smaller test-quality and doc items)

## Deferred follow-ups (with justification)

- **Prod build strips `console.error`** (terser `drop_console: true`): tracked in #63. Identical pre-existing behavior in Phase B; the `onError(code, message)` callback IS preserved in prod and carries the sanitized message — operators get the structured signal, just not the dev-channel grep-bait. Not introduced by Phase C.
- **Browser harness for renderer protocol**: 0.7.0 release-tag prep concern. Will file follow-up issue. jsdom coverage is faithful for the unit-level protocol logic; cross-origin task-queue semantics will need a real-browser smoke test before 0.7.0 cuts.
- **Discriminated `SHARCSecurityEvent.type`**: tracked in #62 / Phase D. Phase C reserves `'renderer_failed'`, `'renderer_origin_mismatch'`, `'renderer_protocol_error'` event-type strings; structured emission lands when the discriminated union does.
- **`placementSessionId` prefix in console.error**: defer to Phase D when `onSecurityEvent` wires the structured channel. Spec line 545's blanket claim should be updated then.
- **Reference renderer + service-worker detection + navigation bridge + RENDERER_UNAUTHORIZED_NAVIGATION (2118)**: Phase D scope, explicitly out of Phase C.

## No version bump

`SHARC_VERSION` stays at 0.6.2. Phase C ships under the 0.7.0 milestone (per `project_proposal_split_release_plan.md`); the version bump lands when all renderer-protocol phases are merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)