### PR TITLE
chore(docs): post-0.7.0 housekeeping — sweep historical doc path refs (examples/test/ → test/browser/)

### DIFF
--- a/docs/design/arch-audio-volume-change.md
+++ b/docs/design/arch-audio-volume-change.md
@@ -325,7 +325,7 @@ This is a **companion implementation task** in scope for the same v1 ticket.
 
 ---
 
-## Test Harness (`examples/test/mraid-test.html`)
+## Test Harness (`test/browser/mraid-test.html`)
 
 The test harness must maintain **two independent state variables**: `currentVolumePct` (0–100) and `isMuted` (boolean). When building a `setAudioState()` call, only the dimension the user just changed is updated — the other is read from current state.
 
@@ -541,8 +541,8 @@ sharcContainer.setAudioState({ volumePercentage, isMuted })   [sharc-container.j
 - [ ] `sharc-mraid-bridge.js` — Add `mraid.getVolume()` method (reads `_s._env.volume`)
 - [ ] `sharc-creative.js` — Route `AUDIO_VOLUME_CHANGE` message → `SHARC.on('audioVolumeChange', ...)` dispatcher; forward all three args fields
 - [ ] `sharc-safeframe-bridge.js` — No changes required (v1 out of scope)
-- [ ] `examples/test/mraid-test.html` — Two independent state vars: `currentVolumePct` and `isMuted`
-- [ ] `examples/test/mraid-test.html` — Mute button calls `setAudioState({ volumePercentage: currentVolumePct, isMuted: !isMuted })`
-- [ ] `examples/test/mraid-test.html` — Volume slider calls `setAudioState({ volumePercentage: sliderValue, isMuted: isMuted })`
-- [ ] `examples/test/mraid-test.html` — Visual distinction: muted vs. volume-at-zero (separate indicator, not just slider position)
-- [ ] `examples/test/mraid-test.html` — Add `vol-slider` to enabled/disabled element list
+- [ ] `test/browser/mraid-test.html` — Two independent state vars: `currentVolumePct` and `isMuted`
+- [ ] `test/browser/mraid-test.html` — Mute button calls `setAudioState({ volumePercentage: currentVolumePct, isMuted: !isMuted })`
+- [ ] `test/browser/mraid-test.html` — Volume slider calls `setAudioState({ volumePercentage: sliderValue, isMuted: isMuted })`
+- [ ] `test/browser/mraid-test.html` — Visual distinction: muted vs. volume-at-zero (separate indicator, not just slider position)
+- [ ] `test/browser/mraid-test.html` — Add `vol-slider` to enabled/disabled element list

--- a/docs/design/prd-placement-changes.md
+++ b/docs/design/prd-placement-changes.md
@@ -588,10 +588,10 @@ Phase 2 validates the Phase 1 implementation across all four test surfaces. Ther
 
 | # | Surface | Entry Point | Loading Model | Notes |
 |---|---------|------------|---------------|-------|
-| 1 | SHARC Core Harness | `examples/test/index.html` | Direct `<script>` in creative HTML | Tests native SHARC placement change API. Creative loads `sharc-protocol.js` + `sharc-creative.js` directly. |
-| 2 | MRAID Bridge Harness | `examples/test/mraid-test.html` | Wrapper model: `.html` (DOM) + `.js` (logic) split, `__SHARC_TEST_mraidCreativeInit` callback | Tests MRAID `resize()`/`expand()`/`close()` through the SHARC-MRAID bridge. Creative uses `window.mraid` API. |
-| 3 | SafeFrame Bridge Harness | `examples/test/safeframe-test.html` | Wrapper model: `.html` (DOM) + `.js` (logic) split, `__SHARC_TEST_sfCreativeInit` callback | Tests SafeFrame `$sf.ext.expand()`/`collapse()` through the SHARC-SafeFrame bridge. Creative uses `window.$sf.ext` API. |
-| 4 | MRAID Compliance Suite | `examples/test/mraid-3-compliance-runner.html` | Compliance runner loads self-contained HTML files directly (bypasses wrapper model) | Formal IAB MRAID 3.0 compliance vectors. Self-contained creatives with inline `<script>`. Uses `EventTester`/`SequentialRunner` pattern from existing negative tests. |
+| 1 | SHARC Core Harness | `test/browser/index.html` | Direct `<script>` in creative HTML | Tests native SHARC placement change API. Creative loads `sharc-protocol.js` + `sharc-creative.js` directly. |
+| 2 | MRAID Bridge Harness | `test/browser/mraid-test.html` | Wrapper model: `.html` (DOM) + `.js` (logic) split, `__SHARC_TEST_mraidCreativeInit` callback | Tests MRAID `resize()`/`expand()`/`close()` through the SHARC-MRAID bridge. Creative uses `window.mraid` API. |
+| 3 | SafeFrame Bridge Harness | `test/browser/safeframe-test.html` | Wrapper model: `.html` (DOM) + `.js` (logic) split, `__SHARC_TEST_sfCreativeInit` callback | Tests SafeFrame `$sf.ext.expand()`/`collapse()` through the SHARC-SafeFrame bridge. Creative uses `window.$sf.ext` API. |
+| 4 | MRAID Compliance Suite | `test/browser/mraid-3-compliance-runner.html` | Compliance runner loads self-contained HTML files directly (bypasses wrapper model) | Formal IAB MRAID 3.0 compliance vectors. Self-contained creatives with inline `<script>`. Uses `EventTester`/`SequentialRunner` pattern from existing negative tests. |
 
 #### 9.2 Test Matrix
 
@@ -655,9 +655,9 @@ Each test surface requires new or updated test creatives. The following specifie
 ##### Creative 1: SHARC Core Placement Test Creative
 
 **Files:**
-- `examples/test/test-placement-creative.html` -- self-contained creative (direct `<script>` loading, same pattern as `test-creative.html`)
+- `test/browser/test-placement-creative.html` -- self-contained creative (direct `<script>` loading, same pattern as `test-creative.html`)
 
-**Harness:** SHARC Core (`examples/test/index.html`)
+**Harness:** SHARC Core (`test/browser/index.html`)
 
 **What it tests:** Native SHARC placement change API -- resize, expand, collapse, close region, constraints query, animation hints, policy rejections.
 
@@ -691,10 +691,10 @@ Each test surface requires new or updated test creatives. The following specifie
 ##### Creative 2: MRAID Resize Test Creative (updates to existing)
 
 **Files:**
-- `examples/test/test-mraid-creative.html` -- add resize controls to existing DOM
-- `examples/test/test-mraid-creative.js` -- add resize functions to existing logic
+- `test/browser/test-mraid-creative.html` -- add resize controls to existing DOM
+- `test/browser/test-mraid-creative.js` -- add resize functions to existing logic
 
-**Harness:** MRAID Bridge (`examples/test/mraid-test.html`)
+**Harness:** MRAID Bridge (`test/browser/mraid-test.html`)
 
 **What it tests:** MRAID `setResizeProperties()` + `resize()` + `close()` cycle through the SHARC-MRAID bridge.
 
@@ -718,10 +718,10 @@ Each test surface requires new or updated test creatives. The following specifie
 ##### Creative 3: SafeFrame Directional Expand Test Creative (updates to existing)
 
 **Files:**
-- `examples/test/test-safeframe-creative.html` -- add directional expand controls to existing DOM
-- `examples/test/test-safeframe-creative.js` -- add directional expand functions
+- `test/browser/test-safeframe-creative.html` -- add directional expand controls to existing DOM
+- `test/browser/test-safeframe-creative.js` -- add directional expand functions
 
-**Harness:** SafeFrame Bridge (`examples/test/safeframe-test.html`)
+**Harness:** SafeFrame Bridge (`test/browser/safeframe-test.html`)
 
 **What it tests:** SafeFrame `$sf.ext.expand()` with directional offsets (t/l/r/b), and status tracking through the expand/collapse lifecycle.
 
@@ -744,7 +744,7 @@ Each test surface requires new or updated test creatives. The following specifie
 - `examples/compliance-ads/resize-positive/resize-positive.html` -- self-contained creative with inline `<script>` (same model as `resize-negative/`)
 - `examples/compliance-ads/resize-positive/resize-positive-tests.js` -- test logic using `EventTester`/`SequentialRunner` pattern
 
-**Harness:** MRAID Compliance Suite (`examples/test/mraid-3-compliance-runner.html`)
+**Harness:** MRAID Compliance Suite (`test/browser/mraid-3-compliance-runner.html`)
 
 **What it tests:** Formal MRAID 3.0 resize compliance -- positive cases. The mirror image of the existing `resize-negative` test vector.
 
@@ -781,7 +781,7 @@ Each test surface requires new or updated test creatives. The following specifie
 
 The existing harness HTML files need modifications to support the new test creatives and policy configuration.
 
-##### `examples/test/index.html` -- SHARC Core Harness
+##### `test/browser/index.html` -- SHARC Core Harness
 
 - **Policy Configuration Panel:** Add a collapsible panel to the harness (outside the ad iframe) with controls for configuring `placementPolicy` on the `SHARCContainer` constructor:
   - `maxWidth` number input (default: empty = unconstrained)
@@ -793,17 +793,17 @@ The existing harness HTML files need modifications to support the new test creat
 - **Creative Selector:** Add dropdown or input to select between `test-creative.html` (existing) and `test-placement-creative.html` (new)
 - **Dimension/Position Readout:** Display the iframe's current computed dimensions and offset position below the ad slot, updated on every placement change
 
-##### `examples/test/mraid-test.html` -- MRAID Bridge Harness
+##### `test/browser/mraid-test.html` -- MRAID Bridge Harness
 
 - **Feature Configuration:** Add a checkbox or toggle to enable/disable `com.iabtechlab.sharc.placement.resize` feature on the container (controls whether `mraid.supports('resize')` returns true)
 - **Resize Properties Panel:** Add a collapsible panel with inputs for resize properties (width, height, offsetX, offsetY, customClosePosition dropdown, allowOffscreen checkbox, useCustomClose checkbox) so the tester can configure properties interactively rather than using hardcoded values. Note: `useCustomClose` no longer triggers bridge-side close indicator injection; it only controls whether the creative renders its own additional close visual.
 
-##### `examples/test/safeframe-test.html` -- SafeFrame Bridge Harness
+##### `test/browser/safeframe-test.html` -- SafeFrame Bridge Harness
 
 - **Directional Expand Panel:** Add a panel with number inputs for t, l, r, b offset values, pre-populated with reasonable defaults (e.g., t:50, l:0, r:100, b:0)
 - No policy panel needed -- SafeFrame creatives do not configure container policy
 
-##### `examples/test/mraid-3-compliance-runner.html` -- Compliance Runner
+##### `test/browser/mraid-3-compliance-runner.html` -- Compliance Runner
 
 - **Add new test vectors to the runner's test list:** Register `resize-positive` and `resize-sizechange` alongside the existing `resize-negative` and other test sets
 - No structural changes to the runner itself -- it already loads arbitrary compliance creatives
@@ -837,14 +837,14 @@ Phase 2 is complete when all of the following conditions are met:
 
 | Artifact | Status |
 |----------|--------|
-| `examples/test/test-placement-creative.html` | Created |
-| `examples/test/test-mraid-creative.html` (updated) | Updated with resize controls |
-| `examples/test/test-mraid-creative.js` (updated) | Updated with resize functions |
-| `examples/test/test-safeframe-creative.html` (updated) | Updated with directional expand controls |
-| `examples/test/test-safeframe-creative.js` (updated) | Updated with directional expand functions |
-| `examples/test/index.html` (updated) | Updated with policy panel and creative selector |
-| `examples/test/mraid-test.html` (updated) | Updated with feature toggle and resize props panel |
-| `examples/test/safeframe-test.html` (updated) | Updated with directional expand panel |
+| `test/browser/test-placement-creative.html` | Created |
+| `test/browser/test-mraid-creative.html` (updated) | Updated with resize controls |
+| `test/browser/test-mraid-creative.js` (updated) | Updated with resize functions |
+| `test/browser/test-safeframe-creative.html` (updated) | Updated with directional expand controls |
+| `test/browser/test-safeframe-creative.js` (updated) | Updated with directional expand functions |
+| `test/browser/index.html` (updated) | Updated with policy panel and creative selector |
+| `test/browser/mraid-test.html` (updated) | Updated with feature toggle and resize props panel |
+| `test/browser/safeframe-test.html` (updated) | Updated with directional expand panel |
 | `examples/compliance-ads/resize-positive/resize-positive.html` | Created |
 | `examples/compliance-ads/resize-positive/resize-positive-tests.js` | Created |
 | `examples/compliance-ads/resize-sizechange/resize-sizechange.html` | Created |

--- a/docs/test-creative-specs.md
+++ b/docs/test-creative-specs.md
@@ -10,16 +10,16 @@
 
 ## Overview
 
-This document specifies four test creatives and one compliance test suite for verifying the Enhanced Placement Change System. All creatives follow the established SHARC test harness patterns documented in `examples/test/CREATIVE-AUTHORING.md`.
+This document specifies four test creatives and one compliance test suite for verifying the Enhanced Placement Change System. All creatives follow the established SHARC test harness patterns documented in `test/browser/CREATIVE-AUTHORING.md`.
 
 **Test creative types:**
 
 | # | Creative | Path | Loading Model | Bridge |
 |---|----------|------|---------------|--------|
-| 1 | SHARC Core Placement | `examples/test/test-placement-creative.{html,js}` | Wrapper (mraid-wrapper.html or direct) | None (native SHARC API) |
-| 2 | MRAID Resize | `examples/test/test-mraid-resize-creative.{html,js}` | Wrapper (mraid-wrapper.html) | MRAID bridge |
+| 1 | SHARC Core Placement | `test/browser/test-placement-creative.{html,js}` | Wrapper (mraid-wrapper.html or direct) | None (native SHARC API) |
+| 2 | MRAID Resize | `test/browser/test-mraid-resize-creative.{html,js}` | Wrapper (mraid-wrapper.html) | MRAID bridge |
 | 3 | MRAID Resize Positive Compliance | `examples/compliance-ads/resize-positive/resize-positive-tests.{html,js}` | Compliance runner (mraid-3-compliance-runner.html) | MRAID bridge |
-| 4 | SafeFrame Directional Expand | `examples/test/test-safeframe-expand-creative.{html,js}` | Wrapper (safeframe-wrapper.html) | SafeFrame bridge |
+| 4 | SafeFrame Directional Expand | `test/browser/test-safeframe-expand-creative.{html,js}` | Wrapper (safeframe-wrapper.html) | SafeFrame bridge |
 
 **Conventions applied throughout:**
 
@@ -39,7 +39,7 @@ This document specifies four test creatives and one compliance test suite for ve
 
 **Note:** This creative loads differently from MRAID/SafeFrame test creatives. It uses the SHARC API directly (like `test-creative.html`) and is loaded as a standalone creative within the SHARC container, not through a bridge wrapper. It follows the same DOM/JS pattern as `test-creative.html` which loads `sharc-protocol.js` and `sharc-creative.js` via `<script src>` tags. However, since it may also be loaded through the wrapper model for testing purposes, the JS file provides a `__SHARC_TEST_placementCreativeInit` callback that is optional -- the creative self-boots via `SHARC.onReady()` when loaded standalone.
 
-### 1.1 HTML File: `examples/test/test-placement-creative.html`
+### 1.1 HTML File: `test/browser/test-placement-creative.html`
 
 ```html
 <!doctype html>
@@ -265,7 +265,7 @@ This document specifies four test creatives and one compliance test suite for ve
 </html>
 ```
 
-### 1.2 JS File: `examples/test/test-placement-creative.js`
+### 1.2 JS File: `test/browser/test-placement-creative.js`
 
 ```javascript
 // WARNING: __SHARC_TEST_placementCreativeInit is a SHARC test harness convention.
@@ -525,7 +525,7 @@ This document specifies four test creatives and one compliance test suite for ve
 
 **Purpose:** Test MRAID `resize()` and `setResizeProperties()` through the SHARC MRAID bridge. Verifies the full MRAID 3.0 resize lifecycle including state transitions, error handling, and close region behavior.
 
-### 2.1 HTML File: `examples/test/test-mraid-resize-creative.html`
+### 2.1 HTML File: `test/browser/test-mraid-resize-creative.html`
 
 ```html
 <!doctype html>
@@ -804,7 +804,7 @@ This document specifies four test creatives and one compliance test suite for ve
 </html>
 ```
 
-### 2.2 JS File: `examples/test/test-mraid-resize-creative.js`
+### 2.2 JS File: `test/browser/test-mraid-resize-creative.js`
 
 ```javascript
 // WARNING: __SHARC_TEST_mraidCreativeInit is a SHARC test harness convention.
@@ -1517,7 +1517,7 @@ All entries appear in the compliance runner's log pane or browser console.
 
 **Purpose:** Test SafeFrame `$sf.ext.expand()` with directional offsets (`t`, `l`, `r`, `b`) through the SHARC SafeFrame bridge. Verifies overlay expand, push expand rejection, collapse, and callback status transitions.
 
-### 4.1 HTML File: `examples/test/test-safeframe-expand-creative.html`
+### 4.1 HTML File: `test/browser/test-safeframe-expand-creative.html`
 
 ```html
 <!doctype html>
@@ -1774,7 +1774,7 @@ All entries appear in the compliance runner's log pane or browser console.
 </html>
 ```
 
-### 4.2 JS File: `examples/test/test-safeframe-expand-creative.js`
+### 4.2 JS File: `test/browser/test-safeframe-expand-creative.js`
 
 ```javascript
 // WARNING: __SHARC_TEST_sfCreativeInit is a SHARC test harness convention.
@@ -1977,13 +1977,13 @@ window.__SHARC_TEST_sfCreativeInit = function init() {
 
 The following harness page changes are needed but are **not part of this spec** (the spec covers creative-side test assets only):
 
-1. **`examples/test/index.html`** -- Add a link/option for `test-placement-creative.html` as a SHARC core creative.
+1. **`test/browser/index.html`** -- Add a link/option for `test-placement-creative.html` as a SHARC core creative.
 
-2. **`examples/test/mraid-test.html`** -- Add `test-mraid-resize-creative.html` to the creative dropdown/selector.
+2. **`test/browser/mraid-test.html`** -- Add `test-mraid-resize-creative.html` to the creative dropdown/selector.
 
-3. **`examples/test/safeframe-test.html`** -- Add `test-safeframe-expand-creative.html` to the creative dropdown/selector.
+3. **`test/browser/safeframe-test.html`** -- Add `test-safeframe-expand-creative.html` to the creative dropdown/selector.
 
-4. **`examples/test/mraid-3-compliance-runner.html`** -- Add `resize-positive/resize-test.html` to the compliance test list alongside the existing `resize-negative/resize-test.html` entry.
+4. **`test/browser/mraid-3-compliance-runner.html`** -- Add `resize-positive/resize-test.html` to the compliance test list alongside the existing `resize-negative/resize-test.html` entry.
 
 ---
 
@@ -1991,12 +1991,12 @@ The following harness page changes are needed but are **not part of this spec** 
 
 | File | Type | Lines (est.) | Loading Model |
 |------|------|-------------|---------------|
-| `examples/test/test-placement-creative.html` | HTML (DOM+styles) | ~180 | Standalone or wrapper |
-| `examples/test/test-placement-creative.js` | JS (all logic) | ~220 | `__SHARC_TEST_placementCreativeInit` + self-boot |
-| `examples/test/test-mraid-resize-creative.html` | HTML (DOM+styles) | ~200 | mraid-wrapper.html |
-| `examples/test/test-mraid-resize-creative.js` | JS (all logic) | ~180 | `__SHARC_TEST_mraidCreativeInit` |
+| `test/browser/test-placement-creative.html` | HTML (DOM+styles) | ~180 | Standalone or wrapper |
+| `test/browser/test-placement-creative.js` | JS (all logic) | ~220 | `__SHARC_TEST_placementCreativeInit` + self-boot |
+| `test/browser/test-mraid-resize-creative.html` | HTML (DOM+styles) | ~200 | mraid-wrapper.html |
+| `test/browser/test-mraid-resize-creative.js` | JS (all logic) | ~180 | `__SHARC_TEST_mraidCreativeInit` |
 | `examples/compliance-ads/resize-positive/resize-test.html` | HTML (self-contained) | ~15 | Compliance runner |
 | `examples/compliance-ads/resize-positive/resize-positive-tests.js` | JS (automated tests) | ~350 | Inline `<script>` from HTML |
 | `examples/compliance-ads/resize-positive/resize-test.js` | JS (shim) | ~18 | Wrapper fallback |
-| `examples/test/test-safeframe-expand-creative.html` | HTML (DOM+styles) | ~200 | safeframe-wrapper.html |
-| `examples/test/test-safeframe-expand-creative.js` | JS (all logic) | ~170 | `__SHARC_TEST_sfCreativeInit` |
+| `test/browser/test-safeframe-expand-creative.html` | HTML (DOM+styles) | ~200 | safeframe-wrapper.html |
+| `test/browser/test-safeframe-expand-creative.js` | JS (all logic) | ~170 | `__SHARC_TEST_sfCreativeInit` |


### PR DESCRIPTION
## Summary

PR 3 of 3 in the post-0.7.0 repo structure cleanup. PRs [#78](https://github.com/jeffreycarlson/SHARC/pull/78) and [#79](https://github.com/jeffreycarlson/SHARC/pull/79) shipped the must-fix items + the structural reorg respectively. This PR sweeps 51 stale `examples/test/*` references across 3 historical working documents that prescribe a path convention which no longer matches shipped state post-reorg.

**Mechanical: 1 commit, 3 files, +51/-51 LOC. `s|examples/test/|test/browser/|g` substitution.**

## Why a separate PR

The Software Architect's 2026-05-07 audit explicitly excluded `docs/design/` from PR 2's scope ("historical PRDs / architecture analyses"). PR 2's OpenClaw spot-check raised completeness — should the structural reorg also sweep these prescriptive references in dated working docs?

Splitting into a third PR:
- Keeps PR 2's structural-reorg scope clean (architectural moves only)
- Gives the doc-content sweep its own focused review
- Preserves the audit trail of "was this in original scope" vs. "follow-up cleanup"

## Files swept

| File | Type | Date | Refs |
|---|---|---|---|
| `docs/test-creative-specs.md` | Spec v1.0 | 2026-04-12 | 20 |
| `docs/design/prd-placement-changes.md` | PRD v1.2 | 2026-04-12 | 25 |
| `docs/design/arch-audio-volume-change.md` | ADR v1.1 | 2026-04-09 | 6 |

## What the sweep moves

These 3 docs prescribe future-state work (test creatives + harness usage). The path convention they reference (`examples/test/`) was changed to `test/browser/` in PR 2. After this PR:

- All 5 referenced **existing** harness files resolve correctly:
  - `test/browser/CREATIVE-AUTHORING.md`
  - `test/browser/index.html`
  - `test/browser/mraid-test.html`
  - `test/browser/safeframe-test.html`
  - `test/browser/mraid-3-compliance-runner.html`
- **Planned** test creative files (`test-placement-creative.{html,js}`, `test-mraid-resize-creative.{html,js}`, `test-safeframe-expand-creative.{html,js}`) remain planning references — the sweep just moves the planned location to match the new convention. Anyone implementing the spec would now drop the files in `test/browser/`.

## Test gate

- `npm run build` ✓
- `npm run test:smoke` ✓

(Docs-only; no code paths affected.)

## Test plan

- [ ] Verify zero remaining `examples/test/` refs in active code paths: `git grep "examples/test/" -- ':!docs/research' ':!docs/reviews' ':!CHANGELOG.md'` returns zero hits
- [ ] OpenClaw spot-check on the latest commit (please pull `74c8e3e`, not an earlier checkout)
- [ ] Note: dated review files in `docs/reviews/` may still contain `examples/test/` references — those are point-in-time audit snapshots, intentionally retained per PR 1 + PR 2 precedent. Out of scope for this sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

