### PR TITLE
chore(release): bump to 0.7.1 + CHANGELOG date (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-05-10
+
 ### Added
 
 - **Container-driven bridge loading** ([#82]). `SHARCContainer` now detects

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # SHARC (Secure HTML Ad Richmedia Container)
 
-![Package status](https://img.shields.io/badge/package-v0.7.0%20(pre--publish)-informational)
+![Package status](https://img.shields.io/badge/package-v0.7.1%20(pre--publish)-informational)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/InteractiveAdvertisingBureau/SHARC/actions/workflows/ci.yml/badge.svg)](https://github.com/InteractiveAdvertisingBureau/SHARC/actions/workflows/ci.yml)
 
 Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol reference implementation.
 
 > 📋 This repository is the current SHARC reference implementation and working specification set.
-> It is in active pre-1.0 development at package version `0.7.0` and is not yet published to npm.
+> It is in active pre-1.0 development at package version `0.7.1` and is not yet published to npm.
 > Start with the curated docs index at [docs/README.md](docs/README.md) and the current state summary at [docs/current-status.md](docs/current-status.md).
 
 ## Overview
@@ -83,9 +83,9 @@ All public entry points build into `dist/` as ESM (`.mjs`) plus browser/IIFE bun
 
 After the package is published, public CDN URL patterns should mirror the current `dist/` filenames:
 
-- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.0/dist/sharc-container.js`
-- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.0/dist/sharc-creative.js`
-- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.0/dist/sharc-protocol.js`
+- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.1/dist/sharc-container.js`
+- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.1/dist/sharc-creative.js`
+- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.1/dist/sharc-protocol.js`
 
 Versioning guidance:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iabtechlab/sharc",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol",
   "type": "module",
   "files": [

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -26,7 +26,7 @@
  * container.load();
  * ```
  *
- * @version 0.7.0
+ * @version 0.7.1
  */
 
 'use strict';

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -34,7 +34,7 @@
  * </script>
  * ```
  *
- * @version 0.7.0
+ * @version 0.7.1
  */
 
 'use strict';

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -14,7 +14,7 @@
  *   3. sharc-mraid-bridge.js → window.mraid (this file)
  *   4. <MRAID creative>
  *
- * @version 0.7.0
+ * @version 0.7.1
  * @see mraid-bridge-design.md
  */
 

--- a/src/sharc-navigation-bridge.js
+++ b/src/sharc-navigation-bridge.js
@@ -78,7 +78,7 @@
  *
  * Spec: docs/proposals/creative-sources.md § Click-through enforcement.
  *
- * @version 0.7.0
+ * @version 0.7.1
  */
 
 'use strict';

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -28,7 +28,7 @@
  *   - creativeType and impressionType MUST be set before impressionOccurred()
  *   - AdSession must be started before any events are fired
  *
- * @version 0.7.0
+ * @version 0.7.1
  * @see https://iabtechlab.com/standards/open-measurement-sdk/
  * @see https://github.com/IABTechLab/SHARC
  */

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -13,7 +13,7 @@
  *
  * Both extend SHARCProtocolBase which provides the shared message bus.
  *
- * @version 0.7.0
+ * @version 0.7.1
  * @see https://github.com/IABTechLab/SHARC
  */
 
@@ -27,7 +27,7 @@
 // ---------------------------------------------------------------------------
 
 /** Current SHARC spec version this implementation conforms to. */
-const SHARC_VERSION = '0.7.0';
+const SHARC_VERSION = '0.7.1';
 
 /**
  * Renderer protocol version — bumps independently of {@link SHARC_VERSION}.

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -19,7 +19,7 @@
  *   - exp-push (push expand) — deferred to v2; fires 'failed' callback
  *   - $sf.ext.cookie() — permanently excluded; fires 'failed' callback
  *
- * @version 0.7.0
+ * @version 0.7.1
  * @see safeframe-bridge-design.md
  */
 


### PR DESCRIPTION
## Summary

Mechanical version bump for the 0.7.1 patch release. Per the established G2-style precedent for 0.7.0, this is a small focused PR separate from the substantive 0.7.1 work shipped via PR #87.

**1 commit, 11 files, +18/-16 LOC.** Pure version-stamp + CHANGELOG dating.

## Changes

`scripts/sync-version.js` (invoked by `npm version patch`) propagated 0.7.0 → 0.7.1 across:

- `package.json` + `package-lock.json`
- `SHARC_VERSION` constant in `src/sharc-protocol.js`
- `@version` JSDoc tags in 7 source files (sharc-protocol, sharc-container, sharc-creative, sharc-mraid-bridge, sharc-safeframe-bridge, sharc-omid-bridge, sharc-navigation-bridge)
- README.md version badge + CDN URL patterns

Plus one manual edit beyond sync-version.js coverage:

- `README.md:10` prose line (`at package version 0.7.0` → `0.7.1`). Same sync-version.js gap noted in issue #86; manual fix per Phase G2 precedent.

CHANGELOG.md heading move:

- `[Unreleased]` → `[0.7.1] - 2026-05-10`
- New empty `[Unreleased]` placeholder retained above

## Test gate

All green with new version embedded in dist:

- `npm run build`
- `npm run test:bridges-detection`
- `npm run test:creative-sources`
- `npm run test:creative-sources-load`
- `npm run test:smoke`
- `npm run test:types`
- `npm run size` (no budget impact)

## Tag procedure (post-merge)

After this PR squash-merges to `main`:

```bash
git checkout main && git pull origin main
MERGE_SHA=$(git rev-parse HEAD)
git tag -a v0.7.1 -m "SHARC 0.7.1 — Container-driven bridge loading (#82)" "$MERGE_SHA"
git push origin v0.7.1
```

`release.yml` (shipped in PR #81) will auto-create the GitHub Release with notes extracted from the `[0.7.1] - 2026-05-10` CHANGELOG section.

## Test plan

- [ ] CI green on this PR (per branch protection)
- [ ] Post-merge: tag `v0.7.1` on the squash-merge commit
- [ ] Post-merge: `release.yml` workflow fires on tag push and creates the GitHub Release
- [ ] Post-merge: verify the Release page at `github.com/jeffreycarlson/SHARC/releases/tag/v0.7.1` has the expected notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
