### PR TITLE
feat(89): HTML lifecycle adapter (0.7.2 PR 2/3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "test:creative-sdk-autoinstall": "node test/node/test-creative-sdk-autoinstall.js",
     "test:bridges-detection": "node test/node/test-bridges-detection.js",
     "test:non-sharc-loading": "node test/node/test-non-sharc-loading.js",
+    "test:html-lifecycle-adapter": "node test/node/test-html-lifecycle-adapter.js",
     "test:renderer-fallback": "node test/node/test-renderer-domparser-fallback.js",
     "test:perf": "node test/node/test-creative-sources-perf.js",
     "test:types": "tsc -p test/types/tsconfig.json",

--- a/src/lifecycle-adapters/base-adapter.js
+++ b/src/lifecycle-adapters/base-adapter.js
@@ -97,9 +97,18 @@ class BaseLifecycleAdapter {
    * `:rendered` envelope validation). Base class is a no-op; subclasses
    * override if they have an initial-transition gate to re-evaluate.
    *
-   * Underscore-prefix marks this as an internal API not intended for
-   * operator consumption; the container is the only legitimate caller.
-   * Not `@private` so TS allows the cross-class call site in container.
+   * **Subclass authors:** any override MUST respect
+   * `container._requireSharcInit === true` and yield to the
+   * handshake-driven `LOADING → READY → ACTIVE` path during LOADING.
+   * The strict-mode race (adapter promotes before handshake completes)
+   * permanently corrupts the handshake-driven lifecycle — see PR #98
+   * findings + 0.7.2 design § 8.2.
+   *
+   * Underscore-prefix marks this as an internal API; `@protected`
+   * scopes it to the class hierarchy (container + 0.7.3 framework
+   * subclasses) while keeping it accessible across the cross-class
+   * boundary that TS would otherwise reject.
+   * @protected
    */
   _maybeAdvanceToActive() {
     /* base no-op — subclasses override */

--- a/src/lifecycle-adapters/base-adapter.js
+++ b/src/lifecycle-adapters/base-adapter.js
@@ -88,6 +88,22 @@ class BaseLifecycleAdapter {
   detach() {
     this._container = null;
   }
+
+  /**
+   * Internal-but-cross-class hook the container calls to invite the
+   * adapter to re-check its initial-transition gate. Used when a
+   * container-side signal relevant to the adapter's gate has changed
+   * (e.g., Markup variant flipping `creativeRendered = true` after
+   * `:rendered` envelope validation). Base class is a no-op; subclasses
+   * override if they have an initial-transition gate to re-evaluate.
+   *
+   * Underscore-prefix marks this as an internal API not intended for
+   * operator consumption; the container is the only legitimate caller.
+   * Not `@private` so TS allows the cross-class call site in container.
+   */
+  _maybeAdvanceToActive() {
+    /* base no-op — subclasses override */
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lifecycle-adapters/base-adapter.js
+++ b/src/lifecycle-adapters/base-adapter.js
@@ -1,0 +1,101 @@
+/**
+ * @fileoverview SHARC Lifecycle Adapter — Abstract Base Class
+ *
+ * Abstract base for the SHARC lifecycle adapter family introduced in 0.7.2.
+ * Concrete subclasses derive container state transitions from environment-
+ * specific signals: the 0.7.2 first-half ships {@link HtmlAdapter} (browser-
+ * native signals only); 0.7.3 will add `MraidAdapter` and `SafeFrameAdapter`
+ * subclasses that layer framework-specific signals on top.
+ *
+ * Open-closed contract:
+ *   - Container instantiates exactly one adapter in `load()` via
+ *     `SHARCContainer._selectLifecycleAdapter(apiFramework)`.
+ *   - Container calls `adapter.attach(this)` once `_iframe` exists.
+ *   - Container calls `adapter.detach()` in `_terminate()`.
+ *
+ * Subclasses override `attach` and `detach` to register and tear down
+ * environment listeners. The base implementation tracks the attached
+ * container and defends against double-attach (a class of double-listener
+ * bugs that surfaced during 0.7.0 development).
+ *
+ * See 0.7.2 design doc § 8.1 ("Architectural shape — adapter classes")
+ * for the rationale that picked the adapter-class shape over inline-switch
+ * or registry alternatives.
+ *
+ * @version 0.7.1
+ */
+
+'use strict';
+
+/**
+ * Abstract base class for SHARC lifecycle adapters.
+ *
+ * Subclasses MUST override `attach(container)` and `detach()`. The base
+ * implementation enforces the single-attach invariant — calling `attach`
+ * twice without an intervening `detach` throws to surface the bug at the
+ * second-call site rather than silently double-registering listeners.
+ *
+ * @example
+ * // Subclassing (skeleton):
+ * class MyAdapter extends BaseLifecycleAdapter {
+ *   attach(container) {
+ *     super.attach(container);  // sets this._container and runs the guard
+ *     // register listeners...
+ *   }
+ *   detach() {
+ *     // unregister listeners...
+ *     super.detach();           // clears this._container
+ *   }
+ * }
+ */
+class BaseLifecycleAdapter {
+  constructor() {
+    /**
+     * The container instance this adapter is attached to, or `null` when
+     * detached. Subclasses read `this._container` to reach the state machine,
+     * iframe element, and protocol surface.
+     * @type {?Object}
+     * @protected
+     */
+    this._container = null;
+  }
+
+  /**
+   * Attaches the adapter to a container. Subclasses MUST call `super.attach`
+   * first to enforce the single-attach invariant and store the container
+   * reference, then register their own listeners / observers.
+   *
+   * @param {Object} container - The {@link SHARCContainer} instance to observe.
+   * @throws {Error} If the adapter is already attached (defense-in-depth
+   *   against double-listener registration).
+   */
+  attach(container) {
+    if (this._container !== null) {
+      throw new Error(
+        '[SHARCLifecycleAdapter] attach() called twice without detach() — '
+        + 'lifecycle adapters MUST be detached before re-attaching to '
+        + 'prevent double-listener registration.'
+      );
+    }
+    this._container = container;
+  }
+
+  /**
+   * Detaches the adapter. Subclasses MUST unregister their listeners /
+   * observers and then call `super.detach()` to clear the container
+   * reference. Safe to call when not attached — a no-op in that case.
+   */
+  detach() {
+    this._container = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { BaseLifecycleAdapter };
+}
+
+export { BaseLifecycleAdapter };

--- a/src/lifecycle-adapters/html-adapter.js
+++ b/src/lifecycle-adapters/html-adapter.js
@@ -356,7 +356,15 @@ class HtmlAdapter extends BaseLifecycleAdapter {
    *     already advanced it, or `close()` raced and put it in
    *     `TERMINATED`).
    *   - The initial transition has already fired.
-   * @private
+   *   - Strict mode (`requireSharcInit: true`) — the handshake-driven
+   *     path owns the initial transition; adapter yields per § 8.2.
+   *   - Markup variant with `creativeRendered === false` — iframe
+   *     `load` fired on the renderer document, not the creative.
+   *
+   * Overrides `BaseLifecycleAdapter._maybeAdvanceToActive` (base no-op).
+   * Container may call this to invite a gate re-evaluation when a
+   * container-side signal changed (e.g., `_onRendererRendered` flipping
+   * `creativeRendered = true`).
    */
   _maybeAdvanceToActive() {
     if (this._container === null) return;
@@ -511,10 +519,31 @@ class HtmlAdapter extends BaseLifecycleAdapter {
       return; // already there / done
     }
 
+    // ── Race-avoidance: yield to handshake in strict + LOADING ─────────
+    // In strict mode (`requireSharcInit: true`), the handshake is the
+    // canonical driver of state. If the adapter walks LOADING → ACTIVE
+    // → HIDDEN → FROZEN on a freeze/pagehide event while a handshake
+    // is in-flight, the subsequent `_handleInitResolved` →
+    // `setState(READY)` becomes invalid (`'frozen' → 'ready'`) and the
+    // handshake-driven lifecycle is permanently broken.
+    //
+    // For strict-mode LOADING, no-op on freeze/pagehide. The browser's
+    // bfcache freezes the iframe implicitly; when the page is restored,
+    // the container is still in LOADING and the handshake can proceed
+    // normally. Operators don't get an `onStateChange(FROZEN)` callback
+    // in this narrow window, which is consistent with the broader
+    // principle: in strict mode with no handshake yet, there is no
+    // SHARC session and no SHARC state lifecycle to report.
+    if (state === ContainerStates.LOADING
+        && this._container._requireSharcInit === true) {
+      return;
+    }
+
     if (state === ContainerStates.LOADING) {
-      // Edge case — page enters bfcache before iframe finished loading.
-      // LOADING → FROZEN is not a direct edge; promote to ACTIVE first
-      // (the new 0.7.2 edge from § 4.5), then walk through HIDDEN.
+      // Permissive-mode LOADING — operator opted out of expecting a
+      // handshake, so the adapter owns the lifecycle. Promote to
+      // ACTIVE first (new 0.7.2 edge from § 4.5), then walk through
+      // HIDDEN to FROZEN.
       this._initialTransitionFired = true;
       this._container.setState(ContainerStates.ACTIVE);
     }

--- a/src/lifecycle-adapters/html-adapter.js
+++ b/src/lifecycle-adapters/html-adapter.js
@@ -365,6 +365,7 @@ class HtmlAdapter extends BaseLifecycleAdapter {
    * Container may call this to invite a gate re-evaluation when a
    * container-side signal changed (e.g., `_onRendererRendered` flipping
    * `creativeRendered = true`).
+   * @protected
    */
   _maybeAdvanceToActive() {
     if (this._container === null) return;

--- a/src/lifecycle-adapters/html-adapter.js
+++ b/src/lifecycle-adapters/html-adapter.js
@@ -1,0 +1,523 @@
+/**
+ * @fileoverview SHARC HTML Lifecycle Adapter
+ *
+ * Browser-native lifecycle adapter — derives SHARC state transitions from
+ * iframe `load`, IntersectionObserver, `pagehide` / `pageshow`, and
+ * `freeze` / `resume` events when no handshake-driven path is available.
+ *
+ * Scope (0.7.2 first half):
+ *   - Generic HTML creatives (`apiFramework === null`).
+ *   - Creatives whose declared framework does not yet have a dedicated
+ *     adapter (MRAID, SafeFrame) — the HTML adapter is the fallback
+ *     baseline until 0.7.3 ships framework-specific subclasses.
+ *
+ * Coexistence with the SHARC handshake (§ 8.2):
+ *   - The adapter attaches in `load()` regardless of `requireSharcInit`.
+ *   - When a SHARC-aware creative handshakes, the handshake-driven
+ *     `LOADING → READY → ACTIVE` transition runs first; the adapter observes
+ *     the resulting `ACTIVE` state and yields to it (the initial
+ *     `LOADING → ACTIVE` transition is gated on the current state actually
+ *     being `LOADING`).
+ *   - Subsequent visibility / bfcache / freeze transitions still fire from
+ *     the adapter — those layer on top of the existing
+ *     `_attachPageLifecycleListeners()` chain without conflict.
+ *
+ * Test surface limits (§ 8.4):
+ *   - jsdom does NOT model bfcache itself; `pagehide` / `pageshow` events
+ *     with `persisted: true` can be dispatched programmatically, so the
+ *     adapter's wire is testable as event-dispatch even though the bfcache
+ *     restoration roundtrip is Chrome-only end-to-end.
+ *   - jsdom does NOT ship an IntersectionObserver implementation. Tests
+ *     stub `global.IntersectionObserver` with a manually-triggerable mock.
+ *
+ * @version 0.7.1
+ */
+
+'use strict';
+
+import { BaseLifecycleAdapter } from './base-adapter.js';
+import { ContainerStates } from '../sharc-protocol.js';
+
+/**
+ * Intersection ratio threshold for the ACTIVE / PASSIVE / HIDDEN
+ * classification (§ 8.3). 0.5 mirrors common viewability conventions and
+ * aligns with the MRAID `viewable` definition.
+ * @type {number}
+ */
+const INTERSECTION_THRESHOLD = 0.5;
+
+/**
+ * HTML lifecycle adapter — observes browser-native lifecycle signals and
+ * drives SHARC state transitions for non-handshake creatives.
+ *
+ * Event-to-state mapping (§ 8.3):
+ *
+ * | Signal                                       | Transition          |
+ * |----------------------------------------------|---------------------|
+ * | iframe `load` AND intersection ≥ 0.5         | `LOADING → ACTIVE`  |
+ * | intersection ≥ 0.5 while in `LOADING` after  | `LOADING → ACTIVE`  |
+ * |   iframe-load                                |                     |
+ * | intersection ratio 0 in `ACTIVE` / `PASSIVE` | `* → HIDDEN`        |
+ * | partial intersection (0 < r < 0.5) in        | `ACTIVE → PASSIVE`  |
+ * |   `ACTIVE`                                   |                     |
+ * | intersection ≥ 0.5 in `PASSIVE` / `HIDDEN`   | `* → ACTIVE`        |
+ * | `pagehide` (persisted: true)                 | `* → FROZEN`        |
+ * | `pageshow` (persisted: true)                 | `FROZEN → ACTIVE` / |
+ * |                                              |   `FROZEN → PASSIVE`|
+ * | `freeze`                                     | `* → FROZEN`        |
+ * | `resume`                                     | `FROZEN → ACTIVE` / |
+ * |                                              |   `FROZEN → PASSIVE`|
+ *
+ * Non-goals: the adapter does NOT observe `RESIZED` — there is no clean
+ * browser-native signal for "renderable area changed" without coordination
+ * with the container's placement-change machinery. Deferred to the MRAID
+ * adapter (0.7.3) which can anchor against `mraid.size` semantics.
+ *
+ * @example
+ * // Container wires the adapter in load():
+ * this._lifecycleAdapter = SHARCContainer._selectLifecycleAdapter(this._apiFramework);
+ * this._lifecycleAdapter.attach(this);
+ * // ... and detaches in _terminate():
+ * this._lifecycleAdapter.detach();
+ */
+class HtmlAdapter extends BaseLifecycleAdapter {
+  constructor() {
+    super();
+
+    /**
+     * `true` once the iframe `load` event has fired. One half of the
+     * gate that promotes `LOADING → ACTIVE`.
+     * @type {boolean}
+     * @private
+     */
+    this._iframeLoaded = false;
+
+    /**
+     * Last observed intersection ratio (`0.0`–`1.0`). `null` until the
+     * IntersectionObserver has fired at least once. Other half of the
+     * `LOADING → ACTIVE` gate (paired with `_iframeLoaded`).
+     * @type {?number}
+     * @private
+     */
+    this._intersectionRatio = null;
+
+    /**
+     * Last observed `isIntersecting` flag from the IntersectionObserver.
+     * Tracked separately from {@link _intersectionRatio} so the "0% but
+     * still intersecting" edge case is unambiguous (browsers can report
+     * `isIntersecting: true` with ratio 0 in narrow geometry edge cases).
+     * @type {boolean}
+     * @private
+     */
+    this._isIntersecting = false;
+
+    /**
+     * The IntersectionObserver instance, or `null` when detached / not
+     * yet attached. Constructed in `attach()` once the container's
+     * `_iframe` is available.
+     * @type {?IntersectionObserver}
+     * @private
+     */
+    this._intersectionObserver = null;
+
+    /**
+     * `true` once `_maybeAdvanceToActive` has fired the `LOADING → ACTIVE`
+     * transition (or observed it firing from the handshake path). Prevents
+     * the adapter from re-issuing the initial transition if both iframe-
+     * load and intersection-visible fire after coalescing.
+     * @type {boolean}
+     * @private
+     */
+    this._initialTransitionFired = false;
+
+    /** @type {?(event: Event) => void} @private */
+    this._iframeLoadHandler = null;
+    /** @type {?(event: PageTransitionEvent) => void} @private */
+    this._pagehideHandler = null;
+    /** @type {?(event: PageTransitionEvent) => void} @private */
+    this._pageshowHandler = null;
+    /** @type {?(event: Event) => void} @private */
+    this._freezeHandler = null;
+    /** @type {?(event: Event) => void} @private */
+    this._resumeHandler = null;
+  }
+
+  /**
+   * Attaches the adapter to the container. Registers:
+   *   - An iframe `load` listener (one-shot — gate flips on first load).
+   *   - An IntersectionObserver on the iframe element with a single
+   *     threshold at {@link INTERSECTION_THRESHOLD}.
+   *   - Window `pagehide` / `pageshow` listeners (bfcache signals).
+   *   - Document `freeze` / `resume` listeners (broadens the existing
+   *     handler chain which only covers `HIDDEN → FROZEN`).
+   *
+   * After registration, schedules a microtask that may fire the initial
+   * `LOADING → ACTIVE` transition synchronously if both signals are already
+   * available (e.g. iframe was cached, intersection observer fired
+   * immediately). Subsequent transitions fire on event arrival.
+   *
+   * @param {Object} container - The {@link SHARCContainer} instance. MUST
+   *   have `_iframe` already populated (attach is called from `load()`
+   *   AFTER `_createIframe()`).
+   */
+  attach(container) {
+    super.attach(container);
+
+    const iframe = container._iframe;
+    if (!iframe) {
+      // Defensive — container's load() flow always populates _iframe
+      // before adapter.attach(). If this ever fires, container code path
+      // re-ordered without updating the adapter; surface loudly.
+      throw new Error(
+        '[SHARCLifecycleAdapter] attach() called before container._iframe '
+        + 'was populated — adapter must attach after _createIframe().'
+      );
+    }
+
+    // Iframe load — one-shot. The browser may fire `load` multiple times
+    // for srcdoc / src reassignment; the adapter only cares about the
+    // first transition gate. (Subsequent `load` fires are handled by the
+    // container's separate renderer-backstop chain.)
+    this._iframeLoadHandler = () => {
+      if (this._iframeLoaded) return;
+      this._iframeLoaded = true;
+      this._maybeAdvanceToActive();
+    };
+    iframe.addEventListener('load', this._iframeLoadHandler, false);
+
+    // IntersectionObserver — environment-provided. jsdom tests stub
+    // `global.IntersectionObserver` with a manually-triggerable mock.
+    // Guarded: if no IntersectionObserver is available (very old runtime),
+    // skip wiring; the adapter still functions for handshake-completed
+    // creatives (which advance independently) and degrades gracefully —
+    // initial transition will fire on iframe-load alone via the coalesce
+    // microtask.
+    if (typeof IntersectionObserver === 'function') {
+      this._intersectionObserver = new IntersectionObserver(
+        (entries) => this._onIntersectionChange(entries),
+        { threshold: [0, INTERSECTION_THRESHOLD, 1] },
+      );
+      this._intersectionObserver.observe(iframe);
+    }
+
+    // bfcache wires — `pagehide` / `pageshow` with `persisted: true`.
+    // Distinct from `freeze` / `resume` which the container's existing
+    // listener chain partially covers (HIDDEN → FROZEN only).
+    this._pagehideHandler = (event) => this._onPagehide(event);
+    this._pageshowHandler = (event) => this._onPageshow(event);
+    window.addEventListener('pagehide', this._pagehideHandler, false);
+    window.addEventListener('pageshow', this._pageshowHandler, false);
+
+    // Freeze / resume — broaden the existing container handler chain
+    // (`_attachPageLifecycleListeners` covers only HIDDEN → FROZEN per
+    // its sync semantics). The adapter widens to `* → FROZEN` per § 8.3
+    // so a creative that freezes from PASSIVE / ACTIVE also reaches FROZEN.
+    this._freezeHandler = () => this._onFreeze();
+    this._resumeHandler = () => this._onResume();
+    document.addEventListener('freeze', this._freezeHandler, false);
+    document.addEventListener('resume', this._resumeHandler, false);
+
+    // Microtask coalesce — § 8.3 last paragraph. After attach returns
+    // synchronously, the next microtask checks whether both gate
+    // conditions are already met (iframe cached + initial intersection
+    // already fired) and fires at most one transition.
+    queueMicrotask(() => {
+      if (this._container === null) return; // detached during the microtask gap
+      this._maybeAdvanceToActive();
+    });
+  }
+
+  /**
+   * Detaches the adapter — disconnects the IntersectionObserver,
+   * removes all event listeners, and clears handler references. Safe to
+   * call when not attached (no-op).
+   */
+  detach() {
+    if (this._container === null) {
+      // No-op — adapter was never attached, or detach was already called.
+      super.detach();
+      return;
+    }
+
+    const iframe = this._container._iframe;
+    if (iframe && this._iframeLoadHandler) {
+      try {
+        iframe.removeEventListener('load', this._iframeLoadHandler, false);
+      } catch (_) { /* ignore — iframe may already be detached from DOM */ }
+    }
+    this._iframeLoadHandler = null;
+
+    if (this._intersectionObserver) {
+      try { this._intersectionObserver.disconnect(); } catch (_) { /* ignore */ }
+      this._intersectionObserver = null;
+    }
+
+    if (this._pagehideHandler) {
+      window.removeEventListener('pagehide', this._pagehideHandler, false);
+      this._pagehideHandler = null;
+    }
+    if (this._pageshowHandler) {
+      window.removeEventListener('pageshow', this._pageshowHandler, false);
+      this._pageshowHandler = null;
+    }
+    if (this._freezeHandler) {
+      document.removeEventListener('freeze', this._freezeHandler, false);
+      this._freezeHandler = null;
+    }
+    if (this._resumeHandler) {
+      document.removeEventListener('resume', this._resumeHandler, false);
+      this._resumeHandler = null;
+    }
+
+    super.detach();
+  }
+
+  // -------------------------------------------------------------------------
+  // Event handlers
+  // -------------------------------------------------------------------------
+
+  /**
+   * IntersectionObserver callback. Tracks the most recent ratio +
+   * `isIntersecting` flag and drives the visibility transitions per § 8.3.
+   * @param {IntersectionObserverEntry[]} entries
+   * @private
+   */
+  _onIntersectionChange(entries) {
+    if (this._container === null) return;
+    if (!entries || entries.length === 0) return;
+
+    // Latest entry wins — observe() is called with a single target so
+    // multi-entry batches collapse to the most recent state.
+    const entry = entries[entries.length - 1];
+    this._intersectionRatio = typeof entry.intersectionRatio === 'number'
+      ? entry.intersectionRatio
+      : 0;
+    this._isIntersecting = !!entry.isIntersecting;
+
+    const state = this._container.getState();
+
+    if (state === ContainerStates.LOADING) {
+      // Initial-transition gate — paired with iframe-load.
+      this._maybeAdvanceToActive();
+      return;
+    }
+
+    // Post-LOADING visibility classification per § 8.3.
+    if (!this._isIntersecting || this._intersectionRatio === 0) {
+      // Fully off-screen — drive to HIDDEN if we're somewhere visible.
+      if (state === ContainerStates.ACTIVE || state === ContainerStates.PASSIVE) {
+        this._container.setState(ContainerStates.HIDDEN);
+      }
+      return;
+    }
+
+    if (this._intersectionRatio >= INTERSECTION_THRESHOLD) {
+      // Sufficiently visible — promote to ACTIVE from PASSIVE / HIDDEN.
+      if (state === ContainerStates.PASSIVE || state === ContainerStates.HIDDEN) {
+        // HIDDEN → ACTIVE is not a direct edge in STATE_TRANSITIONS
+        // (HIDDEN → PASSIVE → ACTIVE is the canonical path). Step through
+        // PASSIVE so the state machine accepts the transition.
+        if (state === ContainerStates.HIDDEN) {
+          this._container.setState(ContainerStates.PASSIVE);
+        }
+        this._container.setState(ContainerStates.ACTIVE);
+      }
+      return;
+    }
+
+    // Partial (0 < ratio < 0.5) — demote ACTIVE to PASSIVE.
+    if (state === ContainerStates.ACTIVE) {
+      this._container.setState(ContainerStates.PASSIVE);
+    }
+  }
+
+  /**
+   * Fires the initial `LOADING → ACTIVE` transition when both gates are
+   * met: iframe-load has fired AND intersection ratio ≥ threshold. Also
+   * accommodates the case where IntersectionObserver is unavailable
+   * (environment fallback): a fired iframe-load alone advances after
+   * the coalesce microtask.
+   *
+   * Skipped when:
+   *   - The container is no longer in `LOADING` (handshake-driven path
+   *     already advanced it, or `close()` raced and put it in
+   *     `TERMINATED`).
+   *   - The initial transition has already fired.
+   * @private
+   */
+  _maybeAdvanceToActive() {
+    if (this._container === null) return;
+    if (this._initialTransitionFired) return;
+
+    const state = this._container.getState();
+
+    if (state !== ContainerStates.LOADING) {
+      // Handshake-driven path advanced the container before our gates
+      // closed. § 8.2: yield silently — record that we've observed the
+      // transition so we don't double-fire if a late intersection event
+      // arrives.
+      this._initialTransitionFired = true;
+      return;
+    }
+
+    // Both gates required when IntersectionObserver is available.
+    if (this._intersectionObserver) {
+      if (!this._iframeLoaded) return;
+      if (this._intersectionRatio === null) return;
+      if (!this._isIntersecting) return;
+      if (this._intersectionRatio < INTERSECTION_THRESHOLD) return;
+    } else {
+      // Degraded mode — no IntersectionObserver, advance on iframe-load
+      // alone. Matches the "polyfill-able with explicit triggering"
+      // contract in § 8.4: environments without IO get a less precise
+      // signal but the adapter still functions.
+      if (!this._iframeLoaded) return;
+    }
+
+    this._initialTransitionFired = true;
+    this._container.setState(ContainerStates.ACTIVE);
+  }
+
+  /**
+   * `pagehide` handler. § 8.3 — when `persisted: true`, the page is
+   * entering bfcache; drive to FROZEN from any pre-TERMINATED state.
+   * @param {PageTransitionEvent} event
+   * @private
+   */
+  _onPagehide(event) {
+    if (this._container === null) return;
+    if (!event || !event.persisted) return;
+    this._transitionToFrozen();
+  }
+
+  /**
+   * `pageshow` handler. § 8.3 — when `persisted: true`, the page is
+   * restoring from bfcache; advance from FROZEN per current visibility.
+   *
+   * Real-bfcache restoration in jsdom is not modeled — only the event
+   * dispatch is. Chrome-only end-to-end (Puppeteer follow-up per § 8.4).
+   * @param {PageTransitionEvent} event
+   * @private
+   */
+  _onPageshow(event) {
+    if (this._container === null) return;
+    if (!event || !event.persisted) return;
+    this._transitionFromFrozen();
+  }
+
+  /**
+   * `freeze` handler. § 8.3 — broadens the container's existing
+   * `_onFreeze` (which only fires HIDDEN → FROZEN) to `* → FROZEN`.
+   * @private
+   */
+  _onFreeze() {
+    if (this._container === null) return;
+    this._transitionToFrozen();
+  }
+
+  /**
+   * `resume` handler. § 8.3 says "adapter does not duplicate" the
+   * container's existing `_onResume` FROZEN → ACTIVE/PASSIVE/HIDDEN
+   * resolution — but the existing handler resolves to PASSIVE whenever
+   * `document.hasFocus()` is false (no way to be more precise without
+   * intersection signal). The adapter LAYERS intersection-driven
+   * promotion on top: if the container resolved to PASSIVE because
+   * focus is unknown but the iframe is fully visible per
+   * IntersectionObserver, promote to ACTIVE. This is the "adapter
+   * contributes browser signals the container chain lacks" pattern
+   * from § 8.2 — not a duplicate, an augmentation.
+   *
+   * Future framework-specific subclasses (MraidAdapter, SafeFrameAdapter
+   * in 0.7.3) will override `_onResume` to layer framework signals
+   * (e.g. `mraid.viewableChange`) on top of this intersection-driven
+   * promotion.
+   * @private
+   */
+  _onResume() {
+    if (this._container === null) return;
+    // Container's existing _onResume ran first (registered before
+    // adapter's attach). State is now PASSIVE/HIDDEN/ACTIVE per
+    // visibility + focus + the original FROZEN edge. Only intervene
+    // when state is PASSIVE and intersection signal supports ACTIVE.
+    const state = this._container.getState();
+    if (state !== ContainerStates.PASSIVE) return;
+    if (this._intersectionRatio === null) return;
+    if (!this._isIntersecting) return;
+    if (this._intersectionRatio < INTERSECTION_THRESHOLD) return;
+    this._container.setState(ContainerStates.ACTIVE);
+  }
+
+  // -------------------------------------------------------------------------
+  // Transition helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Drives the container to FROZEN from any pre-TERMINATED state.
+   * Walks through HIDDEN if necessary because `STATE_TRANSITIONS` only
+   * has a direct `HIDDEN → FROZEN` edge; ACTIVE / PASSIVE step through
+   * HIDDEN first.
+   * @private
+   */
+  _transitionToFrozen() {
+    const state = this._container.getState();
+
+    if (state === ContainerStates.FROZEN || state === ContainerStates.TERMINATED) {
+      return; // already there / done
+    }
+
+    if (state === ContainerStates.LOADING) {
+      // Edge case — page enters bfcache before iframe finished loading.
+      // LOADING → FROZEN is not a direct edge; promote to ACTIVE first
+      // (the new 0.7.2 edge from § 4.5), then walk through HIDDEN.
+      this._initialTransitionFired = true;
+      this._container.setState(ContainerStates.ACTIVE);
+    }
+
+    if (this._container.getState() === ContainerStates.ACTIVE
+        || this._container.getState() === ContainerStates.PASSIVE) {
+      this._container.setState(ContainerStates.HIDDEN);
+    }
+    if (this._container.getState() === ContainerStates.HIDDEN) {
+      this._container.setState(ContainerStates.FROZEN);
+    }
+  }
+
+  /**
+   * Drives the container from FROZEN to ACTIVE or PASSIVE per current
+   * visibility. No-op when not in FROZEN.
+   * @private
+   */
+  _transitionFromFrozen() {
+    const state = this._container.getState();
+    if (state !== ContainerStates.FROZEN) return;
+
+    // Restore via the canonical FROZEN → ACTIVE / PASSIVE / HIDDEN edges
+    // already in STATE_TRANSITIONS. Pick destination based on visibility:
+    //   - intersection ≥ 0.5 and document visible → ACTIVE
+    //   - intersection > 0 but < 0.5 and document visible → PASSIVE
+    //   - otherwise → HIDDEN
+    const docVisible = typeof document !== 'undefined'
+      && document.visibilityState === 'visible';
+    const ratio = this._intersectionRatio;
+
+    if (docVisible && ratio !== null
+        && this._isIntersecting && ratio >= INTERSECTION_THRESHOLD) {
+      this._container.setState(ContainerStates.ACTIVE);
+    } else if (docVisible && ratio !== null
+        && this._isIntersecting && ratio > 0) {
+      this._container.setState(ContainerStates.PASSIVE);
+    } else {
+      this._container.setState(ContainerStates.HIDDEN);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { HtmlAdapter, INTERSECTION_THRESHOLD };
+}
+
+export { HtmlAdapter, INTERSECTION_THRESHOLD };

--- a/src/lifecycle-adapters/html-adapter.js
+++ b/src/lifecycle-adapters/html-adapter.js
@@ -174,12 +174,16 @@ class HtmlAdapter extends BaseLifecycleAdapter {
       );
     }
 
-    // Iframe load — one-shot. The browser may fire `load` multiple times
-    // for srcdoc / src reassignment; the adapter only cares about the
-    // first transition gate. (Subsequent `load` fires are handled by the
-    // container's separate renderer-backstop chain.)
+    // Iframe load — re-fires on every load event. The Markup variant
+    // produces two load events: (1) the renderer-doc load, and (2) the
+    // `document.write(creativeHtml)` load when the creative content is
+    // injected. The Markup gate in `_maybeAdvanceToActive`
+    // (`creativeRendered === true`) ensures we only advance after the
+    // second load. The URL variant has one load event; `_maybeAdvanceToActive`'s
+    // `_initialTransitionFired` latch prevents double-firing. Subsequent
+    // unauthorized loads are handled by the container's separate
+    // renderer-backstop chain (G2) — adapter is observability-only.
     this._iframeLoadHandler = () => {
-      if (this._iframeLoaded) return;
       this._iframeLoaded = true;
       this._maybeAdvanceToActive();
     };
@@ -313,6 +317,15 @@ class HtmlAdapter extends BaseLifecycleAdapter {
 
     if (this._intersectionRatio >= INTERSECTION_THRESHOLD) {
       // Sufficiently visible — promote to ACTIVE from PASSIVE / HIDDEN.
+      // § 8.3 row 5: "Gated on parent document also being visible."
+      // (Browsers usually suspend IO callbacks while the document is
+      // hidden, but the spec doesn't guarantee it — synthetic events
+      // can still trigger this branch. Matches `_transitionFromFrozen`'s
+      // visibility check at line ~509.)
+      const docVisible = typeof document !== 'undefined'
+        && document.visibilityState === 'visible';
+      if (!docVisible) return;
+
       if (state === ContainerStates.PASSIVE || state === ContainerStates.HIDDEN) {
         // HIDDEN → ACTIVE is not a direct edge in STATE_TRANSITIONS
         // (HIDDEN → PASSIVE → ACTIVE is the canonical path). Step through
@@ -357,6 +370,39 @@ class HtmlAdapter extends BaseLifecycleAdapter {
       // transition so we don't double-fire if a late intersection event
       // arrives.
       this._initialTransitionFired = true;
+      return;
+    }
+
+    // ── Race-avoidance: yield to the handshake-driven path in strict mode ──
+    // The adapter exists for non-handshake creatives. In strict mode
+    // (`requireSharcInit: true`, the default), the container expects a
+    // SHARC handshake; the `createSession` timeout fatal-errors at 5s if
+    // none arrives. If the adapter races ahead and fires `LOADING →
+    // ACTIVE` synchronously before the handshake's `setState(READY)`
+    // bootstrap (~200ms after iframe-load via `initChannel`), the
+    // handshake's `READY` and `ACTIVE` transitions are rejected by the
+    // state machine ("Invalid transition: 'active' → 'ready'") and
+    // operators never see `onStateChange(READY)`. Gate on permissive
+    // mode so the adapter's initial-transition path only fires when the
+    // operator has explicitly opted out of expecting a handshake. The
+    // adapter's other transitions (visibility, freeze, bfcache) still
+    // fire in both modes — they're observability augmentation that
+    // doesn't conflict with the handshake-driven `LOADING → READY →
+    // ACTIVE` path.
+    if (this._container._requireSharcInit === true) return;
+
+    // ── Markup-variant gate: wait for the renderer protocol to complete ──
+    // For the Markup variant, the iframe `load` event fires when the
+    // renderer document loads — BEFORE `document.write(creativeHtml)`
+    // writes the actual creative content. Advancing to ACTIVE on
+    // renderer-load is premature: operators using `onStateChange(ACTIVE)`
+    // for impression/viewability timing would start measurement before
+    // the creative is visible. Wait for `creativeRendered === true`
+    // (set in `_onRendererRendered` after `:rendered` envelope
+    // validation). URL variant unaffected — its iframe `load` IS the
+    // creative document loading.
+    if (this._container.creativeSource === 'html'
+        && !this._container.creativeRendered) {
       return;
     }
 

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -2411,10 +2411,13 @@ class SHARCContainer {
     // after `document.write(creativeHtml)` which also re-triggers the
     // gate — but the explicit poke makes the no-IO fallback path work
     // reliably regardless of load-event ordering. `BaseLifecycleAdapter`
-    // declares `_maybeAdvanceToActive` as a base no-op so this call is
-    // safe across all adapter variants (current + future 0.7.3 subclasses).
+    // declares `_maybeAdvanceToActive` as a `@protected` no-op so the
+    // generated `.d.ts` keeps the symbol out of the public type surface;
+    // bracket-notation call bypasses TS's protected-visibility check
+    // (SHARCContainer is not a subclass of BaseLifecycleAdapter) without
+    // weakening the API contract for external consumers.
     if (this._lifecycleAdapter) {
-      this._lifecycleAdapter._maybeAdvanceToActive();
+      this._lifecycleAdapter['_maybeAdvanceToActive']();
     }
     // Stamp the wall-clock timestamp at the moment `:rendered` is accepted.
     // The backstop (armed below) reads this to compute `msSinceRender` for
@@ -2835,6 +2838,15 @@ class SHARCContainer {
    * skip the redundant `setState` — the session is established correctly
    * regardless, and `_sendStartCreative` still fires.
    *
+   * **Narrow gap remains:** the skip below only fires when state is no
+   * longer LOADING. In permissive mode + bfcache-during-handshake (the
+   * adapter's `_transitionToFrozen` walks the container from LOADING
+   * through HIDDEN to FROZEN), a subsequent late `_handleInitResolved`
+   * still produces a one-shot `'frozen' → 'ready'` invalid-transition
+   * warn. Narrow combo (permissive + bfcache + handshake-aware creative
+   * arriving slowly) — accepted as cosmetic warn for the edge case;
+   * session is still established correctly via `acceptSession`.
+   *
    * @param {*} resolveValue
    * @private
    */
@@ -2913,10 +2925,14 @@ class SHARCContainer {
 
   /**
    * Transitions the container to ACTIVE and syncs environment state to the creative.
-   * Shared by all three ACTIVE transition sites:
-   *   - _handleStartCreativeResolved (initial start)
-   *   - _onPageFocus (focus regained from PASSIVE)
-   *   - _onResume (unfreeze with visible + focused page)
+   * Shared by four ACTIVE transition sites:
+   *   - `_handleStartCreativeResolved` (initial start)
+   *   - `_onPageFocus` (focus regained from PASSIVE)
+   *   - `_onResume` (unfreeze with visible + focused page)
+   *   - HTML lifecycle adapter (0.7.2) — in permissive mode, the adapter
+   *     may drive ACTIVE ahead of the handshake; the late-handshake's
+   *     `_handleStartCreativeResolved` then hits this helper with state
+   *     already at ACTIVE
    *
    * Skips the `setState` when the container is already in ACTIVE — this
    * is the late-handshake-after-adapter-promotion case (0.7.2 permissive

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -2403,6 +2403,19 @@ class SHARCContainer {
       this._rendererMessageHandler = null;
     }
     this.creativeRendered = true;
+    // 0.7.2: poke the lifecycle adapter to re-check its initial-transition
+    // gate. The Markup-variant gate in `HtmlAdapter._maybeAdvanceToActive`
+    // waits for `creativeRendered === true`. In environments without
+    // IntersectionObserver, no other signal would re-trigger the gate
+    // after this flips. Real browsers fire a second iframe `load` event
+    // after `document.write(creativeHtml)` which also re-triggers the
+    // gate — but the explicit poke makes the no-IO fallback path work
+    // reliably regardless of load-event ordering. `BaseLifecycleAdapter`
+    // declares `_maybeAdvanceToActive` as a base no-op so this call is
+    // safe across all adapter variants (current + future 0.7.3 subclasses).
+    if (this._lifecycleAdapter) {
+      this._lifecycleAdapter._maybeAdvanceToActive();
+    }
     // Stamp the wall-clock timestamp at the moment `:rendered` is accepted.
     // The backstop (armed below) reads this to compute `msSinceRender` for
     // the 2118 `UnauthorizedNavigationEvent` payload — operators monitoring
@@ -2811,11 +2824,29 @@ class SHARCContainer {
   /**
    * Called when the creative resolves Container:init.
    * Transitions to READY, optionally fires startCreative.
+   *
+   * In permissive mode (`requireSharcInit: false`) with a late SHARC
+   * handshake, the HTML lifecycle adapter may have already promoted the
+   * container past READY (e.g. to ACTIVE via iframe-load + intersection).
+   * In that case the `setState(READY)` would be rejected by the state
+   * machine ("Invalid transition: 'active' → 'ready'") and the
+   * handshake-driven lifecycle would be broken. Detect that the adapter
+   * has already advanced past where this handler would transition us and
+   * skip the redundant `setState` — the session is established correctly
+   * regardless, and `_sendStartCreative` still fires.
+   *
    * @param {*} resolveValue
    * @private
    */
   _handleInitResolved(resolveValue) {
-    this.setState(ContainerStates.READY);
+    if (this._stateMachine.getState() === ContainerStates.LOADING) {
+      this.setState(ContainerStates.READY);
+    }
+    // Else: adapter promoted us past READY (permissive-mode late
+    // handshake). State is already at/past where we'd take it; skip the
+    // setState to avoid an invalid-transition warn. Continue with the
+    // post-init flow (autoStart) so the handshake's downstream effects
+    // still apply.
 
     if (this.autoStart) {
       this._sendStartCreative();
@@ -2886,10 +2917,21 @@ class SHARCContainer {
    *   - _handleStartCreativeResolved (initial start)
    *   - _onPageFocus (focus regained from PASSIVE)
    *   - _onResume (unfreeze with visible + focused page)
+   *
+   * Skips the `setState` when the container is already in ACTIVE — this
+   * is the late-handshake-after-adapter-promotion case (0.7.2 permissive
+   * mode): the adapter advanced LOADING → ACTIVE via iframe-load +
+   * intersection before the SHARC handshake completed. The handshake's
+   * `_handleStartCreativeResolved` would otherwise trigger an invalid
+   * `'active' → 'active'` self-transition warn. Environment-state sync
+   * still fires so the post-handshake creative gets current audio /
+   * placement state.
    * @private
    */
   _transitionToActive() {
-    this.setState(ContainerStates.ACTIVE);
+    if (this._stateMachine.getState() !== ContainerStates.ACTIVE) {
+      this.setState(ContainerStates.ACTIVE);
+    }
     this._syncAudioState();
     this._syncPlacementState();
   }

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -58,6 +58,15 @@ const {
   : ((typeof window !== 'undefined' && window.SHARC && window.SHARC.Protocol) || {});
 
 // ---------------------------------------------------------------------------
+// Lifecycle adapters (0.7.2 § 8) — internal dependency, bundled by rollup.
+// ---------------------------------------------------------------------------
+// The HTML adapter ships in 0.7.2 first half. 0.7.3 adds MraidAdapter /
+// SafeFrameAdapter subclasses; selection happens in
+// `_selectLifecycleAdapter(apiFramework)` below.
+
+import { HtmlAdapter } from './lifecycle-adapters/html-adapter.js';
+
+// ---------------------------------------------------------------------------
 // Defaults
 // ---------------------------------------------------------------------------
 
@@ -1289,6 +1298,17 @@ class SHARCContainer {
     /** @type {SHARCStateMachine} @private */
     this._stateMachine = new SHARCStateMachine(ContainerStates.LOADING);
 
+    /**
+     * Lifecycle adapter instance — populated in `load()` via
+     * {@link SHARCContainer._selectLifecycleAdapter}. Drives state
+     * transitions from browser-native (and in 0.7.3, framework-specific)
+     * signals when no SHARC handshake is available. Detached in
+     * `_terminate()`. See 0.7.2 design § 8.
+     * @type {?import('./lifecycle-adapters/base-adapter.js').BaseLifecycleAdapter}
+     * @private
+     */
+    this._lifecycleAdapter = null;
+
     /** Active timeout handles (for cleanup). @type {Object.<string,number>} @private */
     this._timeouts = {};
 
@@ -1410,6 +1430,15 @@ class SHARCContainer {
     this._createIframe();
     this._registerProtocolListeners();
     this._attachPageLifecycleListeners();
+    // 0.7.2 § 8 — lifecycle adapter attaches AFTER _createIframe (needs
+    // `this._iframe`) and after the page-lifecycle listeners. Adapter
+    // attaches regardless of `requireSharcInit`: for handshake-aware
+    // creatives it yields to the handshake-driven `LOADING → READY →
+    // ACTIVE` path (§ 8.2); for non-handshake creatives it drives the new
+    // `LOADING → ACTIVE` edge (§ 4.5). MRAID / SafeFrame subclasses ship
+    // in 0.7.3 — selection logic is structured to extend cleanly.
+    this._lifecycleAdapter = SHARCContainer._selectLifecycleAdapter(this._apiFramework);
+    this._lifecycleAdapter.attach(this);
     // 0.7.2 § 4.2 + Rule 11: skip the `createSession` fatal-timeout when the
     // operator opted out via `requireSharcInit: false`. All other timeouts
     // (renderer protocol, init/start resolve, close sequence) remain armed —
@@ -3479,6 +3508,15 @@ class SHARCContainer {
     // Remove page lifecycle listeners
     this._detachPageLifecycleListeners();
 
+    // 0.7.2 § 8 — detach the lifecycle adapter (disconnects the
+    // IntersectionObserver, removes bfcache + freeze / resume listeners).
+    // Guarded for the case where _terminate runs before load() (e.g.
+    // construction-time fatal error: adapter was never attached).
+    if (this._lifecycleAdapter) {
+      try { this._lifecycleAdapter.detach(); } catch (_) { /* ignore */ }
+      this._lifecycleAdapter = null;
+    }
+
     // Clean up extensions
     this._extensions.forEach((ext) => {
       if (typeof ext.destroy === 'function') {
@@ -4896,6 +4934,37 @@ class SHARCContainer {
     // Layer 2: reserved no-op for forward bid-context-derived detection.
     // Layer 3: fallthrough to null.
     return null;
+  }
+
+  /**
+   * Picks the lifecycle adapter for the resolved `apiFramework`. 0.7.2
+   * ships only the HTML adapter — it handles generic creatives
+   * (`apiFramework === null`) and is also the fallback baseline for
+   * frameworks whose dedicated adapters have not shipped yet (MRAID,
+   * SafeFrame). See 0.7.2 design § 8.1 and § 8.5.
+   *
+   * Selection structure is intentionally extensible so 0.7.3 can add
+   * MRAID / SafeFrame branches without restructuring:
+   *
+   * ```javascript
+   * // 0.7.3 (illustrative — not shipped):
+   * if (MRAID_CODES.has(apiFramework)) return new MraidAdapter();
+   * if (apiFramework === SAFEFRAME_API_CODE) return new SafeFrameAdapter();
+   * return new HtmlAdapter();
+   * ```
+   *
+   * @param {number|null} apiFramework - The resolved AdCOM `APIFramework`
+   *   code from {@link _resolveApiFramework}, or `null`.
+   * @returns {import('./lifecycle-adapters/base-adapter.js').BaseLifecycleAdapter}
+   * @private
+   */
+  static _selectLifecycleAdapter(apiFramework) {
+    // 0.7.2 first half: HTML adapter is the only adapter. Branches for
+    // MRAID / SafeFrame land in 0.7.3 (per § 8.5 forward path). The
+    // function intentionally reads `apiFramework` so the parameter shape
+    // and the linter-visible usage are stable as adapter branches land.
+    void apiFramework;
+    return new HtmlAdapter();
   }
 
   /**

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -795,11 +795,27 @@ class SHARCContainerProtocol extends SHARCProtocolBase {
   /**
    * Sends Container:stateChange to the creative.
    * Only sends creative-queryable states (never sends loading or terminated).
+   *
+   * No-ops when no SHARC session has been established (`sessionId === ''`).
+   * The state machine still transitions locally — operators observing the
+   * container via `onStateChange` see the change — but no message is sent to
+   * a non-existent creative session. This makes the 0.7.2 HTML lifecycle
+   * adapter safe in non-handshake mode: the adapter drives `LOADING → ACTIVE`
+   * for creatives that never establish a SHARC session, and `sendStateChange`
+   * is a clean no-op rather than producing an unhandled `Promise.reject(...)`
+   * from `_sendMessage` (which would otherwise be fatal under Node v25's
+   * strict unhandled-rejection semantics).
+   *
    * @param {string} containerState - One of the CREATIVE_QUERYABLE_STATES values.
    */
   sendStateChange(containerState) {
     if (!CREATIVE_QUERYABLE_STATES.has(containerState)) {
       console.warn(`[SHARC Container] Refusing to send non-queryable state '${containerState}' to creative`);
+      return;
+    }
+    if (this.sessionId === '') {
+      // No session = no creative listener. Local state transition already
+      // happened; nothing to send. See JSDoc above for rationale.
       return;
     }
     this._sendMessage(ContainerMessages.STATE_CHANGE, { containerState });

--- a/test/node/test-html-lifecycle-adapter.js
+++ b/test/node/test-html-lifecycle-adapter.js
@@ -483,6 +483,22 @@ flushContainers();
   const ok = c.setState(ContainerStates.READY);
   assert(ok === true,
     'after freeze/pagehide in LOADING: setState(READY) is still legal (LOADING → READY edge intact)');
+
+  // Stronger assertion: the full handshake-driven catch-up path runs
+  // cleanly after the freeze/pagehide attempts. This is what OpenClaw
+  // Finding 1 was actually about — not just "edge is callable" but
+  // "handshake path actually completes without warns."
+  const warnOutput = [];
+  const origWarn = console.warn;
+  console.warn = (...args) => { warnOutput.push(args.join(' ')); };
+  // Reset state to LOADING for a clean run of the catch-up simulation.
+  // (We previously moved to READY for the edge-legality probe.)
+  c._stateMachine.state = ContainerStates.LOADING;
+  c._handleInitResolved({});
+  console.warn = origWarn;
+  const invalidWarnAfterFreeze = warnOutput.find((line) => /Invalid transition/.test(line));
+  assert(!invalidWarnAfterFreeze,
+    'handshake-driven `_handleInitResolved` runs cleanly after strict-mode-LOADING freeze attempts (no invalid-transition warns)');
 }
 flushContainers();
 
@@ -517,11 +533,14 @@ flushContainers();
   await sleep(5);
   console.warn = origWarn;
 
+  // Pin the negative to the broad "no invalid-transition warn at all"
+  // claim — earlier arrow-constrained regex could miss a regression that
+  // fired a different invalid transition during the catch-up path.
   const invalidTransitionWarn = warnOutput.find((line) =>
-    /Invalid transition/.test(line) && /->\s*(ready|active)|→\s*(ready|active)/i.test(line)
+    /Invalid transition/.test(line)
   );
   assert(!invalidTransitionWarn,
-    'no "Invalid transition" warn from setState(READY) or setState(ACTIVE) when adapter already promoted');
+    'no "Invalid transition" warn of any kind during handshake catch-up after adapter promotion');
   assert(c.getState() === ContainerStates.ACTIVE,
     'state remains ACTIVE after handshake catch-up (adapter promotion preserved)');
 }
@@ -566,6 +585,49 @@ flushContainers();
   } finally {
     global.IntersectionObserver = SavedIO;
   }
+}
+flushContainers();
+
+// -- 17. Wiring: _onRendererRendered actually calls adapter poke -----------
+//    Closes the gap CR 1.7 flagged: § 16 above verifies the gate works
+//    after a manual poke, but doesn't verify that _onRendererRendered
+//    is the thing doing the poking. A spy here catches a regression that
+//    removed the call from _onRendererRendered (returning the no-IO
+//    Markup variant to its stuck-in-LOADING failure mode).
+{
+  console.log('\n17. Wiring: _onRendererRendered calls _lifecycleAdapter._maybeAdvanceToActive');
+  const c = track(new SHARCContainer({
+    creativeHtml: '<html><body>x</body></html>',
+    creativeRendererUrl: 'https://r.example/r',
+    placementElement: freshSlot(),
+    requireSharcInit: false,
+    timeouts: { rendererReply: 5000 },
+  }));
+  c.load();
+
+  // Replace the adapter's _maybeAdvanceToActive with a spy that counts calls
+  // and still invokes the original.
+  const orig = c._lifecycleAdapter._maybeAdvanceToActive.bind(c._lifecycleAdapter);
+  let pokeCalls = 0;
+  c._lifecycleAdapter._maybeAdvanceToActive = function () {
+    pokeCalls++;
+    return orig();
+  };
+
+  // Pre-condition: creativeRendered is false until renderer protocol completes.
+  assert(c.creativeRendered === false, 'pre: creativeRendered is false');
+  const pokesBeforeRender = pokeCalls;
+
+  // Invoke _onRendererRendered directly with a synthetic envelope-validated
+  // path. The method uses internal state (_terminated guard + _rendererMessageHandler
+  // detach + _renderedAt stamp) so we set what it needs and call it.
+  c._renderedAt = 0;
+  c._onRendererRendered();
+
+  assert(c.creativeRendered === true,
+    'post: _onRendererRendered sets creativeRendered = true (sanity)');
+  assert(pokeCalls > pokesBeforeRender,
+    '_onRendererRendered invoked the adapter poke (wiring intact)');
 }
 flushContainers();
 

--- a/test/node/test-html-lifecycle-adapter.js
+++ b/test/node/test-html-lifecycle-adapter.js
@@ -441,6 +441,134 @@ flushContainers();
 }
 flushContainers();
 
+// ===========================================================================
+// Round-3 fixes (OpenClaw review 2026-05-16) — regression coverage
+// ===========================================================================
+
+// -- 14. Strict mode + LOADING + freeze: adapter must NOT walk to FROZEN ---
+//    Regression for OpenClaw Finding 1: walking LOADING → ACTIVE → HIDDEN →
+//    FROZEN in strict mode corrupts the handshake-driven path. A later
+//    setState(READY) from _handleInitResolved would be invalid from FROZEN.
+{
+  console.log('\n14. Strict mode + LOADING + freeze: adapter must NOT walk to FROZEN');
+  const c = track(new SHARCContainer({
+    creativeUrl: 'https://ads.example/c.html',
+    placementElement: freshSlot(),
+    // requireSharcInit omitted → defaults to true (strict)
+    timeouts: { createSession: 5000 },
+  }));
+  c.load();
+  assert(c._requireSharcInit === true, 'pre: strict mode active');
+  assert(c.getState() === ContainerStates.LOADING, 'pre: state is LOADING');
+
+  // Fire freeze while in LOADING (handshake hasn't completed).
+  document.dispatchEvent(new dom.window.Event('freeze'));
+  await sleep(5);
+
+  assert(c.getState() === ContainerStates.LOADING,
+    'strict + LOADING + freeze: state remains LOADING (adapter yields to handshake)');
+
+  // Also try pagehide(persisted=true).
+  const pagehideEvt = new dom.window.Event('pagehide');
+  Object.defineProperty(pagehideEvt, 'persisted', { value: true });
+  window.dispatchEvent(pagehideEvt);
+  await sleep(5);
+
+  assert(c.getState() === ContainerStates.LOADING,
+    'strict + LOADING + pagehide(persisted): state remains LOADING (adapter yields)');
+
+  // Verify a subsequent setState(READY) (simulating handshake catch-up after
+  // bfcache restore) is still legal — would be invalid if state had moved
+  // to FROZEN.
+  const ok = c.setState(ContainerStates.READY);
+  assert(ok === true,
+    'after freeze/pagehide in LOADING: setState(READY) is still legal (LOADING → READY edge intact)');
+}
+flushContainers();
+
+// -- 15. Permissive + late SHARC handshake after adapter ACTIVE: no warns --
+//    Regression for OpenClaw Finding 2: adapter advanced to ACTIVE, then late
+//    handshake arrives. _handleInitResolved must skip setState(READY) since
+//    state is already past; _transitionToActive must skip setState(ACTIVE)
+//    since state is already there. No "Invalid transition" warns.
+//    `autoStart: false` so the synthetic _handleInitResolved doesn't call
+//    _sendStartCreative (no port in this jsdom setup → would fatal-error).
+{
+  console.log('\n15. Permissive + late handshake after adapter ACTIVE: handshake catch-up clean');
+  const { c, io } = makeContainer({ autoStart: false });
+  dispatchIframeLoad(c);
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.9 });
+  await sleep(5);
+  assert(c.getState() === ContainerStates.ACTIVE, 'pre: adapter advanced to ACTIVE');
+
+  // Capture state-machine warns during the synthetic handshake catch-up.
+  const warnOutput = [];
+  const origWarn = console.warn;
+  console.warn = (...args) => { warnOutput.push(args.join(' ')); };
+
+  // Simulate _handleInitResolved (post-handshake init resolve). autoStart
+  // is false so this only attempts the setState(READY) — which our fix
+  // makes a no-op when state is already past LOADING.
+  c._handleInitResolved({});
+  // Simulate _handleStartCreativeResolved (start resolve). Calls
+  // _transitionToActive which our fix makes a no-op when state is
+  // already ACTIVE.
+  c._handleStartCreativeResolved();
+  await sleep(5);
+  console.warn = origWarn;
+
+  const invalidTransitionWarn = warnOutput.find((line) =>
+    /Invalid transition/.test(line) && /->\s*(ready|active)|→\s*(ready|active)/i.test(line)
+  );
+  assert(!invalidTransitionWarn,
+    'no "Invalid transition" warn from setState(READY) or setState(ACTIVE) when adapter already promoted');
+  assert(c.getState() === ContainerStates.ACTIVE,
+    'state remains ACTIVE after handshake catch-up (adapter promotion preserved)');
+}
+flushContainers();
+
+// -- 16. No-IntersectionObserver fallback: Markup variant gate re-triggers --
+//    Regression for OpenClaw Finding 3: in environments without
+//    IntersectionObserver, _onRendererRendered must poke the adapter so the
+//    Markup-variant `creativeRendered` gate closes. Otherwise container
+//    stays stuck in LOADING.
+{
+  console.log('\n16. No-IO Markup fallback: _onRendererRendered re-triggers adapter gate');
+  // Temporarily disable the IO stub to simulate the degraded environment.
+  const SavedIO = global.IntersectionObserver;
+  delete global.IntersectionObserver;
+  try {
+    const c = track(new SHARCContainer({
+      creativeHtml: '<html><body>x</body></html>',
+      creativeRendererUrl: 'https://r.example/r',
+      placementElement: freshSlot(),
+      requireSharcInit: false,
+      timeouts: { createSession: 5000 },
+    }));
+    c.load();
+    assert(c._lifecycleAdapter._intersectionObserver === null,
+      'pre: no IntersectionObserver (degraded fallback active)');
+
+    // Iframe load fires (renderer doc) → Markup gate keeps container in LOADING.
+    c._iframe.dispatchEvent(new dom.window.Event('load'));
+    await sleep(5);
+    assert(c.getState() === ContainerStates.LOADING,
+      'pre: Markup variant LOADING with creativeRendered=false → gated, not advanced');
+
+    // Now simulate the renderer protocol completing.
+    c.creativeRendered = true;
+    c._lifecycleAdapter._maybeAdvanceToActive();
+    // (In production, _onRendererRendered would poke the adapter — this test
+    // verifies the explicit poke path that _onRendererRendered now uses.)
+    await sleep(5);
+    assert(c.getState() === ContainerStates.ACTIVE,
+      'after creativeRendered flips + adapter poke: advanced to ACTIVE');
+  } finally {
+    global.IntersectionObserver = SavedIO;
+  }
+}
+flushContainers();
+
 // ── Summary ───────────────────────────────────────────────────────────────
 console.log('');
 if (failures > 0) {

--- a/test/node/test-html-lifecycle-adapter.js
+++ b/test/node/test-html-lifecycle-adapter.js
@@ -1,0 +1,451 @@
+/**
+ * test-html-lifecycle-adapter.js — issue #89 PR 2 coverage (design § 15.4)
+ *
+ * Targeted jsdom coverage for the HTML lifecycle adapter introduced by
+ * 0.7.2 first-half PR 2 (design § 8). Asserts the event-to-state mapping
+ * table from § 8.3 end-to-end against a real SHARCContainer + jsdom DOM,
+ * with `IntersectionObserver` stubbed for explicit triggering.
+ *
+ * Coverage matrix (§ 15.4):
+ *   - Iframe load fires first, then intersection ≥ 50% → exactly one
+ *     LOADING → ACTIVE transition.
+ *   - Intersection fires first, then iframe load → same outcome (coalesced).
+ *   - Iframe loads off-screen, then scrolls in → LOADING → ACTIVE on
+ *     intersection ≥ 50%.
+ *   - Partial visibility (0.3) while ACTIVE → ACTIVE → PASSIVE.
+ *   - Full hide (isIntersecting: false) while ACTIVE → ACTIVE → HIDDEN.
+ *   - Return from PASSIVE to ≥ 50% → PASSIVE → ACTIVE.
+ *   - `pagehide` with persisted: true → * → FROZEN.
+ *   - `pageshow` with persisted: true → FROZEN → ACTIVE (if visible).
+ *   - `freeze` event → * → FROZEN.
+ *   - `resume` event → FROZEN → ACTIVE / PASSIVE per visibility.
+ *   - Adapter coexistence: handshake fires first, adapter does NOT
+ *     duplicate LOADING → ACTIVE; subsequent visibility transitions still
+ *     fire from adapter.
+ *   - Adapter `detach()` after `close()` → no further transitions on
+ *     subsequent event dispatch.
+ *   - bfcache restoration flag — dispatchable as event; real bfcache is
+ *     NOT modeled in jsdom (Chrome-only end-to-end; § 8.4).
+ *
+ * Runs in Node after `npm run build`.
+ */
+
+import { JSDOM } from 'jsdom';
+
+const PUBLISHER_ORIGIN = 'https://publisher.example';
+const dom = new JSDOM(
+  '<!DOCTYPE html><html><body></body></html>',
+  { url: PUBLISHER_ORIGIN + '/page.html', pretendToBeVisual: true },
+);
+global.window = dom.window;
+global.document = dom.window.document;
+// jsdom defaults `document.visibilityState` to `'prerender'`; both the
+// container's existing `_onResume` and the HtmlAdapter's
+// `_transitionFromFrozen` correctly treat that as not-visible. Override
+// to `'visible'` for the tests that assert ACTIVE post-bfcache (#8) and
+// post-resume (#10). Real browsers set this to `'visible'` whenever the
+// tab is active; `'prerender'` only appears during Chrome's experimental
+// prerender flow, which isn't relevant to the bfcache restoration scenarios
+// these tests cover.
+Object.defineProperty(global.document, 'visibilityState', {
+  configurable: true,
+  get() { return 'visible'; },
+});
+global.HTMLElement = dom.window.HTMLElement;
+global.HTMLIFrameElement = dom.window.HTMLIFrameElement;
+global.MessageChannel = dom.window.MessageChannel;
+global.MessagePort = dom.window.MessagePort;
+global.MessageEvent = dom.window.MessageEvent;
+if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.randomUUID !== 'function') {
+  const nodeCrypto = await import('node:crypto');
+  globalThis.crypto = nodeCrypto.webcrypto || nodeCrypto;
+}
+
+// ── IntersectionObserver stub ──────────────────────────────────────────────
+// jsdom does not ship an IntersectionObserver. The HTML adapter constructs
+// one in `attach()`; this stub captures each instance so tests can fire
+// entries on demand. Implements the minimum surface the adapter uses:
+// `observe`, `unobserve`, `disconnect`, plus a non-standard `_trigger`
+// helper that calls the registered callback.
+const _ioInstances = [];
+global.IntersectionObserver = class IntersectionObserverStub {
+  constructor(callback, options) {
+    this._callback = callback;
+    this._options = options || {};
+    this._targets = [];
+    _ioInstances.push(this);
+  }
+  observe(target) { this._targets.push(target); }
+  unobserve(target) { this._targets = this._targets.filter((t) => t !== target); }
+  disconnect() { this._targets = []; }
+  _trigger(entries) { this._callback(entries, this); }
+};
+window.IntersectionObserver = global.IntersectionObserver;
+
+// ── Pre-load protocol exports onto window.SHARC.Protocol ──────────────────
+const protoMod = await import('../../dist/sharc-protocol.mjs');
+window.SHARC = window.SHARC || {};
+window.SHARC.Protocol = protoMod;
+
+const { SHARCContainer } = await import('../../dist/sharc-container.mjs');
+const { ContainerStates } = protoMod;
+
+// ── Container hygiene ─────────────────────────────────────────────────────
+const _liveContainers = [];
+function track(c) { _liveContainers.push(c); return c; }
+function flushContainers() {
+  while (_liveContainers.length) {
+    const c = _liveContainers.pop();
+    try { if (!c._terminated) c._terminate(); } catch (_) { /* ignore */ }
+  }
+}
+process.on('beforeExit', flushContainers);
+
+// ── Assertion harness ─────────────────────────────────────────────────────
+let failures = 0;
+function assert(condition, message) {
+  if (condition) {
+    console.log('  ✓', message);
+  } else {
+    console.error('  ✗', message);
+    failures++;
+  }
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+function freshSlot() {
+  document.body.innerHTML = '';
+  const el = document.createElement('div');
+  el.id = 'ad-slot';
+  document.body.appendChild(el);
+  return el;
+}
+
+/**
+ * Build a permissive URL-variant container, call load(), and return the
+ * container plus the most recently constructed IntersectionObserver
+ * instance from the stub.
+ */
+function makeContainer(overrides = {}) {
+  const prevIoCount = _ioInstances.length;
+  const c = track(new SHARCContainer({
+    creativeUrl: 'https://ads.example/c.html',
+    placementElement: freshSlot(),
+    requireSharcInit: false,
+    timeouts: { createSession: 5000 },
+    ...overrides,
+  }));
+  c.load();
+  const io = _ioInstances[_ioInstances.length - 1];
+  // Sanity: adapter wired a new IO.
+  if (_ioInstances.length === prevIoCount) {
+    throw new Error('test setup: HtmlAdapter did not construct an IntersectionObserver');
+  }
+  return { c, io };
+}
+
+function dispatchIframeLoad(c) {
+  c._iframe.dispatchEvent(new dom.window.Event('load'));
+}
+
+function trigger(io, { isIntersecting, intersectionRatio }) {
+  io._trigger([{
+    target: io._targets[0],
+    isIntersecting,
+    intersectionRatio,
+  }]);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+console.log('test-html-lifecycle-adapter.js — issue #89 PR 2 / § 15.4 coverage\n');
+
+// -- 1. Iframe load first, then intersection ≥ 0.5 → LOADING → ACTIVE ------
+{
+  console.log('1. Iframe load first, then intersection ≥ 0.5 → LOADING → ACTIVE (single transition)');
+  const transitions = [];
+  const { c, io } = makeContainer({
+    onStateChange: (s, prev) => transitions.push(`${prev}->${s}`),
+  });
+
+  dispatchIframeLoad(c);
+  await sleep(5);
+  // No intersection yet — gate not met.
+  assert(c.getState() === ContainerStates.LOADING,
+    'iframe-load alone (no intersection) keeps state in LOADING');
+
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.9 });
+  await sleep(5);
+  assert(c.getState() === ContainerStates.ACTIVE,
+    'both gates met → state is ACTIVE');
+  const activeTransitions = transitions.filter((t) => t === 'loading->active');
+  assert(activeTransitions.length === 1,
+    'exactly one LOADING → ACTIVE transition fired');
+}
+flushContainers();
+
+// -- 2. Intersection first, then iframe load → coalesced single transition -
+{
+  console.log('\n2. Intersection first, then iframe load → LOADING → ACTIVE (coalesced)');
+  const transitions = [];
+  const { c, io } = makeContainer({
+    onStateChange: (s, prev) => transitions.push(`${prev}->${s}`),
+  });
+
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.9 });
+  await sleep(5);
+  assert(c.getState() === ContainerStates.LOADING,
+    'intersection alone (no iframe-load) keeps state in LOADING');
+
+  dispatchIframeLoad(c);
+  await sleep(5);
+  assert(c.getState() === ContainerStates.ACTIVE,
+    'iframe-load completes the gate → state is ACTIVE');
+  const activeTransitions = transitions.filter((t) => t === 'loading->active');
+  assert(activeTransitions.length === 1,
+    'exactly one LOADING → ACTIVE transition fired (coalesced)');
+}
+flushContainers();
+
+// -- 3. Iframe loads off-screen, then scrolls into view --------------------
+{
+  console.log('\n3. Iframe loads off-screen, then scrolls into view → LOADING → ACTIVE on intersection');
+  const { c, io } = makeContainer();
+
+  dispatchIframeLoad(c);
+  trigger(io, { isIntersecting: false, intersectionRatio: 0 });
+  await sleep(5);
+  assert(c.getState() === ContainerStates.LOADING,
+    'iframe-load + 0% visibility → stays in LOADING');
+
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.8 });
+  await sleep(5);
+  assert(c.getState() === ContainerStates.ACTIVE,
+    'subsequent ≥ 0.5 intersection advances LOADING → ACTIVE');
+}
+flushContainers();
+
+// -- 4. Partial visibility (ratio 0.3) while ACTIVE → ACTIVE → PASSIVE -----
+{
+  console.log('\n4. Partial visibility (0 < ratio < 0.5) in ACTIVE → ACTIVE → PASSIVE');
+  const { c, io } = makeContainer();
+  dispatchIframeLoad(c);
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.9 });
+  await sleep(5);
+  assert(c.getState() === ContainerStates.ACTIVE, 'pre: ACTIVE');
+
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.3 });
+  await sleep(5);
+  assert(c.getState() === ContainerStates.PASSIVE,
+    'partial intersection demotes ACTIVE → PASSIVE');
+}
+flushContainers();
+
+// -- 5. Full hide (isIntersecting: false) in ACTIVE → ACTIVE → HIDDEN ------
+{
+  console.log('\n5. Full hide (isIntersecting: false) in ACTIVE → ACTIVE → HIDDEN');
+  const { c, io } = makeContainer();
+  dispatchIframeLoad(c);
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.9 });
+  await sleep(5);
+  assert(c.getState() === ContainerStates.ACTIVE, 'pre: ACTIVE');
+
+  trigger(io, { isIntersecting: false, intersectionRatio: 0 });
+  await sleep(5);
+  assert(c.getState() === ContainerStates.HIDDEN,
+    'isIntersecting=false demotes ACTIVE → HIDDEN');
+}
+flushContainers();
+
+// -- 6. Return from PASSIVE to ≥ 0.5 visibility → PASSIVE → ACTIVE ---------
+{
+  console.log('\n6. Return from PASSIVE to ≥ 0.5 visibility → PASSIVE → ACTIVE');
+  const { c, io } = makeContainer();
+  dispatchIframeLoad(c);
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.9 });
+  await sleep(5);
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.3 });
+  await sleep(5);
+  assert(c.getState() === ContainerStates.PASSIVE, 'pre: PASSIVE');
+
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.75 });
+  await sleep(5);
+  assert(c.getState() === ContainerStates.ACTIVE,
+    'PASSIVE → ACTIVE when intersection returns to ≥ 0.5');
+}
+flushContainers();
+
+// -- 7. pagehide with persisted: true → * → FROZEN -------------------------
+{
+  console.log('\n7. pagehide with persisted: true → * → FROZEN');
+  const { c, io } = makeContainer();
+  dispatchIframeLoad(c);
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.9 });
+  await sleep(5);
+  assert(c.getState() === ContainerStates.ACTIVE, 'pre: ACTIVE');
+
+  const evt = new dom.window.Event('pagehide');
+  Object.defineProperty(evt, 'persisted', { value: true });
+  window.dispatchEvent(evt);
+  await sleep(5);
+  assert(c.getState() === ContainerStates.FROZEN,
+    'pagehide(persisted=true) walks ACTIVE → HIDDEN → FROZEN');
+}
+flushContainers();
+
+// -- 8. pageshow with persisted: true → FROZEN → ACTIVE (if visible) -------
+//    bfcache restoration: dispatchable as event; the real bfcache roundtrip
+//    is NOT modeled in jsdom. This is the Chrome-only end-to-end gap per
+//    § 8.4 — Puppeteer follow-up.
+{
+  console.log('\n8. pageshow with persisted: true → FROZEN → ACTIVE (if visible)');
+  const { c, io } = makeContainer();
+  dispatchIframeLoad(c);
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.9 });
+  await sleep(5);
+
+  // Walk into FROZEN.
+  const pagehideEvt = new dom.window.Event('pagehide');
+  Object.defineProperty(pagehideEvt, 'persisted', { value: true });
+  window.dispatchEvent(pagehideEvt);
+  await sleep(5);
+  assert(c.getState() === ContainerStates.FROZEN, 'pre: FROZEN');
+
+  // (visibility stays at ratio 0.9 in the adapter's cache; jsdom's
+  // document.visibilityState defaults to 'visible'.)
+  const pageshowEvt = new dom.window.Event('pageshow');
+  Object.defineProperty(pageshowEvt, 'persisted', { value: true });
+  window.dispatchEvent(pageshowEvt);
+  await sleep(5);
+  assert(c.getState() === ContainerStates.ACTIVE,
+    'pageshow(persisted=true) restores FROZEN → ACTIVE when visible');
+}
+flushContainers();
+
+// -- 9. freeze event → * → FROZEN ------------------------------------------
+{
+  console.log('\n9. freeze event → * → FROZEN');
+  const { c, io } = makeContainer();
+  dispatchIframeLoad(c);
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.9 });
+  await sleep(5);
+  assert(c.getState() === ContainerStates.ACTIVE, 'pre: ACTIVE');
+
+  document.dispatchEvent(new dom.window.Event('freeze'));
+  await sleep(5);
+  assert(c.getState() === ContainerStates.FROZEN,
+    'freeze walks ACTIVE → HIDDEN → FROZEN');
+}
+flushContainers();
+
+// -- 10. resume event → FROZEN → ACTIVE per visibility ---------------------
+{
+  console.log('\n10. resume event → FROZEN → ACTIVE / PASSIVE per visibility');
+  const { c, io } = makeContainer();
+  dispatchIframeLoad(c);
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.9 });
+  await sleep(5);
+
+  document.dispatchEvent(new dom.window.Event('freeze'));
+  await sleep(5);
+  assert(c.getState() === ContainerStates.FROZEN, 'pre: FROZEN');
+
+  document.dispatchEvent(new dom.window.Event('resume'));
+  await sleep(5);
+  assert(c.getState() === ContainerStates.ACTIVE,
+    'resume → ACTIVE when adapter remembers full intersection');
+}
+flushContainers();
+
+// -- 11. Adapter coexistence: handshake fires first → no duplicate --------
+//    § 8.2: when a SHARC-aware creative handshakes, the handshake-driven
+//    path runs LOADING → READY → ACTIVE first. The adapter must NOT
+//    duplicate LOADING → ACTIVE; subsequent visibility transitions still
+//    fire from the adapter.
+{
+  console.log('\n11. Adapter coexistence: handshake-driven ACTIVE → adapter does not duplicate');
+  const transitions = [];
+  const { c, io } = makeContainer({
+    onStateChange: (s, prev) => transitions.push(`${prev}->${s}`),
+  });
+
+  // Simulate handshake-driven progression. Use the state machine
+  // directly to avoid the protocol-port handshake (jsdom MessageChannel
+  // limitation) — the seam under test is the adapter's behavior, not
+  // the handshake plumbing.
+  c.setState(ContainerStates.READY);
+  c.setState(ContainerStates.ACTIVE);
+  await sleep(5);
+  assert(c.getState() === ContainerStates.ACTIVE, 'pre: handshake drove to ACTIVE');
+
+  const beforeCount = transitions.length;
+  // Now fire iframe-load + intersection. The adapter must observe that
+  // state is already ACTIVE and yield silently.
+  dispatchIframeLoad(c);
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.9 });
+  await sleep(5);
+  // No further state change — adapter yielded.
+  assert(transitions.length === beforeCount,
+    'adapter does NOT fire duplicate LOADING → ACTIVE when state is already ACTIVE');
+
+  // But subsequent visibility transitions still fire.
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.3 });
+  await sleep(5);
+  assert(c.getState() === ContainerStates.PASSIVE,
+    'adapter still drives ACTIVE → PASSIVE on subsequent partial visibility');
+}
+flushContainers();
+
+// -- 12. Adapter detach after close() → no further transitions -------------
+{
+  console.log('\n12. Adapter detach after close() → no transitions on subsequent event dispatch');
+  const { c, io } = makeContainer();
+  dispatchIframeLoad(c);
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.9 });
+  await sleep(5);
+  assert(c.getState() === ContainerStates.ACTIVE, 'pre: ACTIVE');
+
+  c._terminate();
+  assert(c._terminated === true, 'container terminated');
+  assert(c._lifecycleAdapter === null, '_lifecycleAdapter cleared after _terminate');
+
+  // Fire events that previously transitioned — should be no-ops because
+  // the adapter has detached and disconnected the IO.
+  try {
+    io._trigger([{
+      target: io._targets[0],
+      isIntersecting: false,
+      intersectionRatio: 0,
+    }]);
+  } catch (_) { /* IO disconnect cleared targets — trigger may no-op */ }
+  document.dispatchEvent(new dom.window.Event('freeze'));
+  await sleep(5);
+  assert(c.getState() === ContainerStates.TERMINATED,
+    'terminated container stays in TERMINATED — adapter listeners detached');
+}
+flushContainers();
+
+// -- 13. bfcache restoration flag — dispatchable; real bfcache not modeled
+//     in jsdom. The pageshow(persisted=true) event roundtrip IS testable as
+//     event-dispatch (see #8); this guard documents the gap explicitly so
+//     a future reviewer doesn't expect a deeper assertion.
+{
+  console.log('\n13. bfcache restoration — event-dispatch testable; full roundtrip is Chrome-only (§ 8.4)');
+  // We already exercised the pagehide/pageshow event surface in #7 + #8.
+  // This case explicitly documents that the bfcache itself (the "page
+  // re-runs from snapshot" semantic) is NOT modeled in jsdom — only the
+  // event dispatch is. Puppeteer follow-up tracks the gap; not blocking
+  // for 0.7.2 ship.
+  assert(true,
+    'documented: bfcache event-dispatch covered in #7/#8; full Chrome roundtrip is follow-up scope');
+}
+flushContainers();
+
+// ── Summary ───────────────────────────────────────────────────────────────
+console.log('');
+if (failures > 0) {
+  console.error(`✗ ${failures} html-lifecycle-adapter assertion(s) failed.`);
+  process.exit(1);
+} else {
+  console.log('✓ All html-lifecycle-adapter assertions passed.');
+}

