### PR TITLE
feat(container): Creative Sources Phase F — Pages deploy + KNOWN_TEST_RENDERERS guard + Creative Markup demo (#41)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -82,6 +82,8 @@ jobs:
           set -euo pipefail
           mkdir -p _site/renderer _site/dist
           cp examples/renderer/index.html _site/renderer/index.html
+          # Source maps (*.map) ship intentionally — this is an OSS reference SDK
+          # and operator debuggability matters more than source-path obfuscation.
           cp -R dist/. _site/dist/
 
           # Patch the import path. The source has exactly one occurrence

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,128 @@
+name: Deploy GitHub Pages
+
+# SHARC reference renderer + landing page deploy.
+# Phase F of issue #41 (Creative Sources); closes #55 and #23.
+#
+# Triggers:
+#   - push to `main` (default route to production Pages)
+#   - workflow_dispatch (manual re-deploy without code changes)
+#
+# Deliberately NOT triggered on PR branches — Pages has one production
+# environment per repo. A PR-branch deploy would clobber the canonical
+# renderer URL referenced by `KNOWN_TEST_RENDERERS` in
+# `src/sharc-container.js`.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Standard Pages permissions per
+# https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Don't cancel in-flight deploys; queueing keeps the canonical Pages URL
+# pointing at the latest successful build rather than aborting half-way.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Pages site
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build SDK (dist/)
+        run: npm run build
+
+      - name: Stage Pages site
+        # Path-resolution strategy (a) per Phase F brief —
+        # docs/proposals/creative-sources.md § Implementation Phases.
+        #
+        # The renderer source at examples/renderer/index.html imports
+        # `../../dist/sharc-navigation-bridge.mjs` — that resolves to
+        # repo-root `/dist/` from the source location. When deployed
+        # naively to `_site/renderer/` on Pages, that import resolves
+        # to `https://<owner>.github.io/dist/...` which is OUTSIDE the
+        # `/SHARC/` base path → 404 and the bridge silently fails to
+        # install.
+        #
+        # We stage the renderer at `_site/renderer/` and `dist/` at
+        # `_site/dist/`, then sed-rewrite the renderer's relative
+        # import from `../../dist/` (source-tree relative) to `../dist/`
+        # (deployed-tree relative). Result URL:
+        #   https://jeffreycarlson.github.io/SHARC/renderer/
+        # which matches issue #55's spec.
+        #
+        # Alternatives considered:
+        #   (b) <base href> — leaks into creative HTML's resolution
+        #       behaviour, surprising for forks
+        #   (c) Stage at _site/examples/renderer/ — preserves the
+        #       relative path verbatim but produces a URL that doesn't
+        #       match #55, and forks following the URL convention end up
+        #       at a stale path. Rejected.
+        run: |
+          set -euo pipefail
+          mkdir -p _site/renderer _site/dist
+          cp examples/renderer/index.html _site/renderer/index.html
+          cp -R dist/. _site/dist/
+
+          # Patch the import path. The source has exactly one occurrence
+          # of `../../dist/sharc-navigation-bridge.mjs`; sed -i edits in
+          # place. Verify the patch landed before continuing — a silent
+          # no-op here would publish a renderer that 404s on bridge load.
+          sed -i 's|\.\./\.\./dist/|../dist/|g' _site/renderer/index.html
+          if grep -q "\.\./\.\./dist/" _site/renderer/index.html; then
+            echo "ERROR: import-path patch did not fully replace ../../dist/ → ../dist/"
+            grep -n "\.\./\.\./dist/" _site/renderer/index.html || true
+            exit 1
+          fi
+          if ! grep -q "\.\./dist/sharc-navigation-bridge\.mjs" _site/renderer/index.html; then
+            echo "ERROR: expected '../dist/sharc-navigation-bridge.mjs' in patched renderer; not found."
+            exit 1
+          fi
+
+          # Landing page lives at _site/index.html — keeps the bare
+          # https://<owner>.github.io/SHARC/ URL from 404'ing.
+          cp docs/pages-landing.html _site/index.html
+
+          # 404 fallback (GitHub Pages-specific) — same content as the
+          # landing page so any mistyped sub-path lands somewhere useful.
+          cp docs/pages-landing.html _site/404.html
+
+          echo "=== Staged site contents ==="
+          find _site -maxdepth 3 -type f | sort
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,51 @@ changes (full detail in the sections below):
     `document.write` to throw and asserts the fallback completes the
     render and posts `:rendered`.
   - Closes proposal AC L1201 + L1202.
+- **GitHub Pages reference renderer + CI deploy** (Phase F, closes
+  [#55](https://github.com/jeffreycarlson/SHARC/issues/55) and
+  [#23](https://github.com/jeffreycarlson/SHARC/issues/23)). Adds
+  `_config.yml` and `.github/workflows/pages.yml` to deploy the
+  reference renderer at
+  `https://jeffreycarlson.github.io/SHARC/renderer/` and a minimal
+  landing page at `/SHARC/`. Workflow triggers on push to `main` and
+  `workflow_dispatch` (deliberately not on PR branches — Pages has one
+  production environment per repo). Build job stages `examples/
+  renderer/index.html` at `_site/renderer/` and `dist/*` at
+  `_site/dist/`, then sed-rewrites the renderer's relative import
+  `../../dist/` → `../dist/` so module paths resolve correctly under
+  the `/SHARC/` base path. Verification step fails the build if the
+  patch doesn't fully apply.
+- **`KNOWN_TEST_RENDERERS` production-block guard** (Phase F).
+  Operator-observable: `SHARCContainer` constructor throws
+  synchronously when `creativeRendererUrl` matches a known SHARC
+  reference test renderer URL AND `window.location.origin` is not a
+  recognized dev origin. Recognized dev origins: `localhost`,
+  `127.0.0.1`, `*.localhost`, `*.test`, `*.local`, `[::1]`, `0.0.0.0`
+  (anchored regex patterns; suffix-style spoofing such as
+  `notlocalhost.example` does NOT match). The guard runs after rule 7
+  (cross-origin) succeeds, so it only fires when the URL would
+  otherwise pass validation. Production deployments must use an
+  operator-controlled renderer URL — fork `examples/renderer/
+  index.html` and host on operator infrastructure. New module
+  constants: `KNOWN_TEST_RENDERERS` (frozen array; single entry today
+  for the fork URL, upstream URL added at IABTechLab contribution),
+  `DEV_ORIGIN_PATTERNS` (frozen array of anchored regexes). Test
+  coverage in `test-creative-sources.js` block 9.5 (14 new
+  assertions). The error message names the rejected URL and lists the
+  full dev-origin pattern set so the operator sees the failure mode
+  immediately at construction.
+- **Local Creative Markup demo** at `examples/demos/creative-markup/
+  index.html` (Phase F). Self-contained page that constructs a
+  `SHARCContainer` against the hosted reference renderer with a
+  ~1.5 KiB inline HTML banner payload (visible click target with
+  `window.open()` handler, plus a `creative-loaded` postMessage probe).
+  Live message log subscribes to `onStateChange`,
+  `onSecurityEvent`, `onError`, `onNavigation`, `onClose`,
+  `onMessage` and renders each as a tagged scrolling row. Runs ONLY
+  via `node server.cjs` (the demo and the Pages-hosted renderer are
+  intentionally on different origins to satisfy rule 7). The
+  `_config.yml` exclude list keeps `examples/demos/` out of the Pages
+  artifact.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,25 @@ SHARC is a secure container API for managed communication between a publisher-co
 
 The current v1 reference implementation targets web iframes, iOS WKWebView, and Android WebView. Future scope such as CTV is discussed in design material, but is not part of the current supported implementation surface.
 
+## Try It
+
+The SHARC project hosts a reference deployment of the Creative Markup renderer for evaluation and integration testing:
+
+- **Hosted reference renderer:** [`https://jeffreycarlson.github.io/SHARC/renderer/`](https://jeffreycarlson.github.io/SHARC/renderer/) — test/dev only; the SDK refuses to load this URL from production origins via the `KNOWN_TEST_RENDERERS` production-block guard.
+
+A local Creative Markup demo at [`examples/demos/creative-markup/`](./examples/demos/creative-markup/) drives a 300×250 placement against the hosted renderer and prints every container-side event (security events, errors, navigation requests, state changes, port handshake) to a live log:
+
+```bash
+git clone https://github.com/jeffreycarlson/SHARC.git
+cd SHARC
+npm install
+npm run build
+node server.cjs
+# open http://localhost:8765/examples/demos/creative-markup/index.html
+```
+
+The demo runs locally rather than on Pages because Pages would put the demo and renderer on the same origin, collapsing the cross-origin requirement (validation rule 7 — see [Renderer Ownership Model](./docs/proposals/creative-sources.md)). Operators evaluating SHARC for production must fork [`examples/renderer/index.html`](./examples/renderer/index.html) and self-host on operator-controlled infrastructure.
+
 ## Quick Start
 
 ### Current state

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,65 @@
+# SHARC GitHub Pages site metadata.
+#
+# This file exists so GitHub Pages will treat the repo as a Jekyll site,
+# but the active deployment path is the Actions workflow at
+# `.github/workflows/pages.yml` — it stages a curated `_site/` (landing
+# page + reference renderer + dist/) and uploads it via
+# `actions/upload-pages-artifact` + `actions/deploy-pages`. The Jekyll
+# defaults below configure the bare-bones rendering for any future
+# Markdown-driven pages and keep node_modules + tests + agent material
+# out of the published site.
+#
+# Phase F (issue #55) — see docs/proposals/creative-sources.md
+# § Implementation Phases.
+
+title: "SHARC — Secure HTML Ad Richmedia Container"
+description: >-
+  IAB Tech Lab reference implementation for a secure container protocol
+  between ad creatives and publisher pages. Modern successor to MRAID and
+  SafeFrame for rich-media display ads.
+
+# `baseurl` is the path the site is served from. Project Pages on
+# `<owner>.github.io` are always at `/<repo>`, so all links must be
+# `/SHARC/...` to resolve correctly.
+baseurl: "/SHARC"
+url: "https://jeffreycarlson.github.io"
+
+# Keep the published site narrowly scoped. The Actions workflow stages
+# `_site/` explicitly; this exclude list is belt-and-suspenders for any
+# future Jekyll-direct mode and for local `bundle exec jekyll serve`.
+exclude:
+  - .github
+  - .openclaw
+  - .claude
+  - node_modules
+  - src
+  - test
+  - examples/compliance-ads
+  - examples/compliance-ads-safeframe
+  - examples/demos
+  - examples/mraid-wrapper.html
+  - examples/safeframe-wrapper.html
+  - examples/omid-integration-test.html
+  - examples/omid-test-creative.html
+  - examples/test-classic-loading.html
+  - scripts
+  - server.cjs
+  - rollup.config.js
+  - tsconfig.types.json
+  - tsconfig.json
+  - test-creative-sources.js
+  - test-creative-sources-load.js
+  - test-creative-sources-perf.js
+  - test-creative-sdk-autoinstall.js
+  - test-navigation-bridge.js
+  - test-placement-dedup.js
+  - test-placement-stamping.js
+  - test-renderer-domparser-fallback.js
+  - test-smoke.js
+  - test-treeshake.js
+  - "*.tgz"
+  - "size-report.json"
+  - "tarball-contents.txt"
+  - vendor
+  - Gemfile
+  - Gemfile.lock

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1469,7 +1469,25 @@ The `SHARCNavigationError` throws fire INSIDE the renderer iframe (operator's fo
 
 ### Reference renderer
 
-The canonical operator-fork starting point is `examples/renderer/index.html`. Operators MUST also configure their hosting infrastructure to:
+The canonical operator-fork starting point is `examples/renderer/index.html`. The SHARC project hosts a reference deployment at:
+
+- `https://jeffreycarlson.github.io/SHARC/renderer/` — test/dev only
+
+Operators evaluating the SDK can point `creativeRendererUrl` at this hosted URL from a local dev environment without standing up a renderer host. **The hosted URL must NOT be used in production.** The container's `KNOWN_TEST_RENDERERS` guard (added in 0.7.0 / Phase F, issue #55) refuses to load the URL from non-dev origins and throws synchronously at construction with a diagnostic naming the URL and listing the recognized dev-origin patterns. Production deployments must use an operator-controlled renderer URL.
+
+Recognized dev origins (anchored regex patterns, no suffix-spoofing):
+
+- `http://localhost` (any port)
+- `https://localhost` (any port)
+- `http://127.0.0.1` (any port)
+- `https://127.0.0.1` (any port)
+- `http(s)://<subdomain>.localhost` (any port)
+- `http(s)://<subdomain>.test` (any port)
+- `http(s)://<subdomain>.local` (any port)
+- `http(s)://[::1]` (IPv6 loopback, any port)
+- `http(s)://0.0.0.0` (any port)
+
+Operators MUST also configure their hosting infrastructure to:
 
 - Serve the page with `Content-Security-Policy: object-src 'none'; base-uri 'none'` (HTTP-response CSP — the iframe `csp` attribute is Chromium-only)
 - Serve with `Cross-Origin-Resource-Policy: same-origin`

--- a/docs/pages-landing.html
+++ b/docs/pages-landing.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>SHARC — Reference Renderer + Resources (test/dev only)</title>
+<meta name="description" content="SHARC (Secure HTML Ad Richmedia Container) reference renderer and resource landing page. Test/dev only — operators must self-host in production.">
+<style>
+  :root {
+    color-scheme: light dark;
+    --fg: #1a1a1a;
+    --muted: #555;
+    --bg: #fff;
+    --accent: #0a4d92;
+    --warn-bg: #fffbe6;
+    --warn-border: #f6e6a8;
+    --warn-fg: #8a5a00;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --fg: #eee;
+      --muted: #aaa;
+      --bg: #121212;
+      --accent: #6cb2eb;
+      --warn-bg: #2a2510;
+      --warn-border: #5a4f1f;
+      --warn-fg: #f3d680;
+    }
+  }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg); }
+  body {
+    font: 16px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif;
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 32px 24px 64px;
+  }
+  h1 { font-size: 1.65rem; margin: 0 0 4px; }
+  h2 { font-size: 1.15rem; margin: 28px 0 8px; }
+  p, li { color: var(--fg); }
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.92em;
+    background: rgba(127,127,127,0.12);
+    padding: 1px 4px;
+    border-radius: 3px;
+  }
+  a { color: var(--accent); }
+  .lede { color: var(--muted); margin-top: 0; }
+  .banner {
+    background: var(--warn-bg);
+    border: 1px solid var(--warn-border);
+    color: var(--warn-fg);
+    padding: 12px 14px;
+    border-radius: 6px;
+    margin: 18px 0 24px;
+    font-size: 0.95em;
+  }
+  .banner strong { color: var(--warn-fg); }
+  ul.links { padding-left: 20px; }
+  ul.links li { margin: 6px 0; }
+  footer {
+    margin-top: 48px;
+    padding-top: 16px;
+    border-top: 1px solid rgba(127,127,127,0.25);
+    color: var(--muted);
+    font-size: 0.85em;
+  }
+</style>
+</head>
+<body>
+  <h1>SHARC</h1>
+  <p class="lede">Secure HTML Ad Richmedia Container — IAB Tech Lab reference implementation.</p>
+
+  <div class="banner">
+    <strong>Test / development only.</strong>
+    The hosted renderer below is the SHARC project's reference deployment for
+    SDK evaluation and integration testing. The container SDK refuses to load
+    this URL from production origins (see
+    <code>KNOWN_TEST_RENDERERS</code> guard).
+    Operators running SHARC in production must fork
+    <code>examples/renderer/index.html</code> and self-host on operator-controlled
+    infrastructure.
+  </div>
+
+  <h2>Hosted reference renderer</h2>
+  <p>
+    Canonical reference deployment of the Creative Markup renderer protocol.
+    Operators evaluating SHARC can point <code>creativeRendererUrl</code> at
+    this URL from a local dev environment without standing up their own
+    renderer host.
+  </p>
+  <ul class="links">
+    <li><a href="renderer/"><code>https://jeffreycarlson.github.io/SHARC/renderer/</code></a></li>
+  </ul>
+
+  <h2>Try it locally</h2>
+  <p>
+    The Creative Markup demo runs from a local dev server (same-origin policy
+    requires the demo and renderer to be on different origins, so the demo
+    cannot ship on Pages alongside the renderer).
+  </p>
+  <pre><code>git clone https://github.com/jeffreycarlson/SHARC.git
+cd SHARC
+npm install
+npm run build
+node server.cjs
+# open http://localhost:8765/examples/demos/creative-markup/index.html</code></pre>
+
+  <h2>Project</h2>
+  <ul class="links">
+    <li><a href="https://github.com/jeffreycarlson/SHARC">GitHub repository</a></li>
+    <li><a href="https://github.com/jeffreycarlson/SHARC#readme">README</a></li>
+    <li><a href="https://github.com/jeffreycarlson/SHARC/blob/main/docs/api-reference.md">API reference</a></li>
+    <li><a href="https://github.com/jeffreycarlson/SHARC/blob/main/docs/proposals/creative-sources.md">Creative Sources proposal (issue #41)</a></li>
+    <li><a href="https://github.com/jeffreycarlson/SHARC/blob/main/CHANGELOG.md">Changelog</a></li>
+  </ul>
+
+  <footer>
+    <p>
+      This minimal landing page exists so the bare Pages URL doesn't 404.
+      Phase G of the 0.7.0 release sweep replaces it with proper operator-facing docs
+      (<a href="https://github.com/jeffreycarlson/SHARC/issues/57">#57</a>).
+    </p>
+  </footer>
+</body>
+</html>

--- a/examples/demos/creative-markup/index.html
+++ b/examples/demos/creative-markup/index.html
@@ -1,0 +1,454 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>SHARC Creative Markup demo (test/dev only)</title>
+<!--
+  SHARC Creative Markup local demo (issue #41 / #55 — Phase F).
+
+  Loads the SHARC SDK from `dist/`, constructs a SHARCContainer in the
+  Creative Markup variant, and points it at the canonical SHARC reference
+  renderer hosted on GitHub Pages (`https://jeffreycarlson.github.io/SHARC/
+  renderer/`). The live message log on the right shows every container
+  -side observable event (security events, errors, navigation requests,
+  state changes, port handshake) as the protocol unfolds.
+
+  ── WHY THIS RUNS LOCALLY, NOT ON PAGES ─────────────────────────────────
+
+  Same-origin policy. The hosted renderer lives at
+    https://jeffreycarlson.github.io/SHARC/renderer/
+  If this demo were deployed alongside it on Pages, both would share the
+  `jeffreycarlson.github.io` origin — collapsing rule 7 of Phase A's
+  constructor validation (creativeRendererUrl must be cross-origin to the
+  publisher page). Local + Pages-hosted renderer = naturally cross-origin
+  because `localhost:8765` and `jeffreycarlson.github.io` are distinct
+  origins.
+
+  Anyone evaluating SHARC clones the repo and runs `node server.cjs`.
+
+  ── SDK AVAILABILITY GATE ──────────────────────────────────────────────
+
+  The container SDK module imports `./sharc-protocol` at runtime via the
+  `window.SHARC.Protocol` lookup, so we must load `sharc-protocol.mjs`
+  FIRST (it self-publishes to `window.SHARC.Protocol` on evaluation),
+  then import `sharc-container.mjs`. Both are static imports below; the
+  module loader handles ordering.
+
+  ── PRODUCTION-BLOCK GUARD ─────────────────────────────────────────────
+
+  The container's `KNOWN_TEST_RENDERERS` guard refuses to load the
+  hosted reference renderer URL from non-dev origins. localhost is a
+  dev origin, so the guard passes here. If you serve this file via a
+  non-localhost origin (e.g. an ngrok tunnel), construction throws —
+  fork the renderer to your own origin or use a recognized dev TLD
+  (`*.localhost`, `*.test`, `*.local`, `[::1]`, `0.0.0.0`).
+
+  See: docs/proposals/creative-sources.md § Renderer Ownership Model.
+-->
+<style>
+  :root {
+    color-scheme: light dark;
+    --fg: #1a1a1a;
+    --muted: #666;
+    --bg: #fafafa;
+    --panel: #fff;
+    --border: #ddd;
+    --accent: #0a4d92;
+    --warn-bg: #fffbe6;
+    --warn-border: #f6e6a8;
+    --warn-fg: #8a5a00;
+    --log-bg: #f5f5f5;
+    --log-fg: #222;
+    --log-border: #e5e5e5;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --fg: #eee;
+      --muted: #aaa;
+      --bg: #121212;
+      --panel: #1c1c1c;
+      --border: #2c2c2c;
+      --accent: #6cb2eb;
+      --warn-bg: #2a2510;
+      --warn-border: #5a4f1f;
+      --warn-fg: #f3d680;
+      --log-bg: #161616;
+      --log-fg: #ddd;
+      --log-border: #2a2a2a;
+    }
+  }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg); }
+  body {
+    font: 14px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+    padding: 20px;
+  }
+  h1 { font-size: 1.3rem; margin: 0 0 4px; }
+  .lede { color: var(--muted); margin: 0 0 16px; }
+  .banner {
+    background: var(--warn-bg);
+    border: 1px solid var(--warn-border);
+    color: var(--warn-fg);
+    padding: 10px 12px;
+    border-radius: 4px;
+    margin: 0 0 16px;
+    font-size: 0.95em;
+  }
+  .banner strong { color: var(--warn-fg); }
+  .banner code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    background: rgba(0,0,0,0.06);
+    padding: 1px 3px;
+    border-radius: 2px;
+  }
+  .layout {
+    display: grid;
+    grid-template-columns: minmax(320px, 360px) 1fr;
+    gap: 20px;
+  }
+  .panel {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 14px;
+  }
+  .panel h2 {
+    font-size: 0.95rem;
+    margin: 0 0 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--muted);
+  }
+  #placement {
+    width: 300px;
+    height: 250px;
+    border: 1px dashed var(--border);
+    background: var(--log-bg);
+    margin: 0 auto;
+    display: block;
+  }
+  .meta {
+    margin-top: 10px;
+    font-size: 0.85em;
+    color: var(--muted);
+  }
+  .meta dt {
+    font-weight: 600;
+    color: var(--fg);
+    margin-top: 4px;
+  }
+  .meta dd { margin: 0 0 4px 0; word-break: break-all; }
+  .controls { margin-top: 12px; display: flex; gap: 8px; flex-wrap: wrap; }
+  button {
+    font: inherit;
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+    background: var(--panel);
+    color: var(--fg);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  button:hover { border-color: var(--accent); color: var(--accent); }
+  #log {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    background: var(--log-bg);
+    color: var(--log-fg);
+    border: 1px solid var(--log-border);
+    border-radius: 4px;
+    height: 520px;
+    overflow-y: auto;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12px;
+  }
+  #log li {
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--log-border);
+    word-break: break-word;
+  }
+  #log li:last-child { border-bottom: none; }
+  #log li .ts { color: var(--muted); margin-right: 8px; }
+  #log li .tag {
+    display: inline-block;
+    font-size: 10px;
+    padding: 1px 5px;
+    border-radius: 3px;
+    margin-right: 6px;
+    text-transform: uppercase;
+    background: rgba(127,127,127,0.2);
+    color: var(--fg);
+  }
+  #log li .tag-error { background: #c0392b; color: #fff; }
+  #log li .tag-security { background: #d35400; color: #fff; }
+  #log li .tag-state { background: #2980b9; color: #fff; }
+  #log li .tag-render { background: #27ae60; color: #fff; }
+  #log li .tag-nav { background: #8e44ad; color: #fff; }
+  #log li .tag-info { background: rgba(127,127,127,0.3); color: var(--fg); }
+  #log li pre {
+    margin: 4px 0 0;
+    padding: 6px 8px;
+    background: rgba(0,0,0,0.04);
+    border-radius: 3px;
+    font-size: 11px;
+    white-space: pre-wrap;
+    overflow-x: auto;
+  }
+  @media (max-width: 760px) {
+    .layout { grid-template-columns: 1fr; }
+    #log { height: 360px; }
+  }
+</style>
+</head>
+<body>
+  <h1>SHARC Creative Markup demo</h1>
+  <p class="lede">Local <code>node server.cjs</code> page that exercises the renderer protocol against the canonical reference renderer.</p>
+
+  <div class="banner">
+    <strong>Test / dev only.</strong> This demo MUST be served via
+    <code>node server.cjs</code> (or any HTTP origin). It will NOT work
+    via <code>file://</code> — browsers refuse ES module imports from the
+    file scheme. The demo also depends on the
+    <code>KNOWN_TEST_RENDERERS</code> guard recognizing the host as a dev
+    origin (localhost / 127.0.0.1 / *.localhost / *.test / *.local /
+    [::1] / 0.0.0.0). See
+    <code>docs/proposals/creative-sources.md</code>
+    § Renderer Ownership Model.
+  </div>
+
+  <div class="layout">
+    <div class="panel">
+      <h2>Placement (300×250)</h2>
+      <div id="placement"></div>
+      <div class="controls">
+        <button id="btn-construct">Construct + load</button>
+        <button id="btn-close" disabled>Close</button>
+        <button id="btn-clear">Clear log</button>
+      </div>
+      <dl class="meta">
+        <dt>creativeRendererUrl</dt>
+        <dd id="meta-renderer">—</dd>
+        <dt>placementSessionId</dt>
+        <dd id="meta-session">—</dd>
+        <dt>creativeSource</dt>
+        <dd id="meta-source">—</dd>
+        <dt>creativeRendered</dt>
+        <dd id="meta-rendered">—</dd>
+      </dl>
+    </div>
+
+    <div class="panel">
+      <h2>Live message log</h2>
+      <ul id="log" aria-live="polite"></ul>
+    </div>
+  </div>
+
+<!--
+  Module load order matters: the protocol module self-publishes to
+  `window.SHARC.Protocol` on evaluation; the container module then
+  reads that namespace at module-evaluation time. Static imports are
+  resolved by the loader in dependency order, so importing both from
+  one <script type="module"> block is sufficient.
+-->
+<script type="module">
+  // From examples/demos/creative-markup/, ../../../dist/ resolves to repo-root /dist/.
+  import '../../../dist/sharc-protocol.mjs';
+  import { SHARCContainer } from '../../../dist/sharc-container.mjs';
+
+  const RENDERER_URL = 'https://jeffreycarlson.github.io/SHARC/renderer/';
+
+  // Minimal HTML banner payload (~1.5 KiB). Includes:
+  //  - visible image+text element
+  //  - a click handler that calls window.open(...) — intercepted by the
+  //    navigation bridge auto-installed in sharc-creative.js
+  //  - an inline <script> that posts a 'creative-loaded' message so the
+  //    log can confirm the creative actually evaluated
+  //
+  // Wrapped as a complete HTML document because the renderer document.writes
+  // it verbatim into its own document.
+  const CREATIVE_HTML = [
+    '<!DOCTYPE html>',
+    '<html><head><meta charset="utf-8">',
+    '<style>',
+    '  html,body{margin:0;padding:0;height:100%;background:#0a4d92;color:#fff;',
+    '  font:14px/1.4 system-ui,-apple-system,"Segoe UI",sans-serif;}',
+    '  .ad{display:flex;flex-direction:column;align-items:center;justify-content:center;',
+    '  height:100%;text-align:center;cursor:pointer;padding:12px;box-sizing:border-box;}',
+    '  .ad svg{width:48px;height:48px;margin-bottom:8px;}',
+    '  .ad h2{margin:0 0 4px;font-size:18px;}',
+    '  .ad p{margin:0;opacity:0.85;font-size:12px;}',
+    '</style></head><body>',
+    '<div class="ad" id="adRoot" role="button" tabindex="0">',
+    '  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">',
+    '    <path d="M12 2 L2 22 L22 22 Z"/>',
+    '  </svg>',
+    '  <h2>SHARC demo creative</h2>',
+    '  <p>Click anywhere to test navigation</p>',
+    '</div>',
+    '<script>',
+    '  // The renderer\'s post-load environment installs sharc-navigation-bridge',
+    '  // BEFORE document.write(creativeHtml), so window.open here is intercepted',
+    '  // and routed through SHARC.requestNavigation() → operator URL review.',
+    '  document.getElementById("adRoot").addEventListener("click", function () {',
+    '    window.open("https://example.com/landing?utm=sharc-demo", "_blank");',
+    '  });',
+    '  // Notify the publisher demo that the creative HTML actually evaluated',
+    '  // inside the renderer document. The container forwards this via the',
+    '  // standard SHARC channel; this is a low-fi parent.postMessage so the',
+    '  // demo can show the creative ran end-to-end without depending on the',
+    '  // SDK\'s message API (the creative is a static HTML banner, not a',
+    '  // SHARC-aware ad — onMessage in the container picks this up).',
+    '  try { window.parent.postMessage({ type: "creative-loaded" }, "*"); }',
+    '  catch (e) { /* no-op */ }',
+    '<\/script>',
+    '</body></html>',
+  ].join('\n');
+
+  // ── Log + UI plumbing ──────────────────────────────────────────────
+  const logEl = document.getElementById('log');
+  const metaRenderer = document.getElementById('meta-renderer');
+  const metaSession = document.getElementById('meta-session');
+  const metaSource = document.getElementById('meta-source');
+  const metaRendered = document.getElementById('meta-rendered');
+  const btnConstruct = document.getElementById('btn-construct');
+  const btnClose = document.getElementById('btn-close');
+  const btnClear = document.getElementById('btn-clear');
+
+  function logEntry(tag, label, payload) {
+    const li = document.createElement('li');
+    const ts = document.createElement('span');
+    ts.className = 'ts';
+    ts.textContent = new Date().toISOString().substring(11, 23);
+    const tagEl = document.createElement('span');
+    tagEl.className = 'tag tag-' + tag;
+    tagEl.textContent = tag;
+    const text = document.createElement('span');
+    text.textContent = label;
+    li.appendChild(ts);
+    li.appendChild(tagEl);
+    li.appendChild(text);
+    if (payload !== undefined) {
+      const pre = document.createElement('pre');
+      try {
+        pre.textContent = JSON.stringify(payload, null, 2);
+      } catch (_) {
+        pre.textContent = String(payload);
+      }
+      li.appendChild(pre);
+    }
+    logEl.appendChild(li);
+    logEl.scrollTop = logEl.scrollHeight;
+  }
+
+  metaRenderer.textContent = RENDERER_URL;
+  logEntry('info', 'Demo loaded. Click "Construct + load" to start.');
+
+  let container = null;
+
+  // Capture the creative-loaded postMessage from the inline script inside
+  // the creative HTML. event.source will be a cross-origin Window — we
+  // can't read its origin reliably, but the message shape is the marker.
+  window.addEventListener('message', (ev) => {
+    if (ev.data && ev.data.type === 'creative-loaded') {
+      logEntry('render', 'creative HTML evaluated inside renderer', {
+        origin: ev.origin,
+      });
+    }
+  });
+
+  function refreshMeta() {
+    if (!container) {
+      metaSession.textContent = '—';
+      metaSource.textContent = '—';
+      metaRendered.textContent = '—';
+      return;
+    }
+    metaSession.textContent = container.placementSessionId || '—';
+    metaSource.textContent = container.creativeSource || '—';
+    metaRendered.textContent = String(container.creativeRendered);
+  }
+
+  btnConstruct.addEventListener('click', () => {
+    if (container) {
+      logEntry('info', 'Container already constructed; close first.');
+      return;
+    }
+    const placementElement = document.getElementById('placement');
+    try {
+      container = new SHARCContainer({
+        creativeHtml: CREATIVE_HTML,
+        creativeRendererUrl: RENDERER_URL,
+        placementElement: placementElement,
+        placementId: 'demo-creative-markup',
+        placementName: 'creative-markup-demo',
+        autoStart: true,
+        onStateChange: (newState, oldState) => {
+          logEntry('state', 'state ' + oldState + ' → ' + newState);
+          refreshMeta();
+        },
+        onSecurityEvent: (ev) => {
+          logEntry('security', ev.type + ' (severity=' + ev.severity + ')', ev);
+        },
+        onError: (err) => {
+          logEntry('error', 'onError: ' + (err && err.message), err);
+        },
+        onNavigation: (req) => {
+          // operator-side URL review hook (see Navigation Bridge docs)
+          logEntry('nav', 'requestNavigation', req);
+          // For the demo, accept everything so the click-through flow runs.
+          return Promise.resolve({ allowed: true });
+        },
+        onClose: () => {
+          logEntry('info', 'onClose');
+          refreshMeta();
+        },
+        onMessage: (msg) => {
+          // Forwarded creative messages (low-volume in this demo).
+          logEntry('info', 'onMessage: ' + (msg && msg.type), msg);
+        },
+      });
+      logEntry('info', 'SHARCContainer constructed', {
+        creativeRendererUrl: container.creativeRendererUrl,
+        placementSessionId: container.placementSessionId,
+        creativeSource: container.creativeSource,
+      });
+      refreshMeta();
+      btnConstruct.disabled = true;
+      btnClose.disabled = false;
+
+      // load() drives the renderer iframe + protocol exchange.
+      if (typeof container.load === 'function') {
+        const result = container.load();
+        if (result && typeof result.then === 'function') {
+          result.then(
+            (v) => logEntry('info', 'load() resolved', v),
+            (e) => logEntry('error', 'load() rejected: ' + (e && e.message)),
+          );
+        }
+      }
+    } catch (e) {
+      logEntry('error', 'construction threw: ' + e.message);
+      container = null;
+    }
+  });
+
+  btnClose.addEventListener('click', () => {
+    if (!container) return;
+    try {
+      if (typeof container.close === 'function') container.close();
+    } catch (e) {
+      logEntry('error', 'close() threw: ' + e.message);
+    }
+    container = null;
+    btnClose.disabled = true;
+    btnConstruct.disabled = false;
+    refreshMeta();
+  });
+
+  btnClear.addEventListener('click', () => {
+    logEl.innerHTML = '';
+    logEntry('info', 'Log cleared.');
+  });
+</script>
+</body>
+</html>

