### PR TITLE
feat(89): non-SHARC creative loading + framework detection (0.7.2 PR 1/3)

### DIFF
--- a/docs/design/0.7.2-NEXT-SESSION-PROMPT.md
+++ b/docs/design/0.7.2-NEXT-SESSION-PROMPT.md
@@ -1,0 +1,123 @@
+# Next-session bootstrap prompt for SHARC 0.7.2 Stage 3
+
+**Copy/paste the prompt below into a fresh Claude Code session to pick up Stage 3 (spike comparison) cleanly.**
+
+The fresh session has no context from the prior conversation. The prompt + the snapshot doc at `docs/design/0.7.2-WORK-IN-PROGRESS.md` + the locked design at `docs/design/0.7.2-non-sharc-loading.md` + project memory should give it everything it needs.
+
+---
+
+## The prompt (copy below this line)
+
+I'm picking up an in-flight design workstream for SHARC 0.7.2. Plan C methodology, Stages 1+2 complete; **Stage 3 (spike comparison) is next**. Don't re-derive anything — read the existing artifacts and execute Stage 3 cleanly.
+
+## Start by reading these (in order)
+
+1. **`docs/design/0.7.2-WORK-IN-PROGRESS.md`** in the worktree at `/Users/openclaw/.openclaw/workspace-dev/github/jeffreycarlson/SHARC-claude/` — full session-state snapshot. Read end-to-end. This is your most useful single artifact.
+
+2. **`docs/design/0.7.2-non-sharc-loading.md`** (same worktree) — the locked design. 11,522 words, 16 sections. The deliverable for Stage 3 compares this against the spike.
+
+3. Project memory:
+   - `project_plan_c_methodology.md` — the methodology
+   - `project_proposal_split_release_plan.md` — release context (0.7.0 + 0.7.1 GA; 0.7.2 first-half design locked)
+   - `project_adcom_anchor.md` — AdCOM-aligned framework detection (relevant to Q3 lock)
+   - `feedback_focused_pr_splits.md` — PR scope discipline
+   - `feedback_verify_before_flipping.md`, `feedback_commit_dont_hedge.md` — voice/disposition
+
+4. **Issue #89** via `gh issue view 89 --repo jeffreycarlson/SHARC` — the originating issue for 0.7.2 first-half work.
+
+## Where things live (filesystem layout)
+
+| Location | Branch | Purpose |
+|---|---|---|
+| `/Users/openclaw/.openclaw/workspace-dev/github/jeffreycarlson/SHARC` | `spike/sharc-creative-validator` | Spike branch with parallel 0.7.2 implementation + uncommitted WIP. **READ-ONLY** for Stage 3 purposes. |
+| `/Users/openclaw/.openclaw/workspace-dev/github/jeffreycarlson/SHARC-claude` | `feat/89-non-sharc-loading` | Clean worktree holding the locked design. **Stage 3 work happens here.** |
+
+Both worktrees share the same `.git/` (different working trees pointing at the same repo).
+
+## What Stage 3 produces
+
+A comparison report covering the axes in the snapshot doc's "What Stage 3 needs to produce" section. Specifically:
+
+1. **Convergence table** — axes where the locked design and the spike landed on the same shape (validates both)
+2. **Divergence table** — axes where they differ + why each side's choice is justified
+3. **Spike-only items** — what's in the spike not in the design (scope creep or genuine insight?)
+4. **Design-only items** — what's in the design not in the spike (Plan C win or over-engineering?)
+5. **Stage 4 recommendation** — full implement-per-design / hybrid cherry-pick / adopt-spike-with-tweaks
+
+## Comparison axes (verbatim from snapshot doc)
+
+| Axis | Locked design | Spike to verify against | Convergence? |
+|---|---|---|---|
+| Constructor option name | `requireSharcInit` | spike commit `06f0c1f` | ? |
+| Default value | `true` | ? | ? |
+| Type validation | throw on null | ? | ? |
+| Variant interaction | identical for URL + Markup | ? | ? |
+| Which timeouts skip | createSession only | ? | ? |
+| `apiFramework` accessor | new (AdCOM integer code) | ? | ? |
+| `hasSharcSession` accessor | new (boolean) | ? | ? |
+| Framework detection layer | three-layer pattern | ? | ? |
+| G12 SHARC supersession logic | priority-aware bridge resolver | ? | ? |
+| HTML lifecycle adapter | NEW in 0.7.2 | ? | ? |
+| MRAID/SafeFrame lifecycle | deferred to 0.7.3 | ? | ? |
+| Bridge auto-install no-SHARC | `console.warn` + no install (G9) | ? | ? |
+| Late handshake handling | framework-aware warn | ? | ? |
+| Extension `augmentEnvironmentData()` auto-call | NOT in design | spike has it | ? |
+| OMID container-side wiring | excluded from 0.7.2 first half | spike has it | ? |
+| Test surface | jsdom + framework picker + HTML adapter tests | `test-require-sharc-init.js` 158 lines | ? |
+| Security invariants (G1-G12) | explicitly preserved | ? | ? |
+| Operator close-responsibility | cookbook callout | ? | ? |
+
+## Reading the spike
+
+Three spike commits to inspect:
+
+| Commit | Summary |
+|---|---|
+| `06f0c1f` | SHARC 0.7.2: `requireSharcInit` option + OMID container-side wiring |
+| `684a045` | fix(changelog): restore missing `## [0.7.0]` heading swallowed by 0.7.2 entry |
+| `102e894` | wire `requireSharcInit` through bid-validator → sharc container harness |
+
+Read each commit with `git -C /Users/openclaw/.openclaw/workspace-dev/github/jeffreycarlson/SHARC show <commit>` (NOT in the SHARC-claude worktree — read against the spike's working tree).
+
+Also check uncommitted WIP on the spike with `git -C /Users/openclaw/.openclaw/workspace-dev/github/jeffreycarlson/SHARC status` — OpenClaw may have made additional changes between sessions. Use those as additional signal but recognize they're not "committed implementation."
+
+## Hard rules
+
+- Do NOT edit the spike's working tree (it's OpenClaw's WIP)
+- Do NOT commit anything to the design branch yet (Stage 4 decides what ships)
+- All `gh` commands include `--repo jeffreycarlson/SHARC`
+- Operate primarily in the `SHARC-claude` worktree; read the spike via `git -C /path/to/SHARC ...` rather than `cd`
+- The comparison happens at the synthesis layer (you, the main session) — don't delegate to subagents unless the comparison surfaces a substantive design question that needs architect/PM/SE input
+
+## Stage 4 path-forward criteria
+
+Based on the comparison:
+
+- **High convergence (>80%)**: Adopt spike's code with small tweaks. Plan B-equivalent but with retroactive design rigor.
+- **Mixed convergence (40-80%)**: Cherry-pick from spike where it matches design; reimplement where it diverges.
+- **Low convergence (<40%)**: Discard spike's implementation; implement per design fresh. Pure Plan C.
+
+Strong divergence on architectural shape (framework detection, lifecycle adapter, G12 supersession) suggests **the design wins on architectural breadth**. Strong convergence on the simple boolean (option name + default) suggests **the design wins on validation, but the implementation churn isn't needed**. Likely outcome: **hybrid cherry-pick** — adopt spike's `requireSharcInit` boolean + tests; implement design's framework-detection layer + HTML lifecycle adapter + G12 supersession + G1-G12 guardrails fresh.
+
+But that's speculation — the actual comparison may surface different signal.
+
+## Report format
+
+After Stage 3:
+
+1. Convergence table (axes + design + spike + verdict per row)
+2. Divergence table (same shape)
+3. Spike-only items (likely: scope creep into OMID + validator-coupling)
+4. Design-only items (likely: framework detection, HTML adapter, G12, G1-G12)
+5. Stage 4 recommendation with rationale
+6. Open questions or items needing Jeffrey's input
+
+Aim for ~1500-2500 words total. Tight tables; minimal prose.
+
+## After Stage 3
+
+Stage 4 (decide path forward) and Stage 5 (execute the chosen path: implementation + review pipeline). Both require Jeffrey's input — don't auto-proceed past Stage 3 without confirming the path.
+
+---
+
+End of bootstrap prompt.

--- a/docs/design/0.7.2-STAGE-3-COMPARISON.md
+++ b/docs/design/0.7.2-STAGE-3-COMPARISON.md
@@ -1,0 +1,152 @@
+# SHARC 0.7.2 — Stage 3 Spike Comparison
+
+**Date:** 2026-05-15
+**Stage:** Plan C Stage 3 — locked design vs. parallel spike implementation
+**Locked design:** `docs/design/0.7.2-non-sharc-loading.md` (16 sections, ~12k words, refined 2026-05-15)
+**Spike branch:** `spike/sharc-creative-validator` (commits `06f0c1f`, `684a045`, `102e894` + uncommitted WIP)
+
+---
+
+## TL;DR
+
+The spike and the locked design operate at **different architectural layers**. They share a small behavioral surface (the `requireSharcInit` boolean in the container constructor) where convergence is high. Outside that surface they barely overlap:
+
+- **Design** lives at the **container layer** — new accessors, framework detection in `_resolveApiFramework`, HTML lifecycle adapter, G1–G12 security guardrails, state-machine edge addition.
+- **Spike** lives at the **validator/harness layer** — bid-validator framework detection, orchestrator container-routing, harness bypass when no SHARC declaration. The container-side change is one ~45-line constructor option + extension auto-call.
+
+**Stage 4 decision (Jeffrey, 2026-05-15): implement #89 fresh per the locked design; park the spike branch until #89 merges; then update the validator to use the shipped 0.7.2 architecture.** Reverse-signal pass on the spike's container-side work yielded two small items (extension error-resilience pattern → noted for 0.7.2 second-half; renderer backstop skip-first → separate PR), neither of which changes the locked #89 design. See § 5 for the full disposition.
+
+---
+
+## 1. Convergence table
+
+| Axis | Locked design | Spike | Verdict |
+|---|---|---|---|
+| Constructor option name | `requireSharcInit` | `requireSharcInit` | ✅ Identical |
+| Default value | `true` (strict) | `true` (strict) | ✅ Identical |
+| Location of guard in `load()` | wrap `_startSessionTimeout()` | wrap `_startSessionTimeout()` | ✅ Identical (commit `06f0c1f` line ~1135) |
+| Variant interaction | identical for URL + Markup | identical (no variant branching) | ✅ Identical |
+| Which timeouts skip | only `createSession` | only `createSession` | ✅ Identical |
+| Wire-format impact | none | none ("container-local flag") | ✅ Identical |
+| Test infrastructure | jsdom-primary, deferred Puppeteer/browser harness | jsdom (`test-require-sharc-init.js`, 158 lines) | ✅ Same approach |
+| Renderer backstop scope | G2 stays armed regardless | uncommitted WIP refines backstop with skip-first for Markup `document.write` | ✅ Compatible — spike WIP enhances G2 without weakening it |
+| Version 0.7.2 framing | "first half" (non-SHARC loading); OMID is second half | `package.json` set to 0.7.2 unilaterally with OMID baked in | ⚠️ Same target version, different scope split |
+
+The behavioral surface where the actual `requireSharcInit` option exists is **highly convergent**. Both implementations gate `_startSessionTimeout()` on a boolean, both default `true`, both leave wire format untouched. The spike got the small piece right.
+
+---
+
+## 2. Divergence table
+
+| Axis | Locked design | Spike | Why each is justified | Stage 4 disposition |
+|---|---|---|---|---|
+| Type validation on the option | Throw `TypeError` if value is not `undefined \| boolean` (Q4) | `this._requireSharcInit = requireSharcInit !== false` — coerces all non-`false` values to `true` (including `null`, `0`, `''`, strings, etc.) | Design favors loud failure on operator mistakes; spike favors defensive normalization (its own test #4 asserts `[undefined, null, 0, '']` all → `true`) | **Adopt design.** Operator-input strict validation is the SHARC convention (`allowPopups` family). Spike's silent coercion masks bugs. |
+| Framework detection location | Inside the container — `_resolveApiFramework(creativeMeta)` returns the AdCOM code; exposed via `container.apiFramework` getter | Inside the bid-validator tooling — `sanitizeApiDeclarations()` + `isSharcRuntime()` exported from `tools/creative-validator/src/bid-validator.js`; container has no equivalent | Different consumers: design serves operators who construct `SHARCContainer` directly; spike serves the validator tooling | **Both stay.** Container-side is the canonical SHARC capability (operator-facing). Tooling-side stays as harness-internal optimization. They are not competitors. |
+| SHARC API code values | Placeholder constants `SHARC_API_CODE`, `SAFEFRAME_API_CODE` (numeric values locked at AdCOM publication, § 6.3) | Hardcoded `[10, 11, 12]` for "SHARC 1.0, 1.1, 2.0 draft" in `SHARC_API_CODES` set | Spike picked plausible-but-unofficial integers; design defers to AdCOM publication | **Adopt design's constant pattern.** When AdCOM publishes, the spike's hardcoded array won't necessarily match. Refactor to named constants in `src/sharc-protocol.js`. |
+| OMID container-side wiring | Excluded from 0.7.2 first half; defer to 0.7.2 second half (Q5) | Spike auto-calls extension `augmentEnvironmentData()` at construction time for every extension exposing it — primary consumer is OMID | Spike shipped OMID first half together; design split it for scope discipline + independent design pass | **Defer per design.** Move spike's `augmentEnvironmentData` auto-call to 0.7.2 second-half design pass. Don't ship as first half. |
+| `container.apiFramework` accessor | New in 0.7.2; frozen at construction (G10); JSDoc anchored to AdCOM `APIFramework` | Not present | Design adds operator-facing diagnostic surface; spike has equivalent signal in validator-layer payload (`payload.sharc.requireSharcInit`) | **Adopt design.** Operators using `SHARCContainer` directly need it; tooling-layer signal doesn't satisfy that audience. |
+| `container.hasSharcSession` accessor | New in 0.7.2; getter proxying `_sessionId` | Not present | Design adds outcome-driven companion to declaration-driven `apiFramework` | **Adopt design.** Trivial implementation (~0.25h); operator value is the disambiguation vs. `sessionId !== null`. |
+| HTML lifecycle adapter (§ 8) | New `src/lifecycle-adapters/{base,html}-adapter.js`; drives `LOADING → ACTIVE` for non-handshake creatives; ~8h estimate | Not present | Design adds lifecycle observability for non-SHARC creatives; spike's harness bypasses SHARCContainer entirely for non-SHARC, so adapter wasn't needed in the spike model | **Adopt design.** This is the lifecycle-observability promise of #89 Option C; without it the container is functionally inert post-LOADING for non-SHARC creatives. |
+| State machine `LOADING → ACTIVE` edge (§ 4.5) | One added edge in `STATE_TRANSITIONS` | Not present | Required by HTML adapter (above); spike doesn't need it because it doesn't have the adapter | **Adopt design.** Required for the adapter; trivial diff. |
+| G7 framework-aware late handshake warn | Late `createSession` after `requireSharcInit: false` emits `console.warn` with 4 forensic fields; matrix branched on declared framework | Not present | Closes SE confused-deputy gap; spike doesn't surface this signal at all | **Adopt design.** SE flagged the gap; warn is the diagnostic-loudness payoff that compensates for the lost fatal-timeout. |
+| G9 bridge auto-install timeout warn | Bridge module emits `console.warn` with strict integer cap value on auto-install timeout | Not present (no bridge auto-install changes in spike) | Operational visibility for bridge wiring failures | **Adopt design.** Independent of the rest; ~1h work in bridge modules. |
+| G10 frozen `apiFramework` invariant | MUST be non-writable, never mutated by handshake or late callbacks | Not present (no accessor exists) | Locks an immutability invariant that prevents operator-dashboard drift | **Adopt design.** Required as part of `apiFramework` accessor. |
+| G11 cookbook lint (temporal coupling) | Manual at-merge verification + optional CI grep check | Not present | Doc-surface guardrail | **Adopt design + upgrade.** Make CI grep check required, not optional, since merge-time verification is the kind of thing that gets skipped under pressure (review pushback item from earlier in this session). |
+| G12 SHARC supersession | Priority-aware bridge resolver inhibits MRAID/SafeFrame bridges when SHARC code is declared; OMID stays orthogonal | Not present (spike's `_mapAdComApisToBridges` predates this design) | Honors creative-author intent for portable creatives | **Adopt design.** ~1h work in `_mapAdComApisToBridges`. |
+| `creativeMeta.apis` enrichment from `imp.banner.api` | Not in design (creativeMeta is operator-supplied) | Spike's `extractCreativeMetaApis()` merges `imp.banner.api` from matched impression into `creativeMeta.apis` | Spike serves bid-response normalization; design treats `creativeMeta` as operator-provided | **Keep in validator layer only.** Container should not auto-merge from bid signals; that's the validator's job. No container-side change. |
+| Harness routing when no SHARC declaration | Not addressed (design assumes SHARCContainer is always used) | Spike harness bypasses `SHARCContainer` entirely and renders directly into slot when `isSharcRuntime() === false` | Different architectural model: spike does "container-per-API"; design does "unified container tolerates any creative" | **Surface to Jeffrey.** This is a meaningful design philosophy split — the harness behavior contradicts the unified-container value proposition of #89. See Stage 4 open questions. |
+| Naming collision risk | Single name `requireSharcInit` at container layer | **Same name** at both container AND validator/orchestrator layers with **different semantics** (container: skip timeout / validator: choose SHARC vs. sandbox container) | Convenient shorthand at validator layer; risks operator confusion | **Rename validator-layer flag.** Suggest `useSharcContainer` or `containerKind` in the orchestrator/payload layer to prevent meaning-overload. |
+
+---
+
+## 3. Spike-only items (in spike, not in design)
+
+| Item | Where | Disposition |
+|---|---|---|
+| Extension `augmentEnvironmentData()` auto-call at construction | `src/sharc-container.js:860–880` (commit `06f0c1f`) | **Defer to 0.7.2 second-half** per Q5. Don't bundle into first-half ship. |
+| `sanitizeApiDeclarations()` + `isSharcRuntime()` exports | `tools/creative-validator/src/bid-validator.js` (commit `102e894`) | **Keep in validator layer.** Useful tooling; doesn't need to move into container. |
+| `extractCreativeMetaApis()` — merges `imp.banner.api` from matched impression | Same file | **Keep in validator layer.** Bid-response normalization is the validator's job. |
+| `KNOWN_API_CODES` set in bid-validator (`{1,2,3,5,6,7,8,9,10,11,12}`) | Same file | **Keep but correct factual errors.** Spike comments label codes 8/9 as "OMID 1.1/1.2" — per AdCOM v1.0 those codes are **SIMID 1.0 / 1.1**. Correct the labels; behavior is fortuitously right. |
+| `SHARC_API_CODES = {10, 11, 12}` constant | Same file | **Replace with `SHARC_API_CODE` symbolic constant** referencing the container's named constant (§ 6.3 of design). When AdCOM publishes, swap the integer once, not in two places. |
+| Harness orchestrator container-routing based on `payload.sharc.requireSharcInit` | `tools/creative-validator/src/renderer-orchestrator.js` (commit `102e894`) | **Rename the flag** at orchestrator layer to disambiguate from container-layer `requireSharcInit`. Suggest `useSharcContainer: boolean` or `containerKind: 'sharc' \| 'sandbox'`. |
+| Harness skip-first renderer backstop pattern (Markup variant) | Uncommitted WIP in `src/sharc-container.js:3192–3216` | **Adopt — file as separate PR.** This is a genuine G2 refinement (handles the expected `document.write` load event without flagging it as unauthorized navigation). Does not weaken security; documents the expected event. |
+| Skip-first test coverage update | Uncommitted WIP in `test/node/test-creative-sources-load.js:1806–1825` | **Adopt with the skip-first refinement.** Test now dispatches two load events to verify backstop arms correctly. |
+| Test file `test-require-sharc-init.js` (158 lines, 6 cases) | `test/node/` (commit `06f0c1f`) | **Adopt as starting point** but rewrite test #4 (falsy normalization → `true`) to expect `TypeError` per design Q4. |
+| Tooling test file `test-require-sharc-init.js` (232 lines, 28 cases, in `tools/creative-validator/`) | `tools/creative-validator/` (commit `102e894`) | **Keep in tooling.** Tests validator-layer logic, not container. |
+
+---
+
+## 4. Design-only items (in design, not in spike)
+
+| Item | § ref | Estimated implementation cost |
+|---|---|---|
+| `container.apiFramework` accessor + `_resolveApiFramework` helper | § 6, § 7.2 | 2.0h |
+| `container.hasSharcSession` accessor | § 7.1 | 0.25h |
+| Three-layer detection picker | § 6.1, § 6.2 | included in `_resolveApiFramework` |
+| HTML lifecycle adapter (base class + HTML adapter) | § 8 | ~5h |
+| Adapter wiring in `load()` (`_selectLifecycleAdapter` + attach/detach) | § 8.2 | 1.5h |
+| State machine `LOADING → ACTIVE` edge | § 4.5 | 0.25h |
+| G7 framework-aware late handshake warn (4 forensic fields) | § 7.4, G7 | 1.0h |
+| G9 bridge auto-install timeout warn (strict integer cap value) | § 10.1, G9 | 1.0h |
+| G10 frozen `apiFramework` invariant | G10 | included in accessor work |
+| G11 cookbook + temporal-coupling read pattern | § 11.2, § 12, G11 | included in doc updates |
+| G12 SHARC supersession in `_mapAdComApisToBridges` | § 6.7, G12 | 0.75h |
+| Anti-example § 11.4 (legacy MRAID without SHARC SDK) | § 11.4 | included in doc updates |
+| Test file `test-html-lifecycle-adapter.js` | § 15.4 | 2.5h |
+| Test file `test-non-sharc-loading.js` | § 15.3 | 2.5h |
+| `test-bridges-detection.js` expansion for `apiFramework` + G10/G12 | § 15.2 | 2.5h |
+| Doc updates (api-reference, architecture-design, creative-cookbook, getting-started, SECURITY.md check) | § 12 | 2.0h |
+
+**~20h of design-only work** that is not yet present in any form in the spike. This is the bulk of the 23h estimate from § 16.
+
+---
+
+## 5. Stage 4 decision (Jeffrey, 2026-05-15) — **implement #89 fresh per locked design; park spike**
+
+After review, Jeffrey rejected the hybrid cherry-pick path and chose a cleaner sequencing:
+
+1. **Implement #89 fresh** on `feat/89-non-sharc-loading` per the locked design. **No cherry-picks from the spike.** Even the small ~45-line container skeleton goes in fresh — adopting it as-is would carry the spike's falsy-coercion validation, the spike's factual SIMID/OMID labels, the spike's premature 0.7.2 version bump, and the spike's OMID auto-wire that belongs in second-half.
+2. **Park the spike branch.** Do not edit, do not rebase, do not cherry-pick from. Leave it as a historical reference until #89 merges to main.
+3. **After #89 merges to main:** update the spike's validator (`tools/creative-validator/`) to use the now-shipped 0.7.2 architecture — `container.apiFramework`, `container.hasSharcSession`, named SHARC code constants, renamed validator-layer flag (to avoid collision with the container's `requireSharcInit`). At that point the four open questions from the prior version of this section get answered as part of the validator-update PR, not as part of #89.
+
+### Reverse-signal pass (what the spike's container-side work contributed to #89)
+
+Jeffrey asked for a final pass: did the spike's container-side code surface any architectural ideas worth retroactively incorporating into the locked design? **Yield is limited.** Two items, both small, both **outside** #89's first-half scope:
+
+| Item | Source | Disposition |
+|---|---|---|
+| **A — Extension error resilience pattern.** Spike's auto-call to `ext.augmentEnvironmentData()` is wrapped in try/catch + non-blocking `console.warn` so a broken extension doesn't crash construction. | `src/sharc-container.js:860–880` (commit `06f0c1f`) | **Note for the 0.7.2 second-half OMID design pass.** The auto-call itself doesn't ship in first-half (Q5 lock). When it lands, this is a sensible error-handling shape. |
+| **B — Renderer backstop skip-first for Markup variant.** Spike's WIP adds a `{ once: true }` skip handler that consumes the expected first `load` event from `document.write(creativeHtml)`, then arms the real backstop for any subsequent (unauthorized) load. Test updated to dispatch two load events. | `src/sharc-container.js:3192–3216` + `test/node/test-creative-sources-load.js:1806–1825` (uncommitted spike WIP) | **Separate PR / issue, independent of #89.** Genuine G2 refinement. Can land anytime. Worth filing now so it doesn't get lost. |
+
+Everything else in the spike's container-side work is either convergent (the `requireSharcInit` boolean shape itself), divergent in a way the locked design wins (falsy coercion vs. strict validation), or deferred (OMID auto-wire). No design changes to #89.
+
+### Spike validator disposition (parked work)
+
+The spike's `tools/creative-validator/` is substantial validator harness work — `sanitizeApiDeclarations()`, `isSharcRuntime()`, `extractCreativeMetaApis()`, container orchestration, MRAID/SafeFrame container backends. **All of it stays in the spike branch unchanged** until #89 merges. At that point a follow-up workstream:
+
+- Updates the validator to consume `container.apiFramework` instead of its own `isSharcRuntime()` for SHARC detection (or, more likely, keeps both — validator's tool-side detection is for bid-response normalization, container's accessor is for runtime).
+- Replaces hardcoded `SHARC_API_CODES = {10, 11, 12}` with the named constant from `src/sharc-protocol.js`.
+- Corrects the SIMID/OMID labels in `KNOWN_API_CODES` (codes 8, 9 are SIMID 1.0/1.1, not OMID 1.1/1.2).
+- Renames the validator-layer `requireSharcInit` flag to disambiguate from the container's option (suggest `useSharcContainer` or `containerKind`).
+- Reconciles `package.json` version with whatever main is at when the validator update lands.
+- Either adopts the design's unified-container model in the harness (every creative wrapped in `SHARCContainer`) or keeps the current container-per-API split as a deliberate harness-only choice. **Surface to Jeffrey at validator-update time.**
+
+The total ~23h of #89 implementation work is per the design's § 16 — no spike-derived shortcuts.
+
+---
+
+## 6. Stage 5 launch
+
+Implementation runs against design § 16's 21-step handoff table. Senior Developer agent owns Stages 5+ (implement → review → security audit → devops/sre). Operates in the `SHARC-claude` worktree on `feat/89-non-sharc-loading`. Does not touch the spike worktree or its uncommitted WIP. Does not bump `package.json` to 0.7.2 (version bump is at release per CLAUDE.md).
+
+---
+
+## 7. Methodology note
+
+This is the meeting point where the synthesis layer reads both sources after the architect / PM / SE worked blind to the spike during Stages 1+2. The convergence on the `requireSharcInit` core is meaningful signal — independent paths reached the same shape, which validates both. The divergence is concentrated almost entirely in **what got added around** the core (design's framework detection, HTML adapter, G1–G12 guardrails vs. spike's tooling-layer detection and OMID auto-wire). That asymmetry is what Plan C was designed to surface, and it confirms the design's architectural-breadth investment.
+
+The recommendation is **not** "the design wins" or "the spike wins." It's "the design wins on what the container should expose to operators; the spike wins on what the validator tooling should compute from bid signals; they land in different files and one PR per layer."
+
+---
+
+*End of Stage 3 comparison. Stage 4 is Jeffrey's decision on the recommendation + open questions above; Stage 5 is the implementation pipeline (Senior Developer → Code Reviewer → Security Engineer → DevOps).*

--- a/docs/design/0.7.2-WORK-IN-PROGRESS.md
+++ b/docs/design/0.7.2-WORK-IN-PROGRESS.md
@@ -41,8 +41,20 @@ Stage 3 should run in the `SHARC-claude` worktree. It can read both locations (t
 
 **Design doc:** `/Users/openclaw/.openclaw/workspace-dev/github/jeffreycarlson/SHARC-claude/docs/design/0.7.2-non-sharc-loading.md`
 **Size:** 11,522 words, 16 sections, 41 subsections
-**Status:** Untracked. Will be committed when Stage 4 decides to ship.
+**Status:** Committed in `9c90e8c` (2026-05-15) under `feat/89-non-sharc-loading`.
 **Implementation estimate:** ~23 hours (range 20-26h)
+
+### PR breakdown of the 0.7.2 first-half spec
+
+The design doc captures the **whole** first-half scope. It ships across three focused PRs against `main`, not one omnibus PR. Each PR has its own conformance checklist against the design.
+
+| PR | Scope | Design § reference | Status |
+|---|---|---|---|
+| **PR 1** ([#92](https://github.com/jeffreycarlson/SHARC/pull/92)) | Foundation: constants + state-machine edge + `requireSharcInit` + accessors + framework picker + G7 + G9 + G10 + G12 | § 16 steps 1–9 + § 4.5 | **Open** as of 2026-05-16 |
+| **PR 2** (TBD) | HTML lifecycle adapter + `LOADING → ACTIVE` wire-up + adapter test file | § 8 + § 16 steps 10–12 | Pending |
+| **PR 3** (TBD) | Documentation surface (api-reference, architecture-design, creative-cookbook, getting-started, SECURITY.md check) + CHANGELOG `[Unreleased]` entries | § 12 + § 16 steps 13–21 | Pending |
+
+When reading the design doc, note that § 8 (HTML lifecycle adapter) is **deferred to PR 2**. PR 1 includes the state-machine `LOADING → ACTIVE` edge (§ 4.5) so the adapter route is legal once wired, but PR 1 does NOT instantiate the adapter itself. This is by design (focused PR splits per `feedback_focused_pr_splits`); a single 23h PR would be hard to review.
 
 ### Core decisions (Q1-Q12)
 

--- a/docs/design/0.7.2-WORK-IN-PROGRESS.md
+++ b/docs/design/0.7.2-WORK-IN-PROGRESS.md
@@ -1,0 +1,218 @@
+# SHARC 0.7.2 — Work In Progress Snapshot
+
+**Date:** 2026-05-15
+**Session context:** Plan C design-first methodology, Stages 1+2 complete; Stage 3 (spike comparison) is next.
+**Status:** Design locked at `docs/design/0.7.2-non-sharc-loading.md` (untracked). Ready for spike comparison.
+
+---
+
+## TL;DR for a fresh session
+
+SHARC 0.7.2 is being designed via a "Plan C" methodology — clean architect-led design, then compare against a parallel spike implementation. The design is now fully locked through PM + SE pressure-test rounds and architectural-decision Q&A with Jeffrey. **The next step is Stage 3: read the locked design + the spike's actual implementation, diff them, produce a comparison report, recommend Stage 4 path (full implement-per-design / hybrid cherry-pick / adopt-spike-with-tweaks).**
+
+---
+
+## Plan C methodology — what we did and why
+
+The spike branch (`spike/sharc-creative-validator`) shipped what it called "SHARC 0.7.2" without going through the design → PR → review pipeline. To validate the spike's choices vs. doing a clean design, Jeffrey chose to:
+
+1. **Stage 1: Clean architect-led design** in a separate worktree (`SHARC-claude/`) with the architect deliberately blind to the spike
+2. **Stage 1.5: PM + SE pressure-test** in parallel against the architect's design
+3. **Stage 2: Lock design via Q&A** — Jeffrey resolved 7 open questions + 12 SE guardrails + 1 scope expansion (framework detection) + 1 architecture addition (HTML lifecycle adapter)
+4. **Stage 3: Compare locked design against the spike** ← **YOU ARE HERE**
+5. **Stage 4: Decide path forward** (implement-per-design / hybrid cherry-pick / adopt-spike-with-tweaks)
+
+**Methodological discipline:** the architect and PM and SE were all blind to the spike throughout Stages 1+2. That independence is what makes the Stage 3 comparison meaningful — convergence validates both paths; divergence reveals what each got right or wrong on its own merits.
+
+---
+
+## Filesystem layout
+
+| Location | Branch | Purpose |
+|---|---|---|
+| `/Users/openclaw/.openclaw/workspace-dev/github/jeffreycarlson/SHARC` | `spike/sharc-creative-validator` | OpenClaw's spike work + uncommitted WIP. **DO NOT EDIT.** |
+| `/Users/openclaw/.openclaw/workspace-dev/github/jeffreycarlson/SHARC-claude` | `feat/89-non-sharc-loading` | Clean worktree for the 0.7.2 design work. Holds the locked design doc. **This is where Stage 3 work happens.** |
+
+Stage 3 should run in the `SHARC-claude` worktree. It can read both locations (the spike has the implementation to compare against), but writes happen only in `SHARC-claude`.
+
+---
+
+## Locked design summary
+
+**Design doc:** `/Users/openclaw/.openclaw/workspace-dev/github/jeffreycarlson/SHARC-claude/docs/design/0.7.2-non-sharc-loading.md`
+**Size:** 11,522 words, 16 sections, 41 subsections
+**Status:** Untracked. Will be committed when Stage 4 decides to ship.
+**Implementation estimate:** ~23 hours (range 20-26h)
+
+### Core decisions (Q1-Q12)
+
+| # | Decision | Lock |
+|---|---|---|
+| Q1 | Default value for `requireSharcInit` | `true` (strict, preserves diagnostic timeout) |
+| Q2 | Constructor option name | `requireSharcInit` (matches `allow*` boolean family) |
+| Q3 | Diagnostic accessors | Ship BOTH `container.apiFramework: number \| null` (AdCOM `APIFramework` integer code) AND `container.hasSharcSession: boolean`. Picker recognizes SHARC + MRAID + SafeFrame only; VPAID/SIMID return `null`; OMID excluded (2026-05-15 refinement). |
+| Q4 | `null` validation | Throw `TypeError` (matches `allowPopups` pattern) |
+| Q5 | OMID coupling | First-half ships container-runtime detection; OMID stays in 0.7.2 second-half design pass |
+| Q6 | Browser harness | Defer to follow-up issue (jsdom coverage sufficient for ship) |
+| Q7 | Late `createSession` after timeout | Framework-aware warn: warn when late handshake from non-SHARC-declared creative; silent when declared SHARC |
+| G12 | SHARC + MRAID coexistence (Option D) | SHARC supersedes container-API codes. `apis: [6, SHARC_API_CODE]` → `apiFramework: SHARC_API_CODE`, `bridges: []` (MRAID bridge inhibited; creative uses SHARC runtime; MRAID declaration is informational for OTHER containers). **AdCOM publication assumed (2026-05-15 refinement):** placeholder constants `SHARC_API_CODE` / `SAFEFRAME_API_CODE` carry sentinel values until AdCOM publishes; supersession logic is live and tested today. |
+
+### Architectural additions
+
+- **Framework detection layer (§ 6)** — three-layer pattern mirroring 0.7.1's bridge detection. Resolves `creativeMeta.apis` → `apiFramework` (singular container-runtime code). Picker recognizes SHARC + MRAID + SafeFrame; OMID excluded (measurement); VPAID/SIMID return `null` (video-creative protocols). Design assumes AdCOM publication of SHARC + SafeFrame codes; placeholder constants `SHARC_API_CODE` / `SAFEFRAME_API_CODE` until publication locks the integer values.
+
+- **HTML lifecycle adapter (§ 8)** — NEW. Translates browser-native lifecycle events (IntersectionObserver, `visibilitychange`, `pagehide`/`pageshow`, `freeze`/`resume`) into SHARC state transitions. Activates whenever there's no framework-specific adapter (so it covers generic HTML AND MRAID/SafeFrame creatives in 0.7.2 as baseline; framework-specific adapters layer on in 0.7.3).
+
+- **MRAID + SafeFrame lifecycle adapters deferred to 0.7.3** — touch the 0.7.1 bridge architecture; deserve their own design pass.
+
+- **OMID container-side wiring deferred to 0.7.2 second-half** — separate design (covers extension-based vs bridges-based wiring + creativeHtml mutation question).
+
+### Security guardrails (G1-G12)
+
+12 required implementation guardrails enumerated in § 9. Most critical:
+
+- **G2** — Load-event navigation backstop (2118) MUST arm for both variants regardless of `requireSharcInit`. Highest-impact security boundary.
+- **G5** — Protocol-port session-ID filter MUST drop non-CREATE_SESSION messages when `sessionId === ''`. Prevents unauthenticated creatives from sending `requestNavigation`/`reportInteraction`.
+- **G10** — `container.apiFramework` MUST be frozen at construction; never mutated.
+- **G11** — Cookbook MUST document the temporal coupling between `apiFramework` (frozen) and `hasSharcSession` (changes when handshake fires).
+- **G12** — SHARC + MRAID coexistence resolves to SHARC priority (Option D).
+
+### Forward-deprecation path
+
+Post-AdCOM-registration of SHARC's `APIFramework` code, `requireSharcInit` may be marked legacy in favor of pure declaration-driven detection via `apiFramework`. See `project_upstream_contribution_roadmap.md`.
+
+---
+
+## Spike state (the comparison target)
+
+**Branch:** `spike/sharc-creative-validator`
+**Last sync with main:** `5b83041` (PR #81, before 0.7.1 shipped)
+**Diverged from main:** 2026-05-08
+**Spike does NOT have 0.7.1 work** — `bridges` field, `creativeMeta`, `container.bridges` accessor, `bridge_load_failed` event, Rule 3b — all missing from spike
+
+### Spike's 0.7.2 commits
+
+| Commit | Date | Subject |
+|---|---|---|
+| `06f0c1f` | 2026-05-12 | SHARC 0.7.2: requireSharcInit option + OMID container-side wiring |
+| `684a045` | 2026-05-12 | fix(changelog): restore missing ## [0.7.0] heading swallowed by 0.7.2 entry |
+| `102e894` | 2026-05-13 | wire requireSharcInit through bid-validator → sharc container harness |
+
+Plus 17 earlier commits building the creative validator tooling at `tools/creative-validator/` (4,454 files, ~64M; node_modules gitignored).
+
+### Spike's 0.7.2 SHARC source changes (commit `06f0c1f`)
+
+- Added `requireSharcInit` constructor option (default `true`); skips createSession fatal timeout when `false`
+- Auto-calls extension `augmentEnvironmentData()` at construction time for OMID wiring
+- Bumped `package.json` to 0.7.2 unilaterally (main is at 0.7.1)
+- Added `test/node/test-require-sharc-init.js` (158 lines)
+- Added `[0.7.2]` section in CHANGELOG
+
+### Plus uncommitted spike WIP
+
+```
+M src/sharc-container.js
+M test/node/test-creative-sources-load.js
+M tools/creative-validator/harness/markup-harness.html
+M tools/creative-validator/src/checks.js
+M tools/creative-validator/src/puppeteer-runner.js
+M tools/creative-validator/src/runner.js
+M tools/creative-validator/test-validator.js
+?? minimal-test.js                         (at repo root — clutter)
+?? simple-json-test.js                     (at repo root — clutter)
+?? simple-test.js                          (at repo root — clutter)
+?? test-json-fixtures.js                   (at repo root — clutter)
+?? tools/creative-validator/SHARC-MAPPING-SUMMARY.md
+?? tools/creative-validator/src/sharc-environment-helper.js
+?? tools/creative-validator/test-creativemeta-apis.js  (references creativeMeta — anticipates 0.7.1)
+?? tools/creative-validator/verify-harness-integration.js
+?? tools/creative-validator/verify-sharc-mapping.js
+```
+
+OpenClaw may add more between sessions.
+
+---
+
+## What Stage 3 needs to produce
+
+A comparison report covering these axes (matrix from session conversation):
+
+| Axis | Locked design | Spike (06f0c1f + 102e894) | Convergence? |
+|---|---|---|---|
+| Constructor option name | `requireSharcInit` | ? | ? |
+| Default value | `true` | ? | ? |
+| Type validation | throw on null | ? | ? |
+| Variant interaction | identical for URL + Markup | ? | ? |
+| Which timeouts skip | createSession only | ? | ? |
+| `apiFramework` accessor | new in 0.7.2 | ? | ? |
+| `hasSharcSession` accessor | new in 0.7.2 | ? | ? |
+| Framework detection layer | three-layer pattern | ? | ? |
+| G12 SHARC supersession | priority-aware bridge resolver | ? | ? |
+| HTML lifecycle adapter | NEW in 0.7.2 | ? | ? |
+| MRAID/SafeFrame lifecycle | deferred to 0.7.3 | ? | ? |
+| Bridge auto-install no-SHARC | console.warn + no install (G9) | ? | ? |
+| Late handshake handling | framework-aware warn | ? | ? |
+| Extension `augmentEnvironmentData()` auto-call | (NOT in design) | yes (per commit message) | DIVERGENT |
+| OMID container-side wiring | excluded from 0.7.2 first half | yes (per commit message) | DIVERGENT |
+| Test surface | jsdom + framework picker tests + HTML adapter tests | `test-require-sharc-init.js` (158 lines) | ? |
+| Security invariants (G1-G12) | explicitly preserved | ? | ? |
+| Operator close-responsibility | cookbook callout | ? | ? |
+
+### Stage 3 deliverable structure
+
+1. **Convergence table** — axes where design + spike match (validates both)
+2. **Divergence table** — axes where they differ + why each is justified
+3. **Spike-only items** — what's in spike not in design (scope creep? or genuine insight?)
+4. **Design-only items** — what's in design not in spike (Plan C wins? or over-engineered?)
+5. **Stage 4 recommendation** — full implement-per-design / hybrid cherry-pick / adopt-spike-with-tweaks
+
+### Methodology now (no longer blind)
+
+The architect was blind to the spike during Stages 1+2. Stage 3 is the meeting point — the synthesis layer reads both. Stage 3 is properly "now both sources are visible." The independence of the prior stages is what gives Stage 3 signal.
+
+---
+
+## Open work after Stage 4
+
+Regardless of which Stage 4 path is chosen, downstream work includes:
+
+| Item | Status |
+|---|---|
+| 0.7.2 second-half: OMID container-side wiring | Separate design pass not yet started |
+| 0.7.3: MRAID + SafeFrame lifecycle adapters | Tracked but no design started |
+| 0.7.3: Test coverage for unparseable BRIDGE_URL_TEMPLATE (#83) | Filed |
+| 0.7.3: Test coverage for renderer-side unknown_bridge_skipped (#84) | Filed |
+| 0.7.3: renderMsg field-order alphabetization (#85) | Filed |
+| 0.7.3: CLAUDE.md Version Bump Checklist refinement (#86) | Filed |
+| #75 onNavigation semantics (observation vs allow/deny/rewrite) | Parked for 0.8+ |
+| Spike's clutter cleanup (root-level test scripts, uncommitted WIP) | Whenever spike gets refocused |
+| Spike's package.json version=0.7.2 reconciliation | Required regardless of Stage 4 path |
+
+---
+
+## Reference memories
+
+These persist across sessions in `~/.claude/projects/-Users-openclaw--openclaw-workspace-dev-github-jeffreycarlson-SHARC/memory/`:
+
+- `project_proposal_split_release_plan.md` — release history + 0.7.1 GA status
+- `project_adcom_anchor.md` — AdCOM as SHARC's spec anchor
+- `project_safeframe_sharc_heritage.md` — SafeFrame 2.0 → SHARC lineage
+- `project_upstream_contribution_roadmap.md` — IAB Tech Lab contribution plan
+- `feedback_focused_pr_splits.md` — PR scope discipline
+- `feedback_delegate_dev_work_to_agents.md` — multi-step work goes to subagents
+- `feedback_verify_before_flipping.md` — verify before changing stance
+- `feedback_commit_dont_hedge.md` — direct positions, no hedging
+
+---
+
+## Hard rules (still in effect)
+
+- NEVER force-push
+- NEVER `--no-verify`
+- All `gh` commands include `--repo jeffreycarlson/SHARC`
+- For Stage 3 work in this worktree: do NOT touch the spike's uncommitted WIP
+- The design doc is the single canonical artifact; this WIP snapshot is session-context only
+
+---
+
+**End of snapshot.** Stage 3 picks up by reading the locked design doc + the spike's commits + producing the comparison report.

--- a/docs/design/0.7.2-non-sharc-loading.md
+++ b/docs/design/0.7.2-non-sharc-loading.md
@@ -413,6 +413,8 @@ Per Q3's lock (resolved as the framework-detection scope expansion, not as a one
 
 ## 8. Lifecycle adapter layer
 
+> **PR scope — NOT in PR [#92](https://github.com/jeffreycarlson/SHARC/pull/92).** This entire section ships as **PR 2** of 0.7.2 first-half (see WIP snapshot's "PR breakdown" table). PR 1 (#92) only adds the `LOADING → ACTIVE` state-machine edge (§ 4.5) that legitimizes the adapter route; the adapter class hierarchy, the `_selectLifecycleAdapter` wiring, and the `test-html-lifecycle-adapter.js` test file are all PR 2. The `load()` snippet in § 8.1 (`this._lifecycleAdapter = ...`) is the **PR 2 target**, not what PR 1 implemented. Test § 9 of `test/node/test-non-sharc-loading.js` explicitly asserts the adapter is absent in PR 1.
+
 `requireSharcInit: false` alone is "do not fatal-error on missing handshake" — it does not give operators lifecycle observability. Operators of mixed inventory want the same `onStateChange` signal for non-SHARC creatives that they get for SHARC-aware ones: viewability, visibility, freeze/resume, bfcache restoration. 0.7.2 closes this gap with an **HTML lifecycle adapter** — a thin layer that derives SHARC state transitions from browser-native lifecycle signals when no handshake-driven path is available.
 
 **0.7.2 scope: HTML adapter only.** Generic HTML creatives (`apiFramework === null`) and creatives with framework codes that don't yet have a dedicated adapter (MRAID, SafeFrame) get lifecycle observability via web standards. Framework-specific adapters (MRAID's `mraid.viewableChange`, SafeFrame's `$sf.ext.status()`) are deferred to 0.7.3 (see § 13).

--- a/docs/design/0.7.2-non-sharc-loading.md
+++ b/docs/design/0.7.2-non-sharc-loading.md
@@ -1,0 +1,941 @@
+# 0.7.2 — Loading non-SHARC creatives without `createSession` fatal-timeout
+
+**Status:** Design (ready for implementation — Q1–Q9 locked, see § 13)
+**Issue:** [#89](https://github.com/jeffreycarlson/SHARC/issues/89)
+**Branch:** `feat/89-non-sharc-loading`
+**Target version:** 0.7.2 (patch — first half; OMID container-side wiring is the second half, separately scoped)
+**Predecessors:** 0.7.1 GA (`bridges` field, `creativeMeta`, container-driven bridge loading)
+**Forward bridges:** 0.7.3 will extend the HTML lifecycle adapter (§ 8) with MRAID and SafeFrame variants.
+
+---
+
+## 1. Problem statement
+
+`SHARCContainer.load()` arms a 5 s `createSession` timeout (`src/sharc-container.js:1310`). When the creative inside the iframe never sends `SHARC:Creative:createSession`, the timeout fires `_handleFatalError(ErrorCodes.NO_CREATE_SESSION, ...)` (line 3805–3809), terminating the container.
+
+For SHARC-aware creatives this is the correct failure mode: a missing handshake means a broken creative. But operators increasingly want SHARC's iframe sandbox + navigation bridge + permissions-policy guardrails as a *unified container* across mixed inventory, where many of the creatives served through it have no idea SHARC exists:
+
+- **Generic HTML banners** — image-only or video-only markup with zero JS runtime.
+- **Mixed inventory placements** — house ads, fallback creatives, third-party tags interleaved with SHARC-native ads on the same placement.
+- **Validator / preview tooling** — load arbitrary creatives to inspect; cannot afford a 5 s fatal-error on every non-handshake.
+
+The 0.7.2 goal is to give operators an explicit opt-in that skips the `createSession` fatal-timeout so non-SHARC creatives load to a *stable, queryable, terminable* container instance without changing default behavior for the SHARC-aware path. This work is **container-local**: no wire-format change, no protocol vocabulary expansion, no renderer-protocol field additions. Issue #89 §"Out of scope" reinforces this.
+
+A companion concern, raised during PM + SE pressure-test: operators today have no declaration-driven way to query "what API framework does this creative claim to be?" — they only learn after the handshake fires (or doesn't). 0.7.2 adds a second container accessor, `container.apiFramework`, that resolves the AdCOM `APIFramework` code from `creativeMeta.apis` at construction time. Detection (declarative) and outcome (handshake) become independently queryable signals.
+
+## 2. Constructor option
+
+```typescript
+new SHARCContainer({
+  // existing options...
+  requireSharcInit?: boolean,
+})
+```
+
+| Option | Type | Default | Semantics |
+|---|---|---|---|
+| `requireSharcInit` | `boolean` | `true` | When `true` (default), the container arms the `createSession` timeout exactly as in 0.7.1 — a creative that fails to handshake within `timeouts.createSession` ms fatal-errors with `ErrorCodes.NO_CREATE_SESSION` (2212). When `false`, the timeout is not armed; the container progresses via the HTML lifecycle adapter (§ 4, § 8) and tolerates a creative that never calls `createSession`. |
+
+**Why the noun "`requireSharcInit`" over flag-style alternatives.** Three naming candidates were on the table:
+
+| Candidate | Pro | Con |
+|---|---|---|
+| `requireSharcInit: boolean` | Subject-verb clarity. Default `true` reads as a documented invariant. Symmetric with existing `allowPopups`, `allowModals`, `allowDownloads` (operator-controlled requirement/permission flags). | Slightly verbose. |
+| `nonSharcMode: boolean` | Short. Names the use case directly. | Frames the container as having a "mode" — invites future flag-mode-creep (`legacyMrSafeFrameMode`, `previewMode`). Tense is also wrong: setting to `true` means "permit non-SHARC creatives," not "I am in non-SHARC mode" (because SHARC-aware creatives still work in this mode). |
+| `sessionMode: 'strict' \| 'optional'` | Extensible to future modes if a third arises. | Premature option-space expansion; we have exactly one binary choice today. String enums also force operators to remember magic values, vs `true`/`false`. |
+
+The architect picks `requireSharcInit: boolean`. Symmetric with the existing `allow*` boolean family, names the load-bearing invariant (it is the SHARC init handshake that is being made optional), and the default `true` is self-documenting at construction sites.
+
+**Validation.** Stricter than typical because operator constructor input is human-authored:
+
+```javascript
+if (requireSharcInit !== undefined && typeof requireSharcInit !== 'boolean') {
+  throw new TypeError(
+    '[SHARCContainer] requireSharcInit must be a boolean (got ' + typeof requireSharcInit + ').'
+  );
+}
+```
+
+A new sequenced validation rule: **Rule 11** ("`requireSharcInit` is undefined or a boolean"). Sequenced after Rule 10 (`creativeMeta` shape). No interaction with Rules 1–8 (variant / origin / size) and no coupling to Rule 3b (`bridges`/`creativeMeta` variant-coupling) — § 5 explains why this option *is* variant-agnostic.
+
+**JSDoc entry** inserts alphabetically into the constructor options block (between `placementPolicy` and `supportedFeatures`).
+
+## 3. Default value choice: `true` (strict)
+
+The single most important decision in this design. Two-column matrix:
+
+| Default | Backward compatibility | Operator experience |
+|---|---|---|
+| **`true` (strict)** | Existing operators see zero behavior change at upgrade. The 5 s fatal-timeout fires exactly as in 0.7.1 unless the operator opts in. | Operators wanting non-SHARC creatives must opt in explicitly (`requireSharcInit: false`). One-line config; documented in the cookbook. |
+| `false` (optional) | **Breaking change.** Every existing operator's "creative didn't load" error path silently shifts from "fatal-error within 5 s" to "loaded but inert" — losing a diagnostic signal that today catches misconfigured creatives. | Out-of-the-box convenient for the validator / preview / mixed-inventory cases. |
+
+**Decision: default `true`.** Three reasons:
+
+1. **The 5 s fatal-timeout is a real diagnostic today.** Operators rely on it to surface broken handshakes. Flipping the default to `false` would silently mask the same class of bug 0.7.0 / 0.7.1 / future SHARC versions are trying to make loud. Per `feedback_commit_dont_hedge`, this is the kind of decision where a soft "either default could work" hedge is wrong — the default should preserve the louder signal.
+2. **Pre-1.0 doesn't mean reckless.** Memory `project_pre_1_breaking_changes` permits clean breaks; it does not require them. A clean break that loses observability is still a regression for operators who depend on the observability. Cleanness is about *not shipping deprecation shims*, not about *defaulting to looser behavior*.
+3. **Opt-in matches the intent.** Operators who need non-SHARC loading have a specific use case (validator, mixed inventory, generic banners). They will read the cookbook entry and set the flag deliberately. Operators who *don't* have that use case have no reason to flip the flag, and the strict default means they never accidentally regress on diagnostic loudness.
+
+The 0.7.1 precedent for `bridges`: default is `undefined`/auto-detect rather than a hard requirement. That is consistent — auto-detect is a *helpful* default; strict-init is a *safe* default. Different defaults for different semantic shapes.
+
+## 4. Behavior when `requireSharcInit: false`
+
+The container loads the iframe normally; the only behavior change at `load()` time is that the `createSession` fatal-timeout is not armed. State-machine progression after `load()` runs along one of two parallel routes — handshake-driven or HTML-adapter-driven. Concrete state-machine sequence:
+
+```
+LOADING
+  ├─ iframe created, MessageChannel wired (existing — unchanged)
+  ├─ load() called
+  │    ├─ _createIframe()                     (existing)
+  │    ├─ _registerProtocolListeners()        (existing — listeners stay armed)
+  │    ├─ _attachPageLifecycleListeners()     (existing)
+  │    ├─ _selectLifecycleAdapter().attach()  ── NEW (§ 8): HTML adapter for non-handshake creatives
+  │    └─ _startSessionTimeout()              ── SKIPPED when requireSharcInit === false ──
+  │
+  ├─ (Markup variant): renderer protocol completes → :rendered envelope-validated
+  │    → _onRendererRendered() → backstop armed → iframe load fires → creative executes
+  │
+  ├─ (URL variant): initial iframe load → creative executes
+  │
+  ▼
+[Non-SHARC creative does not call createSession. HTML adapter (§ 8) drives
+ LOADING → ACTIVE on iframe-load + IntersectionObserver visibility, then
+ ACTIVE ↔ PASSIVE ↔ HIDDEN ↔ FROZEN per browser signals. READY is skipped.]
+[OR]
+[SHARC-aware creative calls createSession; handshake proceeds normally — § 4.4]
+```
+
+### 4.1 What state does the container end up in?
+
+In 0.7.2 the container progresses through the standard `LOADING → ACTIVE ↔ PASSIVE ↔ HIDDEN → FROZEN → TERMINATED` lifecycle for non-SHARC creatives via the **HTML lifecycle adapter (§ 8)**. The handshake-driven path (`LOADING → READY → ACTIVE` via `createSession` → `Container:init` → `Container:startCreative`) remains the canonical SHARC-aware route; the HTML adapter is the parallel route for creatives that never handshake.
+
+Three alternatives were considered before the HTML-adapter resolution:
+
+| Alternative | Why rejected |
+|---|---|
+| Stay in `LOADING` indefinitely | Honest about handshake state, but blinds operators to lifecycle events (visibility, viewability, bfcache). Operators of mixed inventory want `onStateChange` for non-SHARC creatives too — they instrument viewability, completion, and freeze/resume on the same lifecycle they get for SHARC-aware creatives. |
+| Auto-transition to `READY` after iframe load, then halt | `READY` semantically means "the creative is initialized and ready for `startCreative`." A non-SHARC creative is not initialized in any SHARC sense. Synthetic `READY` would lie to `onStateChange` listeners that are watching for the post-handshake-init signal. |
+| New `RENDERED_NO_SDK` state | Adds protocol vocabulary for one edge case. Out of scope for 0.7.2's container-local promise. State machine in `src/sharc-protocol.js` lines 111–129 is wire-format-adjacent (creatives query state via `Creative:getContainerState`); expanding the enum is a protocol change. |
+
+**Resolution: skip `READY`, transition `LOADING → ACTIVE` directly via the HTML adapter when iframe `load` + visibility signals say the creative is visible and running.** `READY` stays handshake-exclusive — it remains the truthful "creative initialized through SHARC" signal. The non-handshake path bypasses it. Subsequent transitions (`ACTIVE ↔ PASSIVE ↔ HIDDEN ↔ FROZEN`) are driven by browser-native lifecycle events that already exist on the container's listener chain plus a new IntersectionObserver wire. The new accessor `container.hasSharcSession: boolean` (§ 7) lets operators distinguish "lifecycle observed via HTML adapter" from "lifecycle observed via SHARC handshake" without reading the state machine internals.
+
+See § 8 for the adapter's full event-to-state mapping and architectural shape. See § 4.5 for the single state-machine transition-table addition (`LOADING → ACTIVE`) that legitimizes the adapter route.
+
+### 4.2 Which timeouts skip?
+
+Exactly one: `createSession`. All other timeouts retain identity behavior:
+
+| Timeout | Behavior when `requireSharcInit: false` |
+|---|---|
+| `createSession` (5 s) | **SKIPPED** — not armed in `_startSessionTimeout` |
+| `initResolve` (2 s) | Unchanged — only armed inside `_handleCreateSession`, which only runs if a handshake actually arrives |
+| `startResolve` (2 s) | Unchanged — same path as `initResolve` |
+| `closeSequence` (2 s) | Unchanged — fires on `container.close()` regardless of session state |
+| `rendererLoad` (5 s) | Unchanged — Markup variant only; this is the renderer protocol's load-event timeout, orthogonal to SHARC handshake. Bridge loading + renderer rendering must still succeed for the iframe to even reach the creative. |
+| `rendererReply` (2 s) | Unchanged — same as above |
+
+The renderer-protocol timeouts are explicitly **NOT skipped**. They guard a different invariant: the operator-hosted renderer must respond before the creative can run at all. A non-SHARC creative behind a broken renderer is still a broken render, and operators want that signal.
+
+### 4.3 Which events still fire?
+
+| Event / callback | Behavior when `requireSharcInit: false` (no handshake) |
+|---|---|
+| `onStateChange` | Fires for every transition driven by the HTML lifecycle adapter (§ 8): `LOADING → ACTIVE` on iframe-load + initial visibility, then `ACTIVE ↔ PASSIVE ↔ HIDDEN ↔ FROZEN ↔ TERMINATED` per browser signals. The handshake-specific `LOADING → READY → ACTIVE` path is skipped — `READY` never fires for a non-handshake creative. |
+| `onSecurityEvent` | Fires unchanged — wrapper carve-out warnings, unauthorized-navigation backstops, etc. all fire regardless of handshake. |
+| `onNavigation` | Fires unchanged when the renderer's navigation bridge intercepts a click (Markup variant) or when the load-event backstop catches a navigation (both variants). |
+| `onInteraction` | Only fires from explicit `Creative:reportInteraction` messages, which require a handshake. **Will not fire for non-SHARC creatives.** That is correct — interaction reporting is a SHARC-protocol affordance. |
+| `onMessage` | Fires for any incoming protocol message. For non-SHARC creatives, no SHARC messages arrive, so `onMessage` is silent on the SHARC channel. |
+| `onClose` | Fires unchanged on `container.close()` or `_terminate()`. |
+| `onError` | Fires for non-handshake fatal errors (renderer timeout, renderer-failed, unauthorized navigation, etc.). **Does NOT fire for the missing handshake** when `requireSharcInit: false` — that is the whole point of the option. |
+
+### 4.4 What if the creative DOES eventually call `createSession`?
+
+**Late-arriving `createSession` is accepted, with a framework-aware diagnostic warn** (see § 7.4 for the full warn-matrix). The protocol listener for `CREATE_SESSION` (`src/sharc-container.js:2366`) is registered in `_registerProtocolListeners()` at `load()` time and stays armed indefinitely. `_handleCreateSession` does not check elapsed time — it just calls `_clearTimeout('createSession')` (a no-op when the timeout was never armed), accepts the session, and fires the `Container:init` flow.
+
+This means the option's correct mental model is **"do not fatal-error if the creative is slow / silent,"** not **"refuse handshakes."** A SHARC-aware creative running in a `requireSharcInit: false` container handshakes normally; the option only affects the *missing* path, not the *present* path.
+
+**Why this is safe.** `_handleCreateSession` is idempotent-safe: it accepts a session, transitions state, and sends `Container:init`. It cannot run twice for the same container (the protocol's session-establishment guards it). Late arrival just means the state-machine clock starts later than the iframe-load clock.
+
+**The single edge case to document:** if `container.close()` was called before the handshake arrived, the protocol is already terminated and the incoming `createSession` is dropped at the message-port boundary. No behavior change from today; documented in the cookbook entry.
+
+### 4.5 State-machine transition table — one targeted addition
+
+The state-machine transition table in `src/sharc-protocol.js` lines 123–129 gains exactly one new edge to legitimize the HTML-adapter route. No new states, no new wire-format fields, no rename — just one new edge in an existing freeze-frozen object.
+
+Before (0.7.1):
+
+```
+LOADING   → READY, TERMINATED
+READY     → ACTIVE, TERMINATED
+ACTIVE    → PASSIVE, HIDDEN, TERMINATED
+...
+```
+
+After (0.7.2):
+
+```
+LOADING   → READY, ACTIVE, TERMINATED          ← ACTIVE added
+READY     → ACTIVE, TERMINATED
+ACTIVE    → PASSIVE, HIDDEN, TERMINATED
+...
+```
+
+**Rationale.** The 0.7.1 table modeled only the handshake-driven progression: a creative is "ready" (initialized through SHARC) before it is "active." For SHARC-aware creatives this remains true and the `LOADING → READY → ACTIVE` path is unchanged. For non-handshake creatives, `READY` is not a meaningful state — there is no SHARC init to be ready *for*. The HTML adapter route is `LOADING → ACTIVE` directly, and the table must permit it.
+
+**Why not synthetic `READY`?** Per § 4.1, synthesizing a `READY` transition for non-handshake creatives would emit a misleading signal to `onStateChange` listeners that watch `READY` for post-handshake-init affordances. The honest signal is `LOADING → ACTIVE`. The state machine just needs to recognize that progression as legal.
+
+**Why this is not a wire-format change.** The `ContainerStates` enum itself is unchanged. `Creative:getContainerState` returns the same values it always did. The transition validator (`StateMachine.transition()` in `sharc-protocol.js` line 1306) is the only consumer of the table; its behavior changes only in that it stops emitting the "invalid transition" warn for the new edge. No bridge, creative-SDK, or renderer-protocol consumer sees a different envelope.
+
+**Why `LOADING → TERMINATED` is unaffected.** Still legal; `container.close()` from `LOADING` still works for non-handshake creatives that were closed before the adapter advanced them.
+
+This is the smallest possible vocabulary touch — one edge in a 7-row table — and it is explicitly in-scope for 0.7.2.
+
+### 4.6 Security invariants preserved
+
+**SE-confirmed:** `requireSharcInit: false` weakens diagnostic loudness; it does not weaken any security boundary. The 5 s `createSession` fatal-timeout is a diagnostic signal — every actual security control (sandbox attrs, permissions-policy, cross-origin enforcement, renderer envelope validation, `KNOWN_TEST_RENDERERS` guard, load-event navigation backstop, protocol-port session-ID filter) is handshake-independent and remains armed for `requireSharcInit: false` placements. The option is container-local and introduces no new attack surface.
+
+See § 9 ("Required Implementation Guardrails") for the enumerated MUST-rules (G1–G12) that lock this invariant into implementation.
+
+## 5. Variant interaction
+
+The option applies **identically to both Creative URL and Creative Markup variants.**
+
+| Variant | What runs before the (skipped) handshake | What the option changes |
+|---|---|---|
+| Creative URL | iframe loads `creativeUrl` directly; protocol port is wired via initial-load postMessage handshake | `_startSessionTimeout()` is not called in `load()` |
+| Creative Markup | Renderer protocol completes; `:rendered` envelope accepted; iframe loads creative HTML via `document.write` | Same — `_startSessionTimeout()` is not called in `load()` |
+
+The `createSession` timeout is variant-agnostic — `load()` (`src/sharc-container.js:1306`) calls `_startSessionTimeout()` unconditionally for both variants. The 0.7.2 change is a single `if (this._requireSharcInit) ...` guard around that one line. No variant-specific code paths.
+
+**Rule 3b stays variant-coupled.** The 0.7.1 rule that `bridges` and `creativeMeta` are Markup-only is unaffected. `requireSharcInit` is NOT a Markup-only option; it lives at the SHARC-handshake layer, which both variants share. An operator can pass `requireSharcInit: false` alongside either `creativeUrl` or `creativeHtml + creativeRendererUrl`. No coupling check needed.
+
+**Why this matters for mixed inventory.** Operators with mixed inventory often serve some creatives via URL (third-party ad-server response) and others via Markup (bid-response adm). A variant-coupled `requireSharcInit` would force operators to maintain separate container code paths. Variant-agnostic keeps the unified-container value proposition intact — exactly the use case driving issue #89.
+
+## 6. Framework Detection Layer
+
+Operators today learn what API framework a creative claims only *after* the handshake fires (or fails). 0.7.2 adds a declaration-driven accessor that resolves this at construction time:
+
+```typescript
+container.apiFramework: number | null
+```
+
+The accessor returns the AdCOM `APIFramework` integer code for the container-runtime framework declared by the creative, or `null` when no recognized container-runtime code is declared. Frozen at construction. Mirrors 0.7.1's `container.bridges` semantics: queryable immediately after `new SHARCContainer(...)` returns, before `load()` is called, before any handshake.
+
+JSDoc text:
+
+> AdCOM `APIFramework` integer code for the declared container runtime (per AdCOM v1.0 [List: API Frameworks](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--api-frameworks-)). `null` when no recognized container-runtime code is declared. OMID (code 7) is excluded — handled by separate 0.7.2 measurement design.
+
+### 6.1 Three-layer detection (mirrors 0.7.1 `bridges`)
+
+The container resolves `apiFramework` from declarative signals via three precedence layers — exactly the three-layer pattern 0.7.1 codified for `bridges`:
+
+1. **Layer 1 — Explicit `creativeMeta.apis`.** The container picks the highest-priority container-runtime code present in the array using the precedence ladder in § 6.2.
+2. **Layer 2 — Reserved.** Per the 0.7.1 three-layer pattern. Future implementations may add bid-context-derived detection here (e.g. an OpenRTB-pass-through field). **Currently a no-op.** Reserving the layer keeps the precedence numbering forward-compatible.
+3. **Layer 3 — Fallthrough to `null`.** When no recognized container-runtime code is present.
+
+A new private helper `_resolveApiFramework(creativeMeta)` runs at construction, alongside `_resolveBridges()`. Its result is assigned to `this._apiFramework` and exposed via the frozen getter.
+
+### 6.2 Precedence ladder (Layer 1)
+
+When `creativeMeta.apis` contains multiple codes, the container picks the highest-priority container-runtime code. Order is:
+
+| Priority | Framework | AdCOM code(s) | Notes |
+|---|---|---|---|
+| 1 (highest) | SHARC | `SHARC_API_CODE` (placeholder constant; numeric value locked at AdCOM publication) | Assumed registered. See § 6.3. |
+| 2 | MRAID — latest version wins | `6` (MRAID 3.0), `5` (MRAID 2.0), `3` (MRAID 1.0) | Within MRAID, higher number wins (`6 > 5 > 3`). |
+| 3 | SafeFrame | `SAFEFRAME_API_CODE` (placeholder constant; numeric value locked at AdCOM publication) | Assumed registered. See § 6.3. |
+| — | OMID | `7` | **EXCLUDED from the picker.** OMID is measurement, not container runtime — handled by the separate 0.7.2 measurement design. See § 6.4. |
+| — | Video-creative APIs (VPAID, SIMID) | `1`, `2`, `8`, `9` | **NOT picker targets.** Video-creative protocols, not display-container runtimes. Picker returns `null` when these are the only declarations. Operators read `creativeMeta.apis` directly if they need to branch on video-creative declarations. |
+| — | Vendor-specific | `500+` | Returned as `null` (not a known framework). Operators can read `creativeMeta.apis` directly if they need to inspect vendor codes. |
+
+The picker iterates `creativeMeta.apis`, computes each entry's priority, and returns the highest-priority code (lowest priority number). Codes outside the table are ignored at the picker level (still preserved in the operator-visible `creativeMeta.apis` input).
+
+> **JSDoc note (applied to both `container.apiFramework` and the `_resolveApiFramework` helper):** When a creative declares multiple codes, the picker returns the highest-priority container-runtime code. To inspect all declared codes, read `creativeMeta.apis` directly.
+
+### 6.3 AdCOM code constants
+
+Per memory `project_upstream_contribution_roadmap`, dual registration of SafeFrame 1.0 and SHARC 1.0 in AdCOM's `APIFramework` list is on the IAB Tech Lab WG outreach roadmap. **This design assumes that registration completes before 0.7.2 ships** — the picker, the G12 supersession resolver, and the test surface all treat SHARC and SafeFrame as recognized container-runtime codes.
+
+The actual numeric values are unknown until AdCOM publishes. The implementation MUST therefore introduce two named constants:
+
+```javascript
+const SHARC_API_CODE = <integer>;       // locked to AdCOM-published value
+const SAFEFRAME_API_CODE = <integer>;   // locked to AdCOM-published value
+```
+
+These constants are referenced throughout `_resolveApiFramework`, `_mapAdComApisToBridges`, the priority ladder helper, and the G12 supersession branches. When AdCOM publishes the codes, the implementer updates exactly two integer literals — no logic changes, no test-shape changes. The constants live in `src/sharc-protocol.js` (alongside `ContainerStates` and other registered enums) so both container and renderer have a single source of truth.
+
+**Until AdCOM publishes** (release-blocker check): the constants carry sentinel values that the implementer documents at the constant site. Tests reference the constants symbolically (e.g. `SHARC_API_CODE`, not a hardcoded integer) so test behavior remains correct after AdCOM publication.
+
+A creative declaring `creativeMeta.apis: [6]` (MRAID 3.0 alone) → `apiFramework: 6`. ✓ — unchanged from 0.7.1 behavior. A creative declaring `creativeMeta.apis: [SHARC_API_CODE]` → `apiFramework: SHARC_API_CODE`, `bridges: []` per § 6.7. A creative declaring SHARC-aware behavior via the SDK handshake but no `creativeMeta.apis` → `apiFramework: null`, `hasSharcSession: true` (declaration-driven vs outcome-driven split).
+
+### 6.4 Why OMID is excluded from the picker
+
+OMID (Open Measurement Interface Definition, AdCOM code `7`) is a **measurement** API, not a **container-runtime** API. A creative can be MRAID 3.0 *and* OMID-instrumented simultaneously — those are orthogonal claims. The picker resolves the container runtime; OMID lives on a separate axis.
+
+If a creative declares `creativeMeta.apis: [7]` alone, the picker returns `null` (no container-runtime code present). Operators can still detect OMID by reading `creativeMeta.apis.includes(7)` directly — the input array is preserved.
+
+The 0.7.2 second-half design (OMID container-side wiring) is the right place to add OMID-specific affordances (e.g. a `container.hasOmidInstrumentation` accessor). This design defers that decision per Q5's lock.
+
+### 6.5 Declaration vs outcome — two orthogonal signals
+
+`apiFramework` (declaration-driven) and `hasSharcSession` (outcome-driven) carry independent signal. Operators use both:
+
+| Creative behavior | `apiFramework` | `hasSharcSession` | Operator interpretation |
+|---|---|---|---|
+| Declares `[6]` (MRAID 3.0) + loads `sharc-creative.js` (auto-handshake) | `6` | `true` | MRAID 3.0 creative wrapped by SHARC SDK. Both declared runtime and SHARC outcome present. |
+| Declares no apis + loads `sharc-creative.js` + handshakes | `null` | `true` | SHARC-aware creative that didn't bother declaring (pre-AdCOM-registration). Operator infers SHARC from the outcome alone. |
+| Declares `[6]` + no SHARC SDK loaded | `6` | `false` | Standard MRAID case. Bridge wires `window.mraid`; no SHARC handshake fires. |
+| Declares `[7]` (OMID alone) | `null` | depends on SDK | OMID-instrumented but no container runtime. `apiFramework` returns `null`; operators read `creativeMeta.apis.includes(7)` to detect OMID. |
+| Declares `[]` or omits `creativeMeta` | `null` | depends on SDK | Generic creative. No declaration; outcome is the only signal. |
+
+The accessors are independently queryable and never lie about each other. An operator dashboard can show "declared framework: MRAID 3.0; SHARC session: yes" as two distinct columns, exactly matching what the container observed.
+
+### 6.6 Edge cases — verbatim spec
+
+- **Layer 1 + multiple codes, mixed runtimes.** `creativeMeta.apis: [6, 2, 7]` (MRAID 3.0, VPAID 2, OMID) → picker returns `6`. MRAID is priority 2; VPAID is not a picker target; OMID is excluded. MRAID wins.
+- **Layer 1 + only OMID.** `creativeMeta.apis: [7]` → picker returns `null`. OMID is excluded from the picker; no other codes present.
+- **Layer 1 + only VPAID or SIMID.** `creativeMeta.apis: [2]` or `[8]` → picker returns `null`. Video-creative codes are not picker targets. Operators read `creativeMeta.apis` directly if they need to branch on video-creative declarations.
+- **Layer 1 + unknown vendor code.** `creativeMeta.apis: [503]` → picker returns `null`. Vendor codes are out of scope; operators inspect input array directly.
+- **Layer 1 + empty array.** `creativeMeta.apis: []` → picker returns `null`. Layer 3 fallthrough.
+- **No `creativeMeta`.** `apiFramework` is `null`. Layer 3 fallthrough.
+- **Markup variant — `creativeMeta` provided.** `apiFramework` resolved at construction. ✓
+- **URL variant — `creativeMeta` is Markup-only (Rule 3b).** `apiFramework` will always be `null` for URL variant (no `creativeMeta` to resolve from). This is intentional — URL variant creatives are operator-pulled from upstream sources where AdCOM data is not propagated. Operators wanting framework declaration use Markup variant.
+
+### 6.7 Priority and supersession rules (G12)
+
+When `creativeMeta.apis` declares **BOTH** a SHARC code AND a container-API code (MRAID or SafeFrame), SHARC takes priority in the picker **AND** inhibits loading of the lower-priority bridges. This honors creative-author intent for portable creatives — one creative file that works in both SHARC and legacy MRAID containers via API fallback — without loading unnecessary bridges in SHARC containers.
+
+**Supersession matrix** (using the placeholder constants from § 6.3):
+
+| `creativeMeta.apis` | `apiFramework` | `bridges` | Rationale |
+|---|---|---|---|
+| `[SHARC_API_CODE]` (SHARC only) | `SHARC_API_CODE` | `[]` | SHARC is runtime, not a bridge. |
+| `[6]` (MRAID 3.0 only) | `6` | `['mraid']` | Current 0.7.1 behavior. Unchanged. |
+| `[6, SHARC_API_CODE]` (MRAID + SHARC) | `SHARC_API_CODE` | `[]` | SHARC supersedes. MRAID bridge inhibited — would be dead weight in a SHARC container. |
+| `[SAFEFRAME_API_CODE, SHARC_API_CODE]` | `SHARC_API_CODE` | `[]` | SHARC supersedes. SafeFrame bridge inhibited. |
+| `[7, SHARC_API_CODE]` (OMID + SHARC, 0.7.2 first half) | `SHARC_API_CODE` | `[]` | OMID handled by 0.7.2 second-half measurement design; no bridge in 0.7.2 first half. |
+| `[7, SHARC_API_CODE]` (OMID + SHARC, 0.7.2 second half) | `SHARC_API_CODE` | `['omid']` | OMID is measurement, **orthogonal** — never superseded. SHARC + OMID coexist. |
+| `[6, 7]` (MRAID + OMID, no SHARC) | `6` | `['mraid', 'omid']` (0.7.2 second half) | No SHARC code, no supersession. Both bridges load. |
+
+**Real-world use case driving G12 D:** a creative author who wants one file to run on both SHARC-native containers and older non-SHARC MRAID containers declares `[6, SHARC_API_CODE]`. The SHARC container picks SHARC (`apiFramework: SHARC_API_CODE`, `bridges: []`); the legacy MRAID container's resolver sees only `[6]` (it doesn't recognize `SHARC_API_CODE`) and runs the MRAID path. The creative gets the best path in each environment without operator branching.
+
+**Bridge resolver is priority-aware:**
+
+```pseudocode
+function _mapAdComApisToBridges(apis):
+  result = new Set()
+  hasSharcCode = apis.includes(SHARC_API_CODE)
+
+  for code in apis:
+    if code === SHARC_API_CODE: continue                    // SHARC is runtime, not a bridge
+    if hasSharcCode and isMraidCode(code): continue         // SHARC supersedes
+    if hasSharcCode and code === SAFEFRAME_API_CODE: continue  // SHARC supersedes
+    // OMID (code 7) is NEVER skipped here — measurement is orthogonal
+
+    bridge = ADCOM_API_TO_BRIDGE[code]
+    if bridge: result.add(bridge)
+
+  return [...result].sort()
+```
+
+**Implementation:** the supersession lives in `_mapAdComApisToBridges` (or equivalent helper). The picker for `apiFramework` already prefers SHARC at priority 1 in § 6.2 — that branch is untouched. The new logic only adds bridge-loading inhibition. See G12 in § 9 for the locked invariant.
+
+## 7. Diagnostic surface
+
+### 7.1 `container.hasSharcSession`
+
+Add a new read-only accessor:
+
+```typescript
+get hasSharcSession(): boolean
+```
+
+Returns `true` once the creative has called `createSession` and the protocol has accepted the session — i.e., `this._protocol.sessionId !== null` (or equivalent — the architect notes the implementer may proxy through `this._sessionId !== ''` depending on the existing private-field convention). Returns `false` until then. The existing `container.sessionId` already returns `null` before the handshake, but a dedicated boolean accessor reads better at call sites:
+
+```javascript
+if (!container.hasSharcSession) {
+  // Display fallback measurement UI, skip SHARC-specific instrumentation, etc.
+}
+```
+
+**Why not just check `container.sessionId !== null`?** Operators conflate "session ID is null" with "container hasn't loaded yet." A named boolean (`hasSharcSession`) disambiguates and makes diagnostic dashboards self-documenting.
+
+**Why not name it `isSharcCreative`?** As issue #89 § 6 floated. The container can't reliably know "is this creative SHARC-aware" — it only knows "has a handshake completed." A creative that handshakes slowly is SHARC-aware but `hasSharcSession` is briefly `false`. A creative that hangs in initialization is SHARC-aware but never reaches the handshake. Naming the accessor for the *observable signal* (`hasSharcSession`) rather than the inferred property (`isSharcCreative`) is more honest.
+
+Implementation: getter that proxies the existing `_sessionId` field. Always-current, no separate state-machine cache to keep coherent.
+
+**Temporal coupling with `apiFramework` — read pattern.** `apiFramework` is frozen at construction (§ 6, G10) and is queryable immediately. `hasSharcSession` changes asynchronously when the handshake fires (or never fires). Operators MUST NOT couple the two reads — querying `hasSharcSession` in the same microtask as `load()` will always return `false` even for a SHARC-aware creative. The correct pattern is:
+
+- Query `apiFramework` immediately after construction. It is stable.
+- Query `hasSharcSession` only after a lifecycle observation window (e.g. in an `onStateChange` callback, or after a timeout long enough for the handshake to plausibly complete — typically the operator's own viewability or completion deadline).
+
+This pattern is enshrined in § 11.2 and called out in the cookbook (G11).
+
+### 7.2 `container.apiFramework`
+
+See § 6 for full semantics. Frozen at construction; queryable before `load()`. Complements `hasSharcSession` — declaration vs outcome.
+
+> **JSDoc note:** When a creative declares multiple codes, the picker returns the highest-priority container-runtime code. To inspect all declared codes, read `creativeMeta.apis` directly.
+
+### 7.3 `container.bridges` continues to populate
+
+The 0.7.1 `container.bridges` diagnostic is **unaffected by `requireSharcInit`**. Bridge resolution runs at construction time (in `_resolveBridges()` via `creativeMeta.apis` and adm scan; § 3 of the 0.7.1 design doc), entirely independent of the handshake. A non-SHARC creative with `bridges: ['mraid']` still reflects `['mraid']` on `container.bridges` — exactly the diagnostic the operator wants to confirm "yes, I asked for the MRAID bridge, and it was wired."
+
+### 7.4 Framework-aware late handshake warn
+
+When `requireSharcInit: false` and a late `createSession` arrives, the container emits a `console.warn` whose content depends on the declared framework. This addresses SE's "confused deputy" diagnostic gap: an unexpected SHARC-handshake from a declared-non-SHARC creative is the exact signal operators want surfaced.
+
+| Scenario | Behavior |
+|---|---|
+| `apiFramework: null` (or no apis declared), `hasSharcSession: false`, late `createSession` at T+47s | `console.warn` — confused-deputy concern (unexpected SHARC behavior from declared-non-SHARC creative). Then accept the session. |
+| `apiFramework: 6` (MRAID 3.0) or any other non-SHARC declared framework picker-target (`5`, `3`, or `SAFEFRAME_API_CODE`), late `createSession` | `console.warn` — declared non-SHARC creative shouldn't be calling `createSession`. Then accept the session. |
+| `apiFramework: SHARC_API_CODE`, late `createSession` | **Accept silently** — declaration matches outcome, just slow. No warn. |
+| `hasSharcSession: true` already, spurious second `createSession` | `console.warn` — idempotency violation; potential reattempt or race. Subsequent `createSession` rejected at the protocol layer per existing semantics. |
+
+The warn message **MUST** include four forensic fields: `placementSessionId`, the `apiFramework` value, the `bridges` value, and `elapsed-since-load` (in ms). The `bridges` value is included because operators correlating "confused deputy" diagnostics often need to know which bridges were resolved alongside the unexpected handshake — same forensic axis as `apiFramework`. Example warn text (architect picks; implementer may polish):
+
+```
+[SHARC] Late createSession received at T+47235ms for placement <placementSessionId>;
+  apiFramework=null (no container-runtime declared), bridges=[]. Container was
+  constructed with requireSharcInit:false; accepting the handshake. If this creative
+  is expected to be SHARC-aware, declare creativeMeta.apis or set requireSharcInit:true.
+```
+
+This makes the confused-deputy signal operator-visible at handshake-time, not just at downstream-failure-time. **The warn fires only when `requireSharcInit: false`** — the strict path (default) still fatal-errors before the late-arrival window opens. See G7 in § 9.
+
+### 7.5 No new `onSecurityEvent` event for skipped timeout
+
+A skipped timeout when the operator explicitly opted in is not a security event. Emitting one would be noise. Operators who want to *observe* that the timeout was skipped read the constructor option they themselves set. Symmetric with how 0.7.1's `bridges: []` (suppress all bridges) doesn't emit a security event.
+
+### 7.6 `container.requireSharcInit` accessor — skipped
+
+Per Q3's lock (resolved as the framework-detection scope expansion, not as a one-line read-back accessor): the option value is not exposed via a round-trip accessor. Operators have the value at their construction site; dashboards correlating "permissive load → downstream behavior" use `apiFramework` + `hasSharcSession` for richer signal. YAGNI on the round-trip read-back.
+
+## 8. Lifecycle adapter layer
+
+`requireSharcInit: false` alone is "do not fatal-error on missing handshake" — it does not give operators lifecycle observability. Operators of mixed inventory want the same `onStateChange` signal for non-SHARC creatives that they get for SHARC-aware ones: viewability, visibility, freeze/resume, bfcache restoration. 0.7.2 closes this gap with an **HTML lifecycle adapter** — a thin layer that derives SHARC state transitions from browser-native lifecycle signals when no handshake-driven path is available.
+
+**0.7.2 scope: HTML adapter only.** Generic HTML creatives (`apiFramework === null`) and creatives with framework codes that don't yet have a dedicated adapter (MRAID, SafeFrame) get lifecycle observability via web standards. Framework-specific adapters (MRAID's `mraid.viewableChange`, SafeFrame's `$sf.ext.status()`) are deferred to 0.7.3 (see § 13).
+
+### 8.1 Architectural shape — adapter classes (Option 1)
+
+The architect picks the adapter-class shape over inline switch or strategy-pattern registry. Rationale:
+
+| Option | Pro | Con |
+|---|---|---|
+| **Adapter classes (chosen)** | Clean open-closed extension point for 0.7.3 MRAID/SafeFrame adapters. Each adapter is independently testable. Composition with the container is explicit. | One more file in `src/`. |
+| Inline switch in container | Smallest 0.7.2 diff. | 0.7.3 work bloats the container further; switch grows by framework. Hard to test in isolation. |
+| Strategy-pattern registry | Maximal flexibility (operators could register custom adapters). | Premature option-space expansion. No operator has asked for custom adapter registration. |
+
+Shape:
+
+```
+src/lifecycle-adapters/
+├── base-adapter.js          // abstract: attach(container), detach()
+├── html-adapter.js          // 0.7.2 — browser-native signals only
+├── (mraid-adapter.js)       // 0.7.3 — extends html-adapter
+└── (safeframe-adapter.js)   // 0.7.3 — extends html-adapter
+```
+
+The container instantiates exactly one adapter in `load()` based on `this._apiFramework`:
+
+```pseudocode
+// in load(), after _attachPageLifecycleListeners()
+this._lifecycleAdapter = _selectLifecycleAdapter(this._apiFramework);
+this._lifecycleAdapter.attach(this);
+```
+
+Selection logic for 0.7.2:
+
+```pseudocode
+function _selectLifecycleAdapter(apiFramework):
+  // 0.7.2: only the HTML adapter exists. It applies in two cases:
+  //   - apiFramework === null (generic HTML creative, or video-creative-only
+  //     declarations like VPAID/SIMID which the picker returns null for)
+  //   - apiFramework matches a framework without a dedicated 0.7.2 adapter
+  //     (MRAID, SafeFrame) — HTML adapter is the fallback baseline
+  //
+  // 0.7.3 will add MraidAdapter / SafeFrameAdapter; selection becomes:
+  //   if (apiFramework in MRAID_CODES) return new MraidAdapter()
+  //   if (apiFramework === SAFEFRAME_API_CODE) return new SafeFrameAdapter()
+  //   return new HtmlAdapter()
+  return new HtmlAdapter()
+```
+
+**The HTML adapter applies whenever there's no framework-specific adapter.** This means MRAID and SafeFrame creatives in 0.7.2 get HTML-adapter lifecycle observability — until their dedicated adapters ship in 0.7.3 with framework-specific signals layered on top. The 0.7.3 adapters subclass `HtmlAdapter` and add framework signals; the universal browser signals stay live.
+
+### 8.2 Adapter activation and the SHARC-aware path
+
+The HTML adapter attaches in `load()` regardless of `requireSharcInit`. When a SHARC-aware creative handshakes, the handshake-driven `LOADING → READY → ACTIVE` transition runs as today; the adapter observes the resulting `ACTIVE` state and yields to it for subsequent visibility-driven transitions, which the existing `_attachPageLifecycleListeners()` chain already handles (`visibilitychange`, `focus`, `blur`, `freeze`, `resume`).
+
+The adapter's job is therefore:
+
+- **For non-handshake creatives:** drive the initial `LOADING → ACTIVE` transition that the handshake would otherwise drive, plus contribute the missing browser signals (IntersectionObserver, `pagehide`/`pageshow`) that the current `_attachPageLifecycleListeners()` does not.
+- **For handshake creatives:** stay out of the way. The handshake handles `LOADING → READY → ACTIVE`; the existing listeners handle subsequent transitions. The adapter's IntersectionObserver and bfcache wires layer on top without conflict — they only fire transitions the existing chain cannot.
+
+### 8.3 HTML adapter event-to-state mapping
+
+| Browser event | SHARC transition | Notes |
+|---|---|---|
+| Iframe `load` fires **AND** IntersectionObserver reports `isIntersecting: true` (≥ 50% threshold) | `LOADING → ACTIVE` | Skips `READY` — `READY` is reserved for handshake-driven init. Both conditions required: a creative that loads off-screen stays in `LOADING` until first intersection. |
+| IntersectionObserver reports `isIntersecting: true` while in `LOADING` (delayed visibility) | `LOADING → ACTIVE` | Same gate; if iframe-load already fired, intersection alone advances. |
+| IntersectionObserver reports `isIntersecting: false` (visibility 0%) | `ACTIVE → HIDDEN` | Fully off-screen / scrolled away. |
+| IntersectionObserver reports partial visibility (< 50%, > 0%) | `ACTIVE → PASSIVE` | Threshold is architect's discretion; 50% mirrors common viewability conventions and aligns with the MRAID viewable definition. |
+| IntersectionObserver returns to ≥ 50% visibility | `PASSIVE/HIDDEN → ACTIVE` | Gated on parent document also being visible. |
+| `document.visibilitychange` → `hidden` on parent doc | `ACTIVE/PASSIVE → HIDDEN` | Existing handler covers `ACTIVE → HIDDEN` and `PASSIVE → HIDDEN`; adapter does not duplicate. |
+| `document.visibilitychange` → `visible` on parent doc | `HIDDEN → ACTIVE` (if IntersectionObserver also reports visible) or `HIDDEN → PASSIVE` (if not) | Existing handler transitions `HIDDEN → PASSIVE`; adapter further promotes to `ACTIVE` when intersection is ≥ 50%. |
+| `pagehide` event (parent doc, `persisted: true`) | `HIDDEN → FROZEN` | bfcache entry. Distinct from `freeze` — fires earlier in the bfcache flow. |
+| `pageshow` event (parent doc, `persisted: true`) | `FROZEN → ACTIVE` (if visible) / `FROZEN → PASSIVE` | bfcache restoration. |
+| `freeze` event (parent doc) | `* → FROZEN` | Existing handler covers `HIDDEN → FROZEN` only; adapter broadens to any pre-`TERMINATED` state. |
+| `resume` event (parent doc) | `FROZEN → ACTIVE/PASSIVE` per visibility | Existing handler; adapter does not duplicate. |
+| Container `close()` from any state | `* → TERMINATED` | Existing behavior. |
+
+**Ordering when multiple signals fire simultaneously** (e.g. iframe-load + initial intersection at construction time): the adapter coalesces via a microtask boundary — after `load()` returns synchronously, a single `queueMicrotask` checks the current intersection + load state and fires at most one transition. Subsequent transitions fire on event arrival.
+
+**`RESIZED` observability.** The HTML adapter does NOT observe `RESIZED` — there is no clean browser-native signal for "creative's renderable area changed" without coordination with the container's own placement-change machinery (which is handshake-driven). Deferred to the MRAID adapter (0.7.3), which has `mraid.size` / `mraid.resizeProperties` semantics to anchor against.
+
+### 8.4 Test surface and limits
+
+| Concern | jsdom | Real browser |
+|---|---|---|
+| `visibilitychange`, `focus`, `blur` | Simulable | ✓ |
+| `IntersectionObserver` | Polyfill-able with explicit triggering (set `isIntersecting` programmatically) | ✓ |
+| `freeze`, `resume` | Simulable as DOM events | ✓ |
+| `pagehide`, `pageshow` with `persisted: true` | Can dispatch the event but bfcache itself is not modeled | Only end-to-end testable in Chrome with bfcache enabled. **Flag for 0.7.2: bfcache restoration is not fully verifiable in jsdom; Puppeteer coverage gated on bfcache support — defer to follow-up.** |
+| Iframe `load` ordering w.r.t. intersection | Simulable with manual event dispatch order | ✓ |
+
+The 0.7.2 test surface is jsdom-primary (per Q6's lock); bfcache-specific paths are documented but not asserted end-to-end. The adapter is structured so the bfcache wire (`pagehide`/`pageshow`) is testable as event-dispatch even when bfcache itself isn't simulated.
+
+### 8.5 0.7.3 forward path — framework-specific adapters
+
+| Adapter | Adds (over HTML adapter) | When ships |
+|---|---|---|
+| `MraidAdapter` | `mraid.viewableChange` → `ACTIVE/PASSIVE` (overrides IntersectionObserver when bridge active), `mraid.sizeChange` → `RESIZED`, MRAID state-machine ground-truth signals. | 0.7.3 |
+| `SafeFrameAdapter` | `$sf.ext.status()` polled signals, `$sf.ext.geom()` for visibility math. | 0.7.3 |
+
+Each subclasses `HtmlAdapter` and layers framework signals on top of the universal browser signals. The open-closed shape locks in here: 0.7.2's adapter base class is the contract.
+
+## 9. Required Implementation Guardrails
+
+The Security Engineer pressure-test surfaced eight MUST-rules (G1–G8) that lock the security invariants of § 4.6 into implementation. G9 was added during the framework-detection scope expansion to specify the bridge-timeout warn. G10–G12 were added during round-2 review for accessor immutability, cookbook temporal coupling, and the SHARC-supersedes-bridges supersession rule (§ 6.7). The Senior Developer implements against all twelve. Test coverage in § 15 references each guardrail by ID.
+
+- **G1.** Sandbox attribute, permissions-policy, and cross-origin enforcement MUST remain identical regardless of `requireSharcInit`. Only `_startSessionTimeout` is gated.
+
+- **G2.** Load-event navigation backstop (`RENDERER_UNAUTHORIZED_NAVIGATION 2118`) MUST arm for both variants regardless of `requireSharcInit`. Highest-impact security boundary.
+
+- **G3.** `KNOWN_TEST_RENDERERS` production-block guard MUST throw synchronously at construction regardless of `requireSharcInit`. Already does; spec as MUST.
+
+- **G4.** Renderer envelope validation (`_isValidRendererEnvelope`) MUST remain unchanged. Cross-frame spoofing prevention.
+
+- **G5.** Protocol-port session-ID filter MUST continue to drop all non-CREATE_SESSION messages when `this.sessionId === ''`. Unauthenticated creatives can't `requestNavigation` over the port.
+
+- **G6.** `close()` from `LOADING` state with a non-SHARC creative MUST be tested. Post-condition invariants enumerated: `closeSequence` timeout fires within budget, `_terminate` runs, `onClose` fires, listeners detached, timeouts cleared.
+
+- **G7.** Late-arriving `createSession` MUST emit `console.warn` per the framework-aware matrix in § 7.4. Warn MUST include `placementSessionId`, `apiFramework`, `bridges`, and `elapsed-since-load`. Closes the confused-deputy diagnostic gap.
+
+- **G8.** OMID 0.7.2 second-half work MUST be compatible with `requireSharcInit: false`. The OMID design pass must verify its container-side wiring does not introduce a new "must-handshake" dependency.
+
+- **G9.** Bridge auto-install timeout (when `window.SHARC` never appears) MUST emit `console.warn` per bridge with a specific message. The bridge module emits the warn; the container does not intervene. The warn template MUST report the **strict integer cap value** (the cap-hit elapsed time at which the polling stopped), not an approximate "~Nms" string. See § 10.1 for the bridge-side spec.
+
+- **G10.** `container.apiFramework` MUST be frozen at construction and MUST NOT be mutated by any subsequent operation including late handshake, `creativeMeta` field re-reads, or extension callbacks. Implement as a getter returning `this._apiFramework`, where `this._apiFramework` is set exactly once in the constructor body alongside `this._bridges`. No setter; no mutation path. This guardrail prevents a class of "the framework changed after I read it" bugs that would silently break operator dashboards.
+
+- **G11.** Operator-facing documentation MUST explicitly call out the temporal coupling between `apiFramework` (frozen at construction) and `hasSharcSession` (changes when handshake fires). The creative-cookbook entry AND the § 11.2 mixed-inventory worked example MUST show the correct read pattern: query `apiFramework` immediately after construction; query `hasSharcSession` only after a lifecycle observation window (`onStateChange` callback or operator-defined deadline), not in a microtask after `load()`. The Senior Developer MUST verify both doc surfaces show this pattern before merge.
+
+- **G12.** When `creativeMeta.apis` declares both `SHARC_API_CODE` and a container-API code (MRAID or `SAFEFRAME_API_CODE`), SHARC supersedes — `container.apiFramework` returns `SHARC_API_CODE` AND `container.bridges` excludes the superseded bridges. OMID (code `7`) is orthogonal and is NEVER superseded — a creative declaring `[SHARC_API_CODE, 7]` resolves to SHARC runtime with OMID measurement coexisting. The supersession lives in `_mapAdComApisToBridges` per the pseudocode in § 6.7. The numeric values of `SHARC_API_CODE` and `SAFEFRAME_API_CODE` are locked at AdCOM publication (§ 6.3); the supersession logic is live and tested against the placeholder constants today.
+
+## 10. Bridge interaction (extensions and auto-install)
+
+### 10.1 Bridge auto-install timeout (G9)
+
+When `requireSharcInit: false` + `bridges: ['mraid']` (Markup variant; URL variant blocked by Rule 3b from 0.7.1) + the creative does NOT load `sharc-creative.js`:
+
+- The bridge module's auto-install polling (the `setTimeout(0)` pattern from 0.7.1, capped at a strict integer tick count) eventually hits the cap without finding `window.SHARC.onReady`.
+- At cap-hit, the bridge install **MUST** emit a `console.warn` with the structure below. The warn reports the **strict integer cap value** (the configured cap-hit elapsed time, e.g. `16000` if the cap is 1000 ticks × ≈16 ms), not an approximate "~Nms" string. The warn includes `placementSessionId` for forensic correlation:
+
+```
+[SHARC MRAID bridge] Auto-install failed for placement <placementSessionId>:
+  window.SHARC not available after <CAP_MS>ms. window.mraid will not be wired.
+  Consider removing 'mraid' from bridges, or loading sharc-creative.js in your
+  creative so the bridge can install on top of the SHARC SDK.
+```
+
+Where `<CAP_MS>` is the bridge module's `BRIDGE_AUTOINSTALL_CAP_MS` constant. Same pattern for the `'safeframe'` bridge with `[SHARC SafeFrame bridge]` prefix and corresponding suggestion. Implementer adjusts the bridge prefix per module.
+
+- Bridge install does **NOT** proceed — `window.mraid` (or `window.$sf`) stays undefined.
+- Any subsequent `mraid.foo()` / `$sf.ext.bar()` call from the creative throws `ReferenceError` as today. **No change to this throw behavior.** The warn surfaces the failure at timeout-time, not just at call-time, so operators see the diagnostic earlier in the lifecycle.
+
+This makes "bridge requested but install failed" operator-visible regardless of whether the creative ever exercises the bridge.
+
+### 10.2 Extensions
+
+Extensions (`options.extensions`, e.g. future `OmidCompatBridge`) interact with the handshake at exactly two seams in `src/sharc-container.js`:
+
+| Seam | Code site | Behavior when `requireSharcInit: false` and no handshake |
+|---|---|---|
+| `injectIntoMarkup(html)` | Line 1618, line 2191 | Runs at iframe-load time, **before** any handshake. Unaffected by `requireSharcInit` — fires regardless. |
+| `getFeatureName()` | Line 2502–2507 | Only called inside `_handleCreateSession`. If no handshake fires, extensions' feature names are never collected. No-op-by-design — there's no `Container:init` to advertise features to. |
+| `destroy()` | Line 3287 | Runs on `_terminate()`. Unchanged. |
+
+### 10.3 MRAID and SafeFrame bridges — auto-install behavior
+
+The 0.7.1 bridge-loading mechanism (`bridges: ['mraid']` or auto-detection via `creativeMeta.apis`) is **independent of the SHARC handshake**. The bridge loads in the renderer page (Markup variant) via dynamic `import()` *before* `document.write(creativeHtml)`. The bridge installs `window.mraid` / `window.$sf` **only when `window.SHARC` is present** — i.e. when `sharc-creative.js` has loaded.
+
+**Critical correction from the prior design draft.** An earlier draft suggested a "legacy MRAID-only creative with no SHARC SDK" works under `requireSharcInit: false`. **It does not.** The MRAID bridge calls `SHARC.requestNavigation(...)` to satisfy `mraid.open()`. `window.SHARC` is installed by `sharc-creative.js`. If `sharc-creative.js` is not loaded, the bridge's auto-install polling times out (per G9 / § 10.1), `window.mraid` stays undefined, and the creative's `mraid.open()` call throws `ReferenceError`.
+
+The constraint is documented explicitly in the cookbook (§ 12): **a creative that wants the MRAID bridge MUST load `sharc-creative.js`.** The SDK auto-handshakes on `DOMContentLoaded`, so the creative will participate in the SHARC handshake even if it never directly calls `SHARC.createSession()`. `requireSharcInit: false` does not change this — the option prevents the *missing-handshake fatal-error*, but the bridge's wiring requirement is orthogonal.
+
+### 10.4 OMID container-side wiring (separate 0.7.2 work)
+
+The OMID design pass that follows this one is the right place for OMID-specific container affordances. Architect's expectation: OMID measurement is fire-and-forget, independent of SHARC handshake, so `requireSharcInit: false` is compatible. G8 enshrines this as a MUST-verify for the OMID design. The OMID design pass also owns the decision on adding accessors like `container.hasOmidInstrumentation` or similar.
+
+## 11. Worked examples (correct use cases)
+
+The valid use cases for `requireSharcInit: false`. These supersede the prior draft's "legacy MRAID-only" example, which was internally inconsistent (see § 10.3).
+
+### 11.1 Generic HTML banner with NO SHARC code
+
+A static image + click-handler banner that has zero SHARC awareness. No `sharc-creative.js`, no bridges, no protocol messages.
+
+```javascript
+const container = new SHARCContainer({
+  creativeHtml: '<html><body><a href="https://advertiser.example/landing"><img src="..."></a></body></html>',
+  creativeRendererUrl: 'https://renderer.example.com/...',
+  requireSharcInit: false,
+  // bridges omitted entirely
+  onStateChange: (newState, prevState) => {
+    console.log(`[banner] ${prevState} → ${newState}`);
+    // Will see LOADING → ACTIVE on iframe-load + visibility,
+    // then ACTIVE ↔ HIDDEN as the user scrolls.
+  },
+});
+container.load(slotEl);
+```
+
+Container loads, renderer renders, creative executes. No `createSession` fires; no fatal-timeout. The HTML lifecycle adapter (§ 8) advances `LOADING → ACTIVE` on iframe-load + IntersectionObserver visibility, and fires subsequent transitions on scroll / tab-switch / bfcache events. The click navigates via the renderer's load-event backstop (G2 still armed). Operator closes the container based on their own lifecycle signal (impression-completion, viewability timeout, etc.).
+
+### 11.2 Mixed-inventory placement
+
+An operator runs a placement where some creatives are SHARC-aware (third-party SHARC-instrumented tags) and some are plain HTML (house ads, fallback creatives). Some carry OMID measurement, some don't. Same placement, same container code path.
+
+```javascript
+function loadCreative(creativeAdm, creativeMeta) {
+  const container = new SHARCContainer({
+    creativeHtml: creativeAdm,
+    creativeMeta, // declarative framework signals from upstream
+    creativeRendererUrl: 'https://renderer.example.com/...',
+    requireSharcInit: false, // tolerate any creative shape
+    onStateChange: (newState) => {
+      if (newState === 'TERMINATED') cleanupMeasurement(container);
+    },
+  });
+
+  // CORRECT — apiFramework is frozen at construction; read it immediately.
+  const declaredFramework = container.apiFramework;
+  const declaresOmid = (creativeMeta?.apis || []).includes(7);
+  console.log(`[mixed] declared framework=${declaredFramework}, OMID=${declaresOmid}, bridges=${container.bridges.join(',')}`);
+
+  container.load(slotEl);
+
+  // INCORRECT — would always return false because the handshake hasn't fired yet:
+  // if (container.hasSharcSession) { ... }   // ❌ raced with load()
+
+  // CORRECT — query hasSharcSession only after a lifecycle observation window,
+  // either from onStateChange (when the creative transitions to READY/ACTIVE)
+  // or after an operator-defined deadline:
+  setTimeout(() => {
+    if (container.hasSharcSession) {
+      // SHARC-aware path: full instrumentation
+      attachSharcMetrics(container);
+    } else {
+      // Non-SHARC path: HTML adapter lifecycle is the only signal
+      attachFallbackMetrics(container);
+    }
+  }, viewabilityDeadlineMs);
+
+  return container;
+}
+```
+
+SHARC-aware creatives auto-handshake (the SDK calls `createSession` for them); `container.hasSharcSession` becomes `true`; the canonical `LOADING → READY → ACTIVE` runs. Plain HTML creatives never handshake; `container.hasSharcSession` stays `false`; the HTML adapter drives `LOADING → ACTIVE → ...` instead. OMID-instrumented creatives are detected via `creativeMeta.apis.includes(7)` — orthogonal to the container-runtime axis (`apiFramework`), per § 6.4 and the G12 supersession matrix in § 6.7.
+
+The operator's branching logic queries three independent signals — `apiFramework` (declaration, immediate), `hasSharcSession` (outcome, post-lifecycle), and `creativeMeta.apis.includes(7)` (OMID instrumentation, immediate) — to drive measurement / lifecycle decisions. The temporal-coupling read pattern is enforced by G11.
+
+### 11.3 Validator / preview tooling
+
+A tool that loads arbitrary creatives for inspection (e.g. a creative QA dashboard, a bid-response visualizer). The tool cannot afford a 5 s fatal-error on every load — most inspected creatives won't be SHARC-aware.
+
+```javascript
+const container = new SHARCContainer({
+  creativeHtml: arbitraryHtmlUnderInspection,
+  creativeRendererUrl: 'https://validator-renderer.example.com/...',
+  requireSharcInit: false,
+});
+container.load(previewSlot);
+
+// Read declarative signal immediately:
+console.log('Declared framework:', container.apiFramework);
+console.log('Bridges resolved:', container.bridges);
+
+// ...later, after lifecycle observation window:
+if (container.hasSharcSession) {
+  console.log('Creative completed SHARC handshake.');
+}
+container.close();
+```
+
+The accessors give the validator the declaration and the outcome separately — exactly the QA dashboard signal it needs.
+
+### 11.4 Anti-example — legacy MRAID-only without SHARC SDK
+
+**This use case is not supported.** Documented explicitly because the prior design draft mistakenly suggested it.
+
+```javascript
+// INCORRECT — this configuration does not work as one might guess.
+new SHARCContainer({
+  creativeHtml: legacyMraidMarkup, // does NOT load sharc-creative.js
+  creativeRendererUrl: 'https://renderer.example.com/...',
+  bridges: ['mraid'],
+  requireSharcInit: false,
+});
+```
+
+Why it fails: the MRAID bridge requires `window.SHARC` to exist (loaded by `sharc-creative.js`) to call `SHARC.requestNavigation(...)`. If `sharc-creative.js` is absent, the bridge's auto-install times out (warn per G9), `window.mraid` stays undefined, and the creative's `mraid.open()` throws `ReferenceError`.
+
+The correct configuration for a legacy-style MRAID creative is to ALSO load `sharc-creative.js` in the creative — the SDK auto-handshakes on `DOMContentLoaded`, so the creative gets `window.mraid` (from the bridge) *and* `window.SHARC` (from the SDK), without needing to explicitly call `SHARC.createSession()`. `requireSharcInit: false` is then unnecessary for this case (the SDK's auto-handshake fires the missing path); but it remains compatible.
+
+The cookbook entry (§ 12) documents this constraint with the same code samples.
+
+## 12. Documentation deltas
+
+| File | Change |
+|---|---|
+| `docs/api-reference.md` § 1 (Constructor Options) | New `requireSharcInit` entry, alphabetical. Type `boolean`, default `true`, semantics. Link to this design doc. |
+| `docs/api-reference.md` § 2 (Container properties / accessors) | New `container.hasSharcSession` entry. New `container.apiFramework` entry with AdCOM link. |
+| `docs/api-reference.md` § (Error Codes table) | **Explicit caveat line:** "`NO_CREATE_SESSION (2212)` is not emitted when `requireSharcInit: false`." Operators grepping "when does 2212 fire" find this caveat inline. |
+| `docs/architecture-design.md` § (state machine) | Note the two parallel transition paths into `ACTIVE` — handshake-driven (`LOADING → READY → ACTIVE`) and HTML-adapter-driven (`LOADING → ACTIVE`, skipping `READY`). Cross-reference § 8 of this design doc. |
+| `docs/creative-cookbook.md` | New section: "Loading non-SHARC creatives." Three concrete code snippets from § 11.1, 11.2, 11.3. **Cookbook callout (G11):** must show the temporal-coupling read pattern from § 11.2 — query `apiFramework` immediately, query `hasSharcSession` only after a lifecycle observation window. **Cookbook callout:** "When `requireSharcInit: false`, the container will not auto-terminate on a missing handshake. You are responsible for calling `container.close()` based on your own lifecycle signal." Plus the anti-example from § 11.4 documenting why "legacy MRAID without SHARC SDK" does not work. |
+| `docs/getting-started.md` | **New one-paragraph pointer** in the section that discusses what happens after `container.load()`: "If you're loading non-SHARC creatives (generic HTML banners, mixed inventory, validator tooling), see the cookbook entry for `requireSharcInit` for the opt-in switch and the supported configurations." |
+| `README.md` | Version-bump badge + CDN URL touches per `CLAUDE.md` § Version Bump Checklist. No semantic content change — the version sync hook propagates the new value automatically. |
+| `SECURITY.md` (if present in repo) | **Implementation MUST check whether `SECURITY.md` exists** before merge. If present, verify it reflects the new G1–G12 invariants and the `requireSharcInit` option. If it does not currently mention the handshake-as-diagnostic boundary, add a paragraph aligning it with G1–G9 (security boundaries are handshake-independent; `requireSharcInit: false` weakens diagnostic loudness, not security). |
+| `CHANGELOG.md` `[Unreleased]` | New `### Added` entries; bump to `[0.7.2] - <release date>` at release time. |
+
+CHANGELOG `[Unreleased]` skeleton:
+
+```markdown
+## [Unreleased]
+
+### Added
+
+- **Non-SHARC creative loading** — `SHARCContainer` now accepts a
+  `requireSharcInit: boolean` constructor option (default `true`). When set
+  to `false`, the container skips the 5 s `createSession` fatal-timeout,
+  allowing operators to load generic HTML banners and mixed inventory under
+  a unified container code path. ([#89])
+
+- **HTML lifecycle adapter** — non-SHARC creatives now progress through the
+  container state machine via browser-native lifecycle signals
+  (`visibilitychange`, IntersectionObserver, `pagehide`/`pageshow`,
+  `freeze`/`resume`). The adapter skips the handshake-exclusive `READY`
+  state and advances `LOADING → ACTIVE` directly when the iframe loads and
+  becomes visible. Operators get `onStateChange` observability for non-SHARC
+  creatives. MRAID and SafeFrame adapters extending this foundation will
+  ship in 0.7.3.
+
+- **Framework declaration accessor** — `container.apiFramework: number | null`
+  resolves the AdCOM `APIFramework` code from `creativeMeta.apis` at
+  construction time. Frozen, queryable before `load()`. Picker recognizes
+  SHARC, MRAID, and SafeFrame as container-runtime codes; OMID is excluded
+  (separate measurement design); VPAID and SIMID are not picker targets
+  (video-creative protocols, not display-container runtimes — return `null`).
+  When `creativeMeta.apis` declares both a SHARC code and a container-API
+  code, SHARC supersedes — `apiFramework` returns the SHARC code and
+  `bridges` excludes the superseded MRAID/SafeFrame entries.
+
+- **SHARC handshake accessor** — `container.hasSharcSession: boolean` reports
+  whether a SHARC handshake has completed. Complements `apiFramework`
+  (declaration vs outcome).
+
+### Changed
+
+- (None expected — this is purely additive surface.)
+```
+
+## 13. Design decisions (resolved)
+
+All nine design questions are resolved. The Senior Developer implements against these locks; the conversation that produced them is referenced in the issue thread.
+
+1. **Default value for `requireSharcInit`.** **Resolved (Jeffrey, 2026-05-15):** default `true` (strict). Rationale: preserves the 5 s fatal-timeout as a diagnostic signal for existing operators; permissive default would silently mask broken-handshake bugs. PM and SE concurred with architect.
+
+2. **Option name.** **Resolved (Jeffrey, 2026-05-15):** `requireSharcInit: boolean`. Rationale: symmetric with the existing `allow*` boolean family; names the load-bearing invariant; self-documenting default. PM and SE concurred with architect.
+
+3. **Framework detection — scope expansion.** **Resolved (Jeffrey, 2026-05-15):** ship BOTH `container.apiFramework: number | null` (declaration-driven, AdCOM-aligned) AND `container.hasSharcSession: boolean` (outcome-driven). Rationale: Jeffrey reframed the original Q3 (boolean read-back of `requireSharcInit`) into a substantive framework-detection layer mirroring 0.7.1's three-layer `bridges` pattern. See § 6 for the full picker and precedence ladder. **Refined (Jeffrey, 2026-05-15):** picker scope is **container-runtime codes only** — SHARC, MRAID, SafeFrame. OMID (`7`) is excluded (measurement, not container runtime). VPAID (`1`, `2`) and SIMID (`8`, `9`) are **not picker targets** (video-creative protocols, not display-container runtimes); they return `null`. Operators read `creativeMeta.apis` directly if they need to branch on video-creative declarations. The original "expose `container.requireSharcInit` round-trip accessor" question is dropped — operators get richer signal from `apiFramework` + `hasSharcSession`.
+
+4. **`requireSharcInit: null` handling.** **Resolved (Jeffrey, 2026-05-15):** throw `TypeError`. Rationale: matches strict-bool validation of other boolean options (`allowPopups`, etc.); no special-case "null is undefined" carve-out. PM and SE concurred with architect.
+
+5. **OMID container-side wiring scope.** **Resolved (Jeffrey, 2026-05-15):** OMID stays in the second-half 0.7.2 design pass — separate work item, separate design doc. First-half 0.7.2 (this design) ships container-runtime framework detection but excludes OMID from the picker. G8 in § 9 enshrines the compatibility-MUST for the OMID design.
+
+6. **Browser harness for non-SHARC creatives.** **Resolved (Jeffrey, 2026-05-15):** defer to a follow-up issue. Rationale: jsdom coverage in `test/node/test-non-sharc-loading.js` is sufficient for the 0.7.2 ship; a third browser-harness page (alongside `mraid-test.html` and `safeframe-test.html`) needs its own wrapper-conventions design pass. PM and SE concurred with architect.
+
+7. **Late-arriving `createSession` after `requireSharcInit: false`.** **Resolved (Jeffrey, 2026-05-15):** framework-aware warn (not silent, not reject). Rationale: SE's confused-deputy concern made the original "accept silently" lock too quiet; the framework-detection scope expansion made it possible to gate the warn on `apiFramework`, so the warn fires only when the late handshake conflicts with the declaration (or there is no declaration). See the matrix in § 7.4. Warn includes `placementSessionId`, `apiFramework`, `bridges`, and elapsed-since-load for forensic value.
+
+8. **SHARC vs container-API supersession (G12 D).** **Resolved (Jeffrey, 2026-05-16):** when `creativeMeta.apis` declares both `SHARC_API_CODE` and a container-API code (MRAID or `SAFEFRAME_API_CODE`), SHARC takes priority in the picker **AND** inhibits loading of the lower-priority bridges. OMID (code 7) is orthogonal — never superseded. Rationale: honors creative-author intent for portable creatives (one file works in both SHARC and legacy MRAID containers via API fallback) without loading dead-weight bridges in SHARC containers. **Refined (Jeffrey, 2026-05-15):** the design assumes AdCOM publishes SHARC and SafeFrame codes; implementation uses placeholder constants `SHARC_API_CODE` / `SAFEFRAME_API_CODE` whose integer values are locked at AdCOM publication (§ 6.3). The supersession logic is live and tested today. See § 6.7 for the pseudocode and G12 in § 9 for the locked invariant.
+
+9. **Lifecycle observability for non-SHARC creatives (Option C scope lock).** **Resolved (Jeffrey, 2026-05-16):** ship an **HTML lifecycle adapter in 0.7.2** that drives state transitions from browser-native signals (iframe `load`, IntersectionObserver, `visibilitychange`, `pagehide`/`pageshow`, `freeze`/`resume`). MRAID and SafeFrame adapters are **deferred to 0.7.3** as subclasses that layer framework-specific signals on top. Rationale: operators of mixed inventory want `onStateChange` for non-SHARC creatives too; "stay in `LOADING` indefinitely" blinded them to viewability, freeze/resume, and bfcache. Scope is bounded to 0.7.2 by deferring the framework-specific work. See § 8 for the adapter design and § 13 forward-looking notes for the 0.7.3 path.
+
+## 14. Forward-looking notes
+
+**Forward path:** Post-1.0, `requireSharcInit` may be marked legacy in favor of pure declaration-driven detection via `apiFramework`. Once `SHARC_API_CODE` is the canonical operator declaration, `creativeMeta.apis: [SHARC_API_CODE]` is more semantically correct than setting `requireSharcInit: true`. Until then, `requireSharcInit` is the explicit operator switch.
+
+**0.7.3 — MRAID and SafeFrame lifecycle adapters.** Extend the 0.7.2 HTML-adapter foundation (§ 8) with framework-specific subclasses. `MraidAdapter` adds `mraid.viewableChange` (overrides IntersectionObserver when the bridge is active), `mraid.sizeChange` (drives the deferred `RESIZED` transition), and the MRAID state-machine ground-truth signals. `SafeFrameAdapter` adds `$sf.ext.status()` polled signals and `$sf.ext.geom()` for visibility math. Each adds framework-specific lifecycle signals layered on top of the universal browser signals — the open-closed shape locked by the 0.7.2 adapter base class. This is the natural follow-up issue to #89.
+
+**AdCOM code publication** (per memory `project_upstream_contribution_roadmap`): dual registration of SafeFrame 1.0 and SHARC 1.0 in AdCOM's API Frameworks list is the externally-owned dependency that locks `SHARC_API_CODE` and `SAFEFRAME_API_CODE` to their final integer values. The 0.7.2 design ships against placeholder constants (§ 6.3); when AdCOM publishes, the implementer updates the two integer literals — no logic changes, no test-shape changes. Operators already declaring `creativeMeta.apis` are forward-compatible without code changes.
+
+**Bid-context-derived detection (Layer 2):** the reserved layer in § 6.1 may eventually carry detection from a bid-context field (e.g. an OpenRTB pass-through of `bid.apis`). Currently no-op; reserving the layer keeps the precedence numbering stable.
+
+## 15. Test surface
+
+### 15.1 Constructor validation
+
+Add to `test/node/test-creative-sources.js`:
+
+| Case | Expected |
+|---|---|
+| `requireSharcInit: true` | Accepted; behavior identical to 0.7.1 |
+| `requireSharcInit: false` | Accepted; `_startSessionTimeout` is not called by `load()` |
+| `requireSharcInit: undefined` (omit) | Defaults to `true` |
+| `requireSharcInit: null` | `TypeError` (per Q4 lock) |
+| `requireSharcInit: 'false'` (string) | `TypeError` |
+| `requireSharcInit: 0`, `1` | `TypeError` (no truthy/falsy coercion) |
+| `requireSharcInit: false` alongside `creativeUrl` | Accepted (variant-agnostic) |
+| `requireSharcInit: false` alongside `creativeHtml + creativeRendererUrl` | Accepted |
+
+### 15.2 `apiFramework` resolution
+
+The architect picks: **extend `test/node/test-bridges-detection.js`** with a new section (~30–50 assertions) covering the picker. Same file because the resolution mechanism is the same three-layer pattern as `bridges`; co-locating the tests keeps the resolution logic discoverable. If the file is already large at implementation time, the Senior Developer may split into a new `test/node/test-api-framework-detection.js` — implementer's call.
+
+Coverage matrix:
+
+| Case | `creativeMeta.apis` input | Expected `apiFramework` |
+|---|---|---|
+| MRAID 3.0 alone | `[6]` | `6` |
+| MRAID 3.0 + MRAID 2.0 | `[6, 5]` | `6` (higher MRAID wins) |
+| MRAID 3.0 + VPAID 2 | `[6, 2]` | `6` (VPAID not a picker target; MRAID wins) |
+| MRAID 3.0 + OMID | `[6, 7]` | `6` (OMID excluded) |
+| OMID alone | `[7]` | `null` (excluded) |
+| VPAID alone | `[2]` (or `[1]`) | `null` (not a picker target) |
+| SIMID alone | `[8]` (or `[9]`) | `null` (not a picker target) |
+| Vendor-specific | `[503]` | `null` |
+| Empty array | `[]` | `null` |
+| Omitted `creativeMeta` | (no creativeMeta) | `null` |
+| URL variant (Rule 3b) | (no creativeMeta) | `null` |
+| Multiple unknowns + one known | `[503, 6, 999]` | `6` |
+| SHARC alone | `[SHARC_API_CODE]` | `SHARC_API_CODE` |
+| SafeFrame alone | `[SAFEFRAME_API_CODE]` | `SAFEFRAME_API_CODE` |
+| **G10:** mutation attempt after construction | `[6]`, then attempt to overwrite `container.apiFramework` | property is non-writable; `container.apiFramework` returns `6` |
+| **G10:** `creativeMeta` re-read after late handshake | `[6]`, late `createSession` fires | `container.apiFramework` still `6` (never mutates) |
+| **G12:** SHARC supersedes MRAID | `[6, SHARC_API_CODE]` | `apiFramework: SHARC_API_CODE`, `bridges: []` |
+| **G12:** SHARC supersedes SafeFrame | `[SAFEFRAME_API_CODE, SHARC_API_CODE]` | `apiFramework: SHARC_API_CODE`, `bridges: []` |
+| **G12:** OMID + SHARC coexist | `[7, SHARC_API_CODE]` | `apiFramework: SHARC_API_CODE`; bridges include `'omid'` in 0.7.2 second-half (not 0.7.2 first half) |
+| **G12:** MRAID alone (no supersession) | `[6]` | `apiFramework: 6`, `bridges: ['mraid']` (unchanged from 0.7.1) |
+
+### 15.3 End-to-end behavior — new `test/node/test-non-sharc-loading.js`
+
+jsdom-based, mirrors `test-creative-sources-load.js`. Coverage matrix:
+
+| Scenario | `requireSharcInit` | Creative behavior | Expected outcome | Guardrails verified |
+|---|---|---|---|---|
+| Default strict: SHARC creative handshakes | `true` (default) | calls `createSession` within budget | container → READY → ACTIVE; no error; `hasSharcSession === true` | — |
+| Default strict: non-SHARC creative | `true` (default) | never calls `createSession` | container fatal-errors after 5 s with `NO_CREATE_SESSION` (2212) | — |
+| Permissive: SHARC creative handshakes | `false` | calls `createSession` within 5 s | no observable difference from strict + SHARC | — |
+| Permissive: SHARC creative handshakes late | `false` | calls `createSession` at 8 s | container accepts; `hasSharcSession === true`; **`console.warn` fires per G7** | G7 |
+| Permissive: non-SHARC creative — HTML adapter drives lifecycle | `false` | never calls `createSession` | container advances `LOADING → ACTIVE` via HTML adapter; `onStateChange` fires; `hasSharcSession === false`; `container.close()` cleanly terminates | G6 |
+| Permissive + close mid-load (pre-ACTIVE) | `false` | never calls `createSession`; close before iframe-load | LOADING → TERMINATED; `onClose` fires; no error | G6 |
+| Permissive + handshake after close | `false` | close at 3 s, then `createSession` at 4 s | late `createSession` dropped at terminated-protocol boundary | — |
+| Permissive + declared MRAID, late handshake | `false`; `creativeMeta.apis: [6]` | `createSession` at T+8s | warn includes `apiFramework=6`, `bridges=['mraid']` per G7 matrix | G7 |
+| Permissive + no declaration, late handshake | `false`; no `creativeMeta` | `createSession` at T+8s | warn includes `apiFramework=null`, `bridges=[]` per G7 matrix | G7 |
+| Permissive + load-event nav backstop armed | `false` | non-SHARC creative attempts navigation | `RENDERER_UNAUTHORIZED_NAVIGATION` (2118) fires per G2 | G2 |
+| Permissive + sandbox attrs unchanged | `false` | iframe inspection | sandbox / permissions-policy / cross-origin identical to strict path per G1 | G1 |
+| Permissive + `KNOWN_TEST_RENDERERS` guard | `false`; test-renderer URL in production-mode | construction throws per G3 | G3 |
+
+### 15.4 HTML lifecycle adapter — new `test/node/test-html-lifecycle-adapter.js`
+
+Targeted jsdom coverage for the § 8 adapter. The Senior Developer instantiates the adapter against a mock container shim and asserts transitions on event arrival. Coverage matrix:
+
+| Scenario | Trigger | Expected SHARC transition |
+|---|---|---|
+| Iframe load fires first, then intersection ≥ 50% | dispatch `load`, then update IntersectionObserver | `LOADING → ACTIVE` (exactly one transition) |
+| Intersection fires first, then iframe load | inverse order | `LOADING → ACTIVE` (exactly one transition; coalesced) |
+| Iframe loads off-screen, then scrolls in | `load` with no intersection, then ≥ 50% | `LOADING → ACTIVE` on intersection |
+| Partial visibility (< 50%, > 0%) | IntersectionObserver `intersectionRatio: 0.3` while in ACTIVE | `ACTIVE → PASSIVE` |
+| Full hide (0%) | IntersectionObserver `isIntersecting: false` while in ACTIVE | `ACTIVE → HIDDEN` |
+| Return from PASSIVE to full visibility | intersectionRatio back to ≥ 0.5 | `PASSIVE → ACTIVE` |
+| Tab hidden (parent doc) | `document.visibilityState = 'hidden'` + `visibilitychange` | `* → HIDDEN` |
+| Tab visible + intersection visible | `visibilityState = 'visible'` + visible | `HIDDEN → ACTIVE` |
+| `pagehide` with `persisted: true` | event dispatch | `* → FROZEN` |
+| `pageshow` with `persisted: true` | event dispatch | `FROZEN → ACTIVE` (if visible) |
+| `freeze` event | event dispatch | `* → FROZEN` |
+| `resume` event | event dispatch | `FROZEN → ACTIVE/PASSIVE` per visibility |
+| Adapter on SHARC-aware container — handshake fires first | `createSession` → `READY` → `ACTIVE` before adapter intersection | adapter does not duplicate `LOADING → ACTIVE`; subsequent visibility transitions still fire from adapter |
+| Adapter detached on `close()` | adapter.detach() | no further transitions on subsequent event dispatch |
+| bfcache restoration flag | dispatch `pageshow` with `persisted: true` after `pagehide` | transition fires; **comment flags that real bfcache is not modeled in jsdom — Chrome-only end-to-end** |
+
+### 15.5 G11 documentation lint
+
+The G11 invariant lives in operator-facing documentation. The Senior Developer MUST verify at merge time that:
+
+- `docs/creative-cookbook.md`'s "Loading non-SHARC creatives" section shows the temporal-coupling read pattern (query `apiFramework` immediately; query `hasSharcSession` from `onStateChange` or after an operator deadline).
+- § 11.2 of this design doc shows the same pattern (the canonical reference).
+
+Optional: a simple grep-style CI check could assert that the cookbook contains the literal string `hasSharcSession` and `onStateChange` within the same section — guards against accidental future deletions. Not required for 0.7.2 ship.
+
+### 15.6 Bridge timeout warn (G9)
+
+Add to `test/node/test-bridges-detection.js` (or new file): assertions that the MRAID and SafeFrame bridge modules emit the specified `console.warn` after auto-install timeout when `window.SHARC` is not present. Mock the bridge's polling cap to a small value for test speed. Verify the warn message reports the strict integer cap value (not an approximate "~Nms" string).
+
+### 15.7 Regression coverage for the SHARC handshake path
+
+The existing `test-creative-sources-load.js` covers the SHARC-aware path. Adding `hasSharcSession === true` and `apiFramework === <expected>` assertions after handshake locks the new accessors into the regression suite.
+
+### 15.8 No Puppeteer changes required for 0.7.2 first half
+
+Non-handshake path is fully exercised in jsdom. The existing Puppeteer suite is unaffected by `requireSharcInit` — its creatives all handshake normally. **bfcache restoration in real Chrome is the one HTML-adapter path that jsdom cannot fully simulate** (per § 8.4); a Puppeteer-bfcache follow-up issue tracks this gap. Not blocking for 0.7.2 ship.
+
+### 15.9 Browser harness deferred per Q6
+
+Per Q6's lock, the new browser harness page is a follow-up issue. jsdom coverage in § 15.3 + § 15.4 is sufficient for the 0.7.2 ship.
+
+## 16. Implementation handoff
+
+Ordered for the Senior Developer. Each step independently verifiable.
+
+| # | Step | Files | Estimate |
+|---|---|---|---|
+| 1 | Constructor option destructure + Rule 11 validation | `src/sharc-container.js` (constructor body) | 0.5 h |
+| 2 | Store `this._requireSharcInit` on instance | `src/sharc-container.js` (constructor body, near `this._bridges` storage) | 0.25 h |
+| 3 | New helper `_resolveApiFramework(creativeMeta)` | `src/sharc-container.js` (alongside `_resolveBridges`) | 1.5 h |
+| 4 | Store `this._apiFramework` on instance + frozen getter `container.apiFramework` (G10 — non-writable) | `src/sharc-container.js` | 0.5 h |
+| 5 | New getter `container.hasSharcSession` (proxies `_sessionId`) | `src/sharc-container.js` | 0.25 h |
+| 6 | Update `_mapAdComApisToBridges` for SHARC supersession (G12 — priority-aware bridge resolver per § 6.7 pseudocode) | `src/sharc-container.js` | 0.75 h |
+| 7 | Guard `_startSessionTimeout` invocation in `load()` | `src/sharc-container.js:1310` — wrap in `if (this._requireSharcInit) ...` | 0.25 h |
+| 8 | Framework-aware warn in `_handleCreateSession` (Q7 matrix per § 7.4; include `bridges` in warn message) | `src/sharc-container.js` (inside `_handleCreateSession`) | 1 h |
+| 9 | Bridge auto-install timeout warn (G9 — strict integer cap value) | `src/sharc-mraid-bridge.js`, `src/sharc-safeframe-bridge.js` | 1 h |
+| 10 | Add `ACTIVE` to `LOADING`'s permitted transitions in `STATE_TRANSITIONS` table (§ 4.5) | `src/sharc-protocol.js` line 123 | 0.25 h |
+| 11 | Lifecycle adapter base class + HTML adapter (§ 8) | `src/lifecycle-adapters/base-adapter.js`, `src/lifecycle-adapters/html-adapter.js` | 5 h |
+| 12 | Wire adapter selection in `load()` (`_selectLifecycleAdapter` + `attach`/`detach`) | `src/sharc-container.js` (`load()`, `_terminate`) | 1.5 h |
+| 13 | JSDoc updates (constructor option, both accessors, adapter classes) | `src/sharc-container.js`, `src/lifecycle-adapters/*.js` | 0.75 h |
+| 14 | Expand `test-bridges-detection.js` with `apiFramework` picker coverage + G10/G12 cases (or new file `test-api-framework-detection.js` if size warrants) | `test/node/` | 2.5 h |
+| 15 | New test file `test-non-sharc-loading.js` | `test/node/` | 2.5 h |
+| 16 | New test file `test-html-lifecycle-adapter.js` (§ 15.4) | `test/node/` | 2.5 h |
+| 17 | Constructor-validation cases in `test-creative-sources.js` | `test/node/` | 0.5 h |
+| 18 | `hasSharcSession` + `apiFramework` regression in `test-creative-sources-load.js` | `test/node/` | 0.5 h |
+| 19 | Doc updates (api-reference, architecture-design, creative-cookbook, getting-started, README badge/CDN, SECURITY.md check; including cookbook callout per G11 + error-codes caveat + getting-started pointer per § 12) | `docs/`, `README.md`, `SECURITY.md` (if present) | 2 h |
+| 20 | CHANGELOG `[Unreleased]` entries (incl. HTML lifecycle adapter, G12 supersession) | `CHANGELOG.md` | 0.25 h |
+| 21 | `dist/` rebuild (`npm run build`) | — | 0.25 h |
+
+**Total: ~23 hours of implementation work** (range ~20–26 h depending on test-file split, adapter-test depth, and bridge-warn polish). Plus review + fix passes + version bump at release time per `CLAUDE.md` § Version Bump Checklist.
+
+Larger than the prior estimate (~13.5 h) because of two scope additions: (a) the HTML lifecycle adapter base class + HTML implementation + dedicated test file (~8 h aggregate across steps 10, 11, 15), and (b) the G12 supersession resolver + tests (~1 h). The `requireSharcInit` mechanism itself remains a single one-line behavior guard; the surface growth is on the diagnostic-accessor side and the lifecycle-observability layer.
+
+---
+
+*This design doc moves from "Status: Design" to "Status: Design (ready for implementation)" with Q1–Q9 locked per § 13 (including G12 D supersession and the HTML lifecycle adapter scope-C lock). Stage 3 of the design-first methodology (comparison against the parallel spike workstream) is downstream of this revision.*

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "test:navigation-bridge": "node test/node/test-navigation-bridge.js",
     "test:creative-sdk-autoinstall": "node test/node/test-creative-sdk-autoinstall.js",
     "test:bridges-detection": "node test/node/test-bridges-detection.js",
+    "test:non-sharc-loading": "node test/node/test-non-sharc-loading.js",
     "test:renderer-fallback": "node test/node/test-renderer-domparser-fallback.js",
     "test:perf": "node test/node/test-creative-sources-perf.js",
     "test:types": "tsc -p test/types/tsconfig.json",

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -50,6 +50,8 @@ const {
   ContainerStates,
   ErrorCodes,
   SHARC_VERSION,
+  SHARC_API_CODE,
+  SAFEFRAME_API_CODE,
   RENDERER_PROTOCOL_VERSION,
 } = (typeof module !== 'undefined' && module.exports)
   ? require('./sharc-protocol')
@@ -516,6 +518,14 @@ class SHARCContainer {
    *   any DOM mutation. When omitted, placement requests bypass policy validation entirely.
    * @param {Object} [options.closeButtonStyles] - CSS overrides for the auto-rendered close button.
    *   Keys map to the close button element's style properties (e.g. `top`, `right`, `width`).
+   * @param {boolean} [options.requireSharcInit=true] - When `true` (default), the container arms the
+   *   `createSession` timeout exactly as in 0.7.1: a creative that fails to handshake within
+   *   `timeouts.createSession` ms fatal-errors with `ErrorCodes.NO_CREATE_SESSION` (2212). When
+   *   `false`, the timeout is not armed; non-SHARC creatives (generic HTML banners, mixed inventory,
+   *   validator tooling) load to a stable, queryable, terminable container instance without timing
+   *   out. SHARC-aware creatives still handshake normally when this is `false` — the option only
+   *   affects the missing-handshake path. Throws `TypeError` for non-boolean values (no truthy/falsy
+   *   coercion). See 0.7.2 design § 2, § 13 Q1-Q4.
    */
   constructor(options = {}) {
     const {
@@ -549,6 +559,7 @@ class SHARCContainer {
       useMarkupInjection = false,
       placementPolicy,
       closeButtonStyles,
+      requireSharcInit,
     } = options;
 
     // ── Legacy guard: reject old `containerEl` key ──
@@ -884,6 +895,17 @@ class SHARCContainer {
       }
     }
 
+    // Rule 11: `requireSharcInit` is undefined or a boolean. Strict — no
+    // truthy/falsy coercion. Mirrors the validation pattern of the `allow*`
+    // boolean family (allowPopups, allowModals, etc.). See 0.7.2 design § 2
+    // (Constructor option) and § 13 Q4.
+    if (requireSharcInit !== undefined && typeof requireSharcInit !== 'boolean') {
+      throw new TypeError(
+        '[SHARCContainer] requireSharcInit must be a boolean '
+        + '(got ' + (requireSharcInit === null ? 'null' : typeof requireSharcInit) + ').'
+      );
+    }
+
     // ── Synchronous isolation guard (proposal Part 7) ──
     // Throws at construction — before any iframe, MessageChannel, or page
     // lifecycle listener is created — if the placement element is already
@@ -989,6 +1011,51 @@ class SHARCContainer {
           })
         : []
     );
+
+    /**
+     * Whether the container enforces the SHARC `createSession` handshake.
+     * `true` (default) arms the 5 s `createSession` fatal-timeout in `load()`,
+     * matching 0.7.1 behavior. `false` skips the timeout so non-SHARC
+     * creatives can load to a stable container instance without fatal-erroring
+     * on the missing handshake. See 0.7.2 design § 2 + § 4. Strictly typed —
+     * Rule 11 throws `TypeError` for any non-boolean value (including `null`,
+     * `0`, strings).
+     * @type {boolean}
+     * @private
+     */
+    this._requireSharcInit = requireSharcInit === undefined ? true : requireSharcInit;
+
+    /**
+     * AdCOM `APIFramework` integer code for the declared container runtime,
+     * resolved at construction via the three-layer picker (§ 6.1). `null` when
+     * no recognized container-runtime code is declared (or Creative URL
+     * variant — `creativeMeta` is Markup-only per Rule 3b). Picker recognizes
+     * SHARC, MRAID, SafeFrame; OMID (7) is excluded (measurement, not
+     * container runtime); VPAID (1, 2) and SIMID (8, 9) are not picker
+     * targets (video-creative protocols).
+     *
+     * G10 invariant: frozen at construction; never mutates after this
+     * assignment. The public `container.apiFramework` getter is defined via
+     * `Object.defineProperty` with a closure-captured value below — even if
+     * `this._apiFramework` is overwritten, the public accessor still returns
+     * the original. See 0.7.2 design § 6 + § 9 G10.
+     * @type {number | null}
+     * @private
+     */
+    this._apiFramework = hasCreativeHtml
+      ? SHARCContainer._resolveApiFramework(creativeMeta)
+      : null;
+
+    // G10: closure-capture for true immutability. Reads the local at
+    // construction time; any subsequent overwrite of `this._apiFramework`
+    // (via buggy extension, malicious creative-side mutation attempt, etc.)
+    // does NOT affect what `container.apiFramework` returns.
+    const _frozenApiFramework = this._apiFramework;
+    Object.defineProperty(this, 'apiFramework', {
+      get() { return _frozenApiFramework; },
+      enumerable: true,
+      configurable: false,
+    });
 
     /**
      * `true` if injection ran and at least one injector returned a non-empty
@@ -1304,10 +1371,19 @@ class SHARCContainer {
    * @returns {SHARCContainer} this (for chaining)
    */
   load() {
+    // 0.7.2: capture load-invocation wall-clock for the G7 framework-aware
+    // late-handshake warn (elapsed-since-load forensic field per § 7.4).
+    this._loadedAt = Date.now();
     this._createIframe();
     this._registerProtocolListeners();
     this._attachPageLifecycleListeners();
-    this._startSessionTimeout();
+    // 0.7.2 § 4.2 + Rule 11: skip the `createSession` fatal-timeout when the
+    // operator opted out via `requireSharcInit: false`. All other timeouts
+    // (renderer protocol, init/start resolve, close sequence) remain armed —
+    // they guard different invariants and are not handshake-conditional.
+    if (this._requireSharcInit) {
+      this._startSessionTimeout();
+    }
     return this;
   }
 
@@ -1345,6 +1421,27 @@ class SHARCContainer {
    */
   get sessionId() {
     return this._protocol.sessionId || null;
+  }
+
+  /**
+   * Whether the creative has completed the SHARC `createSession` handshake.
+   * `true` once `_handleCreateSession` has accepted a session; `false` until
+   * then. Outcome-driven companion to {@link apiFramework} (which is
+   * declaration-driven, frozen at construction).
+   *
+   * Operators querying this in the same microtask as `load()` will always
+   * see `false` even for SHARC-aware creatives — the handshake fires
+   * asynchronously. Query from `onStateChange` callbacks or after a
+   * lifecycle-observation deadline. See 0.7.2 design § 7.1, § 11.2, and G11.
+   *
+   * Returns `false` (not `null`) when no handshake has occurred — the boolean
+   * shape disambiguates "container hasn't loaded yet" from "session ID is
+   * unset" that `sessionId !== null` conflates.
+   *
+   * @returns {boolean}
+   */
+  get hasSharcSession() {
+    return this._protocol.sessionId !== '';
   }
 
   /**
@@ -2482,6 +2579,64 @@ class SHARCContainer {
    */
   _handleCreateSession(msg) {
     this._clearTimeout('createSession');
+
+    // ── 0.7.2 G7: framework-aware late handshake warn ──────────────────
+    // When the operator opted out of the strict path (`requireSharcInit:
+    // false`) and a handshake arrives anyway, surface a `console.warn`
+    // whose loudness depends on the declared framework. Closes the SE
+    // confused-deputy diagnostic gap: an unexpected SHARC-handshake from a
+    // declared-non-SHARC creative is the exact signal operators want.
+    //
+    // Matrix per § 7.4:
+    //   - apiFramework === SHARC_API_CODE  → silent (declaration matches)
+    //   - hasSharcSession already true     → idempotency warn
+    //   - otherwise                        → confused-deputy warn
+    //
+    // The warn fires ONLY when `requireSharcInit === false`. The strict
+    // path (default) fatal-errors on the missing handshake before any late
+    // arrival is possible, so this branch is unreachable when strict.
+    if (this._requireSharcInit === false) {
+      const elapsedMs = this._loadedAt ? (Date.now() - this._loadedAt) : 0;
+      // Internal read uses the private field directly. The public
+      // `container.apiFramework` getter is closure-captured (G10) and
+      // protects against external mutation; internal code is trusted not
+      // to mutate `this._apiFramework` after construction.
+      const apiFrameworkValue = this._apiFramework;
+      const bridgesSnapshot = this.bridges.slice();
+      const placementSessionId = this.placementSessionId;
+      const alreadyHasSession = this._protocol.sessionId !== '';
+
+      if (alreadyHasSession) {
+        // Idempotency: a second createSession arriving after one was already
+        // accepted. Existing protocol-layer guards reject the duplicate;
+        // this warn surfaces it for operator forensics.
+        console.warn(
+          '[SHARC] Duplicate createSession received at T+' + elapsedMs + 'ms '
+          + 'for placement ' + placementSessionId + '; '
+          + 'apiFramework=' + (apiFrameworkValue === null ? 'null' : apiFrameworkValue) + ', '
+          + 'bridges=[' + bridgesSnapshot.join(',') + ']. '
+          + 'Subsequent createSession will be rejected at the protocol layer.'
+        );
+      } else if (apiFrameworkValue === SHARC_API_CODE) {
+        // Declaration matches outcome — slow but expected. No warn.
+      } else {
+        // Confused-deputy: late handshake from a creative that did NOT
+        // declare SHARC. Forensic fields per § 7.4: four required fields
+        // — placementSessionId, apiFramework, bridges, elapsed-since-load.
+        const apiFrameworkLabel = apiFrameworkValue === null
+          ? 'null (no container-runtime declared)'
+          : String(apiFrameworkValue);
+        console.warn(
+          '[SHARC] Late createSession received at T+' + elapsedMs + 'ms '
+          + 'for placement ' + placementSessionId + '; '
+          + 'apiFramework=' + apiFrameworkLabel + ', '
+          + 'bridges=[' + bridgesSnapshot.join(',') + ']. '
+          + 'Container was constructed with requireSharcInit:false; accepting the handshake. '
+          + 'If this creative is expected to be SHARC-aware, declare creativeMeta.apis or '
+          + 'set requireSharcInit:true.'
+        );
+      }
+    }
 
     // Establish session
     this._protocol.acceptSession(msg);
@@ -4607,17 +4762,98 @@ class SHARCContainer {
    * nothing on purpose" signal; that's what an explicit `bridges: []` is
    * for. See design doc § 3.5 multi-framework truth table.
    *
+   * **G12 supersession (0.7.2):** when `apis` contains `SHARC_API_CODE`
+   * AND a container-API code (MRAID or `SAFEFRAME_API_CODE`), SHARC
+   * supersedes — the lower-priority container-runtime bridges are inhibited
+   * so a SHARC container does not load dead-weight MRAID/SafeFrame bridges
+   * for portable creatives that declare both. OMID (`7`) is orthogonal and
+   * NEVER superseded — `[SHARC_API_CODE, 7]` resolves to SHARC runtime with
+   * OMID measurement coexisting. SHARC itself is a runtime, not a bridge,
+   * so the SHARC code never produces a bridge entry. See 0.7.2 design § 6.7
+   * and § 9 G12.
+   *
    * @param {number[]} apis - AdCOM APIFramework integer codes.
    * @returns {string[]} Sorted, deduplicated bridge identifier array.
    * @private
    */
   static _mapAdComApisToBridges(apis) {
     const result = new Set();
+    const hasSharcCode = apis.indexOf(SHARC_API_CODE) !== -1;
     for (let i = 0; i < apis.length; i++) {
-      const bridge = ADCOM_API_TO_BRIDGE[apis[i]];
+      const code = apis[i];
+      // SHARC is a runtime, not a bridge — never produces a bridge entry.
+      if (code === SHARC_API_CODE) continue;
+      // G12 supersession: SHARC presence inhibits MRAID + SafeFrame bridges.
+      // OMID (7) is orthogonal and NEVER skipped here (measurement axis).
+      if (hasSharcCode) {
+        if (code === 3 || code === 5 || code === 6) continue; // MRAID family
+        if (code === SAFEFRAME_API_CODE) continue;             // SafeFrame
+      }
+      const bridge = ADCOM_API_TO_BRIDGE[code];
       if (bridge) result.add(bridge);
     }
     return SHARCContainer._sortDedupBridges([...result]);
+  }
+
+  /**
+   * Three-layer API-framework detection pipeline (0.7.2 § 6). Resolves the
+   * AdCOM `APIFramework` integer code declared by the creative for the
+   * container runtime, or `null` when none is declared. Result drives the
+   * frozen `container.apiFramework` accessor (G10).
+   *
+   * Layers, in strict precedence order:
+   *   1. Explicit `creativeMeta.apis` — pick highest-priority container-
+   *      runtime code from the array per the priority ladder.
+   *   2. Reserved no-op (future bid-context-derived detection).
+   *   3. Fallthrough to `null`.
+   *
+   * Picker priority ladder:
+   *   - 1 (highest): SHARC (`SHARC_API_CODE`)
+   *   - 2:           MRAID — `6` (3.0) > `5` (2.0) > `3` (1.0). Higher wins.
+   *   - 3:           SafeFrame (`SAFEFRAME_API_CODE`)
+   *
+   * **Excluded from picker:**
+   *   - OMID (`7`): measurement, not container runtime. § 6.4.
+   *   - VPAID (`1`, `2`) and SIMID (`8`, `9`): video-creative protocols, not
+   *     display-container runtimes. Operators read `creativeMeta.apis`
+   *     directly if they need to branch on these. § 6.2.
+   *   - Vendor codes (≥ 500): unrecognized; return `null`.
+   *
+   * Static so the constructor's resolution call doesn't need a `this`
+   * reference (it runs before `this._apiFramework` is assigned).
+   *
+   * @param {{apis?: number[]}|null|undefined} creativeMeta
+   * @returns {number|null}
+   * @private
+   */
+  static _resolveApiFramework(creativeMeta) {
+    if (!creativeMeta || !Array.isArray(creativeMeta.apis) || creativeMeta.apis.length === 0) {
+      return null;
+    }
+    const apis = creativeMeta.apis;
+    // Layer 1: pick highest-priority recognized container-runtime code.
+    // SHARC > MRAID-latest > SafeFrame. Within MRAID, higher number wins.
+    let best = null;
+    let bestPriority = Infinity;
+    const priorityOf = (code) => {
+      if (code === SHARC_API_CODE) return 1;
+      if (code === 6) return 2;          // MRAID 3.0
+      if (code === 5) return 2.1;        // MRAID 2.0 (within-family tiebreak)
+      if (code === 3) return 2.2;        // MRAID 1.0
+      if (code === SAFEFRAME_API_CODE) return 3;
+      return Infinity; // OMID, VPAID, SIMID, vendor codes: not picker targets
+    };
+    for (let i = 0; i < apis.length; i++) {
+      const p = priorityOf(apis[i]);
+      if (p < bestPriority) {
+        best = apis[i];
+        bestPriority = p;
+      }
+    }
+    if (best !== null) return best;
+    // Layer 2: reserved no-op for forward bid-context-derived detection.
+    // Layer 3: fallthrough to null.
+    return null;
   }
 
   /**

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -1051,9 +1051,11 @@ class SHARCContainer {
      * @private
      */
     // Initial assignment establishes the type for TS inference; the
-    // immediately-following defineProperty converts it to a locked
-    // (non-writable + non-configurable) data property. Same semantic
-    // effect, but TS sees the assignment line.
+    // immediately-following defineProperty converts the property to
+    // locked (non-writable + non-configurable) data semantics. Same shape
+    // for both the private `_apiFramework` backing field and the public
+    // `apiFramework` accessor — the public form is also assigned so TS
+    // picks it up as a class member in the generated .d.ts.
     this._apiFramework = hasCreativeHtml
       ? SHARCContainer._resolveApiFramework(creativeMeta)
       : null;
@@ -1063,10 +1065,29 @@ class SHARCContainer {
       configurable: false,
       enumerable: false,
     });
+
+    /**
+     * AdCOM `APIFramework` integer code for the declared container runtime
+     * (per AdCOM v1.0 `APIFramework` list). `null` when no recognized
+     * container-runtime code is declared, or when the container is in
+     * Creative URL variant (Rule 3b — `creativeMeta` is Markup-only).
+     *
+     * Frozen at construction (G10): non-writable + non-configurable.
+     * Assignment is a no-op in sloppy mode and throws in strict; the
+     * accessor cannot be redefined or deleted.
+     *
+     * Companion to {@link hasSharcSession} — declaration-driven (immediate,
+     * frozen) vs. outcome-driven (asynchronous, post-handshake). See 0.7.2
+     * design § 6 + § 7.2 + § 9 G10.
+     *
+     * @type {number | null}
+     */
+    this.apiFramework = this._apiFramework;
     Object.defineProperty(this, 'apiFramework', {
-      get() { return this._apiFramework; },
-      enumerable: true,
+      value: this._apiFramework,
+      writable: false,
       configurable: false,
+      enumerable: true,
     });
 
     /**
@@ -2592,69 +2613,75 @@ class SHARCContainer {
   _handleCreateSession(msg) {
     this._clearTimeout('createSession');
 
-    // ── 0.7.2 G7: framework-aware late handshake warn ──────────────────
+    // ── 0.7.2 unconditional idempotency guard ──────────────────────────
+    // A second createSession arriving after one was already accepted is
+    // ALWAYS a protocol violation, regardless of `requireSharcInit`. The
+    // underlying protocol layer (`acceptSession`) is not idempotent —
+    // calling it twice overwrites `sessionId` and re-triggers
+    // `Container:init`. Guard at the container layer with an
+    // unconditional warn + early-return for both strict and permissive
+    // modes. § 7.4 idempotency row, expanded from permissive-only to
+    // unconditional during PR #92 review.
+    const elapsedMs = this._loadedAt ? (Date.now() - this._loadedAt) : 0;
+    // G10: `this._apiFramework` is locked at construction (non-writable +
+    // non-configurable). Internal reads are safe by construction.
+    const apiFrameworkValue = this._apiFramework;
+    const bridgesSnapshot = this.bridges.slice();
+    const placementSessionId = this.placementSessionId;
+    if (this._protocol.sessionId !== '') {
+      console.warn(
+        '[SHARC] Duplicate createSession received at T+' + elapsedMs + 'ms '
+        + 'for placement ' + placementSessionId + '; '
+        + 'apiFramework=' + (apiFrameworkValue === null ? 'null' : apiFrameworkValue) + ', '
+        + 'bridges=[' + bridgesSnapshot.join(',') + ']. '
+        + 'The original session remains active; this duplicate is rejected.'
+      );
+      return;
+    }
+
+    // ── 0.7.2 G7: framework-aware handshake-mismatch warn (permissive) ─
     // When the operator opted out of the strict path (`requireSharcInit:
-    // false`) and a handshake arrives anyway, surface a `console.warn`
-    // whose loudness depends on the declared framework. Closes the SE
-    // confused-deputy diagnostic gap: an unexpected SHARC-handshake from a
-    // declared-non-SHARC creative is the exact signal operators want.
+    // false`) and a handshake arrives from a creative whose declaration
+    // doesn't match SHARC, emit the confused-deputy warn. Closes the SE
+    // confused-deputy diagnostic gap: an unexpected SHARC-handshake from
+    // a declared-non-SHARC creative is the exact signal operators want.
     //
     // Matrix per § 7.4:
     //   - apiFramework === SHARC_API_CODE  → silent (declaration matches)
-    //   - hasSharcSession already true     → idempotency warn
-    //   - otherwise                        → confused-deputy warn
+    //   - otherwise (any non-SHARC code or null) → confused-deputy warn
     //
     // The warn fires ONLY when `requireSharcInit === false`. The strict
-    // path (default) fatal-errors on the missing handshake before any late
-    // arrival is possible, so this branch is unreachable when strict.
-    if (this._requireSharcInit === false) {
-      const elapsedMs = this._loadedAt ? (Date.now() - this._loadedAt) : 0;
-      // G10: `this._apiFramework` is locked as non-writable +
-      // non-configurable at construction (see constructor body). The
-      // internal read is safe by construction — no buggy extension or
-      // hostile creative-side mutation can affect this value.
-      const apiFrameworkValue = this._apiFramework;
-      const bridgesSnapshot = this.bridges.slice();
-      const placementSessionId = this.placementSessionId;
-      const alreadyHasSession = this._protocol.sessionId !== '';
-
-      if (alreadyHasSession) {
-        // Idempotency: a second createSession arrived after one was already
-        // accepted. Warn for operator forensics, then early-return so the
-        // duplicate does NOT reach acceptSession (which would otherwise
-        // overwrite this._protocol.sessionId and re-trigger Container:init
-        // — the protocol layer is not idempotent on its own).
-        console.warn(
-          '[SHARC] Duplicate createSession received at T+' + elapsedMs + 'ms '
-          + 'for placement ' + placementSessionId + '; '
-          + 'apiFramework=' + (apiFrameworkValue === null ? 'null' : apiFrameworkValue) + ', '
-          + 'bridges=[' + bridgesSnapshot.join(',') + ']. '
-          + 'The original session remains active; this duplicate is rejected.'
-        );
-        return;
-      } else if (apiFrameworkValue === SHARC_API_CODE) {
-        // Declaration matches outcome — slow but expected. No warn.
-      } else {
-        // Confused-deputy: late handshake from a creative that did NOT
-        // declare SHARC. Forensic fields per § 7.4: four required fields
-        // — placementSessionId, apiFramework, bridges, elapsed-since-load.
-        const apiFrameworkLabel = apiFrameworkValue === null
-          ? 'null (no container-runtime declared)'
-          : String(apiFrameworkValue);
-        console.warn(
-          '[SHARC] Late createSession received at T+' + elapsedMs + 'ms '
-          + 'for placement ' + placementSessionId + '; '
-          + 'apiFramework=' + apiFrameworkLabel + ', '
-          + 'bridges=[' + bridgesSnapshot.join(',') + ']. '
-          + 'Container was constructed with requireSharcInit:false; accepting the handshake. '
-          + 'If this creative is expected to be SHARC-aware, declare creativeMeta.apis or '
-          + 'set requireSharcInit:true.'
-        );
-      }
+    // path (default) fatal-errors on the missing handshake before any
+    // arrival window opens. Word "Unexpected" rather than "Late" — the
+    // diagnostic is about declaration mismatch, not timing (a prompt
+    // T+5ms handshake from a non-SHARC-declared creative is still a
+    // confused-deputy signal worth surfacing).
+    if (this._requireSharcInit === false && apiFrameworkValue !== SHARC_API_CODE) {
+      const apiFrameworkLabel = apiFrameworkValue === null
+        ? 'null (no container-runtime declared)'
+        : String(apiFrameworkValue);
+      console.warn(
+        '[SHARC] Unexpected createSession received at T+' + elapsedMs + 'ms '
+        + 'for placement ' + placementSessionId + '; '
+        + 'apiFramework=' + apiFrameworkLabel + ', '
+        + 'bridges=[' + bridgesSnapshot.join(',') + ']. '
+        + 'Container was constructed with requireSharcInit:false; accepting the handshake. '
+        + 'If this creative is expected to be SHARC-aware, declare creativeMeta.apis or '
+        + 'set requireSharcInit:true.'
+      );
     }
 
     // Establish session
     this._protocol.acceptSession(msg);
+
+    // ── 0.7.2 invalid-UUID early-return ────────────────────────────────
+    // `acceptSession` validates UUID v4 format (SEC-006); on invalid it
+    // calls `_reject` and returns without setting `sessionId`. The
+    // pre-0.7.2 code path continued the init flow anyway, which would
+    // send `Container:init` with an empty sessionId (filtered at the
+    // protocol port). Fail-closed instead: if the session wasn't
+    // established, do NOT continue with init.
+    if (this._protocol.sessionId === '') return;
 
     // Read placement type declared by the creative ('inline' or 'interstitial')
     const pt = msg.args && msg.args.placementType;

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -155,6 +155,13 @@ const ADCOM_API_TO_BRIDGE = Object.freeze({
   3: 'mraid',
   5: 'mraid',
   6: 'mraid',
+  // 0.7.2: SafeFrame entry via the named placeholder constant (publication-
+  // locked per § 6.3). Completes the picker ↔ bridge resolver symmetry —
+  // a creative declaring `creativeMeta.apis: [SAFEFRAME_API_CODE]` resolves
+  // to `apiFramework: SAFEFRAME_API_CODE` AND `bridges: ['safeframe']`.
+  // OMID (code 7) intentionally absent in first-half — measurement bridge
+  // ships in 0.7.2 second-half OMID design pass.
+  [SAFEFRAME_API_CODE]: 'safeframe',
 });
 
 /**
@@ -1034,25 +1041,30 @@ class SHARCContainer {
      * container runtime); VPAID (1, 2) and SIMID (8, 9) are not picker
      * targets (video-creative protocols).
      *
-     * G10 invariant: frozen at construction; never mutates after this
-     * assignment. The public `container.apiFramework` getter is defined via
-     * `Object.defineProperty` with a closure-captured value below — even if
-     * `this._apiFramework` is overwritten, the public accessor still returns
-     * the original. See 0.7.2 design § 6 + § 9 G10.
+     * G10 invariant: locked as non-writable + non-configurable below. Neither
+     * external code (`container._apiFramework = X`) nor internal code paths
+     * (G7 warn read, future feature work) can mutate the value after
+     * construction. The public `container.apiFramework` getter reads through
+     * to this locked field and is itself non-configurable. See 0.7.2 design
+     * § 6 + § 9 G10.
      * @type {number | null}
      * @private
      */
+    // Initial assignment establishes the type for TS inference; the
+    // immediately-following defineProperty converts it to a locked
+    // (non-writable + non-configurable) data property. Same semantic
+    // effect, but TS sees the assignment line.
     this._apiFramework = hasCreativeHtml
       ? SHARCContainer._resolveApiFramework(creativeMeta)
       : null;
-
-    // G10: closure-capture for true immutability. Reads the local at
-    // construction time; any subsequent overwrite of `this._apiFramework`
-    // (via buggy extension, malicious creative-side mutation attempt, etc.)
-    // does NOT affect what `container.apiFramework` returns.
-    const _frozenApiFramework = this._apiFramework;
+    Object.defineProperty(this, '_apiFramework', {
+      value: this._apiFramework,
+      writable: false,
+      configurable: false,
+      enumerable: false,
+    });
     Object.defineProperty(this, 'apiFramework', {
-      get() { return _frozenApiFramework; },
+      get() { return this._apiFramework; },
       enumerable: true,
       configurable: false,
     });
@@ -2597,26 +2609,29 @@ class SHARCContainer {
     // arrival is possible, so this branch is unreachable when strict.
     if (this._requireSharcInit === false) {
       const elapsedMs = this._loadedAt ? (Date.now() - this._loadedAt) : 0;
-      // Internal read uses the private field directly. The public
-      // `container.apiFramework` getter is closure-captured (G10) and
-      // protects against external mutation; internal code is trusted not
-      // to mutate `this._apiFramework` after construction.
+      // G10: `this._apiFramework` is locked as non-writable +
+      // non-configurable at construction (see constructor body). The
+      // internal read is safe by construction — no buggy extension or
+      // hostile creative-side mutation can affect this value.
       const apiFrameworkValue = this._apiFramework;
       const bridgesSnapshot = this.bridges.slice();
       const placementSessionId = this.placementSessionId;
       const alreadyHasSession = this._protocol.sessionId !== '';
 
       if (alreadyHasSession) {
-        // Idempotency: a second createSession arriving after one was already
-        // accepted. Existing protocol-layer guards reject the duplicate;
-        // this warn surfaces it for operator forensics.
+        // Idempotency: a second createSession arrived after one was already
+        // accepted. Warn for operator forensics, then early-return so the
+        // duplicate does NOT reach acceptSession (which would otherwise
+        // overwrite this._protocol.sessionId and re-trigger Container:init
+        // — the protocol layer is not idempotent on its own).
         console.warn(
           '[SHARC] Duplicate createSession received at T+' + elapsedMs + 'ms '
           + 'for placement ' + placementSessionId + '; '
           + 'apiFramework=' + (apiFrameworkValue === null ? 'null' : apiFrameworkValue) + ', '
           + 'bridges=[' + bridgesSnapshot.join(',') + ']. '
-          + 'Subsequent createSession will be rejected at the protocol layer.'
+          + 'The original session remains active; this duplicate is rejected.'
         );
+        return;
       } else if (apiFrameworkValue === SHARC_API_CODE) {
         // Declaration matches outcome — slow but expected. No warn.
       } else {

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -992,19 +992,15 @@ if (typeof window !== 'undefined') {
     // Polls via setTimeout(0); the SDK call to `Object.assign(window.SHARC, …)`
     // runs synchronously when the creative's <script src="…sharc-creative.js">
     // tag executes after `document.write(creativeHtml)`. In practice the wait
-    // is one or two ticks. A polling cap is unnecessary — if the SDK never
-    // loads, the bridge stays uninstalled and `window.mraid` is undefined,
-    // which is the correct failure mode (creative breaks loudly, container
-    // load-event backstop catches any redirect).
+    // is one or two ticks. A polling cap protects against an infinite loop
+    // and provides a deterministic timeout for the G9 operator-visible warn.
     var _mraidWireTries = 0;
-    // Hard cap (~1000 ticks ≈ 4-16s at typical setTimeout(0) floor). The
-    // container's 2s `:rendered` timeout will fire first if the SDK never
-    // appears, producing a loud renderer_protocol_timeout (error 2114).
-    // The cap protects against an infinite loop in edge cases where the
-    // timeout itself fails to fire. Above this, give up silently — the
-    // creative will fail visibly when it calls `mraid.*`, which is the
-    // desired loud failure for a misconfigured deploy.
+    // 0.7.2 G9: strict cap. 1000 ticks × the setTimeout(0) clamp floor
+    // (~4 ms in modern browsers, ~16 ms in older). We report the integer
+    // tick count and the conservative wall-clock upper bound for operator
+    // forensics. See 0.7.2 design § 10.1.
     var _mraidWireMax = 1000;
+    var _mraidWireCapMs = 16000; // conservative upper bound: 1000 × 16 ms
     function _trySharcMraidWire() {
       if (anyWin.__sharcMraidBridgeInstalled) return;
       if (anyWin.SHARC && typeof anyWin.SHARC.onReady === 'function') {
@@ -1014,7 +1010,25 @@ if (typeof window !== 'undefined') {
         return;
       }
       _mraidWireTries++;
-      if (_mraidWireTries >= _mraidWireMax) return;
+      if (_mraidWireTries >= _mraidWireMax) {
+        // G9: surface the auto-install failure at timeout-time, not just
+        // when the creative eventually calls `mraid.*`. The bridge stays
+        // uninstalled (correct failure mode); the warn gives operators a
+        // ~16s-earlier diagnostic. PlacementSessionId is intentionally
+        // omitted in 0.7.2 first half — the bridge runs in the renderer
+        // iframe and has no direct handle to the container's session ID.
+        // Follow-up issue tracks threading it via the :render envelope.
+        if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+          console.warn(
+            '[SHARC MRAID bridge] Auto-install failed: '
+            + 'window.SHARC not available after ' + _mraidWireMax + ' ticks '
+            + '(cap ' + _mraidWireCapMs + 'ms). window.mraid will not be wired. '
+            + 'Consider removing "mraid" from bridges, or loading sharc-creative.js '
+            + 'in your creative so the bridge can install on top of the SHARC SDK.'
+          );
+        }
+        return;
+      }
       setTimeout(_trySharcMraidWire, 0);
     }
     _trySharcMraidWire();

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -30,6 +30,32 @@
 const SHARC_VERSION = '0.7.1';
 
 /**
+ * Placeholder AdCOM `APIFramework` integer code for SHARC.
+ *
+ * Until AdCOM upstream registration completes (memory
+ * `project_upstream_contribution_roadmap`), SHARC has no canonical integer
+ * in AdCOM v1.0's `APIFramework` list. This sentinel sits comfortably
+ * outside AdCOM's currently-assigned range so it does not collide with any
+ * registered framework. At AdCOM publication, the implementer updates this
+ * constant to the published value — no other code changes are required
+ * because every picker, supersession rule, and test references this
+ * symbolic name rather than a hardcoded integer.
+ *
+ * See 0.7.2 design doc § 6.3 ("AdCOM code constants") for the full pattern.
+ */
+const SHARC_API_CODE = 9001;
+
+/**
+ * Placeholder AdCOM `APIFramework` integer code for SafeFrame.
+ *
+ * Companion to {@link SHARC_API_CODE} — SafeFrame is also unregistered in
+ * AdCOM v1.0. Same publication-locking pattern.
+ *
+ * See 0.7.2 design doc § 6.3.
+ */
+const SAFEFRAME_API_CODE = 9002;
+
+/**
  * Renderer protocol version — bumps independently of {@link SHARC_VERSION}.
  *
  * Sent in `SHARC:Renderer:render` so the renderer page can reject containers
@@ -120,7 +146,11 @@ const CREATIVE_QUERYABLE_STATES = new Set([
  * @type {Object.<string, string[]>}
  */
 const STATE_TRANSITIONS = Object.freeze({
-  [ContainerStates.LOADING]: [ContainerStates.READY, ContainerStates.TERMINATED],
+  // LOADING → ACTIVE legitimizes the HTML-adapter route for non-handshake
+  // creatives (0.7.2 design § 4.5). The handshake-driven path remains
+  // LOADING → READY → ACTIVE; the new edge permits the parallel route
+  // without synthesizing a misleading READY state.
+  [ContainerStates.LOADING]: [ContainerStates.READY, ContainerStates.ACTIVE, ContainerStates.TERMINATED],
   [ContainerStates.READY]: [ContainerStates.ACTIVE, ContainerStates.TERMINATED],
   [ContainerStates.ACTIVE]: [ContainerStates.PASSIVE, ContainerStates.HIDDEN, ContainerStates.TERMINATED],
   [ContainerStates.PASSIVE]: [ContainerStates.ACTIVE, ContainerStates.HIDDEN, ContainerStates.TERMINATED],
@@ -1368,6 +1398,8 @@ const SHARCProtocol = {
   STATE_TRANSITIONS,
   MESSAGES_REQUIRING_RESPONSE,
   SHARC_VERSION,
+  SHARC_API_CODE,
+  SAFEFRAME_API_CODE,
   RENDERER_PROTOCOL_VERSION,
 };
 
@@ -1397,5 +1429,7 @@ export {
   STATE_TRANSITIONS,
   MESSAGES_REQUIRING_RESPONSE,
   SHARC_VERSION,
+  SHARC_API_CODE,
+  SAFEFRAME_API_CODE,
   RENDERER_PROTOCOL_VERSION,
 };

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -664,14 +664,12 @@ if (typeof window !== 'undefined') {
   } else if (anyWin.__sharcSafeFrameBridgeAutoInstall && !anyWin.__sharcSafeFrameBridgeInstalled) {
     // Path B.
     var _sfWireTries = 0;
-    // Hard cap (~1000 ticks ≈ 4-16s at typical setTimeout(0) floor). The
-    // container's 2s `:rendered` timeout will fire first if the SDK never
-    // appears, producing a loud renderer_protocol_timeout (error 2114).
-    // The cap protects against an infinite loop in edge cases where the
-    // timeout itself fails to fire. Above this, give up silently — the
-    // creative will fail visibly when it calls `$sf.ext.*`, which is the
-    // desired loud failure for a misconfigured deploy.
+    // 0.7.2 G9: strict cap. 1000 ticks × the setTimeout(0) clamp floor
+    // (~4 ms in modern browsers, ~16 ms in older). At cap-hit, emit
+    // operator-visible `console.warn` with the integer tick count and the
+    // conservative wall-clock upper bound. See 0.7.2 design § 10.1.
     var _sfWireMax = 1000;
+    var _sfWireCapMs = 16000; // conservative upper bound: 1000 × 16 ms
     function _trySharcSafeFrameWire() {
       if (anyWin.__sharcSafeFrameBridgeInstalled) return;
       if (anyWin.SHARC && typeof anyWin.SHARC.onReady === 'function') {
@@ -681,7 +679,23 @@ if (typeof window !== 'undefined') {
         return;
       }
       _sfWireTries++;
-      if (_sfWireTries >= _sfWireMax) return;
+      if (_sfWireTries >= _sfWireMax) {
+        // G9: surface the auto-install failure at timeout-time, not just
+        // when the creative eventually calls `$sf.ext.*`. The bridge stays
+        // uninstalled (correct failure mode); the warn gives operators a
+        // ~16s-earlier diagnostic. PlacementSessionId is intentionally
+        // omitted in 0.7.2 first half — see MRAID bridge for rationale.
+        if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+          console.warn(
+            '[SHARC SafeFrame bridge] Auto-install failed: '
+            + 'window.SHARC not available after ' + _sfWireMax + ' ticks '
+            + '(cap ' + _sfWireCapMs + 'ms). window.$sf will not be wired. '
+            + 'Consider removing "safeframe" from bridges, or loading sharc-creative.js '
+            + 'in your creative so the bridge can install on top of the SHARC SDK.'
+          );
+        }
+        return;
+      }
       setTimeout(_trySharcSafeFrameWire, 0);
     }
     _trySharcSafeFrameWire();

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -136,6 +136,8 @@ declare global {
       SHARC_VERSION?: string;
       Protocol?: {
         SHARC_VERSION?: string;
+        SHARC_API_CODE?: number;
+        SAFEFRAME_API_CODE?: number;
         RENDERER_PROTOCOL_VERSION?: string;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         SHARCProtocolBase: any;

--- a/test/node/test-bridges-detection.js
+++ b/test/node/test-bridges-detection.js
@@ -743,21 +743,33 @@ function makeMarkupOpts(extra) {
   assert(c5.apiFramework === 6,
     'G10: container.apiFramework still returns original after direct assignment attempt (got ' + c5.apiFramework + ')');
 
-  // G10 closure-capture: even if the private backing field is overwritten,
-  // the public accessor returns the value captured at construction.
-  c5._apiFramework = 12345;
+  // G10: the private backing field `_apiFramework` is locked at construction
+  // (Object.defineProperty with writable:false + configurable:false). A
+  // write attempt is a silent no-op in sloppy mode and throws in strict;
+  // either way the public accessor still returns the construction value.
+  let mutationThrew = false;
+  try { c5._apiFramework = 12345; } catch (e) { mutationThrew = true; }
+  assert(c5._apiFramework === 6,
+    'G10: locked _apiFramework is non-writable; direct mutation has no effect on the backing field');
   assert(c5.apiFramework === 6,
-    'G10 closure-capture: container.apiFramework returns construction value even after _apiFramework overwrite');
+    'G10: container.apiFramework reads through the locked backing field and survives mutation attempt');
 
-  // G10: property is non-configurable. delete fails.
+  // G10: private field is also non-configurable. delete is inert.
+  try { delete c5._apiFramework; } catch (e) { /* strict throws */ }
+  assert(c5._apiFramework === 6, 'G10: locked _apiFramework survives delete attempt');
+
+  // G10: public accessor is non-configurable. delete fails.
   let deleteThrew = false;
   try { delete c5.apiFramework; } catch (e) { deleteThrew = true; }
   assert(c5.apiFramework === 6, 'G10: container.apiFramework survives delete attempt');
 
-  // G10: property descriptor reports non-configurable.
-  const desc = Object.getOwnPropertyDescriptor(c5, 'apiFramework');
-  assert(desc && desc.configurable === false,
-    'G10: apiFramework property descriptor reports configurable: false');
+  // G10: both descriptors report configurable:false.
+  const pubDesc = Object.getOwnPropertyDescriptor(c5, 'apiFramework');
+  assert(pubDesc && pubDesc.configurable === false,
+    'G10: public apiFramework property descriptor reports configurable: false');
+  const privDesc = Object.getOwnPropertyDescriptor(c5, '_apiFramework');
+  assert(privDesc && privDesc.writable === false && privDesc.configurable === false,
+    'G10: private _apiFramework descriptor reports writable: false AND configurable: false');
 }
 
 // -- 15. G12 SHARC supersession — _mapAdComApisToBridges --------------------
@@ -777,6 +789,10 @@ function makeMarkupOpts(extra) {
   assertDeepEqual(map([6, SHARC_API_CODE]), [],   '[MRAID 3.0, SHARC] → [] (MRAID superseded)');
   assertDeepEqual(map([3, 5, 6, SHARC_API_CODE]), [],
     '[MRAID 1/2/3, SHARC] → [] (all MRAID variants superseded)');
+
+  // SafeFrame alone → ['safeframe'] (Fix 3 in PR 1: completes picker↔bridge symmetry).
+  assertDeepEqual(map([SAFEFRAME_API_CODE]), ['safeframe'],
+    'SafeFrame alone → ["safeframe"] (ADCOM_API_TO_BRIDGE now maps SAFEFRAME_API_CODE)');
 
   // SHARC + SafeFrame → SafeFrame inhibited (G12).
   assertDeepEqual(map([SAFEFRAME_API_CODE, SHARC_API_CODE]), [],

--- a/test/node/test-bridges-detection.js
+++ b/test/node/test-bridges-detection.js
@@ -644,6 +644,230 @@ console.log('test-bridges-detection.js — issue #82 (0.7.1) coverage\n');
     'adm scan mean over ' + N + ' iterations < 50ms (got ' + meanMs.toFixed(3) + 'ms)');
 }
 
+// ===========================================================================
+// 0.7.2 (issue #89) — _resolveApiFramework picker + G10 + G12 + Rule 11
+// ===========================================================================
+
+const SHARC_API_CODE = protoMod.SHARC_API_CODE;
+const SAFEFRAME_API_CODE = protoMod.SAFEFRAME_API_CODE;
+
+function makeMarkupOpts(extra) {
+  // Minimal Markup-variant valid options. creativeMeta is required to
+  // exercise the picker in the constructor path (Rule 3b — Markup-only).
+  return Object.assign({
+    creativeHtml: '<html><body>creative</body></html>',
+    creativeRendererUrl: 'https://renderer.example/r.html',
+    placementElement: document.createElement('div'),
+  }, extra);
+}
+
+// -- 13. _resolveApiFramework picker — § 6.2 priority ladder + § 6.6 edges --
+{
+  console.log('\n13. _resolveApiFramework picker — priority ladder + edge cases');
+
+  const pick = (apis) => SHARCContainer._resolveApiFramework({ apis });
+
+  // Recognized container-runtime codes.
+  assertDeepEqual(pick([6]), 6,                              'MRAID 3.0 alone → 6');
+  assertDeepEqual(pick([5]), 5,                              'MRAID 2.0 alone → 5');
+  assertDeepEqual(pick([3]), 3,                              'MRAID 1.0 alone → 3');
+  assertDeepEqual(pick([6, 5]), 6,                           'MRAID 3.0 + 2.0 → 6 (higher MRAID wins)');
+  assertDeepEqual(pick([3, 5, 6]), 6,                        'MRAID 1.0 + 2.0 + 3.0 → 6 (highest MRAID wins)');
+  assertDeepEqual(pick([SHARC_API_CODE]), SHARC_API_CODE,    'SHARC alone → SHARC_API_CODE');
+  assertDeepEqual(pick([SAFEFRAME_API_CODE]), SAFEFRAME_API_CODE, 'SafeFrame alone → SAFEFRAME_API_CODE');
+
+  // Priority: SHARC > MRAID > SafeFrame.
+  assertDeepEqual(pick([6, SHARC_API_CODE]), SHARC_API_CODE,
+    '[MRAID 3.0, SHARC] → SHARC (priority 1 beats priority 2)');
+  assertDeepEqual(pick([SAFEFRAME_API_CODE, SHARC_API_CODE]), SHARC_API_CODE,
+    '[SafeFrame, SHARC] → SHARC');
+  assertDeepEqual(pick([6, SAFEFRAME_API_CODE]), 6,
+    '[MRAID 3.0, SafeFrame] → MRAID (priority 2 beats priority 3)');
+
+  // OMID excluded (measurement, not container runtime).
+  assertDeepEqual(pick([7]), null,                           'OMID alone → null (excluded)');
+  assertDeepEqual(pick([6, 7]), 6,                           '[MRAID 3.0, OMID] → 6 (OMID excluded)');
+  assertDeepEqual(pick([SHARC_API_CODE, 7]), SHARC_API_CODE, '[SHARC, OMID] → SHARC (OMID orthogonal)');
+
+  // VPAID and SIMID — not picker targets (video-creative protocols).
+  assertDeepEqual(pick([1]), null,                           'VPAID 1.0 alone → null (not picker target)');
+  assertDeepEqual(pick([2]), null,                           'VPAID 2.0 alone → null (not picker target)');
+  assertDeepEqual(pick([8]), null,                           'SIMID 1.0 alone → null (not picker target)');
+  assertDeepEqual(pick([9]), null,                           'SIMID 1.1 alone → null (not picker target)');
+  assertDeepEqual(pick([1, 2, 8, 9]), null,                  '[VPAID + SIMID] → null');
+  assertDeepEqual(pick([6, 2]), 6,                           '[MRAID, VPAID] → MRAID (VPAID skipped)');
+
+  // Vendor codes.
+  assertDeepEqual(pick([503]), null,                         'Vendor code 503 → null');
+  assertDeepEqual(pick([503, 6, 999]), 6,                    'Multiple unknowns + one known → 6');
+
+  // Empty/missing.
+  assertDeepEqual(pick([]), null,                            'Empty array → null');
+  assertDeepEqual(SHARCContainer._resolveApiFramework(undefined), null, 'undefined creativeMeta → null');
+  assertDeepEqual(SHARCContainer._resolveApiFramework(null), null,      'null creativeMeta → null');
+  assertDeepEqual(SHARCContainer._resolveApiFramework({}), null,        '{} creativeMeta → null');
+  assertDeepEqual(SHARCContainer._resolveApiFramework({apis: null}), null,
+    '{apis:null} creativeMeta → null');
+}
+
+// -- 14. container.apiFramework accessor + G10 frozen invariant -----------
+{
+  console.log('\n14. container.apiFramework accessor — G10 frozen at construction');
+
+  const c1 = new SHARCContainer(makeMarkupOpts({ creativeMeta: { apis: [6] } }));
+  assert(c1.apiFramework === 6, 'container.apiFramework returns picked code (6 for MRAID 3.0)');
+
+  const c2 = new SHARCContainer(makeMarkupOpts({ creativeMeta: { apis: [SHARC_API_CODE] } }));
+  assert(c2.apiFramework === SHARC_API_CODE, 'container.apiFramework returns SHARC_API_CODE');
+
+  const c3 = new SHARCContainer(makeMarkupOpts({ /* no creativeMeta */ }));
+  assert(c3.apiFramework === null, 'container.apiFramework is null when no creativeMeta declared');
+
+  // URL variant: creativeMeta is Markup-only per Rule 3b. apiFramework is null.
+  const c4 = new SHARCContainer({
+    creativeUrl: 'https://ads.example/c.html',
+    placementElement: document.createElement('div'),
+  });
+  assert(c4.apiFramework === null, 'URL variant: apiFramework always null (Rule 3b)');
+
+  // G10: getter is non-writable. Direct overwrite has no effect.
+  const c5 = new SHARCContainer(makeMarkupOpts({ creativeMeta: { apis: [6] } }));
+  let assignmentThrew = false;
+  try {
+    // In strict mode this throws; in sloppy mode it silently fails. Either way
+    // the read-back must still return the original value.
+    c5.apiFramework = 99;
+  } catch (e) {
+    assignmentThrew = true;
+  }
+  assert(c5.apiFramework === 6,
+    'G10: container.apiFramework still returns original after direct assignment attempt (got ' + c5.apiFramework + ')');
+
+  // G10 closure-capture: even if the private backing field is overwritten,
+  // the public accessor returns the value captured at construction.
+  c5._apiFramework = 12345;
+  assert(c5.apiFramework === 6,
+    'G10 closure-capture: container.apiFramework returns construction value even after _apiFramework overwrite');
+
+  // G10: property is non-configurable. delete fails.
+  let deleteThrew = false;
+  try { delete c5.apiFramework; } catch (e) { deleteThrew = true; }
+  assert(c5.apiFramework === 6, 'G10: container.apiFramework survives delete attempt');
+
+  // G10: property descriptor reports non-configurable.
+  const desc = Object.getOwnPropertyDescriptor(c5, 'apiFramework');
+  assert(desc && desc.configurable === false,
+    'G10: apiFramework property descriptor reports configurable: false');
+}
+
+// -- 15. G12 SHARC supersession — _mapAdComApisToBridges --------------------
+{
+  console.log('\n15. G12 SHARC supersession — bridge resolver inhibits MRAID/SafeFrame when SHARC declared');
+
+  const map = (apis) => SHARCContainer._mapAdComApisToBridges(apis);
+
+  // Baseline (no SHARC code): unchanged from 0.7.1.
+  assertDeepEqual(map([6]), ['mraid'],            'MRAID 3.0 alone → ["mraid"]');
+  assertDeepEqual(map([3, 5, 6]), ['mraid'],      'MRAID family → ["mraid"] (deduped)');
+
+  // SHARC alone: empty (SHARC is runtime, not a bridge).
+  assertDeepEqual(map([SHARC_API_CODE]), [],      'SHARC alone → [] (runtime, not bridge)');
+
+  // SHARC + MRAID → MRAID inhibited (G12).
+  assertDeepEqual(map([6, SHARC_API_CODE]), [],   '[MRAID 3.0, SHARC] → [] (MRAID superseded)');
+  assertDeepEqual(map([3, 5, 6, SHARC_API_CODE]), [],
+    '[MRAID 1/2/3, SHARC] → [] (all MRAID variants superseded)');
+
+  // SHARC + SafeFrame → SafeFrame inhibited (G12).
+  assertDeepEqual(map([SAFEFRAME_API_CODE, SHARC_API_CODE]), [],
+    '[SafeFrame, SHARC] → [] (SafeFrame superseded)');
+
+  // OMID is orthogonal — never superseded (measurement axis).
+  // OMID code 7 has no bridge mapping in 0.7.1 (deferred to 0.7.2 second-half),
+  // so it produces no bridge entry regardless of SHARC presence today.
+  assertDeepEqual(map([7, SHARC_API_CODE]), [],
+    '[OMID, SHARC] → [] (no OMID bridge yet, but G12 does NOT skip OMID)');
+
+  // No SHARC code present: supersession dormant, MRAID survives.
+  assertDeepEqual(map([6, 7]), ['mraid'],         '[MRAID, OMID] → ["mraid"] (no SHARC code, no supersession)');
+}
+
+// -- 16. requireSharcInit Rule 11 validation --------------------------------
+{
+  console.log('\n16. requireSharcInit (Rule 11) — strict boolean validation');
+
+  // Accepted shapes.
+  const cTrue = new SHARCContainer(makeMarkupOpts({ requireSharcInit: true }));
+  assert(cTrue._requireSharcInit === true,                 'requireSharcInit: true accepted');
+  const cFalse = new SHARCContainer(makeMarkupOpts({ requireSharcInit: false }));
+  assert(cFalse._requireSharcInit === false,               'requireSharcInit: false accepted');
+  const cUndef = new SHARCContainer(makeMarkupOpts({ /* omit */ }));
+  assert(cUndef._requireSharcInit === true,                'omitted requireSharcInit → defaults to true');
+  const cExplicitUndef = new SHARCContainer(makeMarkupOpts({ requireSharcInit: undefined }));
+  assert(cExplicitUndef._requireSharcInit === true,        'requireSharcInit: undefined → defaults to true');
+
+  // Rejected shapes — Rule 11 throws TypeError. No truthy/falsy coercion.
+  assertThrows(
+    () => new SHARCContainer(makeMarkupOpts({ requireSharcInit: null })),
+    /requireSharcInit must be a boolean.*null/,
+    'requireSharcInit: null → TypeError (no coercion to true)',
+    TypeError
+  );
+  assertThrows(
+    () => new SHARCContainer(makeMarkupOpts({ requireSharcInit: 0 })),
+    /requireSharcInit must be a boolean.*number/,
+    'requireSharcInit: 0 → TypeError (no truthy/falsy coercion)',
+    TypeError
+  );
+  assertThrows(
+    () => new SHARCContainer(makeMarkupOpts({ requireSharcInit: 1 })),
+    /requireSharcInit must be a boolean.*number/,
+    'requireSharcInit: 1 → TypeError',
+    TypeError
+  );
+  assertThrows(
+    () => new SHARCContainer(makeMarkupOpts({ requireSharcInit: '' })),
+    /requireSharcInit must be a boolean.*string/,
+    'requireSharcInit: "" → TypeError',
+    TypeError
+  );
+  assertThrows(
+    () => new SHARCContainer(makeMarkupOpts({ requireSharcInit: 'false' })),
+    /requireSharcInit must be a boolean.*string/,
+    'requireSharcInit: "false" → TypeError',
+    TypeError
+  );
+  assertThrows(
+    () => new SHARCContainer(makeMarkupOpts({ requireSharcInit: {} })),
+    /requireSharcInit must be a boolean.*object/,
+    'requireSharcInit: {} → TypeError',
+    TypeError
+  );
+
+  // Accepted alongside both variants.
+  const cUrl = new SHARCContainer({
+    creativeUrl: 'https://ads.example/c.html',
+    placementElement: document.createElement('div'),
+    requireSharcInit: false,
+  });
+  assert(cUrl._requireSharcInit === false,                 'requireSharcInit accepted in Creative URL variant (variant-agnostic)');
+}
+
+// -- 17. container.hasSharcSession accessor --------------------------------
+{
+  console.log('\n17. container.hasSharcSession — outcome-driven boolean accessor');
+
+  const c = new SHARCContainer(makeMarkupOpts({ creativeMeta: { apis: [6] } }));
+  assert(c.hasSharcSession === false,
+    'hasSharcSession is false before any handshake (no session established)');
+  assert(typeof c.hasSharcSession === 'boolean',
+    'hasSharcSession returns a primitive boolean (not null/undefined)');
+
+  // Declaration vs outcome — apiFramework and hasSharcSession are independent.
+  assert(c.apiFramework === 6, 'apiFramework = 6 (declaration)');
+  assert(c.hasSharcSession === false, 'hasSharcSession = false (no outcome yet)');
+}
+
 // ── Summary ───────────────────────────────────────────────────────────────
 console.log('');
 if (failures > 0) {

--- a/test/node/test-creative-sources-load.js
+++ b/test/node/test-creative-sources-load.js
@@ -312,6 +312,23 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       'Markup: iframe data-sharc-creative-rendered flips to "true" on envelope-valid :rendered');
   }
   flushContainers();
+
+  // 1f — 0.7.2: new accessors visible alongside existing diagnostic surface.
+  // `apiFramework` reflects the picker result; `hasSharcSession` stays
+  // `false` until the createSession handshake completes (jsdom's
+  // MessageChannel doesn't connect, so the post-:rendered handshake doesn't
+  // complete here — full hasSharcSession=true exercise lives in real-browser
+  // integration). See 0.7.2 design § 15.7.
+  {
+    const { container } = buildAndLoad({ creativeMeta: { apis: [6] } }, { respond: false });
+    assert(container.apiFramework === 6,
+      '0.7.2 regression: container.apiFramework reflects creativeMeta.apis picker result (MRAID 3.0 → 6)');
+    assert(container.hasSharcSession === false,
+      '0.7.2 regression: container.hasSharcSession is false before handshake completes');
+    assert(container._requireSharcInit === true,
+      '0.7.2 regression: container._requireSharcInit defaults to true (strict path)');
+  }
+  flushContainers();
 }
 
 // -- 2. Conditional sandbox tokens — overrides flow through to the attribute

--- a/test/node/test-non-sharc-loading.js
+++ b/test/node/test-non-sharc-loading.js
@@ -1,0 +1,337 @@
+/**
+ * test-non-sharc-loading.js — issue #89 (0.7.2 first half) coverage
+ *
+ * End-to-end behavior tests for `requireSharcInit: false` and the
+ * companion accessors `container.apiFramework` / `container.hasSharcSession`.
+ * Pure jsdom unit tests — no Puppeteer, no real network.
+ *
+ * Coverage axes (per 0.7.2 design § 15.3):
+ *   - Default strict (`requireSharcInit: true`): `createSession` fatal-timeout
+ *     fires when handshake doesn't arrive within `timeouts.createSession`.
+ *   - Permissive (`requireSharcInit: false`): timeout NOT armed; container
+ *     stays alive past the would-be cap.
+ *   - Permissive + late SHARC handshake: accepted; G7 framework-aware
+ *     console.warn fires with four forensic fields.
+ *   - Permissive + late handshake from declared-non-SHARC creative:
+ *     confused-deputy warn fires.
+ *   - Permissive + late handshake from declared-SHARC creative: silent
+ *     accept (declaration matches outcome).
+ *   - `hasSharcSession` flips from false → true after handshake.
+ *   - Permissive + close() mid-load: clean termination (G6).
+ *
+ * Notes / scope gaps surfaced for PR 2 (HTML lifecycle adapter):
+ *   - Permissive + no handshake: container currently STAYS in LOADING.
+ *     PR 2 adds the HTML adapter that drives `LOADING → ACTIVE` via
+ *     iframe-load + IntersectionObserver. Test below documents the gap
+ *     with a TODO so PR 2 extends rather than rewrites the assertion.
+ *
+ * Runs in Node after `npm run build`.
+ */
+
+import { JSDOM } from 'jsdom';
+
+const PUBLISHER_ORIGIN = 'https://publisher.example';
+const RENDERER_URL = 'https://renderer.operator.example/r/';
+const dom = new JSDOM(
+  '<!DOCTYPE html><html><body></body></html>',
+  { url: PUBLISHER_ORIGIN + '/page.html' },
+);
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.HTMLIFrameElement = dom.window.HTMLIFrameElement;
+global.MessageChannel = dom.window.MessageChannel;
+global.MessagePort = dom.window.MessagePort;
+global.MessageEvent = dom.window.MessageEvent;
+if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.randomUUID !== 'function') {
+  const nodeCrypto = await import('node:crypto');
+  globalThis.crypto = nodeCrypto.webcrypto || nodeCrypto;
+}
+
+const protoMod = await import('../../dist/sharc-protocol.mjs');
+window.SHARC = window.SHARC || {};
+window.SHARC.Protocol = protoMod;
+
+const { SHARCContainer } = await import('../../dist/sharc-container.mjs');
+const { ErrorCodes, SHARC_API_CODE } = protoMod;
+
+// Container hygiene — terminate any survivors between sections so the 5 s
+// fatal timeout (and other leaked timers) don't pollute downstream assertions.
+const _liveContainers = [];
+function track(c) { _liveContainers.push(c); return c; }
+function flushContainers() {
+  while (_liveContainers.length) {
+    const c = _liveContainers.pop();
+    try { if (!c._terminated) c._terminate(); } catch (_) { /* ignore */ }
+  }
+}
+process.on('beforeExit', flushContainers);
+
+let failures = 0;
+function assert(condition, message) {
+  if (condition) {
+    console.log('  ✓', message);
+  } else {
+    console.error('  ✗', message);
+    failures++;
+  }
+}
+
+function freshSlot() {
+  document.body.innerHTML = '';
+  const el = document.createElement('div');
+  el.id = 'ad-slot';
+  document.body.appendChild(el);
+  return el;
+}
+
+function markupOpts(overrides) {
+  return {
+    creativeHtml: '<html><body>creative</body></html>',
+    creativeRendererUrl: RENDERER_URL,
+    placementElement: freshSlot(),
+    ...overrides,
+  };
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+console.log('test-non-sharc-loading.js — issue #89 (0.7.2) coverage\n');
+
+// -- 1. Default strict: missing handshake fatal-errors after createSession --
+{
+  console.log('1. Default strict: missing handshake → NO_CREATE_SESSION (2212)');
+  const errorOutput = [];
+  const orig = console.error;
+  console.error = (...args) => { errorOutput.push(args.join(' ')); };
+
+  let errCode = null;
+  const c = track(new SHARCContainer({
+    creativeUrl: 'https://ads.example/c.html',
+    placementElement: freshSlot(),
+    timeouts: { createSession: 30 }, // abbreviated for test speed
+    onError: (code) => { errCode = code; },
+  }));
+  assert(c._requireSharcInit === true, 'default _requireSharcInit === true');
+  c.load();
+  await sleep(80);
+  console.error = orig;
+
+  assert(errCode === ErrorCodes.NO_CREATE_SESSION,
+    'onError fired with NO_CREATE_SESSION (2212) when no handshake arrives');
+}
+flushContainers();
+
+// -- 2. Permissive: missing handshake does NOT fatal-error -----------------
+{
+  console.log('\n2. Permissive (requireSharcInit:false): missing handshake → no fatal-error');
+  let errCode = null;
+  const c = track(new SHARCContainer({
+    creativeUrl: 'https://ads.example/c.html',
+    placementElement: freshSlot(),
+    requireSharcInit: false,
+    timeouts: { createSession: 30 },
+    onError: (code) => { errCode = code; },
+  }));
+  assert(c._requireSharcInit === false, '_requireSharcInit === false when passed');
+  c.load();
+  await sleep(80);
+
+  assert(errCode === null, 'onError NOT fired — fatal-timeout was not armed');
+  assert(c._terminated !== true, 'container remains alive (not terminated)');
+}
+flushContainers();
+
+// -- 3. Permissive + close() mid-load: clean termination (G6) --------------
+{
+  console.log('\n3. Permissive + close() mid-load: clean termination (G6)');
+  let closeFired = false;
+  const c = track(new SHARCContainer({
+    creativeUrl: 'https://ads.example/c.html',
+    placementElement: freshSlot(),
+    requireSharcInit: false,
+    timeouts: { closeSequence: 20 },
+    onClose: () => { closeFired = true; },
+  }));
+  c.load();
+  // No handshake — but operator wants to terminate anyway.
+  c.close();
+  await sleep(40);
+  assert(closeFired === true, 'onClose fired despite missing handshake');
+}
+flushContainers();
+
+// -- 4. Permissive + late handshake from declared-non-SHARC creative -------
+//    G7: framework-aware warn fires (confused deputy).
+{
+  console.log('\n4. Permissive + late handshake from MRAID-declared creative → confused-deputy warn');
+  const warnOutput = [];
+  const origWarn = console.warn;
+  console.warn = (...args) => { warnOutput.push(args.join(' ')); };
+
+  const c = track(new SHARCContainer({
+    ...markupOpts({ creativeMeta: { apis: [6] } }),
+    requireSharcInit: false,
+    timeouts: { createSession: 30 },
+  }));
+  c.load();
+  await sleep(40); // past where the fatal-timeout would have fired in strict mode
+
+  // Synthesize a late createSession message via the protocol layer.
+  // Use the container's accept path directly — simulates the late-arriving
+  // CREATE_SESSION envelope that would normally come through the message
+  // port. The G7 warn fires inside _handleCreateSession before acceptSession.
+  c._handleCreateSession({
+    type: 'SHARC:Creative:createSession',
+    id: 1,
+    args: { version: protoMod.SHARC_VERSION, placementType: 'inline' },
+  });
+  console.warn = origWarn;
+
+  const expected = warnOutput.find((line) =>
+    /Late createSession received at T\+\d+ms/.test(line)
+    && /apiFramework=6/.test(line)
+    && /bridges=\[mraid\]/.test(line)
+    && /requireSharcInit:false/.test(line)
+  );
+  assert(!!expected,
+    'G7: confused-deputy warn includes apiFramework=6, bridges=[mraid], elapsed-since-load, requireSharcInit:false');
+  // (hasSharcSession transition exercised end-to-end in
+  //  test-creative-sources-load.js with the full renderer protocol.)
+}
+flushContainers();
+
+// -- 5. Permissive + late handshake from SHARC-declared creative → silent --
+{
+  console.log('\n5. Permissive + late handshake from SHARC-declared creative → silent accept');
+  const warnOutput = [];
+  const origWarn = console.warn;
+  console.warn = (...args) => { warnOutput.push(args.join(' ')); };
+
+  const c = track(new SHARCContainer({
+    ...markupOpts({ creativeMeta: { apis: [SHARC_API_CODE] } }),
+    requireSharcInit: false,
+    timeouts: { createSession: 30 },
+  }));
+  c.load();
+  await sleep(40);
+
+  c._handleCreateSession({
+    type: 'SHARC:Creative:createSession',
+    id: 1,
+    args: { version: protoMod.SHARC_VERSION, placementType: 'inline' },
+  });
+  console.warn = origWarn;
+
+  const lateWarn = warnOutput.find((line) => /Late createSession/.test(line));
+  assert(!lateWarn,
+    'G7 silent: no late-handshake warn when declaration matches outcome (apiFramework === SHARC_API_CODE)');
+}
+flushContainers();
+
+// -- 6. Permissive + late handshake from undeclared creative → warn -------
+//    apiFramework: null (no creativeMeta) — confused-deputy warn variant.
+{
+  console.log('\n6. Permissive + late handshake from undeclared creative → confused-deputy warn');
+  const warnOutput = [];
+  const origWarn = console.warn;
+  console.warn = (...args) => { warnOutput.push(args.join(' ')); };
+
+  const c = track(new SHARCContainer({
+    ...markupOpts({ /* no creativeMeta */ }),
+    requireSharcInit: false,
+    timeouts: { createSession: 30 },
+  }));
+  c.load();
+  await sleep(40);
+
+  c._handleCreateSession({
+    type: 'SHARC:Creative:createSession',
+    id: 1,
+    args: { version: protoMod.SHARC_VERSION, placementType: 'inline' },
+  });
+  console.warn = origWarn;
+
+  const lateWarn = warnOutput.find((line) =>
+    /Late createSession received at T\+\d+ms/.test(line)
+    && /apiFramework=null/.test(line)
+    && /bridges=\[\]/.test(line)
+  );
+  assert(!!lateWarn,
+    'G7: undeclared late handshake warn includes apiFramework=null (no container-runtime declared), bridges=[]');
+}
+flushContainers();
+
+// -- 7. Permissive + Creative URL variant (variant-agnostic) ---------------
+{
+  console.log('\n7. Permissive + Creative URL variant — variant-agnostic');
+  let errCode = null;
+  const c = track(new SHARCContainer({
+    creativeUrl: 'https://ads.example/c.html',
+    placementElement: freshSlot(),
+    requireSharcInit: false,
+    timeouts: { createSession: 30 },
+    onError: (code) => { errCode = code; },
+  }));
+  c.load();
+  await sleep(80);
+  assert(errCode === null, 'URL variant: no fatal-error in permissive mode');
+  assert(c.apiFramework === null, 'URL variant: apiFramework always null (Rule 3b — no creativeMeta)');
+  assert(c.hasSharcSession === false, 'URL variant: hasSharcSession false until handshake');
+}
+flushContainers();
+
+// -- 8. Renderer-protocol timeouts STILL fire in permissive mode -----------
+//    Design § 4.2: only createSession is skipped; rendererLoad/rendererReply
+//    remain armed. They guard a different invariant.
+{
+  console.log('\n8. Permissive + renderer-protocol timeouts still fire (only createSession skips)');
+  const errorOutput = [];
+  const orig = console.error;
+  console.error = (...args) => { errorOutput.push(args.join(' ')); };
+
+  let errCode = null;
+  const c = track(new SHARCContainer({
+    ...markupOpts(),
+    requireSharcInit: false,
+    timeouts: { rendererLoad: 20, rendererReply: 20, createSession: 30 },
+    onError: (code) => { errCode = code; },
+  }));
+  c.load();
+  await sleep(80);
+  console.error = orig;
+
+  assert(errCode === ErrorCodes.RENDERER_TIMEOUT || errCode === ErrorCodes.NO_CREATE_SESSION,
+    'Renderer-protocol timeout still fires (createSession skipped, but rendererLoad/Reply armed)');
+}
+flushContainers();
+
+// -- 9. PR 2 SCOPE: HTML lifecycle adapter — currently absent --------------
+//    Documents the design § 8 gap that PR 2 fills. Today, permissive + no
+//    handshake leaves the container in LOADING (no adapter to advance state).
+{
+  console.log('\n9. PR 1 scope guard: HTML lifecycle adapter is PR 2 — currently absent');
+  const c = track(new SHARCContainer({
+    ...markupOpts(),
+    requireSharcInit: false,
+    timeouts: { createSession: 30, rendererLoad: 30, rendererReply: 30 },
+  }));
+  c.load();
+  await sleep(80);
+  // TODO PR 2: after the HTML lifecycle adapter ships, expect
+  //   c.getState() === ContainerStates.ACTIVE
+  // once the iframe load + intersection signals fire.
+  assert(c.getState() !== 'active',
+    'PR 1 only: non-handshake permissive container does NOT auto-advance to ACTIVE '
+    + '(HTML adapter ships in PR 2; § 8)');
+}
+flushContainers();
+
+// ── Summary ───────────────────────────────────────────────────────────────
+console.log('');
+if (failures > 0) {
+  console.error(`✗ ${failures} non-sharc-loading assertion(s) failed.`);
+  process.exit(1);
+} else {
+  console.log('✓ All non-sharc-loading assertions passed.');
+}

--- a/test/node/test-non-sharc-loading.js
+++ b/test/node/test-non-sharc-loading.js
@@ -281,6 +281,58 @@ flushContainers();
 }
 flushContainers();
 
+// -- 7b. G7 duplicate createSession: warn + idempotency rejection ----------
+//    Code review + design § 7.4: a second createSession after one already
+//    accepted must emit the idempotency warn AND must NOT overwrite the
+//    existing session. The container guards this; the underlying protocol
+//    layer is not idempotent on its own (acceptSession overwrites the
+//    sessionId), so the early-return in _handleCreateSession is the
+//    rejection mechanism.
+{
+  console.log('\n7b. G7 duplicate createSession → idempotency warn + early-return rejection');
+  const warnOutput = [];
+  const origWarn = console.warn;
+  console.warn = (...args) => { warnOutput.push(args.join(' ')); };
+
+  const c = track(new SHARCContainer({
+    ...markupOpts({ creativeMeta: { apis: [protoMod.SHARC_API_CODE] } }),
+    requireSharcInit: false,
+    timeouts: { createSession: 30 },
+  }));
+  c.load();
+  await sleep(40);
+
+  // First handshake — silent accept (SHARC-declared, declaration matches outcome).
+  const firstSessionId = '11111111-1111-4111-8111-111111111111';
+  c._handleCreateSession({
+    type: 'SHARC:Creative:createSession',
+    sessionId: firstSessionId,
+    id: 1,
+    args: { version: protoMod.SHARC_VERSION, placementType: 'inline' },
+  });
+  const sessionAfterFirst = c._protocol.sessionId;
+
+  // Duplicate handshake — different sessionId. Idempotency warn must fire
+  // AND the protocol sessionId must NOT change to the new value.
+  c._handleCreateSession({
+    type: 'SHARC:Creative:createSession',
+    sessionId: '22222222-2222-4222-8222-222222222222',
+    id: 2,
+    args: { version: protoMod.SHARC_VERSION, placementType: 'inline' },
+  });
+  console.warn = origWarn;
+
+  const dupWarn = warnOutput.find((line) =>
+    /Duplicate createSession received at T\+\d+ms/.test(line)
+    && /The original session remains active/.test(line)
+  );
+  assert(!!dupWarn,
+    'G7: duplicate createSession warn fires with "original session remains active" rejection text');
+  assert(c._protocol.sessionId === sessionAfterFirst,
+    'G7: duplicate createSession does NOT overwrite the original sessionId (early-return rejection)');
+}
+flushContainers();
+
 // -- 8. Renderer-protocol timeouts STILL fire in permissive mode -----------
 //    Design § 4.2: only createSession is skipped; rendererLoad/rendererReply
 //    remain armed. They guard a different invariant.

--- a/test/node/test-non-sharc-loading.js
+++ b/test/node/test-non-sharc-loading.js
@@ -177,27 +177,25 @@ flushContainers();
   c.load();
   await sleep(40); // past where the fatal-timeout would have fired in strict mode
 
-  // Synthesize a late createSession message via the protocol layer.
-  // Use the container's accept path directly — simulates the late-arriving
-  // CREATE_SESSION envelope that would normally come through the message
-  // port. The G7 warn fires inside _handleCreateSession before acceptSession.
+  // Synthesize a handshake via the protocol layer. Use a valid UUID in
+  // the CREATE_SESSION envelope so acceptSession does not reject; this
+  // exercises the full G7 warn + acceptSession path.
   c._handleCreateSession({
     type: 'SHARC:Creative:createSession',
+    sessionId: '11111111-1111-4111-8111-111111111111',
     id: 1,
     args: { version: protoMod.SHARC_VERSION, placementType: 'inline' },
   });
   console.warn = origWarn;
 
   const expected = warnOutput.find((line) =>
-    /Late createSession received at T\+\d+ms/.test(line)
+    /Unexpected createSession received at T\+\d+ms/.test(line)
     && /apiFramework=6/.test(line)
     && /bridges=\[mraid\]/.test(line)
     && /requireSharcInit:false/.test(line)
   );
   assert(!!expected,
-    'G7: confused-deputy warn includes apiFramework=6, bridges=[mraid], elapsed-since-load, requireSharcInit:false');
-  // (hasSharcSession transition exercised end-to-end in
-  //  test-creative-sources-load.js with the full renderer protocol.)
+    'G7: confused-deputy warn ("Unexpected ...") includes apiFramework=6, bridges=[mraid], elapsed-since-load, requireSharcInit:false');
 }
 flushContainers();
 
@@ -218,14 +216,15 @@ flushContainers();
 
   c._handleCreateSession({
     type: 'SHARC:Creative:createSession',
+    sessionId: '22222222-2222-4222-8222-222222222222',
     id: 1,
     args: { version: protoMod.SHARC_VERSION, placementType: 'inline' },
   });
   console.warn = origWarn;
 
-  const lateWarn = warnOutput.find((line) => /Late createSession/.test(line));
-  assert(!lateWarn,
-    'G7 silent: no late-handshake warn when declaration matches outcome (apiFramework === SHARC_API_CODE)');
+  const mismatchWarn = warnOutput.find((line) => /Unexpected createSession/.test(line));
+  assert(!mismatchWarn,
+    'G7 silent: no confused-deputy warn when declaration matches outcome (apiFramework === SHARC_API_CODE)');
 }
 flushContainers();
 
@@ -247,18 +246,19 @@ flushContainers();
 
   c._handleCreateSession({
     type: 'SHARC:Creative:createSession',
+    sessionId: '33333333-3333-4333-8333-333333333333',
     id: 1,
     args: { version: protoMod.SHARC_VERSION, placementType: 'inline' },
   });
   console.warn = origWarn;
 
-  const lateWarn = warnOutput.find((line) =>
-    /Late createSession received at T\+\d+ms/.test(line)
+  const mismatchWarn = warnOutput.find((line) =>
+    /Unexpected createSession received at T\+\d+ms/.test(line)
     && /apiFramework=null/.test(line)
     && /bridges=\[\]/.test(line)
   );
-  assert(!!lateWarn,
-    'G7: undeclared late handshake warn includes apiFramework=null (no container-runtime declared), bridges=[]');
+  assert(!!mismatchWarn,
+    'G7: undeclared confused-deputy warn includes apiFramework=null (no container-runtime declared), bridges=[]');
 }
 flushContainers();
 
@@ -281,15 +281,9 @@ flushContainers();
 }
 flushContainers();
 
-// -- 7b. G7 duplicate createSession: warn + idempotency rejection ----------
-//    Code review + design § 7.4: a second createSession after one already
-//    accepted must emit the idempotency warn AND must NOT overwrite the
-//    existing session. The container guards this; the underlying protocol
-//    layer is not idempotent on its own (acceptSession overwrites the
-//    sessionId), so the early-return in _handleCreateSession is the
-//    rejection mechanism.
+// -- 7b. Permissive: duplicate createSession → unconditional idempotency ---
 {
-  console.log('\n7b. G7 duplicate createSession → idempotency warn + early-return rejection');
+  console.log('\n7b. Permissive: duplicate createSession → idempotency warn + sessionId preserved');
   const warnOutput = [];
   const origWarn = console.warn;
   console.warn = (...args) => { warnOutput.push(args.join(' ')); };
@@ -302,18 +296,12 @@ flushContainers();
   c.load();
   await sleep(40);
 
-  // First handshake — silent accept (SHARC-declared, declaration matches outcome).
-  const firstSessionId = '11111111-1111-4111-8111-111111111111';
-  c._handleCreateSession({
-    type: 'SHARC:Creative:createSession',
-    sessionId: firstSessionId,
-    id: 1,
-    args: { version: protoMod.SHARC_VERSION, placementType: 'inline' },
-  });
-  const sessionAfterFirst = c._protocol.sessionId;
+  // Establish a session by directly seeding the protocol layer.
+  // (Avoids the jsdom MessageChannel limitation while still exercising
+  // the container's idempotency guard.)
+  c._protocol.sessionId = '11111111-1111-4111-8111-111111111111';
 
-  // Duplicate handshake — different sessionId. Idempotency warn must fire
-  // AND the protocol sessionId must NOT change to the new value.
+  // Duplicate handshake with a different sessionId.
   c._handleCreateSession({
     type: 'SHARC:Creative:createSession',
     sessionId: '22222222-2222-4222-8222-222222222222',
@@ -327,9 +315,106 @@ flushContainers();
     && /The original session remains active/.test(line)
   );
   assert(!!dupWarn,
-    'G7: duplicate createSession warn fires with "original session remains active" rejection text');
-  assert(c._protocol.sessionId === sessionAfterFirst,
-    'G7: duplicate createSession does NOT overwrite the original sessionId (early-return rejection)');
+    'permissive: duplicate createSession warn fires with rejection text');
+  assert(c._protocol.sessionId === '11111111-1111-4111-8111-111111111111',
+    'permissive: duplicate createSession does NOT overwrite the original sessionId');
+}
+flushContainers();
+
+// -- 7c. STRICT mode: duplicate createSession → unconditional idempotency --
+//    OpenClaw review finding #1: the previous fixup only guarded the
+//    permissive path. In strict mode (the default), acceptSession would
+//    still overwrite sessionId on a duplicate. Idempotency must be
+//    unconditional.
+{
+  console.log('\n7c. Strict mode: duplicate createSession → idempotency warn + sessionId preserved');
+  const warnOutput = [];
+  const origWarn = console.warn;
+  console.warn = (...args) => { warnOutput.push(args.join(' ')); };
+
+  const c = track(new SHARCContainer({
+    ...markupOpts({ creativeMeta: { apis: [protoMod.SHARC_API_CODE] } }),
+    // NO requireSharcInit option → defaults to true (strict)
+    timeouts: { createSession: 30 },
+  }));
+  c.load();
+  await sleep(40);
+
+  // Establish a session by directly seeding.
+  c._protocol.sessionId = '44444444-4444-4444-8444-444444444444';
+
+  // Duplicate handshake.
+  c._handleCreateSession({
+    type: 'SHARC:Creative:createSession',
+    sessionId: '55555555-5555-4555-8555-555555555555',
+    id: 2,
+    args: { version: protoMod.SHARC_VERSION, placementType: 'inline' },
+  });
+  console.warn = origWarn;
+
+  assert(c._requireSharcInit === true, 'strict mode active (default)');
+  const dupWarn = warnOutput.find((line) =>
+    /Duplicate createSession received at T\+\d+ms/.test(line)
+    && /The original session remains active/.test(line)
+  );
+  assert(!!dupWarn,
+    'strict mode: duplicate createSession warn fires (idempotency is now unconditional)');
+  assert(c._protocol.sessionId === '44444444-4444-4444-8444-444444444444',
+    'strict mode: duplicate createSession does NOT overwrite the original sessionId');
+}
+flushContainers();
+
+// -- 7d. Invalid-UUID createSession → fail-closed (no init flow) -----------
+//    OpenClaw review finding #1: acceptSession() rejects malformed UUIDs
+//    via SEC-006 but returns without setting sessionId. The pre-PR-#92
+//    code path continued the init flow regardless; now _handleCreateSession
+//    fail-closes by checking sessionId after acceptSession.
+{
+  console.log('\n7d. Invalid-UUID createSession → fail-closed (init flow does NOT run)');
+  const errOutput = [];
+  const origErr = console.error;
+  console.error = (...args) => { errOutput.push(args.join(' ')); };
+
+  const c = track(new SHARCContainer({
+    ...markupOpts({ creativeMeta: { apis: [protoMod.SHARC_API_CODE] } }),
+    requireSharcInit: false,
+    timeouts: { createSession: 30 },
+  }));
+  c.load();
+  await sleep(40);
+
+  // Stub _mergedSupportedFeatures so we can detect whether the init
+  // flow ran past the fail-closed point.
+  let initFlowReached = false;
+  const origAcceptSession = c._protocol.acceptSession.bind(c._protocol);
+  c._protocol.acceptSession = function (msg) {
+    // Mimic SEC-006 reject: don't set sessionId.
+    // (Calling original would also reject on the malformed UUID below,
+    // but we bypass to be deterministic.)
+    return;
+  };
+  const origInitArgs = c._explicitSupportedFeatures;
+  Object.defineProperty(c, '_mergedSupportedFeatures', {
+    set(val) { initFlowReached = true; },
+    get() { return undefined; },
+    configurable: true,
+  });
+
+  c._handleCreateSession({
+    type: 'SHARC:Creative:createSession',
+    sessionId: 'not-a-uuid-at-all',
+    id: 1,
+    args: { version: protoMod.SHARC_VERSION, placementType: 'inline' },
+  });
+  console.error = origErr;
+
+  assert(c._protocol.sessionId === '',
+    'invalid UUID: sessionId remains empty (acceptSession rejected)');
+  assert(initFlowReached === false,
+    'invalid UUID: _handleCreateSession fail-closes — does NOT continue to init flow');
+
+  // Restore.
+  c._protocol.acceptSession = origAcceptSession;
 }
 flushContainers();
 

--- a/test/node/test-non-sharc-loading.js
+++ b/test/node/test-non-sharc-loading.js
@@ -421,25 +421,36 @@ flushContainers();
 // -- 8. Renderer-protocol timeouts STILL fire in permissive mode -----------
 //    Design § 4.2: only createSession is skipped; rendererLoad/rendererReply
 //    remain armed. They guard a different invariant.
+//
+//    OpenClaw review (round 2): assert exactly RENDERER_TIMEOUT AND assert
+//    NO_CREATE_SESSION did not fire — a disjunction would mask a regression
+//    that accidentally re-armed _startSessionTimeout when requireSharcInit
+//    was false.
 {
-  console.log('\n8. Permissive + renderer-protocol timeouts still fire (only createSession skips)');
+  console.log('\n8. Permissive + renderer-protocol timeouts fire; createSession timeout does NOT');
   const errorOutput = [];
   const orig = console.error;
   console.error = (...args) => { errorOutput.push(args.join(' ')); };
 
-  let errCode = null;
+  // Capture EVERY error code raised during the window so we can prove
+  // NO_CREATE_SESSION never appeared.
+  const errCodes = [];
   const c = track(new SHARCContainer({
     ...markupOpts(),
     requireSharcInit: false,
-    timeouts: { rendererLoad: 20, rendererReply: 20, createSession: 30 },
-    onError: (code) => { errCode = code; },
+    // rendererLoad (20ms) wins decisively over the (would-be) createSession
+    // timeout (300ms). The latter must NOT be armed at all when permissive.
+    timeouts: { rendererLoad: 20, rendererReply: 20, createSession: 300 },
+    onError: (code) => { errCodes.push(code); },
   }));
   c.load();
   await sleep(80);
   console.error = orig;
 
-  assert(errCode === ErrorCodes.RENDERER_TIMEOUT || errCode === ErrorCodes.NO_CREATE_SESSION,
-    'Renderer-protocol timeout still fires (createSession skipped, but rendererLoad/Reply armed)');
+  assert(errCodes.includes(ErrorCodes.RENDERER_TIMEOUT),
+    'RENDERER_TIMEOUT fires (rendererLoad/Reply timeouts remain armed in permissive mode)');
+  assert(!errCodes.includes(ErrorCodes.NO_CREATE_SESSION),
+    'NO_CREATE_SESSION does NOT fire (createSession timeout is not armed when requireSharcInit:false)');
 }
 flushContainers();
 


### PR DESCRIPTION
## Summary

PR 1 of 3 implementing 0.7.2 first-half (issue #89 — load non-SHARC creatives without `createSession` fatal-timeout). Foundation chunk: container-layer `requireSharcInit` option, AdCOM-aligned framework detection accessors, G12 SHARC supersession, G7 + G9 diagnostic warns, state-machine `LOADING → ACTIVE` edge.

Design locked in commit 9c90e8c (`docs/design/0.7.2-non-sharc-loading.md`, 16 sections, ~12k words, 21-step implementation handoff in § 16).

Stage 4 decision per `docs/design/0.7.2-STAGE-3-COMPARISON.md`: **implement-per-design fresh; no spike cherry-picks**. The parallel spike branch (`spike/sharc-creative-validator`) is parked until #89 merges to main; its validator tooling will be updated post-merge to use the shipped 0.7.2 architecture.

HTML lifecycle adapter ships in PR 2. Doc updates + CHANGELOG land in PR 3.

## What's in this PR

**Protocol layer (`src/sharc-protocol.js`)**

- Placeholder AdCOM `APIFramework` constants `SHARC_API_CODE` (9001) and `SAFEFRAME_API_CODE` (9002). Sentinel integers outside AdCOM's assigned range; numeric values locked at AdCOM publication per `project_upstream_contribution_roadmap`. The picker, supersession resolver, and tests reference the symbolic names, so publication updates two integer literals — no logic changes.
- `STATE_TRANSITIONS`: `LOADING → ACTIVE` edge added per § 4.5. Legitimizes the parallel route for non-handshake creatives without synthesizing a misleading READY state. Handshake path unchanged.

**Container layer (`src/sharc-container.js`)**

- `requireSharcInit` constructor option (default `true`, Rule 11 strict TypeError validation per § 13 Q4 — no truthy/falsy coercion).
- `load()` guards `_startSessionTimeout()` on `this._requireSharcInit`. Captures `_loadedAt` for G7's elapsed-since-load forensic field. Renderer-protocol timeouts and all security boundaries remain armed (G1–G6, G8).
- `_resolveApiFramework(creativeMeta)` static helper — three-layer picker mirroring 0.7.1's `_resolveBridges`. Picker scope: SHARC + MRAID (highest version wins) + SafeFrame. OMID (7) excluded (measurement, not container runtime). VPAID (1, 2) and SIMID (8, 9) are NOT picker targets (video-creative protocols).
- `container.apiFramework` accessor — frozen at construction via closure-captured `Object.defineProperty` (G10). Non-writable AND non-configurable; even direct overwrite of `this._apiFramework` doesn't affect what the public accessor returns.
- `container.hasSharcSession` accessor — outcome-driven boolean companion to `apiFramework`. Returns `this._protocol.sessionId !== ''`.
- `_mapAdComApisToBridges` G12 supersession — when SHARC code is present, inhibits MRAID/SafeFrame bridge loading. OMID stays orthogonal (measurement, never superseded). § 6.7.
- G7 framework-aware late handshake `console.warn` in `_handleCreateSession`. Fires only when `requireSharcInit === false`. Matrix: silent when `apiFramework === SHARC_API_CODE` (declaration matches outcome); confused-deputy warn otherwise; idempotency warn on spurious duplicate. Four forensic fields: `placementSessionId`, `apiFramework`, `bridges`, elapsed-since-load.

**Bridge layer (`src/sharc-{mraid,safeframe}-bridge.js`)**

- G9 auto-install timeout warns. When `window.SHARC` never appears within the polling cap, emit operator-visible `console.warn` with the strict integer tick count + conservative wall-clock upper bound (1000 ticks × 16ms = 16000ms). PlacementSessionId is intentionally omitted in 0.7.2 first half — tracked separately in #91.

**Types (`src/types/globals.d.ts`)**

- Add `SHARC_API_CODE` / `SAFEFRAME_API_CODE` to the `window.SHARC.Protocol` type intersection so the container's destructure type-checks.

**Test coverage**

- `test/node/test-bridges-detection.js`: +5 sections (~50 assertions) covering the picker (§ 6.2 priority ladder + § 6.6 edge cases), G10 frozen invariant (mutation/delete attempts), G12 SHARC supersession matrix, Rule 11 strict-validation matrix, and `hasSharcSession` baseline shape.
- `test/node/test-non-sharc-loading.js` (new, ~250 lines): end-to-end matrix per § 15.3 — default-strict fatal-timeout fires; permissive skips it; G7 warn matrix (MRAID-declared, SHARC-declared, undeclared); renderer-protocol timeouts still fire in permissive mode (G2-area invariant); `close()` mid-load (G6); URL variant. Includes a PR 2 scope guard documenting where the HTML lifecycle adapter will plug in.
- `test/node/test-creative-sources-load.js`: +3-assertion regression block confirming `apiFramework`, `hasSharcSession`, and `_requireSharcInit` defaults in the Markup-variant load path.
- `package.json`: register `test:non-sharc-loading` script.

## Out of scope (separate PRs / issues)

- **HTML lifecycle adapter** (`src/lifecycle-adapters/`) → PR 2
- **Doc updates + CHANGELOG** → PR 3
- **OMID container-side wiring** → 0.7.2 second-half design pass (not yet started)
- **Extension `augmentEnvironmentData()` auto-call** → 0.7.2 second-half
- **Markup-variant backstop skip-first pattern** → #90 (orthogonal G2 refinement)
- **G9 `placementSessionId` threading** → #91 (renderer-coordination follow-up)
- **`package.json` version bump to 0.7.2** → at release time per `CLAUDE.md` § Version Bump Checklist, not in implementation PRs

## Test plan

- [x] `npm run build` clean (rollup + tsc)
- [x] All 11 jsdom test suites pass:
      `test:smoke`, `test:treeshake`, `test:placement`, `test:placement-stamping`, `test:creative-sources`, `test:creative-sources-load`, `test:navigation-bridge`, `test:creative-sdk-autoinstall`, `test:bridges-detection`, `test:non-sharc-loading`, `test:renderer-fallback`
- [x] G10 closure-capture verified: direct write to `container._apiFramework` does NOT affect what `container.apiFramework` returns
- [x] G10 `Object.getOwnPropertyDescriptor(c, 'apiFramework').configurable === false`
- [x] Rule 11 throws `TypeError` for `null`, `0`, `1`, `''`, `'false'`, `{}` (no truthy/falsy coercion)
- [x] G12 supersession: `[6, SHARC_API_CODE]` → `apiFramework: SHARC_API_CODE`, `bridges: []`
- [x] G7 warn includes all four forensic fields for declared-non-SHARC late handshake; silent when declaration matches
- [ ] Real-browser handshake test (`hasSharcSession` flips `true`) — jsdom MessageChannel doesn't connect end-to-end; full path lives in `test/browser/` real-browser integration; not blocking for PR 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)