--- a/test/node/test-non-sharc-loading.js
+++ b/test/node/test-non-sharc-loading.js
@@ -19,11 +19,12 @@
  *   - `hasSharcSession` flips from false → true after handshake.
  *   - Permissive + close() mid-load: clean termination (G6).
  *
- * Notes / scope gaps surfaced for PR 2 (HTML lifecycle adapter):
- *   - Permissive + no handshake: container currently STAYS in LOADING.
- *     PR 2 adds the HTML adapter that drives `LOADING → ACTIVE` via
- *     iframe-load + IntersectionObserver. Test below documents the gap
- *     with a TODO so PR 2 extends rather than rewrites the assertion.
+ * PR 2 update (HTML lifecycle adapter, issue #89, design § 8):
+ *   - Permissive + no handshake now advances LOADING to ACTIVE via the
+ *     HTML adapter once iframe-load + IntersectionObserver visibility
+ *     fire. Section 9 below exercises the end-to-end seam through the
+ *     container. Targeted adapter coverage lives in
+ *     test-html-lifecycle-adapter.js (design § 15.4).
  *
  * Runs in Node after `npm run build`.
  */
@@ -48,12 +49,37 @@ if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.randomU
   globalThis.crypto = nodeCrypto.webcrypto || nodeCrypto;
 }
 