--- a/examples/demos/creative-markup/index.html
+++ b/examples/demos/creative-markup/index.html
@@ -256,6 +256,7 @@
   import { SHARCContainer } from '../../../dist/sharc-container.mjs';
 
   const RENDERER_URL = 'https://jeffreycarlson.github.io/SHARC/renderer/';
+  const RENDERER_ORIGIN = new URL(RENDERER_URL).origin;
 
   // Minimal HTML banner payload (~1.5 KiB). Includes:
   //  - visible image+text element
@@ -346,9 +347,16 @@
   let container = null;
 
   // Capture the creative-loaded postMessage from the inline script inside
-  // the creative HTML. event.source will be a cross-origin Window — we
-  // can't read its origin reliably, but the message shape is the marker.
+  // the creative HTML.
+  //
+  // Defense-in-depth: only accept creative-loaded notifications from the
+  // renderer origin. Production listeners MUST filter by origin — this
+  // demo establishes that pattern. SHARC's protocol layer already
+  // validates message provenance through MessageChannel; this is the
+  // application-level pattern operators should copy when they accept
+  // raw postMessage events from the renderer iframe.
   window.addEventListener('message', (ev) => {
+    if (ev.origin !== RENDERER_ORIGIN) return;
     if (ev.data && ev.data.type === 'creative-loaded') {
       logEntry('render', 'creative HTML evaluated inside renderer', {
         origin: ev.origin,

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -632,17 +632,33 @@ class SHARCContainer {
       // before any iframe / MessageChannel / page-lifecycle listener attaches.
       // See docs/proposals/creative-sources.md § Renderer Ownership Model
       // and the KNOWN_TEST_RENDERERS / DEV_ORIGIN_PATTERNS module constants.
-      const normalizedRendererUrl = parsedRendererUrl.href;
-      const isKnownTestRenderer = KNOWN_TEST_RENDERERS.some(
-        (testUrl) => normalizedRendererUrl === testUrl
-          || normalizedRendererUrl.startsWith(testUrl)
+      //
+      // Normalize on origin+pathname so the match ignores query/fragment and
+      // catches the canonical URL whether or not the operator includes the
+      // trailing slash. GitHub Pages 301-redirects the slashless variant to
+      // the canonical URL, so both forms must trip the guard — comparing the
+      // raw `parsedRendererUrl.href` would let `…/SHARC/renderer` (no slash)
+      // slip past while `…/SHARC/renderer/` is rejected.
+      const stripTrailingSlash = (s) => s.replace(/\/+$/, '');
+      const candidatePathKey = stripTrailingSlash(
+        parsedRendererUrl.origin + parsedRendererUrl.pathname
       );
+      const isKnownTestRenderer = KNOWN_TEST_RENDERERS.some((testUrl) => {
+        const t = new URL(testUrl);
+        const tKey = stripTrailingSlash(t.origin + t.pathname);
+        // Exact match, OR candidate is under the test renderer's path prefix
+        // (e.g. '.../renderer/foo' is still the test renderer). The `+ '/'`
+        // suffix on the prefix variant prevents accidental matching of
+        // siblings like `/SHARC/renderer-other/`.
+        return candidatePathKey === tKey
+          || candidatePathKey.startsWith(tKey + '/');
+      });
       if (isKnownTestRenderer) {
         const isDevOrigin = windowOrigin !== null
           && DEV_ORIGIN_PATTERNS.some((pattern) => pattern.test(windowOrigin));
         if (!isDevOrigin) {
           throw new Error(
-            '[SHARCContainer] creativeRendererUrl "' + normalizedRendererUrl
+            '[SHARCContainer] creativeRendererUrl "' + parsedRendererUrl.href
             + '" is a known SHARC reference test renderer. Production deployments '
             + 'must use an operator-controlled renderer URL. Recognized dev origins '
             + 'are localhost / 127.0.0.1 / *.localhost / *.test / *.local / [::1] / '

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -112,6 +112,44 @@ const RENDERER_PERMISSIONS_POLICY = [
  */
 const RENDERER_IFRAME_CSP = "object-src 'none'; base-uri 'none'";
 
+/**
+ * Frozen list of canonical SHARC reference renderer URLs hosted by SHARC
+ * maintainers. These are SDK-reference deployments only — operators in
+ * production must use their own operator-controlled renderer URL. Listing
+ * a URL here trips the production-block guard in non-dev origins.
+ *
+ * When SHARC is contributed upstream to IABTechLab, add the upstream URL.
+ *
+ * Issue #55 / Phase F — see docs/proposals/creative-sources.md
+ * § Renderer Ownership Model.
+ */
+const KNOWN_TEST_RENDERERS = Object.freeze([
+  'https://jeffreycarlson.github.io/SHARC/renderer/',
+  // Future upstream: 'https://iabtechlab.github.io/SHARC/renderer/'
+  //                  added when SHARC is contributed upstream.
+]);
+
+/**
+ * Origin patterns recognized as developer/local environments. The
+ * production-block guard fires for `KNOWN_TEST_RENDERERS` only when the
+ * page origin does NOT match one of these patterns, so local dev against
+ * the canonical hosted renderer keeps working.
+ *
+ * Patterns mirror the dev-origin recognition surface called out in the
+ * Phase F brief (localhost / 127.0.0.1 / *.localhost / *.test / *.local
+ * / [::1] / 0.0.0.0). Anchored with `^` / `$` to prevent suffix-style
+ * spoofing (e.g. an attacker-controlled `notlocalhost.example`).
+ */
+const DEV_ORIGIN_PATTERNS = Object.freeze([
+  /^https?:\/\/localhost(:\d+)?$/,
+  /^https?:\/\/127\.0\.0\.1(:\d+)?$/,
+  /^https?:\/\/[a-z0-9-]+\.localhost(:\d+)?$/,
+  /^https?:\/\/[a-z0-9-]+\.test(:\d+)?$/,
+  /^https?:\/\/[a-z0-9-]+\.local(:\d+)?$/,
+  /^https?:\/\/\[::1\](:\d+)?$/,
+  /^https?:\/\/0\.0\.0\.0(:\d+)?$/,
+]);
+
 // SHARC_VERSION imported from sharc-protocol.js
 
 // ---------------------------------------------------------------------------
@@ -582,6 +620,34 @@ class SHARCContainer {
         });
         if (wrapperPolicy === 'block') {
           throw new Error('[SHARCContainer] ' + message);
+        }
+      }
+
+      // Production-block guard (issue #55 / Phase F):
+      // `KNOWN_TEST_RENDERERS` are SDK-reference deployments hosted by SHARC
+      // maintainers for evaluation and integration testing only. Loading one
+      // from a non-dev origin almost always indicates a misconfiguration that
+      // would land the canonical test URL in production traffic. The guard
+      // throws synchronously at construction so the operator sees the failure
+      // before any iframe / MessageChannel / page-lifecycle listener attaches.
+      // See docs/proposals/creative-sources.md § Renderer Ownership Model
+      // and the KNOWN_TEST_RENDERERS / DEV_ORIGIN_PATTERNS module constants.
+      const normalizedRendererUrl = parsedRendererUrl.href;
+      const isKnownTestRenderer = KNOWN_TEST_RENDERERS.some(
+        (testUrl) => normalizedRendererUrl === testUrl
+          || normalizedRendererUrl.startsWith(testUrl)
+      );
+      if (isKnownTestRenderer) {
+        const isDevOrigin = windowOrigin !== null
+          && DEV_ORIGIN_PATTERNS.some((pattern) => pattern.test(windowOrigin));
+        if (!isDevOrigin) {
+          throw new Error(
+            '[SHARCContainer] creativeRendererUrl "' + normalizedRendererUrl
+            + '" is a known SHARC reference test renderer. Production deployments '
+            + 'must use an operator-controlled renderer URL. Recognized dev origins '
+            + 'are localhost / 127.0.0.1 / *.localhost / *.test / *.local / [::1] / '
+            + '0.0.0.0. See docs/proposals/creative-sources.md § Renderer Ownership Model.'
+          );
         }
       }
     }

--- a/test-creative-sources.js
+++ b/test-creative-sources.js
@@ -524,6 +524,95 @@ console.log('test-creative-sources.js — issue #41 Phase A regression\n');
   });
   assert(operatorOk,
     'operator-controlled creativeRendererUrl succeeds from a non-dev origin');
+
+  // -- 9.5(a) URL-variant negative cases ──────────────────────────────────
+  // The guard must canonicalize on origin+pathname so trailing-slash,
+  // query, fragment, and under-prefix variants ALL trip the production
+  // block from a non-dev origin. Pages 301-redirects the slashless variant
+  // to the canonical URL, so a typo there would otherwise silently load
+  // the SDK-reference renderer in production while the guard sat quiet.
+  const urlVariants = [
+    ['https://jeffreycarlson.github.io/SHARC/renderer',     'no trailing slash'],
+    ['https://jeffreycarlson.github.io/SHARC/renderer?foo=bar', 'query string'],
+    ['https://jeffreycarlson.github.io/SHARC/renderer#frag',    'fragment'],
+    ['https://jeffreycarlson.github.io/SHARC/renderer/sub/',    'under-prefix path'],
+  ];
+  for (const [variantUrl, label] of urlVariants) {
+    let captured = null;
+    withWindowOrigin('https://example.com', () => {
+      try {
+        new SHARCContainer(markupOptions({
+          creativeRendererUrl: variantUrl,
+        }));
+      } catch (e) { captured = e; }
+    });
+    assert(captured instanceof Error
+      && captured.message.indexOf('known SHARC reference') !== -1,
+      'URL-variant guard trips: ' + label + ' ("' + variantUrl + '")');
+  }
+
+  // -- 9.5(b) Suffix-spoof negative cases for DEV_ORIGIN_PATTERNS anchors ─
+  // The dev-origin regexes are anchored with ^…$. These cases pin the
+  // anchors against future regression — each origin is NOT a dev origin
+  // (despite resembling one), so loading the canonical reference renderer
+  // from there must throw the production-block error.
+  const suffixSpoofOrigins = [
+    'https://notlocalhost.example',
+    'https://localhost.evil.com',
+    'https://app.test.attacker.io',
+    'https://app.local.evil.io',
+  ];
+  for (const origin of suffixSpoofOrigins) {
+    let captured = null;
+    withWindowOrigin(origin, () => {
+      try {
+        new SHARCContainer(markupOptions({
+          creativeRendererUrl: KNOWN_RENDERER,
+        }));
+      } catch (e) { captured = e; }
+    });
+    assert(captured instanceof Error
+      && captured.message.indexOf('known SHARC reference') !== -1,
+      'suffix-spoof origin "' + origin + '" is not a dev origin (guard trips)');
+  }
+
+  // -- 9.5(c) Rule-7-vs-guard ordering invariant ──────────────────────────
+  // When the page origin matches the renderer origin, rule 7 (cross-origin)
+  // must throw FIRST — before the production-block guard fires. This
+  // invariant matters because a same-origin renderer collapses the sandbox,
+  // and that diagnostic is more actionable than the production-block one.
+  {
+    let captured = null;
+    withWindowOrigin('https://jeffreycarlson.github.io', () => {
+      try {
+        new SHARCContainer(markupOptions({
+          creativeRendererUrl: KNOWN_RENDERER,
+        }));
+      } catch (e) { captured = e; }
+    });
+    assert(captured instanceof Error
+      && captured.message.indexOf('cross-origin to window.location') !== -1,
+      'rule 7 fires before the production-block guard at same origin');
+  }
+
+  // -- 9.5(d) Genuine non-test renderer at the same origin host ───────────
+  // The prefix match must not over-broaden: a different path under the
+  // same host is NOT in KNOWN_TEST_RENDERERS, so the guard must let it
+  // through even from a non-dev origin.
+  {
+    let constructedOk = false;
+    withWindowOrigin('https://example.com', () => {
+      try {
+        const c = new SHARCContainer(markupOptions({
+          creativeRendererUrl: 'https://jeffreycarlson.github.io/SHARC/something-else/',
+        }));
+        constructedOk = c.creativeRendererUrl
+          === 'https://jeffreycarlson.github.io/SHARC/something-else/';
+      } catch (_) { /* fall through */ }
+    });
+    assert(constructedOk,
+      'non-test path under the same host succeeds (prefix match does not over-broaden)');
+  }
 }
 
 // -- 10. Rule 8 — creativeHtml size cap (256 KiB at construction) ──────────

--- a/test-creative-sources.js
+++ b/test-creative-sources.js
@@ -421,6 +421,111 @@ console.log('test-creative-sources.js — issue #41 Phase A regression\n');
   }
 }
 
+// -- 9.5 KNOWN_TEST_RENDERERS production-block guard (issue #55, Phase F) ──
+//
+// Operators MUST self-host in production. Pointing creativeRendererUrl at the
+// SHARC project's reference deployment from a non-dev origin is treated as a
+// misconfiguration and throws synchronously at construction. The guard fires
+// AFTER rule 7 (cross-origin), so the operator only sees this throw when the
+// URL would otherwise pass validation.
+//
+// Strategy: stub `global.window` with a Proxy that intercepts `.location` to
+// return a configurable origin per case. The renderer URL itself is the
+// canonical fork-hosted reference URL (jeffreycarlson.github.io/SHARC/
+// renderer/) — this is the single entry in `KNOWN_TEST_RENDERERS` for the
+// fork; an upstream addition is gated on contribution to IABTechLab.
+{
+  console.log('\n9.5 KNOWN_TEST_RENDERERS production-block guard (issue #55)');
+
+  const KNOWN_RENDERER = 'https://jeffreycarlson.github.io/SHARC/renderer/';
+
+  const originalWindow = global.window;
+  function withWindowOrigin(origin, fn) {
+    // Wrap the real jsdom window so the constructor's reads of unrelated
+    // window properties (top, etc.) still work. Only `location.origin` is
+    // overridden — the rest passes through.
+    const stubLocation = new Proxy(originalWindow.location, {
+      get(target, prop, receiver) {
+        if (prop === 'origin') return origin;
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    global.window = new Proxy(originalWindow, {
+      get(target, prop, receiver) {
+        if (prop === 'location') return stubLocation;
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    try {
+      return fn();
+    } finally {
+      global.window = originalWindow;
+    }
+  }
+
+  // Each entry: [origin, shouldSucceed, label]
+  const devOrigins = [
+    ['http://localhost:8765', true, 'http://localhost:8765 (publisher dev port)'],
+    ['http://127.0.0.1:3000', true, 'http://127.0.0.1:3000'],
+    ['http://my-app.localhost:8080', true, 'http://my-app.localhost:8080 (subdomain)'],
+    ['http://app.test:4000', true, 'http://app.test:4000 (.test TLD)'],
+    ['http://app.local', true, 'http://app.local (.local TLD)'],
+    ['http://[::1]', true, 'http://[::1] (IPv6 loopback)'],
+    ['http://0.0.0.0:9000', true, 'http://0.0.0.0:9000'],
+  ];
+  for (const [origin, _ok, label] of devOrigins) {
+    let constructedOk = false;
+    withWindowOrigin(origin, () => {
+      try {
+        const c = new SHARCContainer(markupOptions({
+          creativeRendererUrl: KNOWN_RENDERER,
+        }));
+        constructedOk = c.creativeRendererUrl === KNOWN_RENDERER;
+      } catch (_) { /* fall through */ }
+    });
+    assert(constructedOk,
+      'known test renderer + dev origin succeeds: ' + label);
+  }
+
+  // Non-dev origins: throw with the diagnostic message.
+  const nonDevOrigins = [
+    'https://example.com',
+    'https://prod.example.org',
+  ];
+  for (const origin of nonDevOrigins) {
+    let captured = null;
+    withWindowOrigin(origin, () => {
+      try {
+        new SHARCContainer(markupOptions({
+          creativeRendererUrl: KNOWN_RENDERER,
+        }));
+      } catch (e) { captured = e; }
+    });
+    assert(captured instanceof Error
+      && /known SHARC reference test renderer/.test(captured.message),
+      'known test renderer + non-dev origin "' + origin + '" throws Error');
+    assert(captured && captured.message.indexOf(KNOWN_RENDERER) !== -1,
+      'error message names the rejected URL ("' + origin + '")');
+    assert(captured && /localhost \/ 127\.0\.0\.1/.test(captured.message),
+      'error message lists recognized dev-origin patterns ("' + origin + '")');
+  }
+
+  // Operator-controlled URL is NOT in the known list, so the guard never
+  // fires regardless of origin. (The fixture's RENDERER_URL points at a
+  // fictitious operator.example domain.)
+  let operatorOk = false;
+  withWindowOrigin('https://prod.example.org', () => {
+    try {
+      const c = new SHARCContainer(markupOptions({
+        creativeRendererUrl: 'https://renderer.example.com/0.7.0/',
+      }));
+      operatorOk = c.creativeRendererUrl === 'https://renderer.example.com/0.7.0/';
+    } catch (_) { /* fall through */ }
+  });
+  assert(operatorOk,
+    'operator-controlled creativeRendererUrl succeeds from a non-dev origin');
+}
+
 // -- 10. Rule 8 — creativeHtml size cap (256 KiB at construction) ──────────
 {
   console.log('\n10. Rule 8 — creativeHtml size cap (256 KiB)');


### PR DESCRIPTION
## Summary

Phase F of the Creative Sources epic (#41) — the deployment-and-infrastructure phase per `docs/proposals/creative-sources.md` § Implementation Phases.

- **Pages + CI deploy infra** — `_config.yml`, `.github/workflows/pages.yml`, minimal landing page. Workflow triggers on `push to main` + `workflow_dispatch` only (deliberately not PR branches — protects the canonical URL referenced by `KNOWN_TEST_RENDERERS`).
- **Reference renderer hosted at `https://jeffreycarlson.github.io/SHARC/renderer/`** — CI stages the renderer + dist artifacts, sed-rewrites the renderer's `../../dist/` import path to `../dist/` so it resolves under `/SHARC/`, and a verification step fails the build if the patch doesn't fully apply.
- **`KNOWN_TEST_RENDERERS` production-block guard** in `src/sharc-container.js` — throws synchronously at construction if the configured `creativeRendererUrl` matches the canonical hosted renderer AND the page origin is not a recognized dev origin. Dev-origin allowlist: `localhost`, `127.0.0.1`, `*.localhost`, `*.test`, `*.local`, `[::1]`, `0.0.0.0`. URL match normalizes on origin+pathname (trailing-slash agnostic) so Pages's slashless 301 variant also trips the guard.
- **Local Creative Markup demo** at `examples/demos/creative-markup/index.html` — runs via `node server.cjs` only (NOT deployed to Pages, intentionally — same-origin would defeat Phase A rule 7). Live message log + origin-filtered `creative-loaded` listener that demonstrates the application-level pattern operators must copy.
- **Docs** — README "Try it" section, CHANGELOG `[0.7.0]` Phase F bullet, `docs/api-reference.md` § Reference renderer additions covering all 7 dev-origin patterns and the guard contract.

Closes #55
Closes #23

## Renderer Ownership Model

Phase F implements the contract from `docs/proposals/creative-sources.md` § Renderer Ownership Model: **operators self-host in production; the canonical hosted renderer is SDK-reference-only.** No bypass mechanism (no `disableTestRendererGuard` flag, no per-operator override) — the contract is not opt-out-able by design.

## Documented deviations from #55 spec

Two deliberate deviations, both flagged by Pass-1 + Compliance review:

1. **Guard is container-side, not renderer-side `TEST_ONLY` constant + HTTP header.** Functionally stronger — fail-fast at construction, before any iframe/MessageChannel side effects, with an operator-friendly error pointing at the docs section. The renderer's `RENDERER_CONFIG.TEST_ONLY = true` (Phase D) and dev banner remain unchanged for the canonical hosted instance.
2. **Demo runs locally via `node server.cjs`, not at `/demos/creative-markup/` on Pages.** Required by Phase A rule 7 — co-hosting demo + renderer on `jeffreycarlson.github.io` would collapse them to same-origin and rule 7 would throw. Operators clone + run locally to evaluate. Decision recorded 2026-05-04.

## Out of scope (deferred to Phase G / #56 / #57 / Future Work)

- Demo deploy to Pages
- Custom domain for the renderer
- IAB-managed canonical renderer URL (parked as comment until upstream contribution)
- Other test harnesses (MRAID, SafeFrame, OMID, core) — #56
- Docs site polish — #57
- Phase G doc rewrites (`architecture-design.md`, `creative-cookbook.md`, `getting-started.md`, `current-status.md`)
- Spec inconsistency reconciliation (perf budgets etc.) — Phase G inconsistency catalog
- `SHARC_VERSION` bump — already at 0.7.0

## Review pipeline

- **Pass-1** — Security Engineer / Code Reviewer / Software Architect, all APPROVE-WITH-FIXES, converged on a trailing-slash bypass in the URL match
- **Consolidation round** — fixed the bypass via origin+pathname normalization with explicit prefix-match boundary, added 10 new test assertions (URL-canon variants, suffix-spoof negatives against regex anchors, rule-7-vs-guard ordering invariant, positive prefix-doesn't-over-broaden case), added origin filter to demo `creative-loaded` listener, documented source-maps decision in workflow comment
- **Compliance Auditor** — PASS-WITH-NOTES; all #55 acceptance criteria met or substantively delivered; #23 fully superseded; no scope creep
- **OpenClaw spot-check** — ship it; three P2/P3 cosmetic findings, all already triaged as accepted/deferred

## Test gate

All green:

- `npm run build`
- `npm run test:creative-sources` (block 9.5: 22 runtime assertions covering guard fire/no-fire, URL canonicalization edges, regex anchor suffix-spoof negatives, rule-7-vs-guard ordering)
- `npm run test:creative-sources-load`
- `npm run test:navigation-bridge`
- `npm run test:creative-sdk-autoinstall`
- `npm run test:types`
- `npm run test:smoke`
- `npm run test:treeshake`
- `npm run size` (no budget impact)

Manual smoke: `curl -sI http://localhost:8765/examples/demos/creative-markup/index.html` → 200; demo + dist module paths all resolve.

## Test plan

- [ ] CI: confirm Pages workflow does NOT fire on PR branch (only `main` + `workflow_dispatch`)
- [ ] Post-merge: confirm Pages workflow fires on first push to `main` and deploys renderer to `https://jeffreycarlson.github.io/SHARC/renderer/`
- [ ] Post-merge: `curl -sI https://jeffreycarlson.github.io/SHARC/renderer/` → 200 with the expected HTML
- [ ] Post-merge: `curl -sI https://jeffreycarlson.github.io/SHARC/dist/sharc-navigation-bridge.mjs` → 200 (validates the sed path-rewrite landed)
- [ ] Post-merge: clone fresh + `npm install` + `npm run build` + `node server.cjs` + browse to `http://localhost:8765/examples/demos/creative-markup/index.html` and verify end-to-end render against the live hosted renderer
- [ ] Verify slashless variant (`https://jeffreycarlson.github.io/SHARC/renderer`) still trips the production-block guard from a non-dev origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)
