### PR TITLE
feat(89): SHARCCreativeInjector reference extension (0.7.2 PR 4/3)

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -33,5 +33,10 @@
     "name": "sharc-navigation-bridge",
     "path": "dist/sharc-navigation-bridge.js",
     "limit": "10 KB"
+  },
+  {
+    "name": "sharc-creative-injector",
+    "path": "dist/sharc-creative-injector.js",
+    "limit": "3 KB"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -36,13 +36,17 @@
     "./sharc-navigation-bridge": {
       "types": "./dist/sharc-navigation-bridge.d.ts",
       "import": "./dist/sharc-navigation-bridge.mjs"
+    },
+    "./sharc-creative-injector": {
+      "types": "./dist/sharc-creative-injector.d.ts",
+      "import": "./dist/sharc-creative-injector.mjs"
     }
   },
   "sideEffects": [
     "./dist/*.js"
   ],
   "scripts": {
-    "version": "node scripts/sync-version.js && git add src/sharc-protocol.js src/sharc-container.js src/sharc-creative.js src/sharc-mraid-bridge.js src/sharc-safeframe-bridge.js src/sharc-omid-bridge.js src/sharc-navigation-bridge.js README.md",
+    "version": "node scripts/sync-version.js && git add src/sharc-protocol.js src/sharc-container.js src/sharc-creative.js src/sharc-mraid-bridge.js src/sharc-safeframe-bridge.js src/sharc-omid-bridge.js src/sharc-navigation-bridge.js src/sharc-creative-injector.js README.md",
     "dev": "node server.cjs",
     "build": "rollup -c && npm run build:types",
     "build:types": "tsc -p tsconfig.types.json",
@@ -61,6 +65,7 @@
     "test:creative-sources-load": "node test/node/test-creative-sources-load.js",
     "test:navigation-bridge": "node test/node/test-navigation-bridge.js",
     "test:creative-sdk-autoinstall": "node test/node/test-creative-sdk-autoinstall.js",
+    "test:creative-sdk-injector": "node test/node/test-sharc-creative-injector.js",
     "test:bridges-detection": "node test/node/test-bridges-detection.js",
     "test:non-sharc-loading": "node test/node/test-non-sharc-loading.js",
     "test:html-lifecycle-adapter": "node test/node/test-html-lifecycle-adapter.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,7 @@ const inputFiles = {
   'sharc-safeframe-bridge': 'src/sharc-safeframe-bridge.js',
   'sharc-omid-bridge': 'src/sharc-omid-bridge.js',
   'sharc-navigation-bridge': 'src/sharc-navigation-bridge.js',
+  'sharc-creative-injector': 'src/sharc-creative-injector.js',
 };
 
 export default Object.keys(inputFiles).map(moduleName => {

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -61,6 +61,11 @@ const replacements = [
     pattern: /(@version )\S+/,
     replacement: `$1${version}`,
   },
+  {
+    file: 'src/sharc-creative-injector.js',
+    pattern: /(@version )\S+/,
+    replacement: `$1${version}`,
+  },
   // README badge
   {
     file: 'README.md',

--- a/src/sharc-creative-injector.js
+++ b/src/sharc-creative-injector.js
@@ -88,7 +88,7 @@
  * 2026-05-17). Design § 10.2 (Extensions) and § 6.3 (operator-injection
  * pattern) provide the surrounding context.
  *
- * @version 0.7.1
+ * @version 0.7.2
  */
 
 'use strict';
@@ -206,8 +206,20 @@ function _buildScriptTag(url, attrs) {
  *                                              `sharc-creative.js` build
  *                                              the operator hosts.
  * @param {boolean} [options.skipIfPresent=true] - If true, markup already
- *                                              containing `sharc-creative.js`
+ *                                              containing a `<script src="…
+ *                                              sharc-creative.js">` tag
  *                                              passes through unchanged.
+ *                                              **Multi-injector caveat:**
+ *                                              if multiple `SHARCCreativeInjector`
+ *                                              instances are configured (e.g.
+ *                                              versioned SDK coexistence),
+ *                                              only the first runs — the
+ *                                              second's `skipIfPresent` sees
+ *                                              the SDK already injected and
+ *                                              skips. Set `skipIfPresent: false`
+ *                                              on at least one if you need
+ *                                              multi-version side-by-side
+ *                                              loading.
  * @param {Object}  [options.scriptAttrs={}]  - Additional `<script>`
  *                                              attributes. See module
  *                                              JSDoc for serialization rules.
@@ -278,11 +290,19 @@ class SHARCCreativeInjector {
     // is "string in, string out."
     if (typeof html !== 'string') return html;
 
-    // Idempotency guard. The `sharc-creative.js` filename match is
-    // intentionally tolerant — operators may host the SDK under various
-    // path prefixes (CDN, versioned subdirs, etc.). The substring presence
-    // is sufficient to skip; we don't try to parse the URL.
-    if (this.skipIfPresent && /sharc-creative\.js/.test(html)) {
+    // Idempotency guard. Requires the SDK to appear inside a
+    // `<script src="...sharc-creative.js">` tag specifically — bare
+    // substring presence (in comments, metadata, log-output strings,
+    // etc.) doesn't trigger the skip. The previous looser substring
+    // check produced silent no-ops when creatives mentioned
+    // `sharc-creative.js` in a `<!-- ... -->` comment or `<meta>`
+    // content without actually loading the SDK; the bridge auto-install
+    // (G9) would then time out and the container would behave as if the
+    // creative was non-SHARC. Tightening to script-src context closes
+    // this footgun. Tolerant of path prefixes (CDN, versioned subdirs,
+    // protocol-relative URLs) because the match only requires the
+    // filename to appear inside the `src` attribute's value.
+    if (this.skipIfPresent && /<script[^>]*\bsrc\s*=\s*["'][^"']*sharc-creative\.js/i.test(html)) {
       return html;
     }
 
@@ -290,16 +310,22 @@ class SHARCCreativeInjector {
 
     // Position 1: after `<head>` open tag. Case-insensitive; tolerates
     // attributes on the tag (`<head lang="en">`, `<HEAD class="...">`).
-    // `replace` with a function (not a string replacement) keeps backreferences
-    // simple and avoids the `$N` escaping pitfall if the matched tag ever
-    // contained `$` characters.
-    const headMatch = html.match(/<head[^>]*>/i);
+    // Lookahead `(?=[\s>])` rejects `<header>`, `<headers>`, etc. — the
+    // bare `<head[^>]*>` pattern would otherwise greedily consume
+    // `<header class="top">` as a valid match (the `[^>]*` happily
+    // gobbles `er class="top"`). Confirmed regression: Bootstrap /
+    // Tailwind landing-page creatives use `<header>` and would have
+    // received the SDK script injected inside the header element
+    // instead of the document head.
+    const headMatch = html.match(/<head(?=[\s>])[^>]*>/i);
     if (headMatch) {
       return html.replace(headMatch[0], headMatch[0] + scriptTag);
     }
 
     // Position 2: after `<html>` open tag (no `<head>` in markup).
-    const htmlMatch = html.match(/<html[^>]*>/i);
+    // Same lookahead defense — rejects `<htmlfoo>` and similar non-`<html>`
+    // tags that happen to start with the four letters.
+    const htmlMatch = html.match(/<html(?=[\s>])[^>]*>/i);
     if (htmlMatch) {
       return html.replace(htmlMatch[0], htmlMatch[0] + scriptTag);
     }

--- a/src/sharc-creative-injector.js
+++ b/src/sharc-creative-injector.js
@@ -1,0 +1,352 @@
+/**
+ * @fileoverview SHARC Creative Injector — operator-side reference extension
+ *
+ * A first-class `SHARCContainer` extension that injects a `<script src="...">`
+ * tag for `sharc-creative.js` (the SHARC creative-side SDK) into legacy
+ * Markup-variant creative HTML before the container hands it to the
+ * renderer. This is the canonical "lift legacy inventory into SHARC"
+ * pattern — operators add the extension to `extensions: [...]` and any
+ * inventory shape (plain HTML, MRAID v1/v2/v3, SafeFrame 1.x) becomes
+ * compatible with the SHARC container without per-creative changes.
+ *
+ * Architectural role:
+ *
+ *   The container already exposes an `extensions: []` constructor option
+ *   that invokes `extension.injectIntoMarkup(html)` against the creative
+ *   markup before iframe load (see `SHARCContainer._runMarkupInjection`).
+ *   This module is a turn-key extension that operators wire up once and
+ *   forget. Without it, operators were rolling their own injection — same
+ *   regex, same edge cases, no shared test coverage. This file consolidates
+ *   the pattern and locks in the doctype-edge refinement that prevents
+ *   accidental quirks-mode rendering.
+ *
+ * Trust model:
+ *
+ *   Operator-side, operator-trusted. The extension runs on the publisher
+ *   page in the container context — same trust boundary as the rest of
+ *   `SHARCContainer`. It does NOT inspect or transform creative content
+ *   beyond the single string-replace that adds the script tag.
+ *
+ * Variant scope:
+ *
+ *   Markup variant only — i.e. `new SHARCContainer({ creativeHtml: ... })`.
+ *   The URL variant (`creativeUrl: ...`) cannot be injected when the URL
+ *   is cross-origin (browser CORS). Operators whose Markup pipeline emits
+ *   plain-HTML/MRAID/SafeFrame adm strings install this extension; URL-only
+ *   pipelines fall back to `requireSharcInit: false` (see design § 11).
+ *
+ * Injection-order contract (doctype-edge refinement, 2026-05-17):
+ *
+ *   The injector inserts the script tag at the FIRST of these positions
+ *   that exists in the markup:
+ *     1. After the `<head>` opening tag (most specific — keeps the script
+ *        in `<head>` scope, where parser-blocking script semantics work).
+ *     2. After the `<html>` opening tag (creative had no `<head>` element).
+ *     3. After the `<!DOCTYPE>` declaration (fragment with doctype only —
+ *        injecting BEFORE the doctype would push the browser into
+ *        quirks-mode rendering, which subtly breaks legacy creatives that
+ *        rely on standards-mode layout). The refinement is the explicit
+ *        AFTER-doctype branch; prior drafts prepended and were quirks-mode-
+ *        triggering on edge cases.
+ *     4. Prepend (true fragment — no doctype, no `<html>`, no `<head>`).
+ *
+ *   Each regex is case-insensitive and tolerates attributes on the open
+ *   tag (e.g. `<head lang="en">`, `<HTML class="...">`).
+ *
+ * Idempotency contract:
+ *
+ *   `skipIfPresent: true` (default) — the injector returns the markup
+ *   unchanged if it already contains the substring `sharc-creative.js`
+ *   (any URL with that filename). This protects against:
+ *     - Operator pipelines that already inject the SDK at an upstream step.
+ *     - Native SHARC creatives that ship the SDK inline.
+ *     - Back-to-back extension runs (e.g. two pipeline stages each adding
+ *       an injector).
+ *   Operators that want to force-inject (different SDK build, multi-version
+ *   coexistence test, etc.) opt out via `skipIfPresent: false`.
+ *
+ * Script-attribute contract:
+ *
+ *   `scriptAttrs: {}` (default) — emits a bare `<script src="..."></script>`,
+ *   which is parser-blocking and synchronous. This is the ONLY attribute
+ *   set that prevents the inline-`mraid.*` race condition for MRAID
+ *   creatives: `defer` allows inline scripts to run before the SDK loads
+ *   (and `mraid` would be undefined when the creative's `mraid.expand()`
+ *   inline fires); `async` is worse. Operators with fully event-driven
+ *   pipelines (no inline `mraid.*` / `$sf.ext.*` calls) can override with
+ *   `{ defer: true }` / `{ async: true }` / `{ integrity: 'sha384-...' }`
+ *   / etc.
+ *
+ *   Attribute serialization rules:
+ *     - `true` → bare attribute name (e.g. `{ async: true }` → ` async`)
+ *     - `false` / `null` / `undefined` → omitted entirely
+ *     - string → `="..."` with quote-escaping (defense against
+ *       attribute-injection if operator passes user-controlled data)
+ *     - other types → coerced to string then escaped
+ *
+ * Spec source: GitHub issue #97 (locked 2026-05-16, doctype refinement
+ * 2026-05-17). Design § 10.2 (Extensions) and § 6.3 (operator-injection
+ * pattern) provide the surrounding context.
+ *
+ * @version 0.7.1
+ */
+
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * HTML-escapes a string value for safe insertion inside a double-quoted
+ * attribute value. Targets the minimum set that breaks out of an attribute:
+ *   `&` → `&amp;` (must come FIRST so we don't double-escape the others)
+ *   `"` → `&quot;`
+ *   `<` → `&lt;`  (defense-in-depth — `<` inside an attribute is legal
+ *                  but escaping it removes any chance an HTML scanner
+ *                  upstream mistakes the boundary)
+ *
+ * Operators passing static URLs and known-safe attribute values don't
+ * need this — but the contract has to assume some operator pipelines
+ * thread user-derived data (RTB macro substitution, A/B test
+ * configuration, etc.) through `scriptAttrs`. Defense-in-depth.
+ *
+ * @param {string} value - Raw attribute value (already coerced to string).
+ * @returns {string} The HTML-attribute-safe escaped value.
+ * @private
+ */
+function _escapeAttr(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;');
+}
+
+/**
+ * Serializes a `scriptAttrs` object into a string suitable for splicing
+ * into a `<script>` open tag. Each entry produces a leading space; the
+ * caller does not need to add separators. Empty object returns `''`.
+ *
+ * @param {Object} attrs - Operator-supplied attribute map.
+ * @returns {string} Serialized attribute string (with leading spaces) or `''`.
+ * @private
+ */
+function _serializeAttrs(attrs) {
+  if (!attrs || typeof attrs !== 'object') return '';
+  const parts = [];
+  const keys = Object.keys(attrs);
+  for (let i = 0; i < keys.length; i++) {
+    const name = keys[i];
+    const value = attrs[name];
+    // Omit falsy non-boolean-true entirely. `false` / `null` / `undefined`
+    // all mean "do not emit this attribute" — matches the React-style
+    // convention operators are accustomed to.
+    if (value === false || value === null || value === undefined) continue;
+    if (value === true) {
+      // Bare attribute (e.g. `async`, `defer`, `nomodule`).
+      parts.push(' ' + name);
+    } else {
+      // String or coercible-to-string. HTML-escape the value to prevent
+      // attribute-injection if the operator threaded user-controlled
+      // data through.
+      parts.push(' ' + name + '="' + _escapeAttr(value) + '"');
+    }
+  }
+  return parts.join('');
+}
+
+/**
+ * Builds the final `<script src="...">` tag from the resolved URL and
+ * the serialized attribute string. Splits out so the injection logic in
+ * `injectIntoMarkup` reads cleanly.
+ *
+ * @param {string} url - The creative-SDK URL (validated by constructor).
+ * @param {Object} attrs - The `scriptAttrs` option.
+ * @returns {string} The complete `<script ...></script>` tag.
+ * @private
+ */
+function _buildScriptTag(url, attrs) {
+  return '<script src="' + _escapeAttr(url) + '"' + _serializeAttrs(attrs) + '></script>';
+}
+
+// ---------------------------------------------------------------------------
+// SHARCCreativeInjector — the extension class
+// ---------------------------------------------------------------------------
+
+/**
+ * Container extension that injects `sharc-creative.js` into Markup-variant
+ * creative HTML at iframe-load time.
+ *
+ * Wires up via the standard `SHARCContainer({ extensions: [...] })` option.
+ * The container invokes `injectIntoMarkup(html)` before posting the markup
+ * to the renderer; this class implements that hook with the doctype-aware
+ * injection logic documented at the top of this file.
+ *
+ * Usage:
+ * ```javascript
+ * import { SHARCContainer } from '@iabtechlab/sharc/sharc-container';
+ * import { SHARCCreativeInjector } from '@iabtechlab/sharc/sharc-creative-injector';
+ *
+ * const container = new SHARCContainer({
+ *   creativeHtml: bid.adm,
+ *   creativeRendererUrl: rendererUrl,
+ *   bridges: ['mraid'],
+ *   extensions: [
+ *     new SHARCCreativeInjector({
+ *       creativeSdkUrl: 'https://operator-cdn.example/sharc-creative.js',
+ *     }),
+ *   ],
+ *   placementElement: slot,
+ * });
+ * container.load();
+ * ```
+ *
+ * @param {Object}  options
+ * @param {string}  options.creativeSdkUrl    - REQUIRED. The URL of the
+ *                                              `sharc-creative.js` build
+ *                                              the operator hosts.
+ * @param {boolean} [options.skipIfPresent=true] - If true, markup already
+ *                                              containing `sharc-creative.js`
+ *                                              passes through unchanged.
+ * @param {Object}  [options.scriptAttrs={}]  - Additional `<script>`
+ *                                              attributes. See module
+ *                                              JSDoc for serialization rules.
+ *
+ * @throws {TypeError} If `creativeSdkUrl` is missing, empty, or not a string.
+ */
+class SHARCCreativeInjector {
+  /**
+   * @param {{ creativeSdkUrl: string, skipIfPresent?: boolean, scriptAttrs?: Object }} options
+   */
+  constructor(options) {
+    /** @type {{ creativeSdkUrl: string, skipIfPresent?: boolean, scriptAttrs?: Object }} */
+    const opts = options || /** @type {any} */ ({});
+    // Required-option validation — fail loud at construction time. Operators
+    // who omit this catch the error in their bootstrap, not at the first
+    // ad load. The TypeError name is conventional for "wrong-type-or-missing
+    // argument" per the Node.js error conventions the rest of SHARC uses.
+    if (typeof opts.creativeSdkUrl !== 'string' || opts.creativeSdkUrl.length === 0) {
+      throw new TypeError(
+        '[SHARCCreativeInjector] creativeSdkUrl is required and must be a '
+          + 'non-empty string (got '
+          + (opts.creativeSdkUrl === undefined ? 'undefined' : typeof opts.creativeSdkUrl)
+          + ').'
+      );
+    }
+
+    /** @type {string} */
+    this.creativeSdkUrl = opts.creativeSdkUrl;
+
+    /** @type {boolean} */
+    this.skipIfPresent = opts.skipIfPresent !== false; // default true
+
+    /** @type {Object} */
+    this.scriptAttrs = (opts.scriptAttrs && typeof opts.scriptAttrs === 'object')
+      ? opts.scriptAttrs
+      : {};
+  }
+
+  /**
+   * Returns the feature name advertised to the creative via Container:init's
+   * `supportedFeatures` array. Lets SHARC-aware creatives detect that the
+   * operator is auto-injecting the SDK and adjust behavior (e.g. skip their
+   * own SDK-load shim).
+   *
+   * @returns {string}
+   */
+  getFeatureName() {
+    return 'com.iabtechlab.sharc.creative-injector';
+  }
+
+  /**
+   * Hook called by `SHARCContainer._runMarkupInjection()` (and the URL-variant
+   * `_fetchAndInjectCreative()` path) before the markup is posted to the
+   * renderer. Returns the markup with the `sharc-creative.js` `<script>` tag
+   * inserted at the most-specific position available — see the module JSDoc
+   * for the full position table and the doctype-edge rationale.
+   *
+   * Idempotent when `skipIfPresent: true` (default): markup that already
+   * contains `sharc-creative.js` is returned unchanged.
+   *
+   * @param {string} html - Raw creative markup.
+   * @returns {string} Markup with the SDK script tag injected (or unchanged
+   *   per `skipIfPresent`).
+   */
+  injectIntoMarkup(html) {
+    // Defensive — extension hooks see whatever the operator put in
+    // `creativeHtml`. The container itself doesn't coerce; the contract
+    // is "string in, string out."
+    if (typeof html !== 'string') return html;
+
+    // Idempotency guard. The `sharc-creative.js` filename match is
+    // intentionally tolerant — operators may host the SDK under various
+    // path prefixes (CDN, versioned subdirs, etc.). The substring presence
+    // is sufficient to skip; we don't try to parse the URL.
+    if (this.skipIfPresent && /sharc-creative\.js/.test(html)) {
+      return html;
+    }
+
+    const scriptTag = _buildScriptTag(this.creativeSdkUrl, this.scriptAttrs);
+
+    // Position 1: after `<head>` open tag. Case-insensitive; tolerates
+    // attributes on the tag (`<head lang="en">`, `<HEAD class="...">`).
+    // `replace` with a function (not a string replacement) keeps backreferences
+    // simple and avoids the `$N` escaping pitfall if the matched tag ever
+    // contained `$` characters.
+    const headMatch = html.match(/<head[^>]*>/i);
+    if (headMatch) {
+      return html.replace(headMatch[0], headMatch[0] + scriptTag);
+    }
+
+    // Position 2: after `<html>` open tag (no `<head>` in markup).
+    const htmlMatch = html.match(/<html[^>]*>/i);
+    if (htmlMatch) {
+      return html.replace(htmlMatch[0], htmlMatch[0] + scriptTag);
+    }
+
+    // Position 3: after `<!DOCTYPE>` (fragment with doctype but no `<html>`
+    // wrapper). Inserting BEFORE the doctype would push the browser into
+    // quirks-mode rendering for the entire document — the explicit
+    // refinement (2026-05-17) is that the doctype branch must inject
+    // AFTER the declaration, not before.
+    const doctypeMatch = html.match(/<!DOCTYPE[^>]*>/i);
+    if (doctypeMatch) {
+      return html.replace(doctypeMatch[0], doctypeMatch[0] + scriptTag);
+    }
+
+    // Position 4: true fragment (no doctype, no `<html>`, no `<head>`).
+    // Prepend — the script tag is the first thing the renderer's
+    // `document.write` will see.
+    return scriptTag + html;
+  }
+
+  /**
+   * Optional cleanup hook. The current implementation holds no resources
+   * (no DOM listeners, no timers, no fetched URLs) so this is a no-op.
+   * Present so future extensions of this class — or operator-extended
+   * subclasses — have a stable lifecycle surface to hook into.
+   */
+  destroy() {
+    // Intentionally empty — no resources to release.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ESM exports
+// ---------------------------------------------------------------------------
+
+export { SHARCCreativeInjector };
+
+// Legacy IIFE — register the class on the SHARC namespace so non-module
+// consumers (a `<script src="dist/sharc-creative-injector.js">` tag) can
+// reach it via `window.SHARC.SHARCCreativeInjector`. First-assignment-wins
+// to match the OmidCompatBridge / navigation-bridge precedent: operators
+// who pre-set the class (e.g. with telemetry wrapping) keep their override.
+if (typeof window !== 'undefined') {
+  /** @type {any} */
+  const _win = window;
+  _win.SHARC = _win.SHARC || {};
+  if (typeof _win.SHARC.SHARCCreativeInjector !== 'function') {
+    _win.SHARC.SHARCCreativeInjector = SHARCCreativeInjector;
+  }
+}

--- a/test/node/test-sharc-creative-injector.js
+++ b/test/node/test-sharc-creative-injector.js
@@ -1,0 +1,481 @@
+/**
+ * test-sharc-creative-injector.js — issue #97 (0.7.2 first-half PR 4)
+ *
+ * Unit coverage for the `SHARCCreativeInjector` reference extension.
+ * Verifies the locked design from issue #97 + the 2026-05-17 doctype-edge
+ * refinement: injection inserts the SDK `<script>` tag at the most
+ * specific position present in the markup (head → html → doctype →
+ * prepend), never BEFORE the doctype declaration (which would push the
+ * browser into quirks-mode rendering).
+ *
+ * Coverage matrix (issue #97 § Test matrix + doctype refinement):
+ *
+ *   Constructor validation
+ *     - creativeSdkUrl: undefined / null / '' / non-string → TypeError
+ *     - creativeSdkUrl: 'https://...'                       → accepted
+ *
+ *   Injection-position contract
+ *     - <head> present (mixed case, with attrs) → after head open tag
+ *     - <html> only (no head)                   → after html open tag
+ *     - <!DOCTYPE> only (no html, no head)      → after doctype (NOT before!)
+ *     - true fragment                            → prepend
+ *
+ *   Idempotency (skipIfPresent: true default)
+ *     - markup already contains `sharc-creative.js` → returned unchanged
+ *     - markup contains a DIFFERENT filename        → still injects
+ *     - skipIfPresent: false                        → always injects
+ *
+ *   Script-attr serialization
+ *     - `{ async: true }`               → ` async` (bare attr)
+ *     - `{ async: true, defer: true }`  → ` async defer`
+ *     - `{ async: false }`              → omitted
+ *     - `{ integrity: 'sha384-...' }`   → ` integrity="sha384-..."`
+ *     - `{ nonce: 'a"b' }`              → HTML-escaped quote
+ *
+ *   Container integration
+ *     - new SHARCContainer({ ..., extensions: [injector] }) →
+ *       container._runMarkupInjection() returns injected markup; the
+ *       `creativeInjected` flag flips true.
+ *
+ * Runs in Node after `npm run build` (the integration test imports the
+ * built container bundle; constructor + injection tests are pure
+ * string-in / string-out and don't need jsdom).
+ */
+
+import { JSDOM } from 'jsdom';
+
+// ── Minimal DOM stub for the integration test ────────────────────────────
+// SHARCContainer construction touches `document` / `HTMLIFrameElement` /
+// `HTMLElement` / `MessageChannel`. Mirror the html-lifecycle-adapter
+// test's setup. The injector itself doesn't need a DOM — only the
+// container-integration section does.
+const PUBLISHER_ORIGIN = 'https://publisher.example';
+const dom = new JSDOM(
+  '<!DOCTYPE html><html><body></body></html>',
+  { url: PUBLISHER_ORIGIN + '/page.html', pretendToBeVisual: true },
+);
+global.window = dom.window;
+global.document = dom.window.document;
+Object.defineProperty(global.document, 'visibilityState', {
+  configurable: true,
+  get() { return 'visible'; },
+});
+global.HTMLElement = dom.window.HTMLElement;
+global.HTMLIFrameElement = dom.window.HTMLIFrameElement;
+global.MessageChannel = dom.window.MessageChannel;
+global.MessagePort = dom.window.MessagePort;
+global.MessageEvent = dom.window.MessageEvent;
+if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.randomUUID !== 'function') {
+  const nodeCrypto = await import('node:crypto');
+  globalThis.crypto = nodeCrypto.webcrypto || nodeCrypto;
+}
+
+// IntersectionObserver stub — the container's HTML lifecycle adapter
+// constructs one in attach(); the integration test never observes
+// transitions but the container won't construct without the stub.
+global.IntersectionObserver = class IntersectionObserverStub {
+  constructor() {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+window.IntersectionObserver = global.IntersectionObserver;
+
+// Pre-load protocol exports onto window.SHARC.Protocol so the container's
+// internal SHARC_VERSION lookup at construction works (matches the
+// html-lifecycle-adapter test).
+const protoMod = await import('../../dist/sharc-protocol.mjs');
+window.SHARC = window.SHARC || {};
+window.SHARC.Protocol = protoMod;
+
+const { SHARCCreativeInjector } = await import('../../dist/sharc-creative-injector.mjs');
+const { SHARCContainer } = await import('../../dist/sharc-container.mjs');
+
+// ── Assertion harness ─────────────────────────────────────────────────────
+let failures = 0;
+function assert(condition, message) {
+  if (condition) {
+    console.log('  ✓', message);
+  } else {
+    console.error('  ✗', message);
+    failures++;
+  }
+}
+
+console.log('test-sharc-creative-injector.js — issue #97 (PR 4) coverage\n');
+
+const SDK_URL = 'https://op.example/sharc-creative.js';
+
+// =========================================================================
+// 1. Constructor validation
+// =========================================================================
+{
+  console.log('1. Constructor validation');
+
+  function expectThrow(label, options) {
+    let threw = null;
+    try { new SHARCCreativeInjector(options); } catch (e) { threw = e; }
+    assert(threw instanceof TypeError,
+      `${label} → TypeError thrown`);
+    assert(threw && /creativeSdkUrl/.test(String(threw.message)),
+      `${label} → error message names creativeSdkUrl`);
+  }
+
+  expectThrow('creativeSdkUrl: undefined (omitted)', {});
+  expectThrow('creativeSdkUrl: null', { creativeSdkUrl: null });
+  expectThrow('creativeSdkUrl: empty string', { creativeSdkUrl: '' });
+  expectThrow('creativeSdkUrl: number (non-string)', { creativeSdkUrl: 123 });
+  expectThrow('creativeSdkUrl: object', { creativeSdkUrl: { url: 'x' } });
+  expectThrow('options: undefined entirely', undefined);
+
+  // Accepted shape.
+  let injector = null;
+  try {
+    injector = new SHARCCreativeInjector({ creativeSdkUrl: SDK_URL });
+  } catch (e) {
+    assert(false, 'accepted creativeSdkUrl construction threw: ' + (e && e.message));
+  }
+  assert(injector !== null, 'valid creativeSdkUrl → instance constructed');
+  assert(injector.creativeSdkUrl === SDK_URL,
+    'instance.creativeSdkUrl mirrors the constructor arg');
+  assert(injector.skipIfPresent === true,
+    'instance.skipIfPresent defaults to true');
+  assert(injector.scriptAttrs && typeof injector.scriptAttrs === 'object',
+    'instance.scriptAttrs defaults to an object');
+  assert(typeof injector.injectIntoMarkup === 'function',
+    'instance exposes injectIntoMarkup(html)');
+  assert(typeof injector.getFeatureName === 'function',
+    'instance exposes getFeatureName()');
+  assert(injector.getFeatureName() === 'com.iabtechlab.sharc.creative-injector',
+    'getFeatureName() returns the canonical feature string');
+  assert(typeof injector.destroy === 'function',
+    'instance exposes destroy() (lifecycle parity with other extensions)');
+}
+
+// =========================================================================
+// 2. Injection-position contract
+// =========================================================================
+{
+  console.log('\n2. Injection-position contract');
+
+  const injector = new SHARCCreativeInjector({ creativeSdkUrl: SDK_URL });
+  const expectedTag = '<script src="' + SDK_URL + '"></script>';
+
+  // 2a — markup with <head> → injected after head open tag
+  {
+    const html = '<!DOCTYPE html><html><head><title>Ad</title></head><body>x</body></html>';
+    const out = injector.injectIntoMarkup(html);
+    const expected = '<!DOCTYPE html><html><head>' + expectedTag + '<title>Ad</title></head><body>x</body></html>';
+    assert(out === expected,
+      '2a. <head> present → script injected immediately after <head> open tag');
+  }
+
+  // 2b — case-insensitive <HEAD>
+  {
+    const html = '<!DOCTYPE html><HTML><HEAD></HEAD><BODY>x</BODY></HTML>';
+    const out = injector.injectIntoMarkup(html);
+    assert(out.indexOf('<HEAD>' + expectedTag) !== -1,
+      '2b. <HEAD> (uppercase) → matched case-insensitively, script injected after open tag');
+  }
+
+  // 2c — <head lang="en"> attrs on the tag
+  {
+    const html = '<html><head lang="en" class="x"></head><body></body></html>';
+    const out = injector.injectIntoMarkup(html);
+    assert(out.indexOf('<head lang="en" class="x">' + expectedTag) !== -1,
+      '2c. <head> with attributes → script injected after full open tag (attrs preserved)');
+  }
+
+  // 2d — <html> only, no <head>
+  {
+    const html = '<!DOCTYPE html><html><body>x</body></html>';
+    const out = injector.injectIntoMarkup(html);
+    assert(out === '<!DOCTYPE html><html>' + expectedTag + '<body>x</body></html>',
+      '2d. <html> present (no <head>) → script injected after <html> open tag');
+  }
+
+  // 2e — <!DOCTYPE> only (no html, no head). The CRITICAL doctype-edge case:
+  //      a naive injector would prepend (placing the tag BEFORE the doctype)
+  //      and trigger quirks-mode rendering. The injector MUST insert AFTER
+  //      the doctype declaration.
+  {
+    const html = '<!DOCTYPE html><body>fragment</body>';
+    const out = injector.injectIntoMarkup(html);
+    assert(out === '<!DOCTYPE html>' + expectedTag + '<body>fragment</body>',
+      '2e. <!DOCTYPE> only → script injected AFTER doctype (regression guard against quirks-mode)');
+    assert(out.indexOf(expectedTag) > out.indexOf('<!DOCTYPE'),
+      '2e (sanity). script tag position is AFTER the doctype declaration, not before');
+  }
+
+  // 2f — lowercase <!doctype html>. Quirks-mode handling must also catch
+  //      the lowercase variant.
+  {
+    const html = '<!doctype html><body>x</body>';
+    const out = injector.injectIntoMarkup(html);
+    assert(out === '<!doctype html>' + expectedTag + '<body>x</body>',
+      '2f. lowercase <!doctype html> → handled, script injected AFTER declaration');
+  }
+
+  // 2g — fragment markup (no doctype, no html, no head) → prepend
+  {
+    const html = '<div class="ad"><img src="img.png"></div>';
+    const out = injector.injectIntoMarkup(html);
+    assert(out === expectedTag + html,
+      '2g. fragment markup → script prepended (no anchor element present)');
+  }
+
+  // 2h — non-string input passes through (defensive contract)
+  {
+    const out = injector.injectIntoMarkup(null);
+    assert(out === null,
+      '2h. non-string input → returned unchanged (defensive — contract is string-in/string-out)');
+  }
+}
+
+// =========================================================================
+// 3. Idempotency (skipIfPresent)
+// =========================================================================
+{
+  console.log('\n3. Idempotency — skipIfPresent contract');
+
+  // 3a — default true: markup already containing `sharc-creative.js` is unchanged
+  {
+    const injector = new SHARCCreativeInjector({ creativeSdkUrl: SDK_URL });
+    const html = '<html><head><script src="https://prior-cdn/sharc-creative.js"></script></head><body>x</body></html>';
+    const out = injector.injectIntoMarkup(html);
+    assert(out === html,
+      '3a. skipIfPresent default true + sharc-creative.js already present → returned unchanged');
+  }
+
+  // 3b — default true: markup with a DIFFERENT filename still gets injected
+  //      (presence check is filename-substring, not generic "any script")
+  {
+    const injector = new SHARCCreativeInjector({ creativeSdkUrl: SDK_URL });
+    const html = '<html><head><script src="https://cdn/some-other-thing.js"></script></head><body></body></html>';
+    const out = injector.injectIntoMarkup(html);
+    assert(out !== html,
+      '3b. skipIfPresent default true + DIFFERENT filename present → still injects (substring is filename-specific)');
+    assert(out.indexOf(SDK_URL) !== -1,
+      '3b (sanity). injected script src matches the configured creativeSdkUrl');
+  }
+
+  // 3c — back-to-back injection through the same instance is idempotent
+  {
+    const injector = new SHARCCreativeInjector({ creativeSdkUrl: SDK_URL });
+    const html = '<html><head></head><body></body></html>';
+    const once = injector.injectIntoMarkup(html);
+    const twice = injector.injectIntoMarkup(once);
+    assert(once === twice,
+      '3c. back-to-back injection through the same instance is a no-op on the second pass');
+    // Count <script> occurrences to confirm there's exactly one.
+    const matches = (once.match(/sharc-creative\.js/g) || []).length;
+    assert(matches === 1,
+      '3c. exactly one sharc-creative.js script tag present after two injection passes');
+  }
+
+  // 3d — skipIfPresent: false → always injects
+  {
+    const injector = new SHARCCreativeInjector({
+      creativeSdkUrl: SDK_URL,
+      skipIfPresent: false,
+    });
+    const html = '<html><head><script src="sharc-creative.js"></script></head><body></body></html>';
+    const out = injector.injectIntoMarkup(html);
+    assert(out !== html,
+      '3d. skipIfPresent: false → injects even when sharc-creative.js already present');
+    // Two occurrences total now.
+    const matches = (out.match(/sharc-creative\.js/g) || []).length;
+    assert(matches === 2,
+      '3d. skipIfPresent: false → two sharc-creative.js script tags present after force-inject');
+  }
+}
+
+// =========================================================================
+// 4. Script-attr serialization
+// =========================================================================
+{
+  console.log('\n4. scriptAttrs serialization');
+
+  // 4a — { async: true } → bare attr
+  {
+    const injector = new SHARCCreativeInjector({
+      creativeSdkUrl: SDK_URL,
+      scriptAttrs: { async: true },
+    });
+    const out = injector.injectIntoMarkup('<html><head></head></html>');
+    assert(out.indexOf('<script src="' + SDK_URL + '" async></script>') !== -1,
+      '4a. { async: true } → emitted as bare attribute (no `="true"`)');
+  }
+
+  // 4b — { async: true, defer: true } → both bare
+  {
+    const injector = new SHARCCreativeInjector({
+      creativeSdkUrl: SDK_URL,
+      scriptAttrs: { async: true, defer: true },
+    });
+    const out = injector.injectIntoMarkup('<html><head></head></html>');
+    assert(out.indexOf('<script src="' + SDK_URL + '" async defer></script>') !== -1,
+      '4b. { async: true, defer: true } → both rendered as bare attributes');
+  }
+
+  // 4c — { async: false } → omitted
+  {
+    const injector = new SHARCCreativeInjector({
+      creativeSdkUrl: SDK_URL,
+      scriptAttrs: { async: false },
+    });
+    const out = injector.injectIntoMarkup('<html><head></head></html>');
+    assert(out.indexOf('<script src="' + SDK_URL + '"></script>') !== -1,
+      '4c. { async: false } → attribute omitted entirely');
+    assert(out.indexOf('async') === -1,
+      '4c (sanity). no `async` substring anywhere in the injected tag');
+  }
+
+  // 4d — null / undefined attr values → omitted
+  {
+    const injector = new SHARCCreativeInjector({
+      creativeSdkUrl: SDK_URL,
+      scriptAttrs: { defer: null, nomodule: undefined, async: true },
+    });
+    const out = injector.injectIntoMarkup('<html><head></head></html>');
+    assert(out.indexOf('<script src="' + SDK_URL + '" async></script>') !== -1,
+      '4d. null / undefined attr values → omitted; only truthy attrs render');
+  }
+
+  // 4e — string attr value
+  {
+    const injector = new SHARCCreativeInjector({
+      creativeSdkUrl: SDK_URL,
+      scriptAttrs: { integrity: 'sha384-XYZ' },
+    });
+    const out = injector.injectIntoMarkup('<html><head></head></html>');
+    assert(out.indexOf('<script src="' + SDK_URL + '" integrity="sha384-XYZ"></script>') !== -1,
+      '4e. { integrity: "sha384-XYZ" } → rendered as quoted attribute');
+  }
+
+  // 4f — string attr containing double-quote → HTML-escaped
+  {
+    const injector = new SHARCCreativeInjector({
+      creativeSdkUrl: SDK_URL,
+      scriptAttrs: { nonce: 'a"b' },
+    });
+    const out = injector.injectIntoMarkup('<html><head></head></html>');
+    assert(out.indexOf('nonce="a&quot;b"') !== -1,
+      '4f. attribute value containing `"` → escaped to `&quot;` (defense against attribute-injection)');
+    assert(out.indexOf('nonce="a"b"') === -1,
+      '4f (sanity). raw unescaped value is NOT present in output');
+  }
+
+  // 4g — string attr containing `&` → HTML-escaped
+  {
+    const injector = new SHARCCreativeInjector({
+      creativeSdkUrl: SDK_URL,
+      scriptAttrs: { 'data-rtb': 'a&b' },
+    });
+    const out = injector.injectIntoMarkup('<html><head></head></html>');
+    assert(out.indexOf('data-rtb="a&amp;b"') !== -1,
+      '4g. attribute value containing `&` → escaped to `&amp;` (entity-correctness)');
+  }
+
+  // 4h — creativeSdkUrl containing `&` (RTB-macro-like) → escaped in src
+  {
+    const injector = new SHARCCreativeInjector({
+      creativeSdkUrl: 'https://op.example/sdk.js?v=1&hash=abc',
+    });
+    const out = injector.injectIntoMarkup('<html><head></head></html>');
+    assert(out.indexOf('src="https://op.example/sdk.js?v=1&amp;hash=abc"') !== -1,
+      '4h. creativeSdkUrl with `&` → src value HTML-escaped (entity-correctness)');
+  }
+}
+
+// =========================================================================
+// 5. Container integration — extension hook fires from SHARCContainer
+// =========================================================================
+{
+  console.log('\n5. SHARCContainer integration');
+
+  // Build a placement element so the container construction doesn't bail.
+  document.body.innerHTML = '';
+  const slot = document.createElement('div');
+  slot.id = 'ad-slot';
+  document.body.appendChild(slot);
+
+  const creativeHtml = '<!DOCTYPE html><html><head></head><body><h1>Ad</h1></body></html>';
+  const injector = new SHARCCreativeInjector({ creativeSdkUrl: SDK_URL });
+
+  let container = null;
+  try {
+    container = new SHARCContainer({
+      creativeHtml,
+      creativeRendererUrl: 'https://renderer.example/0.7.1/index.html',
+      placementElement: slot,
+      requireSharcInit: false,
+      extensions: [injector],
+      timeouts: { createSession: 5000 },
+    });
+  } catch (e) {
+    assert(false, '5. SHARCContainer construction with extensions: [injector] threw: ' + (e && e.message));
+  }
+
+  if (container) {
+    // 5a — container collected the extension
+    assert(Array.isArray(container._extensions) && container._extensions.length === 1
+      && container._extensions[0] === injector,
+      '5a. container._extensions registers the injector instance');
+
+    // 5b — running the injection pipe directly returns the modified markup
+    const injected = container._runMarkupInjection();
+    assert(injected.indexOf('<script src="' + SDK_URL + '"></script>') !== -1,
+      '5b. container._runMarkupInjection() returns markup containing the SDK script tag');
+    assert(container.creativeInjected === true,
+      '5c. container.creativeInjected flag flipped true after injection');
+
+    // 5d — getFeatureName() collected into supportedFeatures contributions.
+    //      Direct check against the injector's reported name (the merge into
+    //      Container:init happens at handshake time; here we verify the
+    //      surface the merge will see).
+    assert(typeof injector.getFeatureName() === 'string'
+      && injector.getFeatureName() === 'com.iabtechlab.sharc.creative-injector',
+      '5d. injector.getFeatureName() advertises com.iabtechlab.sharc.creative-injector');
+
+    // 5e — destroy() is callable without throwing (lifecycle parity).
+    let destroyThrew = false;
+    try { injector.destroy(); } catch (_) { destroyThrew = true; }
+    assert(!destroyThrew,
+      '5e. injector.destroy() is callable without throwing');
+
+    // Cleanup so the process can exit cleanly.
+    try { container._terminate(); } catch (_) { /* ignore */ }
+  }
+}
+
+// =========================================================================
+// 6. Multi-extension sequencing — injector is idempotent across passes
+// =========================================================================
+{
+  console.log('\n6. Multi-extension sequencing — back-to-back injectors do not double-inject');
+
+  const inj1 = new SHARCCreativeInjector({ creativeSdkUrl: SDK_URL });
+  const inj2 = new SHARCCreativeInjector({ creativeSdkUrl: SDK_URL });
+  const html = '<html><head></head><body></body></html>';
+
+  const afterFirst = inj1.injectIntoMarkup(html);
+  const afterSecond = inj2.injectIntoMarkup(afterFirst);
+
+  assert(afterFirst === afterSecond,
+    '6. second injector pass over already-injected markup is a no-op (skipIfPresent dedup)');
+  const matches = (afterSecond.match(/sharc-creative\.js/g) || []).length;
+  assert(matches === 1,
+    '6 (sanity). exactly one sharc-creative.js tag present after two injector passes');
+}
+
+// =========================================================================
+// Summary
+// =========================================================================
+console.log('');
+if (failures > 0) {
+  process.stderr.write(`✗ ${failures} sharc-creative-injector assertion(s) failed.\n`);
+  process.exit(1);
+} else {
+  console.log('✓ All sharc-creative-injector assertions passed.');
+}

--- a/test/node/test-sharc-creative-injector.js
+++ b/test/node/test-sharc-creative-injector.js
@@ -418,17 +418,15 @@ const SDK_URL = 'https://op.example/sharc-creative.js';
   }
 
   if (container) {
-    // 5a — container collected the extension
-    assert(Array.isArray(container._extensions) && container._extensions.length === 1
-      && container._extensions[0] === injector,
-      '5a. container._extensions registers the injector instance');
-
-    // 5b — running the injection pipe directly returns the modified markup
+    // 5a — running the injection pipe returns the modified markup.
+    //      (Dropped a prior assertion that introspected `container._extensions`
+    //      directly — that's a private field per naming convention and the
+    //      public-surface checks below cover the contract.)
     const injected = container._runMarkupInjection();
     assert(injected.indexOf('<script src="' + SDK_URL + '"></script>') !== -1,
-      '5b. container._runMarkupInjection() returns markup containing the SDK script tag');
+      '5a. container._runMarkupInjection() returns markup containing the SDK script tag');
     assert(container.creativeInjected === true,
-      '5c. container.creativeInjected flag flipped true after injection');
+      '5b. container.creativeInjected flag flipped true after injection');
 
     // 5d — getFeatureName() collected into supportedFeatures contributions.
     //      Direct check against the injector's reported name (the merge into
@@ -467,6 +465,76 @@ const SDK_URL = 'https://op.example/sharc-creative.js';
   const matches = (afterSecond.match(/sharc-creative\.js/g) || []).length;
   assert(matches === 1,
     '6 (sanity). exactly one sharc-creative.js tag present after two injector passes');
+}
+
+// =========================================================================
+// 7. Review-fixup regression coverage (post-PR-103 round 1)
+// =========================================================================
+
+// 7a — B1 regression: `<head[^>]*>` regex must NOT match `<header>`.
+//      Before the lookahead fix, Bootstrap/Tailwind landing-page creatives
+//      using `<header>` would have the SDK script injected inside the
+//      header element rather than the document head. The fix is a
+//      lookahead `(?=[\s>])` that requires the next char after "head"
+//      to be whitespace or `>`.
+{
+  const inj = new SHARCCreativeInjector({ creativeSdkUrl: SDK_URL });
+
+  // Pure-`<header>` markup — should fall through to position 4 (prepend),
+  // NOT match position 1's <head> branch.
+  const headerOnly = '<header class="top">welcome</header><main>body</main>';
+  const out1 = inj.injectIntoMarkup(headerOnly);
+  assert(out1.startsWith('<script src="' + SDK_URL + '"></script><header'),
+    '7a-1. <header>-only markup: SDK script prepended (position 4), not injected inside <header>');
+  // Defensive: confirm we did NOT splice anything inside <header>.
+  assert(out1.indexOf('<header class="top"><script') === -1,
+    '7a-2. <header>-only markup: NOT injected inside <header> element');
+
+  // Mixed markup with `<header>` appearing BEFORE `<head>`. The regex must
+  // still correctly find `<head>` and skip the `<header>` false-positive.
+  const mixed = '<!DOCTYPE html><html><body><header>nav</header></body><head><title>x</title></head></html>';
+  const out2 = inj.injectIntoMarkup(mixed);
+  // SDK should be in the real <head>, not inside the <header>.
+  assert(out2.indexOf('<head><script src="' + SDK_URL + '"></script><title>') !== -1,
+    '7a-3. mixed <header> + <head> markup: SDK lands in <head>, not <header>');
+  assert(out2.indexOf('<header><script') === -1,
+    '7a-4. mixed markup: NOT injected inside <header>');
+}
+
+// 7b — S1 regression: `skipIfPresent` must NOT trigger on substring
+//      mentions inside comments, metadata, or arbitrary strings.
+//      Pre-fix: bare substring match `/sharc-creative\.js/` would match
+//      `<!-- sharc-creative.js -->` and skip injection, producing a
+//      silent no-op where the SDK never loaded. Fix tightens the regex
+//      to require a `<script src="…sharc-creative.js">` context.
+{
+  const inj = new SHARCCreativeInjector({ creativeSdkUrl: SDK_URL });
+
+  // Substring in comment — must NOT skip.
+  const commentOnly = '<head><!-- sharc-creative.js was loaded by the gateway --></head><body>x</body>';
+  const out1 = inj.injectIntoMarkup(commentOnly);
+  assert(out1.indexOf('<script src="' + SDK_URL + '"></script>') !== -1,
+    '7b-1. comment containing "sharc-creative.js" substring: SDK still injected (skipIfPresent does not fire on comment)');
+
+  // Substring in meta content — must NOT skip.
+  const metaOnly = '<head><meta name="modules" content="sharc-creative.js, foo.js"></head><body>x</body>';
+  const out2 = inj.injectIntoMarkup(metaOnly);
+  assert(out2.indexOf('<script src="' + SDK_URL + '"></script>') !== -1,
+    '7b-2. <meta> with substring "sharc-creative.js": SDK still injected');
+
+  // Substring in inline script text — must NOT skip (this is a string
+  // mention, not a script-src reference).
+  const inlineMention = '<head><script>console.log("sharc-creative.js not found")</script></head><body>x</body>';
+  const out3 = inj.injectIntoMarkup(inlineMention);
+  assert(out3.indexOf('src="' + SDK_URL + '"></script>') !== -1,
+    '7b-3. inline <script> string mentioning "sharc-creative.js": SDK still injected');
+
+  // Positive control: a real `<script src="...sharc-creative.js">` tag
+  // SHOULD trigger the skip.
+  const realLoad = '<head><script src="https://cdn.operator/sharc-creative.js"></script></head><body>x</body>';
+  const out4 = inj.injectIntoMarkup(realLoad);
+  assert(out4 === realLoad,
+    '7b-4. positive control: real <script src="…sharc-creative.js"> already present → skipIfPresent triggers, returned unchanged');
 }
 
 // =========================================================================

--- a/test/node/test-smoke.js
+++ b/test/node/test-smoke.js
@@ -68,6 +68,11 @@ const esmModules = [
     name: 'sharc-navigation-bridge',
     path: '../../dist/sharc-navigation-bridge.mjs',
     expectedExports: ['installNavigationBridge']
+  },
+  {
+    name: 'sharc-creative-injector',
+    path: '../../dist/sharc-creative-injector.mjs',
+    expectedExports: ['SHARCCreativeInjector']
   }
 ];
 
@@ -79,6 +84,7 @@ const iifeArtifacts = [
   '../../dist/sharc-safeframe-bridge.js',
   '../../dist/sharc-omid-bridge.js',
   '../../dist/sharc-navigation-bridge.js',
+  '../../dist/sharc-creative-injector.js',
 ];
 
 for (const artifact of [...esmModules.map(m => m.path), ...iifeArtifacts]) {


### PR DESCRIPTION
## Summary

Adds `SHARCCreativeInjector` — a turn-key `SHARCContainer` extension that auto-injects `sharc-creative.js` into legacy Markup-variant creative HTML at construction time. **Anchors the "lift legacy inventory into SHARC" operator-integration pattern** locked during the 0.7.2 design review (see WIP doc + design § 6.3 + § 10.2; closes [#97](https://github.com/jeffreycarlson/SHARC/issues/97)).

Operators wire it up once via `extensions: [new SHARCCreativeInjector({ creativeSdkUrl })]` and any inventory shape (plain HTML, MRAID v1/v2/v3, SafeFrame 1.x) becomes SHARC-container-compatible without per-creative changes.

## Public API

```javascript
import { SHARCCreativeInjector } from '@iabtechlab/sharc/sharc-creative-injector';

new SHARCContainer({
  creativeHtml: bid.adm,
  creativeRendererUrl: '...',
  extensions: [
    new SHARCCreativeInjector({
      creativeSdkUrl: 'https://op.cdn/sharc-creative.js',
      // skipIfPresent: true (default) — idempotent if SDK already present
      // scriptAttrs: {}           (default) — synchronous parser-blocking load
    }),
  ],
  // requireSharcInit: true (default) — operator pipeline + injector means
  // every creative handshakes; permissive mode no longer needed for legacy
});
```

## Injection logic (per the locked doctype-edge refinement)

1. `skipIfPresent` match (default true) → return unchanged
2. After `<head[^>]*>` open tag (case-insensitive)
3. Else after `<html[^>]*>` open tag
4. Else after `<!DOCTYPE[^>]*>` — **regression-guarded**; prepending before `<!DOCTYPE>` would put the browser into quirks mode
5. Else prepend (true fragment markup)

## Defaults

- **`scriptAttrs: {}` → synchronous parser-blocking script load.** The only attribute set that prevents the inline-`mraid.*` race condition for MRAID creatives. Operators with event-based pipelines override per-instance: `{ async: true }`, `{ defer: true }`, `{ integrity: 'sha384-...' }`.
- **`skipIfPresent: true`** → idempotent. Multi-injector composition + SHARC-native inventory both no-op correctly.
- **String `scriptAttrs` values are HTML-escaped** (`&`, `"`, `<`) — defense against attribute-injection if operator pipelines thread user-controlled data through.

## Build wiring

- `rollup.config.js` — adds `sharc-creative-injector` entry
- `package.json` — adds `./sharc-creative-injector` export-map entry, registers `test:creative-sdk-injector` script, adds the new src file to the `version` script's `git add` chain
- `scripts/sync-version.js` — adds the new file to the `@version` JSDoc sync list (closes [#100](https://github.com/jeffreycarlson/SHARC/issues/100)'s parallel concern for this module)
- `.size-limit.json` — 3 KB cap entry
- `test/node/test-smoke.js` — new ESM + IIFE artifacts added to smoke matrix

## Test coverage (~50 assertions across 6 sections)

| Section | Coverage |
|---|---|
| Constructor validation | 6 TypeError cases (undefined / null / '' / number / object / no options) + 8 happy-path property checks |
| Injection-position contract | 8 cases including doctype-edge regression guard, lowercase doctype, uppercase HEAD, attrs on open tag, true fragment markup |
| Idempotency | 4 cases — `skipIfPresent` default, different-filename false-positive guard, self-passes, force-inject override |
| `scriptAttrs` serialization | 8 cases — bare booleans, omitted falsy, mixed bool+string, HTML-escape (`&`, `"`, `<`), URL passthrough in `src` |
| SHARCContainer integration | `container._extensions` registration, `_runMarkupInjection()` returns modified markup, `container.creativeInjected` flips true, `destroy()` callable |
| Multi-extension sequencing | Two injector instances in chain produce exactly one `<script>` (skipIfPresent dedup) |

## Out of scope (handled elsewhere)

- **CHANGELOG entry + cookbook section** → PR 3 (next, last in 0.7.2 first-half sequence)
- **IAB Tech Lab canonical CDN URL** → post-upstream-contribution; `creativeSdkUrl` is operator-supplied today
- **Cross-origin URL variant fetch** — that's the existing `useMarkupInjection: true` path; this injector is for Markup variant where the operator provides `creativeHtml`

## Test plan

- [x] `npm run build` — clean (rollup + tsc)
- [x] All 13 jsdom test suites pass: `test:smoke`, `test:treeshake`, `test:placement`, `test:placement-stamping`, `test:creative-sources`, `test:creative-sources-load`, `test:navigation-bridge`, `test:creative-sdk-autoinstall`, `test:bridges-detection`, `test:non-sharc-loading`, `test:html-lifecycle-adapter`, `test:creative-sdk-injector` (NEW), `test:renderer-fallback`
- [x] Smoke test confirms new ESM/IIFE artifacts pass existence + export checks
- [x] Verified doctype-edge regression guard: `<!DOCTYPE html><body>` markup gets script injected AFTER `<!DOCTYPE>`, not before (no quirks mode)
- [x] Multi-extension composition: chained injectors produce exactly one `<script>` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)