### PR TITLE
chore(ci): release.yml — auto-create GitHub Release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,15 @@ jobs:
             exit 0
           fi
 
+          # Detect prerelease tags by the SemVer dash convention (e.g.
+          # `v0.8.0-rc.1`, `v1.0.0-beta`). Stable tags get `--latest`;
+          # prerelease tags get `--prerelease` and are NOT marked latest.
+          if [[ "$VERSION" == *-* ]]; then
+            RELEASE_FLAG=(--prerelease)
+          else
+            RELEASE_FLAG=(--latest)
+          fi
+
           # Extract the matching CHANGELOG section. Pattern matches the version
           # header (`## [X.Y.Z]`) and stops at the next `## [` header.
           NOTES_FILE=$(mktemp)
@@ -112,11 +121,11 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --title "SHARC $VERSION" \
               --generate-notes \
-              --latest
+              "${RELEASE_FLAG[@]}"
           else
             gh release create "$TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --title "SHARC $VERSION" \
               --notes-file "$NOTES_FILE" \
-              --latest
+              "${RELEASE_FLAG[@]}"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,3 +81,42 @@ jobs:
           name: dist-${{ github.ref_name }}
           path: dist/
           if-no-files-found: error
+
+      - name: Create GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+
+          # Skip if a release already exists for this tag (idempotent re-runs).
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::notice title=Release already exists::$TAG release exists; skipping creation."
+            exit 0
+          fi
+
+          # Extract the matching CHANGELOG section. Pattern matches the version
+          # header (`## [X.Y.Z]`) and stops at the next `## [` header.
+          NOTES_FILE=$(mktemp)
+          awk -v v="$VERSION" '
+            $0 ~ "^## \\[" v "\\]" {flag=1; next}
+            /^## \[/ {flag=0}
+            flag
+          ' CHANGELOG.md > "$NOTES_FILE"
+
+          if [ ! -s "$NOTES_FILE" ]; then
+            echo "::warning title=Empty release notes::No CHANGELOG section found for version $VERSION. Falling back to GitHub auto-generated notes."
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "SHARC $VERSION" \
+              --generate-notes \
+              --latest
+          else
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "SHARC $VERSION" \
+              --notes-file "$NOTES_FILE" \
+              --latest
+          fi


### PR DESCRIPTION
## Summary

Closes a gap in the existing `release.yml` workflow: it published to npm and uploaded dist artifacts on tag push, but never created the GitHub *Release* object — so 9 of 10 pushed tags shipped as bare tags with no polished landing page.

**1 commit, 1 file, +39 LOC.**

## Backfill done before this PR

9 GitHub Releases were created manually before this PR opened, addressing the pre-existing gap:

- `v0.7.0` — created with curated title "SHARC 0.7.0 — Creative Sources GA", marked Latest
- `v0.6.2`, `v0.6.1`, `v0.6.0`, `v0.5.4`, `v0.5.3`, `v0.5.2`, `v0.5.1` — backfilled with CHANGELOG-extracted notes, generic titles "SHARC X.Y.Z", marked non-latest
- `v0.5.0` was already a Release (the only one that existed pre-session)

After this PR lands, future tag pushes auto-create the Release object — no manual `gh release create` needed.

## What this PR adds

A new step `Create GitHub Release` to `release.yml`, runs after the existing `Upload dist artifact` step:

```yaml
- name: Create GitHub Release
  shell: bash
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    TAG: ${{ github.ref_name }}
  run: |
    set -euo pipefail
    VERSION="${TAG#v}"

    # Idempotent re-runs
    if gh release view "$TAG" ... ; then
      echo "::notice ::Release already exists; skipping creation."
      exit 0
    fi

    # Extract `## [X.Y.Z]` section to next `## [` header
    NOTES_FILE=$(mktemp)
    awk -v v="$VERSION" '...' CHANGELOG.md > "$NOTES_FILE"

    if [ ! -s "$NOTES_FILE" ]; then
      gh release create "$TAG" --title "SHARC $VERSION" --generate-notes --latest
    else
      gh release create "$TAG" --title "SHARC $VERSION" --notes-file "$NOTES_FILE" --latest
    fi
```

## Design choices

- **Idempotent** — checks `gh release view` first, exits cleanly if a Release already exists. Handles workflow re-runs safely.
- **Defensive fallback** — if the CHANGELOG section is empty (e.g. tag pushed without updating CHANGELOG), uses GitHub's auto-generated notes via `--generate-notes`. Step never fails the workflow due to missing notes.
- **`--latest` always set** — assumes tags are pushed chronologically (common case). For backfill / out-of-order tags, this would be wrong, but those are manual operations anyway.
- **Uses gh CLI** — preinstalled on `ubuntu-latest` runners. No additional action dependencies.
- **`GITHUB_TOKEN`** — already has `contents: write` permission from the existing workflow. No new permissions needed.

## Out of scope

- Asset attachments — source archives auto-attach. Could later attach the npm tarball produced by `npm pack`, but for pre-publish (NPM_TOKEN not yet set) the value is low.
- Pre-release / draft handling — all current tags are stable. If a `v0.X.Y-rc.1` tag pattern is introduced later, the step could detect that and use `--prerelease`.
- CHANGELOG dating in the Release title — current backfills use generic "SHARC X.Y.Z" titles. Could enhance to extract the date from the CHANGELOG header if desired.

## Test gate

- `npm run build` ✓
- `npm run test:smoke` ✓

(Workflow-only change; no runtime code path affected. Real validation comes on the next tag push.)

## Test plan

- [ ] Spot-check the awk extract logic against `CHANGELOG.md` for at least one version (verify the section bounds match)
- [ ] Verify `permissions: contents: write` already in the workflow (yes, line 9)
- [ ] On the next 0.7.x patch or 0.8.0 tag push, confirm the Release object appears at `github.com/jeffreycarlson/SHARC/releases/tag/<TAG>` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