+// IntersectionObserver stub — jsdom does not ship one. The HTML lifecycle
+// adapter (PR 2 / design § 8) constructs an IO during `attach()`; without
+// this stub, the adapter falls into its degraded-mode branch (iframe-load
+// alone advances LOADING → ACTIVE) and section 9 cannot exercise the
+// canonical two-signal coalesce. The stub captures each constructed
+// instance so section 9 can trigger entries manually.
+const _ioInstances = [];
+global.IntersectionObserver = class IntersectionObserverStub {
+  constructor(callback, options) {
+    this._callback = callback;
+    this._options = options || {};
+    this._targets = [];
+    _ioInstances.push(this);
+  }
+  observe(target) { this._targets.push(target); }
+  unobserve(target) { this._targets = this._targets.filter((t) => t !== target); }
+  disconnect() { this._targets = []; }
+  // Test helper — not part of the IO contract.
+  _trigger(entries) { this._callback(entries, this); }
+};
+// Mirror onto the JSDOM window so the adapter's `typeof IntersectionObserver`
+// check (which resolves through `globalThis`) sees the stub regardless of
+// which scope chain it walks.
+window.IntersectionObserver = global.IntersectionObserver;
+
 const protoMod = await import('../../dist/sharc-protocol.mjs');
 window.SHARC = window.SHARC || {};
 window.SHARC.Protocol = protoMod;
 
 const { SHARCContainer } = await import('../../dist/sharc-container.mjs');
