### PR TITLE
chore(release): Phase G2 — date 0.7.0 CHANGELOG entry to 2026-05-05 (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
-## [0.7.0] - 2026-05-01
+## [0.7.0] - 2026-05-05
 
 Closes Creative Sources (issue #41) — the Creative Markup variant
 ships, complete with the renderer protocol, navigation bridge,


### PR DESCRIPTION
## Summary

Phase G2 of the Creative Sources epic (#41) — the final mechanical phase before tagging `v0.7.0`. **Smaller than expected**: 1 commit, 1 file, 1 line.

```
CHANGELOG.md | 2 +-
1 file changed, 1 insertion(+), 1 deletion(-)
```

`## [0.7.0] - 2026-05-01` → `## [0.7.0] - 2026-05-05`

## Why so small

Going into G2, the plan was: `npm version minor` to bump `package.json` 0.6.x → 0.7.0, propagate via `scripts/sync-version.js` to `SHARC_VERSION`, `@version` JSDoc tags, README badge/CDN URLs, and date the CHANGELOG.

When the Senior Developer ran the pre-read, every version touchpoint was **already at 0.7.0** from earlier phase work:

- `package.json`: already `"version": "0.7.0"`
- `package-lock.json`: already `0.7.0` (top-level + `packages[""]`)
- `SHARC_VERSION = '0.7.0'` in `src/sharc-protocol.js`
- All `@version 0.7.0` JSDoc tags across 7 source files (protocol, container, creative + 4 bridges)
- README.md badge `package-v0.7.0` + CDN URLs `@iabtechlab/sharc@0.7.0`

`node scripts/sync-version.js` ran idempotent: `Done. 0 file(s) updated to 0.7.0.`

The only thing actually stale was the CHANGELOG date — pre-filled `2026-05-01` (4 days early). Corrected to `2026-05-05`.

## Side findings (audit trail)

1. **Stale local `v0.7.0` tag deleted.** Found a leftover annotated tag from Phase D-era `npm version` invocation pointing at orphan commit `2da8b6e`. Never on remote (`gh api repos/jeffreycarlson/SHARC/tags` confirmed remote latest is still `v0.6.2`). Deleted via `git tag -d v0.7.0`. Branch is clean of local tags now — the real `v0.7.0` tag will be cut fresh on this PR's squash-merge commit on `main`.
2. **CLAUDE.md "Version Bump Checklist" is incomplete.** Lists 3 source files for `@version` tags but `scripts/sync-version.js` actually propagates to all 7 source files (adds the 4 bridges: mraid, safeframe, omid, navigation) plus README. Worth a docs follow-up post-0.7.0; not blocking.

## Test gate (post-bump verification)

All 12 scripts green:

- `npm run build` — clean (rollup + tsc, version 0.7.0 embedded in dist)
- `npm run test:creative-sources` — all assertions passed (18 sections including Block 9.5)
- `npm run test:creative-sources-load` — all assertions passed
- `npm run test:navigation-bridge` — all passed (3 deferred to #69, existing pattern)
- `npm run test:creative-sdk-autoinstall` — url + markup scenarios passed
- `npm run test:renderer-fallback` — round-6b fallback assertions passed
- `npm run test:placement` — placement-dedup assertions passed
- `npm run test:placement-stamping` — placement-stamping assertions passed
- `npm run test:types` — tsc clean, no errors
- `npm run test:smoke` — 7 ESM imports + IIFE artifacts validated
- `npm run test:treeshake` — passed
- `npm run size` — every artifact under budget (sharc-creative 5.54 kB / 6 kB)

## Compliance

- No force-push, no `--no-verify`
- All `gh` commands targeted `--repo jeffreycarlson/SHARC` (only `gh api repos/jeffreycarlson/SHARC/tags` was used — read-only)
- No PR opened by the implementation agent (this PR is opened by the main session orchestrator)
- No tag created or pushed (tag goes on main's squash-merge commit post-merge, per established A-G1 pattern)

## Post-merge tag procedure

After squash-merge:

```bash
git checkout main
git pull origin main
git tag -a v0.7.0 -m "SHARC 0.7.0 — Creative Sources GA (Phases A-G)" <merge-sha>
git push origin v0.7.0
```

Tag annotation references the full Phase A-G arc; `<merge-sha>` is the squash-merge commit this PR produces.

## Test plan

- [ ] OpenClaw spot-check verifies the CHANGELOG date + version touchpoints + that no stray tags pushed
- [ ] Post-merge: confirm `git tag -l 'v0.7.0'` returns nothing locally before the manual tag step
- [ ] Post-merge: tag `v0.7.0` on the squash-merge commit, push the tag, confirm via `gh release view v0.7.0 --repo jeffreycarlson/SHARC` (will 404 since no GitHub Release object — tag-only is fine for now)

## What ships at 0.7.0

The Creative Sources epic in full — Phases A through G:

- Polymorphic creative source model: Creative URL (`creativeUrl`) + Creative Markup (`creativeHtml` + `creativeRendererUrl`)
- Renderer iframe build + render protocol (`SHARC:Container:handshake`, `:render`, `:rendered`, `:failed`)
- Renderer message validation + close-mid-render handling
- Load-event backstop with `details.variant` discriminator
- Reference renderer + `SHARC:Renderer:` message protocol
- Structured `onSecurityEvent` discriminated union (5 variants)
- Navigation bridge auto-install per variant (Markup via renderer, URL via SDK init)
- GitHub Pages deploy + reference renderer hosting at `https://jeffreycarlson.github.io/SHARC/renderer/`
- `KNOWN_TEST_RENDERERS` production-block guard with 7-pattern dev-origin allowlist
- Local Creative Markup demo
- 4 substantive doc rewrites (`architecture-design.md`, `creative-cookbook.md`, `getting-started.md`, `current-status.md`) + Phase G inconsistency catalog reconciliation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
