### PR TITLE
fix: sync lifecycle adapter versions

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,6 +27,8 @@ git push && git push --tags
 |------|-----------------|
 | `src/sharc-protocol.js` | `SHARC_VERSION` constant + `@version` JSDoc |
 | `src/sharc-container.js` | `@version` JSDoc |
+| `src/lifecycle-adapters/base-adapter.js` | `@version` JSDoc |
+| `src/lifecycle-adapters/html-adapter.js` | `@version` JSDoc |
 | `src/sharc-creative.js` | `@version` JSDoc |
 | `src/sharc-mraid-bridge.js` | `@version` JSDoc |
 | `src/sharc-safeframe-bridge.js` | `@version` JSDoc |

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "./dist/*.js"
   ],
   "scripts": {
-    "version": "node scripts/sync-version.js && git add src/sharc-protocol.js src/sharc-container.js src/sharc-creative.js src/sharc-mraid-bridge.js src/sharc-safeframe-bridge.js src/sharc-omid-bridge.js src/sharc-navigation-bridge.js README.md",
+    "version": "node scripts/sync-version.js && git add src/sharc-protocol.js src/sharc-container.js src/lifecycle-adapters/base-adapter.js src/lifecycle-adapters/html-adapter.js src/sharc-creative.js src/sharc-mraid-bridge.js src/sharc-safeframe-bridge.js src/sharc-omid-bridge.js src/sharc-navigation-bridge.js README.md",
     "dev": "node server.cjs",
     "build": "rollup -c && npm run build:types",
     "build:types": "tsc -p tsconfig.types.json",

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -37,6 +37,16 @@ const replacements = [
     replacement: `$1${version}`,
   },
   {
+    file: 'src/lifecycle-adapters/base-adapter.js',
+    pattern: /(@version )\S+/,
+    replacement: `$1${version}`,
+  },
+  {
+    file: 'src/lifecycle-adapters/html-adapter.js',
+    pattern: /(@version )\S+/,
+    replacement: `$1${version}`,
+  },
+  {
     file: 'src/sharc-creative.js',
     pattern: /(@version )\S+/,
     replacement: `$1${version}`,


### PR DESCRIPTION
## Summary
- add the lifecycle adapter source files to `scripts/sync-version.js` so their `@version` tags stay in sync
- include those files in the `npm version` lifecycle `git add` list
- document the adapter files in `RELEASING.md`

Fixes #100

## Validation
- `node scripts/sync-version.js`
- `git diff --check`
- `gitleaks dir --no-banner --redact RELEASING.md`
- `gitleaks dir --no-banner --redact package.json`
- `gitleaks dir --no-banner --redact scripts/sync-version.js`
- `gitleaks git --no-banner --redact --log-opts HEAD~1..HEAD`

## Notes
- Targeted at `feat/89-html-lifecycle-adapter` because the adapter files are introduced there and are not on `main` yet.
- I updated `RELEASING.md`; I did not find a `CLAUDE.md` file in this branch.
- Not run: build/test suite, because this only changes the release sync script, release staging hook, and release docs.
- AI assistance: OpenAI Codex.