-const { ErrorCodes, SHARC_API_CODE } = protoMod;
+const { ErrorCodes, SHARC_API_CODE, ContainerStates } = protoMod;
 
 // Container hygiene — terminate any survivors between sections so the 5 s
 // fatal timeout (and other leaked timers) don't pollute downstream assertions.
@@ -454,24 +480,50 @@ flushContainers();
 }
 flushContainers();
 
-// -- 9. PR 2 SCOPE: HTML lifecycle adapter — currently absent --------------
-//    Documents the design § 8 gap that PR 2 fills. Today, permissive + no
-//    handshake leaves the container in LOADING (no adapter to advance state).
+// -- 9. HTML lifecycle adapter — non-handshake permissive ACTIVE -----------
+//    Design § 8: PR 2 adds the HTML adapter. With requireSharcInit: false +
+//    no creative handshake, the container now advances LOADING → ACTIVE
+//    once iframe-load fires AND IntersectionObserver reports ≥ 0.5
+//    visibility. The two-signal coalesce is asserted end-to-end through the
+//    container's lifecycle adapter wire — narrow-scope adapter behavior
+//    lives in test-html-lifecycle-adapter.js (design § 15.4).
 {
-  console.log('\n9. PR 1 scope guard: HTML lifecycle adapter is PR 2 — currently absent');
+  console.log('\n9. HTML lifecycle adapter: permissive + no handshake → LOADING → ACTIVE');
+  // Use URL variant to side-step the Markup renderer protocol (and its
+  // timeouts) — the adapter is variant-agnostic per § 5, and URL variant
+  // fires the iframe `load` event on its own.
   const c = track(new SHARCContainer({
-    ...markupOpts(),
+    creativeUrl: 'https://ads.example/c.html',
+    placementElement: freshSlot(),
     requireSharcInit: false,
-    timeouts: { createSession: 30, rendererLoad: 30, rendererReply: 30 },
+    timeouts: { createSession: 300 },
   }));
   c.load();
-  await sleep(80);
-  // TODO PR 2: after the HTML lifecycle adapter ships, expect
-  //   c.getState() === ContainerStates.ACTIVE
-  // once the iframe load + intersection signals fire.
-  assert(c.getState() !== 'active',
-    'PR 1 only: non-handshake permissive container does NOT auto-advance to ACTIVE '
-    + '(HTML adapter ships in PR 2; § 8)');
+
+  assert(c._lifecycleAdapter !== null,
+    'load(): _lifecycleAdapter wired (HtmlAdapter instance)');
+  assert(_ioInstances.length > 0,
+    'HtmlAdapter constructs an IntersectionObserver in attach()');
+
+  const io = _ioInstances[_ioInstances.length - 1];
+
+  // Dispatch iframe `load` synthetically. jsdom does not fire `load` for
+  // a cross-origin iframe src; the adapter listens for it though, so a
+  // direct dispatch is sufficient.
+  c._iframe.dispatchEvent(new dom.window.Event('load'));
+
+  // Trigger intersection at full visibility.
+  io._trigger([{
+    target: c._iframe,
+    isIntersecting: true,
+    intersectionRatio: 0.9,
+  }]);
+
+  // Allow the microtask coalesce to run.
+  await sleep(20);
+
+  assert(c.getState() === ContainerStates.ACTIVE,
+    'PR 2: non-handshake permissive container advanced LOADING → ACTIVE via HTML adapter');
 }
 flushContainers();
 


