### PR TITLE
feat(container): Creative Sources Phase E — Creative URL backstop + SDK nav-bridge auto-install (#41)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Navigation bridge unit coverage (issue #41)
         run: npm run test:navigation-bridge
 
+      - name: Creative SDK auto-install runtime regression (issue #41 Phase E)
+        run: npm run test:creative-sdk-autoinstall
+
       - name: Renderer DOMParser + replaceChildren fallback (issue #41)
         run: npm run test:renderer-fallback
 

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -12,7 +12,7 @@
   {
     "name": "sharc-creative",
     "path": "dist/sharc-creative.js",
-    "limit": "7 KB"
+    "limit": "6 KB"
   },
   {
     "name": "sharc-mraid-bridge",

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -12,7 +12,7 @@
   {
     "name": "sharc-creative",
     "path": "dist/sharc-creative.js",
-    "limit": "5 KB"
+    "limit": "7 KB"
   },
   {
     "name": "sharc-mraid-bridge",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,23 +42,47 @@ changes (full detail in the sections below):
   refuse module imports from `file://` origins. The renderer no longer
   opens cleanly via direct file open. Use the included dev server
   (`node server.cjs`) or any HTTP(S) origin.
-- **Creative URL retains pre-0.7.0 behavior.** The in-renderer
-  navigation bridge auto-install and the container-side load-event
-  backstop are Creative Markup-only in 0.7.0. Creative URL coverage
-  is tracked for Phase E ([issue #70](https://github.com/jeffreycarlson/SHARC/issues/70)).
+- **Creative URL flow gains the navigation bridge and load-event
+  backstop in 0.7.0** (Phase E). The SDK now auto-installs the bridge
+  at init time when running outside the reference renderer (variant
+  detected via `window.__sharcRenderer` presence), and the container
+  arms the load-event backstop after the first iframe `load` for the
+  URL variant. Operators upgrading Creative URL placements get
+  click-through audit coverage and the `RENDERER_UNAUTHORIZED_
+  NAVIGATION` (2118) backstop without code changes — the SDK module
+  bundle now includes the bridge code (+0.6 kB brotli). If you rely
+  on `<a target="_top">` or `window.open` returning a `WindowProxy`
+  in the URL flow, audit those code paths against the bridge's
+  intercept contract documented in `docs/api-reference.md`
+  § Navigation Bridge Error Contract.
 
 ### Added
 
 - **Creative Markup variant** — new constructor options `creativeHtml`
   + `creativeRendererUrl` deliver markup via a cross-origin renderer
-  iframe rather than fetching a creative URL. Phases A–D landed across
-  PRs #66, #67, #68, and this release. Construction-time validation
-  rules 4–8 (HTTPS scheme, no userinfo, cross-origin to publisher,
-  256 KiB cap), CSPRNG fragment-nonce URL assembly, sandbox token
-  configuration via 5 new options (`allowPopups`,
-  `allowTopNavigationByUserActivation`,
+  iframe rather than fetching a creative URL. Phases A–E landed
+  across PRs #66, #67, #68, #71, and this release (Phase E closes
+  [#70](https://github.com/jeffreycarlson/SHARC/issues/70)).
+  Construction-time validation rules 4–8 (HTTPS scheme, no userinfo,
+  cross-origin to publisher, 256 KiB cap), CSPRNG fragment-nonce URL
+  assembly, sandbox token configuration via 5 new options
+  (`allowPopups`, `allowTopNavigationByUserActivation`,
   `allowStorageAccessByUserActivation`, `allowModals`,
   `allowDownloads`), HTTP-CSP-portable iframe `csp` baseline.
+- **Creative URL click-through audit coverage** (Phase E, closes
+  [#70](https://github.com/jeffreycarlson/SHARC/issues/70)). The
+  navigation bridge is now bundled into the `sharc-creative` SDK and
+  auto-installs synchronously at SDK init when running outside the
+  reference renderer (variant detected via `window.__sharcRenderer`
+  presence). The container arms the load-event backstop after the
+  first iframe `load` for the URL variant; any subsequent `load`
+  fires `RENDERER_UNAUTHORIZED_NAVIGATION (2118)` with
+  `details.variant === 'url'`. Pairs with the Phase D Markup-variant
+  backstop (`details.variant === 'markup'`) so both flows ship with
+  identical click-through audit semantics in 0.7.0. SDK bundle grows
+  +0.6 kB brotli (4.92 → 5.51 kB); `installNavigationBridge` and
+  `SHARCNavigationError` are re-exported from `sharc-creative` for
+  ESM consumers.
 - **Renderer protocol** (`SHARC:Renderer:render` / `:rendered` /
   `:failed`). Container posts the markup once the iframe loads; the
   renderer validates the envelope (parent-origin, fragment nonce,
@@ -77,15 +101,18 @@ changes (full detail in the sections below):
   is opt-in via `window.__sharcNavBridgeAutoInstall = true` BEFORE
   load; named export `installNavigationBridge(window?)` returns an
   uninstall function.
-- **Load-event navigation backstop** — after the renderer's
-  envelope-validated `:rendered` arrives, the container watches for
-  subsequent iframe `load` events. A second load means the renderer
-  navigated outside the protocol path (`<a target="_top">`,
+- **Load-event navigation backstop (both variants)** — the container
+  watches for unexpected iframe `load` events after the variant-
+  specific render-anchor: Markup anchors on the envelope-validated
+  `:rendered` accept (Phase D); Creative URL anchors on the first
+  iframe `load` event (Phase E). Any subsequent `load` means the
+  iframe navigated outside the SHARC protocol path (`<a target="_top">`,
   `location.assign`, meta refresh that bypassed the bridge).
-  Terminates with `RENDERER_UNAUTHORIZED_NAVIGATION (2118)`. Defense-
-  in-depth backstop catches navigations the in-renderer bridge missed
-  due to adversarial JS-level overrides. Markup-only in 0.7.0; Creative
-  URL coverage tracked for Phase E ([issue #70](https://github.com/jeffreycarlson/SHARC/issues/70)).
+  Terminates with `RENDERER_UNAUTHORIZED_NAVIGATION (2118)`; the
+  `onSecurityEvent` payload's `details.variant` field discriminates
+  `'markup'` from `'url'` for triage. Defense-in-depth backstop
+  catches navigations the in-renderer bridge missed due to
+  adversarial JS-level overrides — works identically in both flows.
 - **Structured `onSecurityEvent` callback** — operator observability
   hook. Discriminated-union payload over five reserved variants
   (`wrapper_top_frame_inaccessible`, `renderer_origin_mismatch`,
@@ -245,21 +272,29 @@ changes (full detail in the sections below):
   HTML from reading the nonce out of the URL fragment after document.write.
   Operators forking the renderer SHOULD preserve this behavior. See
   `docs/api-reference.md` § Renderer post-validation behavior.
-- **Reference renderer auto-installs `sharc-navigation-bridge` (Markup-only
-  in 0.7.0).** Operators forking `examples/renderer/index.html` get the
-  navigation bridge wired in by default — the renderer imports the bridge
-  as an ES module and installs it via `installNavigationBridge(window)`
-  BEFORE `document.write(creativeHtml)`. The bridge module itself stays
-  opt-in at the module level (default-off `__sharcNavBridgeAutoInstall`);
-  the reference renderer is the canonical example that turns it on. (Prior
-  to this, the bridge module shipped but was not wired into the canonical
-  example renderer — only the navigation-bridge unit tests exercised it.)
-  Required corollary: `server.cjs` now serves `.mjs` files with MIME
-  `application/javascript` so the renderer's module import resolves under
-  the dev server. Operators using nginx / CloudFront / other static origins
-  must configure the `.mjs → application/javascript` MIME mapping
-  explicitly. **The Creative SDK auto-install (for the Creative URL
-  variant) is NOT in 0.7.0** — tracked for Phase E ([issue #70](https://github.com/jeffreycarlson/SHARC/issues/70)).
+- **Reference renderer auto-installs `sharc-navigation-bridge` (Markup
+  variant) AND the SHARC SDK auto-installs it at init time (Creative
+  URL variant).** Both variants now ship with click-through audit
+  coverage by default. Markup: operators forking `examples/renderer/
+  index.html` get the navigation bridge wired in via the renderer's
+  ES-module import + `installNavigationBridge(window)` call BEFORE
+  `document.write(creativeHtml)`. Creative URL (Phase E): the
+  navigation bridge is now bundled into `sharc-creative` (+0.6 kB
+  brotli; size-limit budget raised 5 kB → 7 kB) and auto-installs at
+  SDK init when `window.__sharcRenderer` is absent (URL flow).
+  `installNavigationBridge` and `SHARCNavigationError` are re-
+  exported from `sharc-creative` so ESM consumers loading only the
+  SDK get the bridge API without a second import. The standalone
+  `sharc-navigation-bridge` module continues to ship for operators
+  that prefer to load it separately (the reference renderer uses
+  this path). Required corollary (already shipped in Phase D round-4):
+  `server.cjs` serves `.mjs` files with MIME `application/javascript`
+  for renderer-side module imports. Operators using nginx /
+  CloudFront / other static origins must configure the
+  `.mjs → application/javascript` MIME mapping explicitly. The
+  bridge module itself stays opt-in at the standalone-module level
+  (default-off `__sharcNavBridgeAutoInstall`); the reference renderer
+  and `sharc-creative` are the canonical install points.
 - **Removed `event.stopPropagation()` from navigation bridge interception
   handlers (operator-observable, behavior-preserving on the audit path).**
   The capture-phase anchor-click and form-submit handlers no longer call

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,19 @@ changes (full detail in the sections below):
   in the URL flow, audit those code paths against the bridge's
   intercept contract documented in `docs/api-reference.md`
   § Navigation Bridge Error Contract.
+- **Trust model clarification (operator-observable).** The navigation
+  bridge (`sharc-navigation-bridge`) provides best-effort URL audit for
+  legitimate creatives — operators see what URLs the creative wants to
+  navigate to and can apply allowlist policy. Adversarial creatives can
+  bypass the bridge by setting `window.__sharcRenderer = {}` before
+  SHARC modules load (suppresses the SDK's auto-install), or by
+  re-overriding `window.open` / `location` getters after install. The
+  load-event backstop (`RENDERER_UNAUTHORIZED_NAVIGATION`, code 2118)
+  is the load-bearing enforcement that catches actual cross-document
+  navigation regardless of bridge state — it fires on any iframe `load`
+  event beyond the expected sequence (1 for Creative URL, 2 for
+  Creative Markup). See `docs/proposals/creative-sources.md` § Security
+  Model for full threat-model framing.
 
 ### Added
 
@@ -80,7 +93,7 @@ changes (full detail in the sections below):
   `details.variant === 'url'`. Pairs with the Phase D Markup-variant
   backstop (`details.variant === 'markup'`) so both flows ship with
   identical click-through audit semantics in 0.7.0. SDK bundle grows
-  +0.6 kB brotli (4.92 → 5.51 kB); `installNavigationBridge` and
+  +0.6 kB brotli (4.92 → 5.54 kB); `installNavigationBridge` and
   `SHARCNavigationError` are re-exported from `sharc-creative` for
   ESM consumers.
 - **Renderer protocol** (`SHARC:Renderer:render` / `:rendered` /
@@ -333,10 +346,13 @@ changes (full detail in the sections below):
 
 ### Tests
 
-- 267 jsdom assertions in `test-creative-sources-load.js` (up from 263
-  in the round-3 commit). Phase D round-4 added msSinceRender field
-  asserts, the round-2-text → round-4-text redirect-injection hint
-  assertion, and a non-negative-number type guard.
+- 293 jsdom assertions in `test-creative-sources-load.js` (up from 263
+  in the Phase D round-3 commit). Phase D round-4 added msSinceRender
+  field asserts, the round-2-text → round-4-text redirect-injection
+  hint assertion, and a non-negative-number type guard. Phase E added
+  section 18 (Creative URL load-event backstop) covering arm-on-first-
+  load, second-load → 2118 (`details.variant === 'url'`), terminate
+  detach, re-entrancy, and one-shot-arm idempotency.
 - 34 jsdom assertions in `test-navigation-bridge.js` (3 additional
   cases — `location.assign` / `location.replace` / `location.href`
   setter — are documented as deferred to issue #69 because jsdom's

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1479,6 +1479,8 @@ The canonical operator-fork starting point is `examples/renderer/index.html`. Op
 
 The navigation bridge (`src/sharc-navigation-bridge.js`) is a separate import the renderer page MAY install BEFORE `document.write(creativeHtml)` to route creative-initiated navigation (`window.open`, anchor clicks, form submits, location setters) through `SHARC.requestNavigation()` for operator URL review. The bridge is best-effort; the load-event backstop is the defense-in-depth catch.
 
+For the **Creative URL** variant, the SHARC Creative SDK (`dist/sharc-creative.mjs`) auto-installs the bridge at SDK init when `window.__sharcRenderer` is absent — no operator action required. Variant detection: the reference renderer sets `window.__sharcRenderer` BEFORE `document.write` runs, so the SDK skips its own auto-install in Markup flow (the renderer already installed). In URL flow the marker is absent, so the SDK installs the bridge unconditionally. See [Navigation Bridge Error Contract](#navigation-bridge-error-contract) for the export semantics across both import paths.
+
 ### Error codes
 
 See section 11 below — codes `2114`–`2119` cover the renderer protocol surface.
@@ -1505,7 +1507,7 @@ See section 11 below — codes `2114`–`2119` cover the renderer protocol surfa
 | 2115 | Renderer failed | Renderer reported failure via `SHARC:Renderer:failed` with a non-empty `reason` string. The `reason` is included in the `onError` message (sanitized + truncated to 200 UTF-16 code units). Markup variant only. See [Renderer Protocol](#10-renderer-protocol). |
 | 2116 | Renderer origin mismatch | The renderer's reported `rendererOrigin` did not match the construction-time-derived `_rendererOrigin` (parsed from `creativeRendererUrl`). Indicates a redirect collapsed the cross-origin sandbox guarantee. Configure `creativeRendererUrl` to the post-redirect canonical URL. Markup variant only. See [Renderer Protocol](#10-renderer-protocol). |
 | 2117 | Renderer protocol error | Renderer message had an envelope-valid type (`SHARC:Renderer:rendered` or `SHARC:Renderer:failed`) but malformed payload — `rendererOrigin` (rendered) or `reason` (failed) is missing, not a string, or empty. Markup variant only. See [Renderer Protocol](#10-renderer-protocol). |
-| 2118 | Renderer unauthorized navigation | After the renderer's envelope-validated `:rendered` arrives, the container attaches a `load` listener; a subsequent `load` event means the renderer document navigated outside the SHARC protocol path. Defense-in-depth backstop for click-throughs that bypass the in-renderer navigation bridge. Markup variant only. See [Renderer Protocol](#10-renderer-protocol). |
+| 2118 | Renderer unauthorized navigation | The container attaches a `load` listener after the variant-specific render anchor (Markup: envelope-validated `:rendered`; URL: initial iframe `load`); a subsequent `load` event means the iframe document navigated outside the SHARC protocol path. Defense-in-depth backstop for click-throughs that bypass the navigation bridge. Both variants. `details.variant` discriminates `'markup' \| 'url'`. See [Renderer Protocol](#10-renderer-protocol). |
 | 2119 | Renderer post failed | `iframe.contentWindow.postMessage(SHARC:Renderer:render, ...)` threw synchronously (e.g. `DataCloneError`, null `contentWindow`). Distinct from 2114 (timeout) — a transport-layer send failure is not a latency failure. Markup variant only. See [Renderer Protocol](#10-renderer-protocol). |
 
 ### Container Errors (22xx)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1338,7 +1338,12 @@ If `container.close()` is called between iframe `load` and receipt of `:rendered
 
 ### Load-event navigation backstop (`RENDERER_UNAUTHORIZED_NAVIGATION` 2118)
 
-After the renderer's envelope-validated `:rendered` arrives, the container attaches a `load` listener to the renderer iframe. Any subsequent `load` event means the renderer document navigated to a new URL outside the SHARC protocol path — terminate with `RENDERER_UNAUTHORIZED_NAVIGATION (2118)`.
+The container attaches a `load` listener to the creative iframe at a variant-specific render anchor and terminates with `RENDERER_UNAUTHORIZED_NAVIGATION (2118)` on any subsequent `load` event — that means the iframe document navigated to a new URL outside the SHARC protocol path.
+
+- **Creative Markup** (`details.variant === 'markup'`): the render anchor is the renderer's envelope-validated `:rendered` accept. Any iframe `load` after that point fires 2118.
+- **Creative URL** (`details.variant === 'url'`): the render anchor is the first iframe `load` event itself (the URL flow has no `:rendered` accept). The second `load` and any after fire 2118.
+
+`details.msSinceRender` carries the wall-clock delay from the variant's render anchor to the firing `load` — operators distinguish fast-fire (meta refresh / first-script-tag `window.location` redirects) from slow-fire (DOM-injected redirects, setTimeout-based redirects).
 
 This is browser-observable and cannot be bypassed by JS-level overrides — the load event fires regardless of what the creative HTML did. It does NOT *prevent* the navigation (the browser already started it), but it ensures:
 
@@ -1376,7 +1381,7 @@ The five reserved `type` values and their `details` schemas:
 | `renderer_origin_mismatch` | `'error'` | `2116` | `{ expectedOrigin, actualOrigin }` |
 | `renderer_protocol_error` | `'error'` | `2114` \| `2117` \| `2119` | `{ subtype: 'timeout' \| 'malformed_payload' \| 'post_failed', reason }` |
 | `renderer_failed` | `'error'` | `2115` | `{ reason }` |
-| `unauthorized_navigation` | `'error'` | `2118` | `{ variant: 'markup', msSinceRender: number }` (Phase E will extend with `variant: 'url'`) |
+| `unauthorized_navigation` | `'error'` | `2118` | `{ variant: 'markup' \| 'url', msSinceRender: number }` |
 
 Note: timeout (`2114`) and post-failed (`2119`) both surface as `renderer_protocol_error` on the structured channel — the spec vocabulary does not include them as distinct event types. The `details.subtype` discriminates inside the variant.
 
@@ -1419,7 +1424,7 @@ class SHARCNavigationError extends Error {
 }
 ```
 
-Exported as a named export from `dist/sharc-navigation-bridge.mjs`; also exposed on `window.SHARCNavigationError` for non-module creatives.
+Exported from `dist/sharc-navigation-bridge.mjs` (canonical source). Also re-exported from `dist/sharc-creative.mjs` for ESM consumers loading only the SDK — `instanceof SHARCNavigationError` checks work across both import paths because module caching guarantees the same class identity. Also exposed on `window.SHARCNavigationError` for non-module creatives.
 
 Throw matrix:
 

--- a/docs/proposals/creative-sources.md
+++ b/docs/proposals/creative-sources.md
@@ -457,7 +457,7 @@ The navigation bridge intercepts non-IAB-spec'd navigation patterns:
 - **`window.location.href` setter / `location.assign()` / `location.replace()`** — intercepts in-frame navigation; routes through `SHARC.requestNavigation()`.
 - **Anchor click delegate** — single document-level listener handles both `<a target="_blank">` (popup) and `<a>` without target (in-frame nav). Adds `rel="noopener noreferrer"` defensively; routes URL through `SHARC.requestNavigation()`.
 - **Form submit delegate** — intercepts `<form>` submissions; routes through `SHARC.requestNavigation()`. The `form-action` CSP opt-in (DD-6) provides browser-level enforcement when enabled.
-- **Strip `<meta http-equiv="refresh">`** from `creativeHtml` before `document.write` — meta refresh would redirect the iframe outside any JS interception path. (Renderer-side only; the SDK in Creative URL cannot strip post-load — falls back to container load-event backstop. Markup-only in 0.7.0; Creative URL coverage tracked for Phase E — see [issue #70](https://github.com/jeffreycarlson/SHARC/issues/70).)
+- **Strip `<meta http-equiv="refresh">`** from `creativeHtml` before `document.write` — meta refresh would redirect the iframe outside any JS interception path. (Renderer-side only; the SDK in Creative URL cannot strip post-load — falls back to container load-event backstop. Both variants ship in 0.7.0: Markup via the renderer's bridge install, Creative URL via the SDK's auto-install at init time.)
 
 **The bridge is best-effort.** Adversarial creative HTML can re-override `window.open`, redefine `location` getters, or use other patterns to bypass it. The container-side load-event monitoring (see Security Model § Click-through enforcement) is the defense-in-depth backstop that catches anything the bridge misses.
 
@@ -835,21 +835,13 @@ The variant difference is *who controls the bridge load point* — operator-cont
 
 **Container-side unauthorized-navigation detection (universal backstop):**
 
-> **Scope in 0.7.0**: The load-event backstop is implemented for the
-> Creative Markup variant only. Creative URL coverage (and the matching
-> SDK-side navigation-bridge auto-install) is tracked for Phase E
-> ([issue #70](https://github.com/jeffreycarlson/SHARC/issues/70)). The
-> proposal text below describes the universal design that 0.7.0 + Phase E
-> together deliver; sections that depend on Creative URL coverage are
-> annotated as Phase E forward-looking.
-
-The bridges are best-effort. Adversarial creative HTML can re-override `window.open`, redefine `location` getters, or call `Object.defineProperty` on the patched accessors. The container provides a backstop that does not depend on JS-level enforcement and is designed to work identically for both variants.
+The bridges are best-effort. Adversarial creative HTML can re-override `window.open`, redefine `location` getters, or call `Object.defineProperty` on the patched accessors. The container provides a backstop that does not depend on JS-level enforcement and works identically for both variants.
 
 The container counts iframe `load` events:
-- **Expected sequence (Creative URL):** creative document loads from `creativeUrl`. One load event expected. (Phase E — issue #70.)
-- **Expected sequence (Creative Markup):** renderer page loads → creative document loads (after `document.write` triggers the second load). (Implemented in 0.7.0.)
+- **Expected sequence (Creative URL):** creative document loads from `creativeUrl`. One load event expected.
+- **Expected sequence (Creative Markup):** renderer page loads → creative document loads (after `document.write` triggers the second load).
 - **Any subsequent `load` event** beyond the expected sequence means the iframe navigated to a different URL outside the SHARC protocol path.
-- **Container response:** terminate the session with `RENDERER_UNAUTHORIZED_NAVIGATION (2118)`; fire `onSecurityEvent` with type `unauthorized_navigation`.
+- **Container response:** terminate the session with `RENDERER_UNAUTHORIZED_NAVIGATION (2118)`; fire `onSecurityEvent` with type `unauthorized_navigation` and `details.variant` discriminating Markup (`'markup'`) from Creative URL (`'url'`).
 
 This is browser-observable and cannot be bypassed by JS-level overrides — the load event fires regardless of what the creative HTML did. It does not *prevent* the navigation (browser already started it), but it ensures:
 1. The operator's monitoring sees the unauthorized navigation immediately
@@ -919,7 +911,6 @@ Items considered during 0.7.0 development that are not in scope for this release
 | Item | Status | Target | Tracking | Reasoning |
 |---|---|---|---|---|
 | SRI integrity verification (`creativeRendererIntegrity`) | Deferred | 1.0+ | #24 | Browser APIs do not support SRI on iframe `src` today; the work needs to specify a post-load probe protocol exchanging known asset hashes. Constructor option name is reserved. |
-| Creative URL load-event backstop + SDK nav-bridge auto-install | Deferred | 0.8 (Phase E) | [#70](https://github.com/jeffreycarlson/SHARC/issues/70) | 0.7.0 ships the load-event backstop and the navigation-bridge auto-install for Creative Markup only. Creative URL coverage requires the SDK to auto-install the bridge at SDK init plus container-side wiring of the 1-load expected sequence. Pre-Phase E, Creative URL retains pre-0.7.0 behavior — no in-renderer bridge, no load-event backstop. |
 | Native ad support (rendering bridge or HTML native assembly) | Out of scope for 0.7.0; future work | 0.8+ or 1.x | (file an issue) | Two paths accommodate native without changing the 0.7.0 protocol — see below. Demand-driven. |
 | Creative capability signaling | Out of scope; cross-WG dependency | TBD | (file an issue) | How operators know to use Creative Markup vs Creative URL is orthogonal to this proposal. Future IAB Tech Lab work in coordination with OpenRTB / AdCOM / Prebid may add a SHARC capability signal. |
 | PUC compatibility bridge | Out of scope; Prebid.org coordination required | 0.8+ or 1.x | (file an issue) | See below. |
@@ -1111,9 +1102,9 @@ Which 0.7.0 implementation track owns delivery of each AC:
 - [ ] **#41** Navigation bridge: anchor click delegate (single document-level listener) routes both `target="_blank"` and no-target anchors through `SHARC.requestNavigation()`; defensively adds `rel="noopener noreferrer"`
 - [ ] **#41** Navigation bridge: `<form>` submit delegate routes through `SHARC.requestNavigation()`
 - [ ] **#41** Navigation bridge (renderer-side, Creative Markup only): strips `<meta http-equiv="refresh">` from `creativeHtml` before `document.write`
-- [ ] **#41** Reference renderer (`examples/renderer/index.html`) auto-installs `sharc-navigation-bridge` for the Creative Markup variant in 0.7.0; SHARC Creative SDK auto-install for the Creative URL variant is tracked for Phase E ([issue #70](https://github.com/jeffreycarlson/SHARC/issues/70)).
-- [ ] **#41** Container counts iframe `load` events; expected sequence is variant-specific. Creative Markup: 2 expected loads (renderer page + creative doc after `document.write`); 0.7.0 ships this. Creative URL: 1 expected load (creative doc); Phase E ([issue #70](https://github.com/jeffreycarlson/SHARC/issues/70)) will add this.
-- [ ] **#41** Any iframe `load` event beyond the expected sequence terminates the session with `RENDERER_UNAUTHORIZED_NAVIGATION (2118)` (Creative Markup in 0.7.0; Creative URL in Phase E — issue #70)
+- [ ] **#41** Reference renderer (`examples/renderer/index.html`) auto-installs `sharc-navigation-bridge` for the Creative Markup variant; SHARC Creative SDK auto-installs the bridge at init for the Creative URL variant (variant detected via `window.__sharcRenderer` presence — set by the reference renderer).
+- [ ] **#41** Container counts iframe `load` events; expected sequence is variant-specific. Creative Markup: 2 expected loads (renderer page + creative doc after `document.write`). Creative URL: 1 expected load (creative doc).
+- [ ] **#41** Any iframe `load` event beyond the expected sequence terminates the session with `RENDERER_UNAUTHORIZED_NAVIGATION (2118)`; `onSecurityEvent.details.variant` is `'markup'` or `'url'` per variant.
 - [ ] **#42** `onSecurityEvent` fires with type `unauthorized_navigation` (severity: error) before container terminates
 - [ ] **#41** MRAID bridge owns all MRAID-spec'd navigation (`mraid.open(url)`, etc.) and translates to `SHARC.requestNavigation()` (existing behavior; verified unchanged — no overlap with `sharc-navigation-bridge`)
 - [ ] **#41** SafeFrame bridge owns all SafeFrame-spec'd navigation and translates to `SHARC.requestNavigation()` (existing behavior; no overlap with `sharc-navigation-bridge`)
@@ -1224,6 +1215,24 @@ Which 0.7.0 implementation track owns delivery of each AC:
 - [ ] **N/A** Canonical maintainers commit to evolving the renderer hook surface and config schema in additive, backward-compatible ways across `rendererProtocolVersion`-stable SHARC releases (documented in CONTRIBUTING.md or equivalent)
 - [ ] **#55** Cross-origin renderer testing works in dev harness (issue #23, superseded by #55)
 - [ ] **#55** Reference renderer hosted at `<owner>.github.io/<repo>/renderer/` for testing (placeholder; resolves to whichever repo deploys — fork or upstream)
+
+---
+
+## Implementation Phases
+
+The 0.7.0 milestone ships across seven phases. Phases A–E are SDK code; Phases F–G are deployment and the final release sweep. Each phase is a distinct branch + PR + squash-merge so the review surface stays scoped and reviewable.
+
+| Phase | Status | Scope | PR |
+|---|---|---|---|
+| A | Delivered | Constructor validation + types | [#66](https://github.com/jeffreycarlson/SHARC/pull/66) |
+| B | Delivered | Renderer iframe build + render protocol | [#67](https://github.com/jeffreycarlson/SHARC/pull/67) |
+| C | Delivered | Renderer message validation + close-mid-render | [#68](https://github.com/jeffreycarlson/SHARC/pull/68) |
+| D | Delivered | Load-event backstop (Markup) + reference renderer + structured `onSecurityEvent` + navigation bridge | [#71](https://github.com/jeffreycarlson/SHARC/pull/71) |
+| **E** | **In progress** | Creative URL coverage — load-event backstop + SDK nav-bridge auto-install ([#70](https://github.com/jeffreycarlson/SHARC/issues/70)) | TBD |
+| F | Planned | GitHub Pages deploy + reference renderer hosting + Creative Markup demo ([#55](https://github.com/jeffreycarlson/SHARC/issues/55)) | TBD |
+| G | Planned | Final 0.7.0 release sweep — doc updates (`architecture-design.md`, `creative-cookbook.md`, `getting-started.md`, `current-status.md`), spec inconsistency cleanup (perf budget 600ms vs 500ms), tag `v0.7.0` | TBD |
+
+The proposal `creative-sources.md` IS the 0.7.0 plan in its entirety. Anything outside the proposal becomes 0.8.0 future work; 0.8.0 will have its own phase plan when scoped.
 
 ---
 

--- a/docs/proposals/creative-sources.md
+++ b/docs/proposals/creative-sources.md
@@ -457,7 +457,7 @@ The navigation bridge intercepts non-IAB-spec'd navigation patterns:
 - **`window.location.href` setter / `location.assign()` / `location.replace()`** — intercepts in-frame navigation; routes through `SHARC.requestNavigation()`.
 - **Anchor click delegate** — single document-level listener handles both `<a target="_blank">` (popup) and `<a>` without target (in-frame nav). Adds `rel="noopener noreferrer"` defensively; routes URL through `SHARC.requestNavigation()`.
 - **Form submit delegate** — intercepts `<form>` submissions; routes through `SHARC.requestNavigation()`. The `form-action` CSP opt-in (DD-6) provides browser-level enforcement when enabled.
-- **Strip `<meta http-equiv="refresh">`** from `creativeHtml` before `document.write` — meta refresh would redirect the iframe outside any JS interception path. (Renderer-side only; the SDK in Creative URL cannot strip post-load — falls back to container load-event backstop. Both variants ship in 0.7.0: Markup via the renderer's bridge install, Creative URL via the SDK's auto-install at init time.)
+- **Strip `<meta http-equiv="refresh">`** from `creativeHtml` before `document.write` — meta refresh would redirect the iframe outside any JS interception path. Markup-only: requires pre-`document.write` access to the creative HTML, which the renderer has and the SDK does not. Creative URL falls back to the container's load-event backstop for meta-refresh detection.
 
 **The bridge is best-effort.** Adversarial creative HTML can re-override `window.open`, redefine `location` getters, or use other patterns to bypass it. The container-side load-event monitoring (see Security Model § Click-through enforcement) is the defense-in-depth backstop that catches anything the bridge misses.
 

--- a/docs/proposals/creative-sources.md
+++ b/docs/proposals/creative-sources.md
@@ -1228,7 +1228,7 @@ The 0.7.0 milestone ships across seven phases. Phases A–E are SDK code; Phases
 | B | Delivered | Renderer iframe build + render protocol | [#67](https://github.com/jeffreycarlson/SHARC/pull/67) |
 | C | Delivered | Renderer message validation + close-mid-render | [#68](https://github.com/jeffreycarlson/SHARC/pull/68) |
 | D | Delivered | Load-event backstop (Markup) + reference renderer + structured `onSecurityEvent` + navigation bridge | [#71](https://github.com/jeffreycarlson/SHARC/pull/71) |
-| **E** | **In progress** | Creative URL coverage — load-event backstop + SDK nav-bridge auto-install ([#70](https://github.com/jeffreycarlson/SHARC/issues/70)) | TBD |
+| E | Delivered | Creative URL coverage — load-event backstop + SDK nav-bridge auto-install ([#70](https://github.com/jeffreycarlson/SHARC/issues/70)) | [#73](https://github.com/jeffreycarlson/SHARC/pull/73) |
 | F | Planned | GitHub Pages deploy + reference renderer hosting + Creative Markup demo ([#55](https://github.com/jeffreycarlson/SHARC/issues/55)) | TBD |
 | G | Planned | Final 0.7.0 release sweep — doc updates (`architecture-design.md`, `creative-cookbook.md`, `getting-started.md`, `current-status.md`), spec inconsistency cleanup (perf budget 600ms vs 500ms), tag `v0.7.0` | TBD |
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "test:creative-sources": "node test-creative-sources.js",
     "test:creative-sources-load": "node test-creative-sources-load.js",
     "test:navigation-bridge": "node test-navigation-bridge.js",
+    "test:creative-sdk-autoinstall": "node test-creative-sdk-autoinstall.js",
     "test:renderer-fallback": "node test-renderer-domparser-fallback.js",
     "test:perf": "node test-creative-sources-perf.js",
     "test:types": "tsc -p test/types/tsconfig.json",

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -225,27 +225,32 @@ const RENDERER_IFRAME_CSP = "object-src 'none'; base-uri 'none'";
  */
 
 /**
- * Defense-in-depth backstop event. Fired when the renderer iframe emits a
- * post-`:rendered` `load` event in the Markup variant — meaning the renderer
- * document navigated outside the SHARC protocol path. The `details.variant`
- * discriminator is forward-compatible with Phase E (Creative URL) which
- * will extend with `variant: 'url'` and an internally-tracked load-count
- * scheme; the structured event type, code, message, and timestamps are the
- * fidelity operators rely on.
+ * Defense-in-depth backstop event. Fired when the creative iframe emits an
+ * unexpected `load` event — meaning the iframe document navigated outside
+ * the SHARC protocol path. The `details.variant` discriminator separates
+ * the Markup variant (post-`:rendered` second `load`) from the Creative
+ * URL variant (post-initial-load second `load`). Both variants share the
+ * structured event type, code, and message; operators monitor 2118 and
+ * branch on `details.variant` only when they need variant-specific
+ * triage.
  *
- * `details.msSinceRender` is the wall-clock delay (ms) between the renderer's
- * envelope-validated `:rendered` arriving and the post-render iframe `load`
- * event firing. Helps operators distinguish fast-fire (creative immediately
+ * `details.msSinceRender` is the wall-clock delay (ms) between the
+ * "render-anchor" event (Markup: envelope-validated `:rendered`; URL:
+ * the initial iframe `load`) and the unexpected post-render `load` event
+ * firing. Helps operators distinguish fast-fire (creative immediately
  * reloaded, ~0–100ms) from slow-fire (delayed DOM injection / meta-refresh
  * re-injection, multiple seconds) so they can pre-allocate monitoring
- * buckets and triage redirect-injection patterns.
+ * buckets and triage redirect-injection patterns. Field name is preserved
+ * across variants for grep-stable operator dashboards (the URL variant's
+ * "render anchor" is the initial load, not a `:rendered` reply, but the
+ * delay-since-anchor semantics are identical).
  *
  * @typedef {SHARCSecurityEventBase & {
  *   type: 'unauthorized_navigation',
  *   severity: 'error',
  *   errorCode: 2118,
  *   details: {
- *     variant: 'markup',
+ *     variant: 'markup' | 'url',
  *     msSinceRender: number,
  *   },
  * }} UnauthorizedNavigationEvent
@@ -819,11 +824,17 @@ class SHARCContainer {
     this._iframe = null;
 
     /**
-     * Load-event navigation backstop (Phase D, deliverable 1). Attached in
-     * `_onRendererRendered()` AFTER the renderer's envelope-validated
-     * `:rendered` arrives. Any subsequent iframe `load` event means the
-     * renderer document navigated to a new URL outside the SHARC protocol
-     * path — terminate with `RENDERER_UNAUTHORIZED_NAVIGATION (2118)`.
+     * Load-event navigation backstop. Attached AFTER the iframe's "render
+     * anchor" load is observed:
+     *   - Markup variant: armed in `_onRendererRendered()` after the
+     *     envelope-validated `:rendered` arrives (Phase D, deliverable 1).
+     *   - Creative URL variant: armed in the iframe `load` listener in
+     *     `_createIframe()` after the first (and only-expected) load
+     *     fires (Phase E, deliverable 1).
+     *
+     * Any subsequent iframe `load` event means the iframe document
+     * navigated to a new URL outside the SHARC protocol path — terminate
+     * with `RENDERER_UNAUTHORIZED_NAVIGATION (2118)`.
      *
      * This is the universal backstop the spec § Click-through enforcement
      * (lines 836–849) describes — defense-in-depth against creatives that
@@ -832,10 +843,8 @@ class SHARCContainer {
      * (pushState, hash changes) do NOT fire `load`; only cross-document
      * navigations do.
      *
-     * Detached in `_terminate()`. Markup variant only — Creative URL load-
-     * count enforcement is a follow-up (the spec defines a parallel
-     * "1 load expected for URL" rule, but Phase D scopes only the Markup
-     * post-`:rendered` listener).
+     * Detached in `_terminate()`. Variant-agnostic — same handler shape
+     * for both Markup and Creative URL.
      *
      * @type {((event: Event) => void) | null}
      * @private
@@ -843,11 +852,16 @@ class SHARCContainer {
     this._rendererBackstopHandler = null;
 
     /**
-     * Wall-clock timestamp (`Date.now()`) at the moment the renderer's
-     * envelope-validated `:rendered` arrived and was accepted. Stamped in
-     * `_onRendererRendered()`. Used by `_armRendererBackstop()` to compute
-     * `details.msSinceRender` on the 2118 `UnauthorizedNavigationEvent`.
-     * `null` until `:rendered` is accepted. Phase D round-4 SRE HIGH-1.
+     * Wall-clock timestamp (`Date.now()`) at the moment the "render anchor"
+     * event was observed and accepted:
+     *   - Markup variant: `:rendered` envelope accept (in
+     *     `_onRendererRendered()`).
+     *   - Creative URL variant: initial iframe `load` (in `_createIframe()`).
+     *
+     * Used by `_armRendererBackstop()` to compute `details.msSinceRender`
+     * on the 2118 `UnauthorizedNavigationEvent`. `null` until the render-
+     * anchor event fires. Phase D round-4 SRE HIGH-1; widened in Phase E
+     * to cover the Creative URL render-anchor.
      *
      * @type {number | null}
      * @private
@@ -1272,11 +1286,35 @@ class SHARCContainer {
 
     // ── Creative URL variant (existing behavior). ──
     // Wire MessageChannel directly on iframe load.
+    //
+    // Phase E deliverable 1: arm the load-event navigation backstop after
+    // the FIRST load event fires. The Creative URL variant expects exactly
+    // one cross-document load (the creative document loading from
+    // `creativeUrl`). Any subsequent `load` event = unauthorized navigation
+    // and terminates via `_armRendererBackstop()` (variant-agnostic seam
+    // extracted in Phase D round-1). The arm-on-first-load handler MUST
+    // be one-shot — we use a captured flag to ignore subsequent fires of
+    // this listener (the backstop installed by `_armRendererBackstop()`
+    // is what handles all subsequent loads). Same-document navigations
+    // (pushState, hash changes) do not fire `load`; cross-document do.
+    let initialLoadHandled = false;
     iframe.addEventListener('load', () => {
+      if (initialLoadHandled) return;
+      initialLoadHandled = true;
+      // Stamp the render-anchor timestamp so the backstop's eventual
+      // `details.msSinceRender` payload reflects the URL-variant anchor
+      // (initial load), not the Markup anchor (`:rendered` accept).
+      this._renderedAt = Date.now();
       setTimeout(
         () => this._protocol.initChannel(iframe.contentWindow, '*', this.placementSessionId),
         200
       );
+      // Arm the backstop immediately (synchronously, in the same task as
+      // the initial-load handler) so any post-load redirect injection that
+      // schedules a navigation in a microtask / next-task tick is caught.
+      // The 200ms initChannel deferral above is unrelated — that's an OM
+      // SDK ordering concession, not a backstop concern.
+      this._armRendererBackstop();
     });
 
     if (!this._useMarkupInjection) {
@@ -2938,21 +2976,26 @@ class SHARCContainer {
   }
 
   /**
-   * Attaches the renderer iframe's load-event navigation backstop. Called
-   * AFTER the renderer's envelope-validated `:rendered` arrives. Any
-   * subsequent iframe `load` event means the renderer document navigated
-   * to a new URL outside the SHARC protocol path — defense-in-depth
-   * against creatives that bypass the in-renderer navigation bridge
-   * (window.open re-override, location getter redefinition, meta refresh
-   * that the bridge missed, etc.). Spec § Click-through enforcement
-   * lines 836–849.
+   * Attaches the creative iframe's load-event navigation backstop. Called
+   * AFTER the variant-specific "render anchor" event:
+   *   - Markup: envelope-validated `:rendered` accept (in
+   *     `_onRendererRendered()`).
+   *   - Creative URL: initial iframe `load` event (in `_createIframe()`,
+   *     Phase E deliverable 1).
+   *
+   * Any subsequent iframe `load` event means the iframe document
+   * navigated to a new URL outside the SHARC protocol path —
+   * defense-in-depth against creatives that bypass the in-renderer
+   * navigation bridge (window.open re-override, location getter
+   * redefinition, meta refresh that the bridge missed, etc.). Spec §
+   * Click-through enforcement lines 836–849.
    *
    * Same-document navigations (pushState, hash changes) do not fire
    * `load`; cross-document navigations do. Detection is precise.
    *
-   * Extracted as a seam (Phase D pass-1 review fix) so Phase E can add
-   * the Creative URL load-count backstop hinted at in spec line 841
-   * without re-fragmenting the chokepoint.
+   * Variant-agnostic by construction — the `details.variant` field is
+   * derived from `this.creativeSource` at fire time, so the seam is
+   * usable from both arm sites with no per-call argument shaping.
    *
    * @private
    */
@@ -2965,33 +3008,36 @@ class SHARCContainer {
       // the dev-channel log, then onError + terminate. Detaching the listener
       // happens in `_disarmRendererBackstop`.
       //
-      // `details.variant` discriminates Markup-variant backstops (this path)
-      // from the future Phase E Creative URL backstop. We deliberately do
-      // NOT report a load-count here: the fields varied across variants
-      // (Markup expects 2, URL expects 1) and the structured event type +
-      // errorCode + message are what operators key off. Phase E will extend
-      // by adding `variant: 'url'` without re-shaping this event.
+      // `details.variant` discriminates Markup ('markup') from Creative
+      // URL ('url'). Operators key off the structured event type + code +
+      // message; the variant field is for triage only — both variants
+      // share the same root cause (renderer iframe navigated post-render).
       //
-      // `details.msSinceRender` is the wall-clock delay between :rendered
-      // accept and this load event. Operators monitoring 2118 distinguish
-      // fast-fire (creative immediately reloaded — typically a redirect-
-      // injected `<meta http-equiv="refresh" content="0;url=...">` or a
-      // `window.location` assignment in the creative's first script tag)
-      // from slow-fire (multiple-second delay — DOM-injected redirects,
-      // setTimeout-based redirects). Phase D round-4 SRE HIGH-1.
+      // `details.msSinceRender` is the wall-clock delay between the
+      // variant-specific render-anchor (Markup: `:rendered` accept; URL:
+      // initial iframe load) and this load event. Operators monitoring
+      // 2118 distinguish fast-fire (creative immediately reloaded —
+      // typically a redirect-injected `<meta http-equiv="refresh"
+      // content="0;url=...">` or a `window.location` assignment in the
+      // creative's first script tag) from slow-fire (multiple-second
+      // delay — DOM-injected redirects, setTimeout-based redirects).
+      // Field name is preserved across variants for grep-stable operator
+      // dashboards. Phase D round-4 SRE HIGH-1; widened in Phase E.
       void loadEvent;
+      const variant = (this.creativeSource === 'html') ? 'markup' : 'url';
       const msSinceRender = (typeof this._renderedAt === 'number')
         ? Math.max(0, Date.now() - this._renderedAt)
         : 0;
       this._emitSecurityEventAndTerminate(
         'unauthorized_navigation',
         ErrorCodes.RENDERER_UNAUTHORIZED_NAVIGATION,
-        'Renderer iframe navigated post-render after ' + msSinceRender + 'ms '
-          + '— refusing to proceed. The new document is cross-origin and '
-          + 'its URL is not inspectable; check the creative\'s HTML for '
-          + 'redirect-injection patterns (window.location, meta refresh '
-          + 're-injection, form submits with action=).',
-        { variant: 'markup', msSinceRender: msSinceRender }
+        (variant === 'markup' ? 'Renderer' : 'Creative URL') + ' iframe navigated '
+          + 'post-render after ' + msSinceRender + 'ms — refusing to proceed. '
+          + 'The new document is cross-origin and its URL is not inspectable; '
+          + 'check the creative\'s HTML for redirect-injection patterns '
+          + '(window.location, meta refresh re-injection, form submits with '
+          + 'action=).',
+        { variant: variant, msSinceRender: msSinceRender }
       );
     };
     this._rendererBackstopHandler = backstop;

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -3024,6 +3024,9 @@ class SHARCContainer {
       // Field name is preserved across variants for grep-stable operator
       // dashboards. Phase D round-4 SRE HIGH-1; widened in Phase E.
       void loadEvent;
+      // `creativeSource` is constructor-set and stable across the
+      // container's lifetime — see field doc at the constructor. Safe
+      // to read at fire time; no stale-state hazard.
       const variant = (this.creativeSource === 'html') ? 'markup' : 'url';
       const msSinceRender = (typeof this._renderedAt === 'number')
         ? Math.max(0, Date.now() - this._renderedAt)

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -1292,15 +1292,11 @@ class SHARCContainer {
     // one cross-document load (the creative document loading from
     // `creativeUrl`). Any subsequent `load` event = unauthorized navigation
     // and terminates via `_armRendererBackstop()` (variant-agnostic seam
-    // extracted in Phase D round-1). The arm-on-first-load handler MUST
-    // be one-shot — we use a captured flag to ignore subsequent fires of
-    // this listener (the backstop installed by `_armRendererBackstop()`
-    // is what handles all subsequent loads). Same-document navigations
+    // extracted in Phase D round-1). `{ once: true }` removes this listener
+    // after first fire; the backstop installed by `_armRendererBackstop()`
+    // is what handles all subsequent loads. Same-document navigations
     // (pushState, hash changes) do not fire `load`; cross-document do.
-    let initialLoadHandled = false;
     iframe.addEventListener('load', () => {
-      if (initialLoadHandled) return;
-      initialLoadHandled = true;
       // Stamp the render-anchor timestamp so the backstop's eventual
       // `details.msSinceRender` payload reflects the URL-variant anchor
       // (initial load), not the Markup anchor (`:rendered` accept).
@@ -1315,7 +1311,7 @@ class SHARCContainer {
       // The 200ms initChannel deferral above is unrelated — that's an OM
       // SDK ordering concession, not a backstop concern.
       this._armRendererBackstop();
-    });
+    }, { once: true });
 
     if (!this._useMarkupInjection) {
       // Default path (Option 2 — recommended): publisher-page OM SDK loading.
@@ -3026,8 +3022,27 @@ class SHARCContainer {
       void loadEvent;
       // `creativeSource` is constructor-set and stable across the
       // container's lifetime — see field doc at the constructor. Safe
-      // to read at fire time; no stale-state hazard.
-      const variant = (this.creativeSource === 'html') ? 'markup' : 'url';
+      // to read at fire time; no stale-state hazard. Type is constrained
+      // to `'url' | 'html'` (typedef-enforced); both expected values are
+      // mapped explicitly so a future variant added without updating this
+      // derivation surfaces loudly via console.error rather than silently
+      // coercing to 'url'.
+      let variant;
+      if (this.creativeSource === 'html') {
+        variant = 'markup';
+      } else if (this.creativeSource === 'url') {
+        variant = 'url';
+      } else {
+        console.error(
+          '[SHARCContainer] [' + this.placementSessionId
+          + '] [unauthorized_navigation] unexpected creativeSource: '
+          + String(this.creativeSource)
+          + ' — defaulting variant to "url" (update _armRendererBackstop'
+          + ' AND UnauthorizedNavigationEvent.details typedef when adding'
+          + ' a new creativeSource).'
+        );
+        variant = 'url';
+      }
       const msSinceRender = (typeof this._renderedAt === 'number')
         ? Math.max(0, Date.now() - this._renderedAt)
         : 0;

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -59,6 +59,22 @@ import {
   MESSAGES_REQUIRING_RESPONSE,
 } from './sharc-protocol.js';
 
+// Phase E deliverable 2: bundle the navigation bridge into the SDK so the
+// Creative URL flow auto-installs it at SDK init. Markup variant continues
+// to install the bridge from the renderer page (operators forking
+// `examples/renderer/index.html` get it wired in there); the SDK's auto-
+// install is gated on `window.__sharcRenderer` presence so it's a no-op
+// when the renderer already installed (idempotent at the bridge level too,
+// but the gate avoids a redundant call). +1.1 kB is acceptable for a non-
+// optional dependency in the URL flow. Synchronous install at module
+// evaluation avoids the first-click race that a dynamic import would
+// introduce. The bridge surface (`installNavigationBridge`,
+// `SHARCNavigationError`) is also re-exported from this module so ESM
+// consumers that load only `sharc-creative` get the bridge API without
+// a second import — parity with the standalone `sharc-navigation-bridge`
+// module. Verified by `npm run test:smoke`.
+import { installNavigationBridge, SHARCNavigationError } from './sharc-navigation-bridge.js';
+
 
 
 // ---------------------------------------------------------------------------
@@ -827,6 +843,50 @@ if (typeof window !== 'undefined') {
 
   // Call _boot after window.SHARC assignment completes
   /** @type {any} */ (_instance)._boot();
+
+  // Phase E deliverable 2: auto-install the navigation bridge for the
+  // Creative URL flow.
+  //
+  // Variant detection: `window.__sharcRenderer` is set by the reference
+  // renderer (`examples/renderer/index.html`) at module-evaluation time —
+  // BEFORE `document.write(creativeHtml)` puts the creative SDK on the
+  // page. So if `__sharcRenderer` is present, we're in the Markup variant
+  // and the renderer has already installed the bridge (via its own
+  // `installNavigationBridge(window)` call). If absent, we're in the
+  // Creative URL variant and the SDK is the install point.
+  //
+  // The bridge install is idempotent at the bridge level
+  // (`__sharcNavBridgeInstalled` flag) — calling install twice is safe by
+  // construction. The variant gate is a defense-in-depth optimization
+  // (avoids a redundant call + log noise), not a correctness requirement.
+  //
+  // Expose the named export on the SHARC namespace for parity with the
+  // standalone bridge module's expose pattern (the standalone module also
+  // sets `window.SHARC.installNavigationBridge` for non-module creatives).
+  // Operators that need manual install can call it from their own code.
+  /** @type {any} */
+  const _anyWin = window;
+  window.SHARC.installNavigationBridge = installNavigationBridge;
+  if (!_anyWin.__sharcRenderer && !_anyWin.__sharcNavBridgeInstalled) {
+    // Creative URL flow — install the bridge synchronously at SDK init.
+    // Synchronous install (not dynamic import) avoids the first-click
+    // race that a deferred install would introduce — by the time the
+    // creative HTML's first script tag runs, the bridge is already in
+    // place, intercepting `window.open`, `<a>` clicks, form submits,
+    // and `location.*` setters before any creative code can fire.
+    try {
+      installNavigationBridge(window);
+    } catch (e) {
+      // Defense-in-depth: bridge install should never throw under normal
+      // conditions (the bridge's only throw is for missing window
+      // context, which we just verified above). If a future bridge change
+      // adds a throw path, we log here rather than letting it crash SDK
+      // init — the container-side load-event backstop (RENDERER_
+      // UNAUTHORIZED_NAVIGATION 2118) is the load-bearing fallback for
+      // any bridge install failure.
+      console.error('[SHARC Creative] navigation bridge auto-install failed:', e);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -843,3 +903,13 @@ if (typeof window !== 'undefined' && typeof window.SHARC !== 'undefined' && !win
 }
 
 export { SHARCCreative, _instance as creative, SHARC };
+
+// Phase E deliverable 2: re-export the bundled navigation bridge surface.
+// ESM consumers that load `sharc-creative` get the bridge API for free;
+// no second import required. The standalone `sharc-navigation-bridge`
+// module continues to ship for operators that prefer to load it
+// separately (e.g. inside the reference renderer, where it imports the
+// standalone module to keep the renderer's single-purpose). Both paths
+// share the same exported references — `instanceof` checks against
+// `SHARCNavigationError` work regardless of which import was used.
+export { installNavigationBridge, SHARCNavigationError };

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -864,9 +864,19 @@ if (typeof window !== 'undefined') {
   // standalone bridge module's expose pattern (the standalone module also
   // sets `window.SHARC.installNavigationBridge` for non-module creatives).
   // Operators that need manual install can call it from their own code.
+  //
+  // First-assignment-wins contract: if the operator pre-sets
+  // `window.SHARC.installNavigationBridge` before SHARC modules load (e.g.
+  // to wrap the install with telemetry, custom logging, or a feature
+  // flag), the SDK does NOT clobber that override. Same guard exists in
+  // `sharc-navigation-bridge.js`; if either file's assignment ran
+  // unconditionally the operator's override would be silently overwritten
+  // depending on script-tag order.
   /** @type {any} */
   const _anyWin = window;
-  window.SHARC.installNavigationBridge = installNavigationBridge;
+  if (typeof window.SHARC.installNavigationBridge !== 'function') {
+    window.SHARC.installNavigationBridge = installNavigationBridge;
+  }
   if (!_anyWin.__sharcRenderer && !_anyWin.__sharcNavBridgeInstalled) {
     // Creative URL flow — install the bridge synchronously at SDK init.
     // Synchronous install (not dynamic import) avoids the first-click

--- a/src/sharc-navigation-bridge.js
+++ b/src/sharc-navigation-bridge.js
@@ -517,10 +517,18 @@ export { installNavigationBridge, SHARCNavigationError };
 // `instanceof`-check against it without an import. Independent of the
 // SDK-loaded check below — the error class is meaningful even if the SDK
 // hasn't loaded (the throw it powers fires in exactly that case).
+//
+// First-assignment-wins contract: an operator that pre-sets
+// `window.SHARCNavigationError` before SHARC modules load (e.g. for a
+// custom subclass with extra telemetry fields) keeps their override —
+// the bridge does NOT clobber it. Same pattern as
+// `window.SHARC.installNavigationBridge` below.
 if (typeof window !== 'undefined') {
   /** @type {any} */
   var _winForErr = window;
-  _winForErr.SHARCNavigationError = SHARCNavigationError;
+  if (typeof _winForErr.SHARCNavigationError !== 'function') {
+    _winForErr.SHARCNavigationError = SHARCNavigationError;
+  }
 }
 
 // Browser auto-install: when loaded as a <script> tag in the renderer page
@@ -542,5 +550,14 @@ if (typeof window !== 'undefined' && window.SHARC
   }
   // Expose the named export on the SHARC namespace for parity with the
   // other bridges (window.SHARC.MRAIDCompatBridge, etc.).
-  window.SHARC.installNavigationBridge = installNavigationBridge;
+  //
+  // First-assignment-wins contract: operators may pre-set
+  // `window.SHARC.installNavigationBridge` (e.g. wrapped with telemetry)
+  // before SHARC modules load; the bridge won't clobber that override.
+  // The SDK in `sharc-creative.js` carries the same guard — if either
+  // file's assignment ran unconditionally the operator's override would
+  // be silently overwritten depending on script-tag order.
+  if (typeof window.SHARC.installNavigationBridge !== 'function') {
+    window.SHARC.installNavigationBridge = installNavigationBridge;
+  }
 }

--- a/test-creative-sdk-autoinstall.js
+++ b/test-creative-sdk-autoinstall.js
@@ -1,0 +1,206 @@
+/**
+ * test-creative-sdk-autoinstall.js — Phase E round-1 OpenClaw LOW-2
+ *
+ * Runtime regression coverage for the SDK's navigation-bridge auto-install
+ * behavior at module-evaluation time. Pairs with `test-smoke.js` (which
+ * verifies the EXPORTS are reachable on the SDK bundle) and section 18 of
+ * `test-creative-sources-load.js` (which verifies the CONTAINER-side
+ * load-event backstop) — this file fills the seam between them by proving
+ * the SDK actually triggers `installNavigationBridge(window)` at boot in
+ * the Creative URL variant and skips it in the Creative Markup variant.
+ *
+ * Without this coverage, a future tree-shake / sideEffects regression
+ * could silently strip the auto-install path while leaving the exports
+ * present — bridge would still appear "available" in test-smoke but would
+ * never fire on real Creative URL traffic.
+ *
+ * Two scenarios, each in its own child process (module caching prevents
+ * re-importing the SDK with a different `__sharcRenderer` state in a
+ * single process):
+ *
+ *  1. Creative URL flow — `__sharcRenderer` absent → SDK auto-installs
+ *     the bridge → `window.__sharcNavBridgeInstalled === true` AND
+ *     `window.SHARC.installNavigationBridge` is a function.
+ *
+ *  2. Creative Markup flow — `__sharcRenderer` pre-set → SDK detects the
+ *     renderer marker and SKIPS its own auto-install (the renderer is
+ *     responsible for installing the bridge in that variant). The
+ *     `installNavigationBridge` export is still reachable on
+ *     `window.SHARC` (the namespace assignment is independent of the
+ *     auto-install gate), but the install side-effect is absent.
+ *
+ * Runs in Node after `npm run build` (dev mode, console-call preserving).
+ */
+
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// =========================================================================
+// Mode dispatch — a single file that runs as both the parent harness and
+// as the child worker for each scenario. The parent spawns two children
+// with `SHARC_AUTOINSTALL_MODE=url|markup`; the child runs the assertions
+// for its mode and exits with code 0 (pass) or 1 (fail).
+// =========================================================================
+
+const MODE = process.env.SHARC_AUTOINSTALL_MODE;
+
+if (!MODE) {
+  // -- Parent: spawn one child per scenario, aggregate results. ---------
+  console.log('Running creative SDK auto-install tests...\n');
+
+  const __filename = fileURLToPath(import.meta.url);
+  let failed = 0;
+
+  for (const mode of ['url', 'markup']) {
+    console.log(`──── scenario: ${mode} ────`);
+    const r = spawnSync(
+      process.execPath,
+      [__filename],
+      {
+        env: { ...process.env, SHARC_AUTOINSTALL_MODE: mode },
+        stdio: 'inherit',
+        cwd: path.dirname(__filename),
+      },
+    );
+    if (r.status !== 0) {
+      failed++;
+      console.error(`✗ scenario ${mode} failed (exit ${r.status}).`);
+    } else {
+      console.log(`✓ scenario ${mode} passed.`);
+    }
+    console.log('');
+  }
+
+  if (failed > 0) {
+    console.error(`✗ ${failed} auto-install scenario(s) failed.`);
+    process.exit(1);
+  }
+  console.log('✓ All creative SDK auto-install scenarios passed.');
+  process.exit(0);
+}
+
+// =========================================================================
+// Child: run one scenario.
+// =========================================================================
+
+const { JSDOM } = await import('jsdom');
+const assert = (await import('node:assert/strict')).default;
+
+const PUBLISHER_ORIGIN = 'https://publisher.example';
+const dom = new JSDOM(
+  '<!DOCTYPE html><html><body></body></html>',
+  { url: PUBLISHER_ORIGIN + '/page.html' },
+);
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.HTMLIFrameElement = dom.window.HTMLIFrameElement;
+global.MessageChannel = dom.window.MessageChannel;
+global.MessagePort = dom.window.MessagePort;
+global.MessageEvent = dom.window.MessageEvent;
+if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.randomUUID !== 'function') {
+  const nodeCrypto = await import('node:crypto');
+  globalThis.crypto = nodeCrypto.webcrypto || nodeCrypto;
+}
+
+// Pre-load the protocol so `window.SHARC.requestNavigation` is available
+// when the bridge's auto-install gate consults it. Mirrors the renderer
+// page's load order and the existing test-creative-sources-load.js setup.
+const protoMod = await import('./dist/sharc-protocol.mjs');
+window.SHARC = window.SHARC || {};
+window.SHARC.Protocol = protoMod;
+
+// Build-mode FATAL guard — same pattern as test-creative-sources-load.js
+// and test-navigation-bridge.js. Prod builds with `drop_console: true`
+// would silently void any console-related assertions in this harness; the
+// bridge install path itself is unaffected, but we keep the guard for
+// consistency with sibling tests so a wrong-mode run fails loudly.
+{
+  const fs = await import('node:fs');
+  const distSrc = fs.readFileSync('./dist/sharc-creative.mjs', 'utf8');
+  if (!/console\.error/.test(distSrc)) {
+    console.error(
+      'FATAL: dist/sharc-creative.mjs has zero console.error calls — '
+      + 'this is a production build (terser drop_console=true). Re-run '
+      + '`npm run build` (dev mode) and try again.'
+    );
+    process.exit(1);
+  }
+}
+
+// Scenario-specific setup — must happen BEFORE the SDK import.
+if (MODE === 'markup') {
+  // Pre-set the renderer marker the way `examples/renderer/index.html`
+  // does (a module-eval-time global before the creative HTML is written
+  // into the renderer document). The SDK's auto-install gate reads this.
+  window.__sharcRenderer = {
+    /* opaque sentinel — the SDK only checks for its presence */
+  };
+}
+
+// Now import the SDK. This evaluation triggers the auto-install path.
+await import('./dist/sharc-creative.mjs');
+
+// Allow any synchronous SDK boot work to settle (the auto-install itself
+// is synchronous, but defensive — `_boot()` is invoked in the same tick).
+await new Promise((r) => setTimeout(r, 5));
+
+// =========================================================================
+// Assertions
+// =========================================================================
+
+let failures = 0;
+function check(condition, message) {
+  if (condition) {
+    console.log('  ✓', message);
+  } else {
+    console.error('  ✗', message);
+    failures++;
+  }
+}
+
+if (MODE === 'url') {
+  // -- Creative URL flow: SDK installs the bridge synchronously. -------
+  check(typeof window.SHARC === 'object' && window.SHARC !== null,
+    'URL: window.SHARC namespace is present after SDK import');
+  check(typeof window.SHARC.installNavigationBridge === 'function',
+    'URL: window.SHARC.installNavigationBridge is exposed (function)');
+  check(window.__sharcNavBridgeInstalled === true,
+    'URL: SDK auto-installed the navigation bridge (__sharcNavBridgeInstalled === true)');
+  check(typeof window.SHARC.requestNavigation === 'function',
+    'URL: window.SHARC.requestNavigation is reachable post-install');
+  // The bridge sets `window.SHARCNavigationError` independently of the
+  // install gate. Verify the class is reachable for `instanceof` checks
+  // by non-module creatives that catch the SDK-missing throw.
+  check(typeof window.SHARCNavigationError === 'function',
+    'URL: window.SHARCNavigationError is exposed (class)');
+} else if (MODE === 'markup') {
+  // -- Creative Markup flow: SDK skips its own auto-install. -----------
+  // The renderer would have run its own `installNavigationBridge(window)`
+  // BEFORE `document.write(creativeHtml)` in the real flow. In this
+  // jsdom harness we only verify the SDK's gate fires correctly — i.e.
+  // the SDK-side install side-effect is absent because `__sharcRenderer`
+  // is set. The renderer's own install path is exercised by
+  // `test-navigation-bridge.js`.
+  check(typeof window.SHARC === 'object' && window.SHARC !== null,
+    'Markup: window.SHARC namespace is present after SDK import');
+  check(typeof window.SHARC.installNavigationBridge === 'function',
+    'Markup: window.SHARC.installNavigationBridge is exposed (function) — namespace assignment is independent of the auto-install gate');
+  check(window.__sharcNavBridgeInstalled !== true,
+    'Markup: SDK did NOT auto-install the bridge (__sharcRenderer marker present → install gate closed; renderer is responsible for the install in this variant)');
+  check(window.__sharcRenderer != null,
+    'Markup: __sharcRenderer marker remained in place (sanity — pre-import setup intact)');
+} else {
+  console.error(`✗ unknown SHARC_AUTOINSTALL_MODE: ${MODE}`);
+  process.exit(1);
+}
+
+// =========================================================================
+// Summary
+// =========================================================================
+if (failures > 0) {
+  console.error(`✗ ${failures} ${MODE}-mode assertion(s) failed.`);
+  process.exit(1);
+}
+process.exit(0);

--- a/test-creative-sources-load.js
+++ b/test-creative-sources-load.js
@@ -35,6 +35,12 @@
  *      § Security Model line 729). Re-entrancy guard: `_terminated` blocks
  *      a second emission.
  *
+ * Phase E scope (section 18):
+ *  18. Creative URL variant — load-event navigation backstop after the
+ *      first (and only-expected) iframe `load` event →
+ *      RENDERER_UNAUTHORIZED_NAVIGATION (2118) with `details.variant === 'url'`.
+ *      Parallels section 14 (Markup variant). Closes [#70].
+ *
  * Uses jsdom (no browser harness) — mirrors the test-creative-sources.js
  * pattern. Stubs `iframe.contentWindow.postMessage` to capture the render
  * message and dispatches synthetic `MessageEvent`s on `window` to simulate
@@ -2350,6 +2356,198 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       're-entrancy: onSecurityEvent fires exactly once despite two terminating events');
     assert(securityEvents[0].type === 'renderer_failed',
       're-entrancy: only the FIRST event landed (renderer_failed); second was suppressed by _terminated guard');
+  }
+  flushContainers();
+}
+
+// =========================================================================
+// Phase E — section 18 (Creative URL load-event backstop)
+// =========================================================================
+
+// -- 18. Creative URL variant — load-event navigation backstop → 2118 ('url')
+{
+  console.log('\n18. Creative URL variant — load-event backstop → RENDERER_UNAUTHORIZED_NAVIGATION (2118, variant=url)');
+
+  // Helper: build a Creative URL container, fire the initial iframe `load`
+  // event, wait for the post-load arm-backstop seam to settle. Returns the
+  // wired-up container ready for second-load probes. Mirrors the Markup
+  // variant's `buildPostRender` helper from section 14.
+  async function buildPostUrlLoad(opts = {}) {
+    const slot = freshSlot();
+    const errors = [];
+    const securityEvents = [];
+    const c = track(new SHARCContainer({
+      creativeUrl: 'https://ads.example/creative.html',
+      placementElement: slot,
+      onError: (code, msg) => errors.push({ code, msg }),
+      onSecurityEvent: (event) => securityEvents.push(event),
+      ...opts,
+    }));
+    c.load();
+    // Stub postMessage so the deferred initChannel doesn't fire into a real
+    // contentWindow during the test (the URL variant wires MessageChannel
+    // 200ms after load — irrelevant to the backstop assertions).
+    c._iframe.contentWindow.postMessage = () => {};
+    // First (and only-expected) iframe load: arms the backstop synchronously
+    // in the URL variant's load listener.
+    c._iframe.dispatchEvent(new dom.window.Event('load'));
+    // Yield so the arm-on-first-load handler completes.
+    await new Promise((r) => setTimeout(r, 5));
+    return { container: c, slot, errors, securityEvents };
+  }
+
+  // 18a — Backstop is armed after the FIRST load event in the URL variant.
+  //       The render-anchor timestamp (`_renderedAt`) is also stamped so
+  //       msSinceRender will be a number on subsequent fires.
+  {
+    const { container } = await buildPostUrlLoad();
+    assert(typeof container._rendererBackstopHandler === 'function',
+      'URL: post-initial-load: load-event backstop is attached');
+    assert(typeof container._renderedAt === 'number',
+      'URL: post-initial-load: _renderedAt stamped (Date.now timestamp)');
+    assert(container.creativeSource === 'url',
+      'URL: creativeSource === "url" (sanity — variant detection in backstop fire)');
+    assert(container.creativeRendered === false,
+      'URL: creativeRendered remains false (renderer protocol is Markup-only)');
+  }
+
+  // 18b — Subsequent load event after the initial → 2118 + onSecurityEvent
+  //       fires with type=`unauthorized_navigation`, details.variant === 'url',
+  //       details.msSinceRender >= 0. console.error includes
+  //       `[unauthorized_navigation]` and the URL-variant phrasing.
+  {
+    const { container, errors, securityEvents } = await buildPostUrlLoad();
+    const iframe = container._iframe;
+    const originalError = console.error;
+    const errorOutput = [];
+    console.error = (...args) => { errorOutput.push(args.join(' ')); };
+    try {
+      // Simulate the iframe navigating: dispatch a second `load` event.
+      // (jsdom never actually navigates the cross-origin iframe; we
+      // synthesize the event the browser would have fired.)
+      iframe.dispatchEvent(new dom.window.Event('load'));
+      // Allow the chokepoint's onSecurityEvent + console.error +
+      // handleFatalError to drain.
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      console.error = originalError;
+    }
+    assert(errors.length >= 1 && errors[0].code === ErrorCodes.RENDERER_UNAUTHORIZED_NAVIGATION,
+      'URL: second iframe `load` post-initial-load → onError(RENDERER_UNAUTHORIZED_NAVIGATION) (code 2118)');
+    assert(container._terminated === true,
+      'URL: second iframe `load` post-initial-load → container terminated');
+    assert(errorOutput.some((s) => /\[unauthorized_navigation\]/.test(s)),
+      'URL: second iframe `load` post-initial-load → console.error tagged [unauthorized_navigation]');
+    assert(errorOutput.some((s) => /Creative URL iframe navigated post-render/.test(s)),
+      'URL: second iframe `load` post-initial-load → console.error names URL-variant phrasing');
+
+    // onSecurityEvent fired with the discriminated payload — Phase E
+    // widens the variant to 'markup' | 'url' (typedef + consumer probe).
+    const navEvent = securityEvents.find((e) => e.type === 'unauthorized_navigation');
+    assert(navEvent != null,
+      'URL: second iframe `load` post-initial-load → onSecurityEvent fires with type=unauthorized_navigation');
+    assert(navEvent && navEvent.severity === 'error',
+      'URL: unauthorized_navigation event severity === "error"');
+    assert(navEvent && navEvent.errorCode === ErrorCodes.RENDERER_UNAUTHORIZED_NAVIGATION,
+      'URL: unauthorized_navigation event errorCode === 2118');
+    assert(navEvent && navEvent.details && navEvent.details.variant === 'url',
+      'URL: unauthorized_navigation event.details.variant === "url" (Phase E widening)');
+    // msSinceRender semantics: Markup anchors on `:rendered` accept; URL
+    // anchors on the initial iframe `load`. Field name preserved across
+    // variants for grep-stable operator dashboards.
+    assert(navEvent && navEvent.details && typeof navEvent.details.msSinceRender === 'number',
+      'URL: unauthorized_navigation event.details.msSinceRender is a number');
+    assert(navEvent && navEvent.details && navEvent.details.msSinceRender >= 0,
+      'URL: unauthorized_navigation event.details.msSinceRender is >= 0 (no clock-skew negative)');
+    assert(errorOutput.some((s) => /Creative URL iframe navigated post-render after \d+ms/.test(s)),
+      'URL: console.error names msSinceRender in the timing-aware message');
+    assert(errorOutput.some((s) => /redirect-injection patterns/.test(s)),
+      'URL: console.error names redirect-injection diagnostic hint');
+    assert(navEvent && navEvent.placementSessionId === container.placementSessionId,
+      'URL: unauthorized_navigation event.placementSessionId correlates back to container');
+    assert(navEvent && typeof navEvent.timestamp === 'number',
+      'URL: unauthorized_navigation event.timestamp is a number (Date.now)');
+  }
+
+  // 18c — Backstop detached on _terminate (URL variant). Mirrors 14c.
+  {
+    const { container } = await buildPostUrlLoad();
+    assert(container._rendererBackstopHandler !== null,
+      'URL: pre-terminate: backstop handler is non-null');
+    container.close();
+    await new Promise((r) => setTimeout(r, 80));
+    assert(container._rendererBackstopHandler === null,
+      'URL: post-terminate: backstop handler is nulled out (defense-in-depth detach)');
+  }
+
+  // 18d — Re-entrancy: a backstop fire on an already-terminated URL
+  //       container is a no-op (the chokepoint's `_terminated` guard
+  //       short-circuits). Mirrors 14d.
+  {
+    const { container, errors, securityEvents } = await buildPostUrlLoad();
+    const handler = container._rendererBackstopHandler;
+    container._emitSecurityEventAndTerminate(
+      'renderer_failed',
+      ErrorCodes.RENDERER_FAILED,
+      'baseline failure for URL-variant re-entrancy probe',
+      { reason: 'baseline' }
+    );
+    await new Promise((r) => setTimeout(r, 60));
+    const errorsBefore = errors.length;
+    const eventsBefore = securityEvents.length;
+    if (typeof handler === 'function') handler(new dom.window.Event('load'));
+    await new Promise((r) => setTimeout(r, 30));
+    assert(errors.length === errorsBefore,
+      'URL: backstop fire on terminated container → onError NOT re-fired');
+    assert(securityEvents.length === eventsBefore,
+      'URL: backstop fire on terminated container → onSecurityEvent NOT re-fired');
+  }
+
+  // 18e — The arm-on-first-load handler is one-shot — a stray duplicate
+  //       initial `load` (rare; some hosts double-fire on cache hits)
+  //       does NOT re-arm, re-stamp `_renderedAt`, or fire 2118. The
+  //       second load goes through the backstop (which is what fires).
+  //       This locks in the `initialLoadHandled` flag's idempotency.
+  {
+    const slot = freshSlot();
+    const errors = [];
+    const securityEvents = [];
+    const c = track(new SHARCContainer({
+      creativeUrl: 'https://ads.example/creative.html',
+      placementElement: slot,
+      onError: (code, msg) => errors.push({ code, msg }),
+      onSecurityEvent: (event) => securityEvents.push(event),
+    }));
+    c.load();
+    c._iframe.contentWindow.postMessage = () => {};
+    // First load: arms backstop, stamps _renderedAt.
+    c._iframe.dispatchEvent(new dom.window.Event('load'));
+    await new Promise((r) => setTimeout(r, 5));
+    const stampedAt = c._renderedAt;
+    assert(typeof stampedAt === 'number',
+      'URL: first load stamped _renderedAt');
+    // Second load: this is the unauthorized navigation — should fire 2118
+    // with msSinceRender computed against the FIRST load's stamp, not
+    // re-stamped against this load.
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      // Wait long enough that any wrong "re-stamp" would zero msSinceRender.
+      await new Promise((r) => setTimeout(r, 20));
+      c._iframe.dispatchEvent(new dom.window.Event('load'));
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      console.error = originalError;
+    }
+    const navEvent = securityEvents.find((e) => e.type === 'unauthorized_navigation');
+    assert(navEvent != null,
+      'URL: idempotency probe — second load fires 2118 (sanity)');
+    assert(navEvent && navEvent.details.msSinceRender >= 20,
+      'URL: idempotency probe — msSinceRender reflects FIRST load anchor (>=20ms), not re-stamped on second load');
+    // Defensive: only one nav event fired (the second-load fire), even
+    // though the backstop is still armed if the chokepoint races.
+    assert(securityEvents.filter((e) => e.type === 'unauthorized_navigation').length === 1,
+      'URL: idempotency probe — exactly one unauthorized_navigation event fired');
   }
   flushContainers();
 }

--- a/test-smoke.js
+++ b/test-smoke.js
@@ -34,7 +34,15 @@ const esmModules = [
   {
     name: 'sharc-creative',
     path: './dist/sharc-creative.mjs',
-    expectedExports: ['SHARCCreative', 'creative']
+    // Phase E deliverable 2: the navigation bridge is now bundled into
+    // the SDK so the Creative URL flow auto-installs it at SDK init.
+    // Verify the bridge surface (`installNavigationBridge`,
+    // `SHARCNavigationError`) is reachable via the SDK bundle, alongside
+    // the existing `SHARCCreative` / `creative` exports. This locks in
+    // the +1.1 kB bundling decision against a future change that
+    // accidentally tree-shakes the bridge out of the SDK build (which
+    // would silently regress URL-flow click-through audit coverage).
+    expectedExports: ['SHARCCreative', 'creative', 'installNavigationBridge', 'SHARCNavigationError']
   },
   {
     name: 'sharc-protocol',

--- a/test/types/consumer.ts
+++ b/test/types/consumer.ts
@@ -117,12 +117,31 @@ if (_evt.type === 'wrapper_top_frame_inaccessible') {
   void reason;
   void code;
 } else if (_evt.type === 'unauthorized_navigation') {
-  const variant: 'markup' = _evt.details.variant;
+  // Phase E widened the variant from `'markup'` literal to the
+  // `'markup' | 'url'` union (Creative URL coverage). The probe MUST
+  // accept either branch — a regression that re-narrows to a single
+  // literal would fail to compile here. We exercise both literals via
+  // a switch so a future re-narrow shows up as a missing-case error,
+  // not a silent loss of the URL branch.
+  const variant: 'markup' | 'url' = _evt.details.variant;
   const code: 2118 = _evt.errorCode;
   // Phase D round-4 SRE HIGH-1: details.msSinceRender carries the wall-
-  // clock delay between :rendered accept and the post-render load event.
+  // clock delay between the variant's render-anchor event and the
+  // post-render load event (Markup: `:rendered` accept; URL: initial
+  // iframe load — Phase E).
   const msSinceRender: number = _evt.details.msSinceRender;
-  void variant;
+  switch (variant) {
+    case 'markup': {
+      const m: 'markup' = variant;
+      void m;
+      break;
+    }
+    case 'url': {
+      const u: 'url' = variant;
+      void u;
+      break;
+    }
+  }
   void code;
   void msSinceRender;
 }


### PR DESCRIPTION
## Summary

Phase E of issue #41 — completes the **0.7.0 SDK code milestone** by extending Phase D's load-event backstop seam to the Creative URL variant and bundling the navigation bridge into the Creative SDK.

Closes #70 (re-scoped from 0.8 to 0.7.0 per Jeffrey's direction). Phase D's `_armRendererBackstop()` / `_disarmRendererBackstop()` seam was extracted in round-1 specifically to make Phase E a drop-in extension — that pays off here.

## Two deliverables

### 1. Container-side Creative URL load-event backstop
- After the iframe's initial load (1 expected for Creative URL), arm `_armRendererBackstop()` — same helper Phase D uses for Markup
- Any subsequent `load` event terminates with `RENDERER_UNAUTHORIZED_NAVIGATION` (2118), `details.variant: 'url'`, `details.msSinceRender` measured from the initial load anchor
- `UnauthorizedNavigationEvent.details.variant` typedef widened from literal `'markup'` to `'markup' | 'url'` (the narrow-now-widen-later precedent set in Phase D round-2 expected exactly this widening)
- `test/types/consumer.ts` discriminant probe extended for both branches via exhaustive `switch`

### 2. SDK nav-bridge auto-install (Creative URL only)
- `src/sharc-creative.js` now bundles `sharc-navigation-bridge.js` and auto-installs the bridge at SDK init when `window.__sharcRenderer` is absent (Creative URL variant)
- Variant detection via `window.__sharcRenderer` marker — set by reference renderer BEFORE `document.write` runs in Markup flow, absent in URL flow
- Idempotent at the bridge level (existing `__sharcNavBridgeInstalled` flag) — defense in depth if a future renderer change loses the marker
- Re-exports `installNavigationBridge` and `SHARCNavigationError` from `sharc-creative` so ESM consumers get them transitively; `instanceof SHARCNavigationError` works across both import paths (module caching guarantees same class identity)
- Bundle approach (vs. dynamic import) chosen for synchronous install — avoids first-click race
- `sharc-creative` size: 4.92 kB → 5.54 kB brotli (+0.62 kB; 6 KB budget after round-2 tightening from 7 KB)

## Documentation

- New "Implementation Phases" section in proposal (`creative-sources.md`) documenting the A-G phase plan for 0.7.0
- All "Markup-only in 0.7.0" qualifiers removed from proposal (Creative URL now ships with full coverage)
- Future Work table cleaned (Phase E row removed)
- CHANGELOG `[0.7.0]` adds Creative URL parity bullet; "Markup-only" framing removed from existing bullets that now cover both variants
- api-reference.md aligned with Phase E reality (2118 description covers both variants; renderer protocol section explains SDK auto-install path; SHARCNavigationError export source includes both `sharc-navigation-bridge` and `sharc-creative` re-export)
- Trust-model clarification: bridge is best-effort URL audit for legitimate creatives; load-event backstop (2118) is the load-bearing enforcement for adversarial creatives

## Test surface

- **293** jsdom assertions in `test-creative-sources-load.js` (+26 from Phase D — section 18 covers Creative URL backstop arm-on-first-load, second-load → 2118, terminate detach, re-entrancy, one-shot-arm idempotency)
- **34** in `test-navigation-bridge.js` (3 deferred to #69)
- **9 NEW** in `test-creative-sdk-autoinstall.js` (regression test for SDK auto-install — URL flow: marker absent → bridge installed; Markup flow: marker pre-set → SDK skips install)
- Discriminated-union narrowing exhaustive switch over `'markup' | 'url'` in `test/types/consumer.ts`
- Performance harness (Phase D round-6c): Markup P95 +0.49ms vs URL P95 (well within 600ms budget)

## Defense-in-depth additions (round-1 + round-2)

- **`if absent` guards** on `window.SHARC.installNavigationBridge` and `window.SHARCNavigationError` assignments — operator monkey-patches preserved across both module load paths (first-assignment-wins contract)
- **`{ once: true }` cleanup** for the URL-variant initial-load listener — cleaner than the `initialLoadHandled` flag pattern; semantics unchanged
- **Defensive variant mapping** in `_armRendererBackstop`: explicit `if/else if/else` with a `console.error` on unexpected `creativeSource` rather than silent coercion to `'url'`

## Review trail

6 commits across 1 implementation pass + 2 consolidation rounds:

1. **Implementation** (3 commits) — container backstop / SDK auto-install / proposal phase plan
2. **Round 1** — pass-1 review (Security/Code/Architect) + OpenClaw findings consolidation (8 fixes)
3. **API-reference fix-up** — Compliance Auditor verification surfaced api-reference.md staleness (2 lines)
4. **Round 2** — OpenClaw final-sweep cleanups (4 fixes: phase table flip, size budget tighten, `{ once: true }`, defensive variant mapping)

Reviewers consulted:
- Security Engineer pass-1 / Code Reviewer pass-1 / Software Architect pass-1
- Compliance Auditor verification (Phase E AC closure)
- OpenClaw three rounds (initial / round-1 cleared / final-sweep cleared)

Final Compliance Auditor 0.7.0 completeness audit: **122/124 ACs delivered, 2 deferred to Phase F (#55), 0 missing or untracked.**

## Deferred follow-ups (with tracking)

- **#69** — Browser harness Puppeteer CI integration / `location.*` interception coverage (0.8.x)
- **#72** — `<a target="_blank">` audit gap with bridge suppressed (architectural; pre-existing from Phase D, surfaced in Phase E security review)
- **#42 broader** — callback meta + non-security log tagging (Phase D's `placementSessionId` prefix was the proposal-scoped portion)

## Phase E does NOT bump SHARC_VERSION

Already at 0.7.0 (Phase D bumped). Phase E ships under the same minor version as the rest of A-D; the version tag itself is Phase G's responsibility per the Implementation Phases plan.

## Closes

- Closes #70 (Phase E Creative URL backstop + SDK nav-bridge auto-install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)