### PR DESCRIPTION
## Summary

Implements design § 8 — the HTML lifecycle adapter for SHARC 0.7.2 first half (issue #89, PR 2 of three). Adds browser-native lifecycle observability for non-handshake creatives, closing the `LOADING → ACTIVE` gap that PR 1 opened in the state-machine transition table (§ 4.5).

The adapter is variant-agnostic, coexists with the SHARC handshake path (yields to handshake-driven `LOADING → READY → ACTIVE` when present), and provides the foundation for 0.7.3 MRAID + SafeFrame adapter subclasses (§ 14 / § 8.5).

## What's in this PR

**New files**

- `src/lifecycle-adapters/base-adapter.js` — `BaseLifecycleAdapter` abstract class. `attach(container)` / `detach()` contract with double-attach guard. Open-closed extension point for 0.7.3.
- `src/lifecycle-adapters/html-adapter.js` — `HtmlAdapter` implementing the § 8.3 event-to-state mapping table.

**Modifications**

- `src/sharc-container.js`:
  - Imports `HtmlAdapter`, new private `this._lifecycleAdapter` field
  - New static `_selectLifecycleAdapter(apiFramework)` factory
  - `load()` attaches the adapter after `_attachPageLifecycleListeners()`
  - `_terminate()` detaches the adapter after `_detachPageLifecycleListeners()`
- `src/sharc-protocol.js`:
  - `sendStateChange` no-ops when `sessionId === ''` (rationale: non-handshake creatives still transition through queryable states locally; no creative session means no message to send; pre-fix the rejected `_sendMessage` promise was unhandled and fatal under Node v25)
- `test/node/test-non-sharc-loading.js` § 9: PR 2 scope guard converted from "adapter absent" to end-to-end "adapter advances permissive non-handshake to ACTIVE"
- `package.json`: registers `test:html-lifecycle-adapter` script

**New test file**

- `test/node/test-html-lifecycle-adapter.js` — ~440 lines, 13 sections, ~50 assertions. Covers § 15.4 matrix end-to-end with an `IntersectionObserver` stub.

## Event-to-state mapping (§ 8.3)

| Browser event | Adapter transition |
|---|---|
| iframe `load` + IntersectionObserver ≥ 0.5 | `LOADING → ACTIVE` (gated, coalesced via microtask) |
| IntersectionObserver `intersectionRatio: 0.3` in ACTIVE | `ACTIVE → PASSIVE` |
| IntersectionObserver `isIntersecting: false` in ACTIVE | `ACTIVE → HIDDEN` |
| `pagehide(persisted: true)` | walks `* → HIDDEN → FROZEN` (adapter owns; container has no pagehide listener) |
| `pageshow(persisted: true)` | `FROZEN → ACTIVE / PASSIVE / HIDDEN` per cached intersection + visibility |
| `freeze` | broadens container's `HIDDEN → FROZEN` to `* → FROZEN` |
| `resume` | layers PASSIVE → ACTIVE promotion on top of container's existing handler when intersection allows |

## Coexistence with handshake path (§ 8.2)

- Adapter `attach()` runs regardless of `requireSharcInit` — adapter owns its own handshake-coexistence logic
- When a SHARC handshake completes `LOADING → READY → ACTIVE` before the adapter's gates close, the adapter detects the state advance and yields silently (marks `_initialTransitionFired = true` and returns)
- Subsequent visibility / freeze / bfcache transitions still fire from the adapter on top of the container's existing chain — adapter contributes browser signals (`IntersectionObserver`, `pagehide`/`pageshow`) that the existing `_attachPageLifecycleListeners()` doesn't cover

## Design notes applied during implementation

1. **`ContainerStates$1` in dist bundle** is rollup's internal export-property disambiguation — single source of truth, reference equality holds. Verified.
2. **`sendStateChange` no-op when no session** is the surgical fix for Node v25's strict unhandled-rejection on `_sendMessage` calls with no port. Non-handshake creatives can now transition through queryable states without the rejected promise becoming fatal. JSDoc explains the rationale.
3. **Test jsdom config** uses `pretendToBeVisual: true` + explicit `visibilityState = 'visible'` override (jsdom defaults to `'prerender'`, which both the container and adapter correctly treat as not-visible).

## Out of scope (separate PRs / issues)

- **PR 3** (docs + CHANGELOG + cookbook with transition-vs-steady-state framing) — last in the 0.7.2 first-half queue
- **PR 4** (#97 — `SHARCCreativeInjector` reference extension) — parallel to PR 2
- **0.7.3** — MRAID + SafeFrame adapter subclasses (§ 14)
- **Issue #90** — Markup-variant renderer backstop skip-first
- **Issue #91** — G9 placementSessionId threading

## Test plan

- [x] `npm run build` clean (rollup + tsc)
- [x] All 12 jsdom test suites pass:
      `test:smoke`, `test:treeshake`, `test:placement`, `test:placement-stamping`, `test:creative-sources`, `test:creative-sources-load`, `test:navigation-bridge`, `test:creative-sdk-autoinstall`, `test:bridges-detection`, `test:non-sharc-loading`, `test:html-lifecycle-adapter` (NEW), `test:renderer-fallback`
- [x] No regression in the existing handshake-driven path (`test:creative-sources-load` covers renderer protocol + backstop + envelope validation)
- [x] Adapter coexistence verified: simulated handshake-driven `LOADING → READY → ACTIVE` is not duplicated by adapter; subsequent visibility transitions still fire from adapter on top
- [x] Detach on `close()` / `_terminate()` verified — no listeners or observers left attached
- [ ] Real-browser bfcache roundtrip (`pagehide(persisted=true)` → swap-out → `pageshow(persisted=true)`) — jsdom can only dispatch the events, not model the bfcache itself; full path is Chrome-only. Tracked via test § 13's documentation guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)