### PR TITLE
docs(release): finish SHARC 0.7.2 docs and version cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,156 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-05-18
+
+Closes the first half of issue [#89] and issue [#97]. This release
+documents the transition-state operator path: SHARC creatives still
+handshake directly with the container in the steady state, while
+operators can now load legacy plain HTML, MRAID, and SafeFrame adm
+without per-creative changes.
+
+### Added
+
+- **`requireSharcInit` constructor option** ([#89], [#92]). Boolean,
+  default `true`. When `false`, the container skips the `createSession`
+  fatal-timeout so non-SHARC creatives load to a stable, queryable,
+  terminable container instance without timing out on the missing
+  handshake. Throws `TypeError` for non-boolean values (Rule 11).
+  See the README transition section and the operator cookbook.
+
+- **`creativeSdkUrl` constructor option** ([#97], [#105]). String,
+  optional. When set, the container auto-injects
+  `<script src="...sharc-creative.js"></script>` into Markup-variant
+  creative HTML at load time, lifting legacy adm into SHARC without
+  per-creative changes. Throws `TypeError` for non-string or empty
+  values (Rule 12). Markup variant only in 0.7.2; Creative URL variant
+  parity is tracked in [#106].
+
+- **`creativeSdkSkipIfPresent` constructor option** ([#105]). Boolean,
+  default `true`. Idempotency guard for built-in SDK injection; markup
+  already containing a real `<script src="...sharc-creative.js">` tag
+  passes through unchanged. Set `false` only when the operator needs
+  forced injection, such as versioned-SDK coexistence tests.
+
+- **`creativeSdkScriptAttrs` constructor option** ([#105]). Object,
+  default `{}`. Adds attributes to the auto-injected SDK tag.
+  Serialization follows React-style rules: `true` becomes a bare
+  attribute, `false` / `null` / `undefined` are omitted, and strings
+  are quoted and HTML-escaped. Attribute names are validated against a
+  strict HTML5 subset; invalid names are skipped with `console.warn`.
+
+- **`container.apiFramework` getter** ([#89], [#92]). Returns the
+  declared container runtime as an AdCOM `APIFramework` integer code
+  (`number | null`), resolved through the three-layer picker. The
+  property is frozen non-writable and non-configurable.
+
+- **`container.hasSharcSession` getter** ([#89], [#92]). Returns
+  `true` once the SHARC `createSession` handshake has been accepted and
+  `false` before then. This outcome-driven signal complements the
+  declaration-driven `apiFramework` accessor.
+
+- **`com.iabtechlab.sharc.creative-injector` feature flag** ([#105]).
+  Advertised in `supportedFeatures` when `creativeSdkUrl` is set, so
+  SHARC-aware creatives and operator extensions can detect
+  operator-side SDK injection and skip their own SDK-load shim.
+
+- **HTML lifecycle adapter** ([#89], [#98]). New
+  `src/lifecycle-adapters/html-adapter.js` drives the `LOADING -> ACTIVE`
+  transition for Markup-variant creatives without a SHARC handshake
+  using iframe `load` plus IntersectionObserver visibility. It also
+  routes browser lifecycle signals such as visibility, freeze, and
+  bfcache restore.
+
+- **`LOADING -> ACTIVE` state-machine edge** ([#89], [#92]). Allows
+  non-handshake creatives to become active without synthesizing a
+  misleading `READY` state. The SHARC handshake path remains unchanged.
+
+- **`SHARC_API_CODE` (9001) and `SAFEFRAME_API_CODE` (9002)
+  placeholder constants** ([#89], [#92]) exported from
+  `sharc-protocol.js`. They are pending IAB AdCOM enum registration;
+  the dual SafeFrame 1.0 and SHARC 1.0 registration path is tracked in
+  the upstream contribution roadmap.
+
+### Changed
+
+- **`sendStateChange` is now a no-op when no SHARC session exists**
+  ([#89], [#98]). Non-handshake creatives still transition locally, but
+  the container no longer posts lifecycle messages into a renderer that
+  has no session port.
+
+- **`_runMarkupInjection` now runs built-in SDK injection first**
+  ([#97], [#105]). When `creativeSdkUrl` is set, the container injects
+  the SDK before running operator-supplied extensions in registration
+  order. Extensions see markup with the SDK already present.
+
+### Migration from PR [#103] preview
+
+The closed PR [#103] preview exposed a standalone
+`SHARCCreativeInjector` extension. That class was never released. In
+0.7.2, the same capability is part of `SHARCContainer` itself.
+
+Before:
+
+```js
+import { SHARCContainer } from '@iabtechlab/sharc/sharc-container';
+import { SHARCCreativeInjector } from '@iabtechlab/sharc/sharc-creative-injector';
+
+const container = new SHARCContainer({
+  // ...
+  extensions: [
+    new SHARCCreativeInjector({
+      creativeSdkUrl: 'https://cdn.operator.example/sharc-creative.js',
+      skipIfPresent: true,
+      scriptAttrs: { async: true },
+    }),
+  ],
+});
+```
+
+After:
+
+```js
+import { SHARCContainer } from '@iabtechlab/sharc/sharc-container';
+
+const container = new SHARCContainer({
+  // ...
+  creativeSdkUrl: 'https://cdn.operator.example/sharc-creative.js',
+  creativeSdkSkipIfPresent: true,
+  creativeSdkScriptAttrs: { async: true },
+});
+```
+
+The rewrite is mechanical because the injector was folded into the
+container after the architectural redirect on [#97]. Operators should
+also remove any custom extension that injects `sharc-creative.js`
+unless it is explicitly idempotent.
+
+### Notes
+
+- Pre-1.0 releases ship breaking changes cleanly: no aliases and no
+  deprecation shims. Operators upgrading from 0.7.1 only need to act if
+  they tracked the closed PR [#103] preview branch.
+- `creativeSdkUrl` applies to the Markup variant in 0.7.2. Setting it
+  on a Creative URL container is a no-op and does not advertise the
+  injector feature; parity is tracked in [#106].
+- Operator extension idempotency is documented in the operator cookbook
+  and closes [#108]. Static-helper relocation remains tracked in [#109].
+- Internal hardening for non-string-coercible attribute values is
+  tracked in [#107]. Deferred skip-detection regex edge cases are
+  cataloged in [#104].
+
+[#89]: https://github.com/jeffreycarlson/SHARC/issues/89
+[#92]: https://github.com/jeffreycarlson/SHARC/pull/92
+[#97]: https://github.com/jeffreycarlson/SHARC/issues/97
+[#98]: https://github.com/jeffreycarlson/SHARC/pull/98
+[#103]: https://github.com/jeffreycarlson/SHARC/pull/103
+[#104]: https://github.com/jeffreycarlson/SHARC/issues/104
+[#105]: https://github.com/jeffreycarlson/SHARC/pull/105
+[#106]: https://github.com/jeffreycarlson/SHARC/issues/106
+[#107]: https://github.com/jeffreycarlson/SHARC/issues/107
+[#108]: https://github.com/jeffreycarlson/SHARC/issues/108
+[#109]: https://github.com/jeffreycarlson/SHARC/issues/109
+
 ## [0.7.1] - 2026-05-10
 
 ### Added

--- a/PR110-review.md
+++ b/PR110-review.md
@@ -1,0 +1,47 @@
+# PR #110 Review — SHARC 0.7.2 docs + cookbook + version cut
+
+**Reviewer:** code-reviewer agent (GLM 5 Turbo) via OpenClaw
+**Date:** 2026-05-18
+
+## Verdict: Conditional Pass
+
+All docs/cookbook work is complete and accurate. Two blockers must be addressed before merge.
+
+## Acceptance Criteria Audit
+
+| Criterion | Status |
+|-----------|--------|
+| ✅ CHANGELOG.md [0.7.2] section covers all shipped items | PASS |
+| ✅ README.md constructor options table has all 4 new options | PASS |
+| ✅ README.md has apiFramework and hasSharcSession accessors | PASS |
+| ✅ README.md has transition-vs-steady-state framing | PASS |
+| ✅ Cookbook has 3+ recipes with working code samples | PASS |
+| ✅ Migration breadcrumb from closed #103 is discoverable | PASS |
+| ✅ Version bumped to 0.7.2 (package.json + src/* @version) | PASS |
+| ✅ No stale 0.7.1 references in src/, README.md, CHANGELOG.md | PASS |
+| 💛 PR description needs cross-references (#106, #107, #109, closes #108) | SEE NOTES |
+
+## Findings
+
+### Medium (1)
+
+**docs/api-reference.md is stale for 0.7.2 surface**
+The README points operators to the API reference, but `docs/api-reference.md` does NOT document the new 0.7.2 additions:
+- `requireSharcInit` (constructor option)
+- `creativeSdkUrl` (constructor option)
+- `creativeSdkSkipIfPresent` (constructor option)
+- `creativeSdkScriptAttrs` (constructor option)
+- `container.apiFramework` (getter)
+- `container.hasSharcSession` (getter)
+
+This is a discoverability gap for operators who deep-dive into the API reference. Should be added in this PR or a follow-up before 0.7.2 tag.
+
+### Low
+
+**PR description is minimal** — should cross-reference the related issues (#106, #107, #109) and close #108 for traceability.
+
+## Notes
+
+- `npm run check` passes clean. ✅
+- Branch now rebased onto current main (was behind PRs #98 and #105). ✅
+- No source changes in `src/*.js` — docs-only PR as scoped. ✅

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # SHARC (Secure HTML Ad Richmedia Container)
 
-![Package status](https://img.shields.io/badge/package-v0.7.1%20(pre--publish)-informational)
+![Package status](https://img.shields.io/badge/package-v0.7.2%20(pre--publish)-informational)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/InteractiveAdvertisingBureau/SHARC/actions/workflows/ci.yml/badge.svg)](https://github.com/InteractiveAdvertisingBureau/SHARC/actions/workflows/ci.yml)
 
 Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol reference implementation.
 
 > 📋 This repository is the current SHARC reference implementation and working specification set.
-> It is in active pre-1.0 development at package version `0.7.1` and is not yet published to npm.
+> It is in active pre-1.0 development at package version `0.7.2` and is not yet published to npm.
 > Start with the curated docs index at [docs/README.md](docs/README.md) and the current state summary at [docs/current-status.md](docs/current-status.md).
 
 ## Overview
@@ -17,6 +17,14 @@ SHARC is a secure container API for managed communication between a publisher-co
 **Goal:** _Write one ad; serve it across supported SHARC environments._
 
 The current v1 reference implementation targets web iframes, iOS WKWebView, and Android WebView. Future scope such as CTV is discussed in design material, but is not part of the current supported implementation surface.
+
+## Transition vs. Steady State
+
+In the steady state, SHARC creatives handshake directly with the container via `createSession`. The container observes the full SHARC lifecycle, installs bridges, and audits navigation through the protocol.
+
+In the transition state, operators have inventory that does not yet speak SHARC: legacy plain HTML, MRAID, and SafeFrame adm from mixed supply. SHARC 0.7.2 ships two operator-side options for that path: `requireSharcInit: false` lets the container accept non-SHARC creatives without fatal-erroring, and `creativeSdkUrl` lets the container auto-inject the SHARC creative-side SDK so legacy adm becomes SHARC-compatible at load time.
+
+See the [operator cookbook](docs/operator-cookbook.md) for concrete integration recipes.
 
 ## Try It
 
@@ -70,6 +78,47 @@ Browser globals:
 - `window.SHARC.Container` — container constructor
 - `window.SHARC` — creative API surface (`onReady`, `onStart`, `requestNavigation`, etc.)
 
+## Container Constructor Options
+
+Selected options most relevant to operators are listed here. The full API surface, including sandbox, renderer-protocol, and callback options, is documented in [docs/api-reference.md](docs/api-reference.md).
+
+### Creative Source
+
+Exactly one creative source is required.
+
+| Option | Type | Default | Purpose |
+|---|---|---|---|
+| `creativeUrl` | string | `undefined` | URL of a SHARC-aware creative HTML page. |
+| `creativeHtml` | string | `undefined` | Inline Markup-variant creative HTML, commonly OpenRTB `bid.adm`. Requires `creativeRendererUrl`. |
+| `creativeRendererUrl` | string | `undefined` | HTTPS URL of an operator-hosted renderer page. Required when `creativeHtml` is set. |
+
+### Transition-State Options
+
+| Option | Type | Default | Purpose |
+|---|---|---|---|
+| `requireSharcInit` | boolean | `true` | When `false`, skips the `createSession` fatal-timeout so non-SHARC creatives load to a stable container instance. Useful for mixed inventory, validator tooling, and generic HTML banners. |
+| `creativeSdkUrl` | string | `undefined` | URL of the operator-hosted `sharc-creative.js` bundle. When set on a Markup-variant container, the container auto-injects a `<script src="...">` tag into the creative HTML at load time, lifting legacy adm into SHARC without per-creative changes. |
+| `creativeSdkSkipIfPresent` | boolean | `true` | Idempotency guard for `creativeSdkUrl`; when `true`, markup already containing a real `<script src="...sharc-creative.js">` tag is left alone. |
+| `creativeSdkScriptAttrs` | object | `{}` | Additional `<script>` attributes for the auto-injected tag, for example `{ integrity: 'sha384-...' }` or `{ nonce: 'abc' }`. Default `{}` emits a bare parser-blocking synchronous tag, the only attribute set that prevents the inline-`mraid.*` race condition. |
+
+### Bridge Detection
+
+| Option | Type | Default | Purpose |
+|---|---|---|---|
+| `bridges` | `string[]` | auto-detected | Explicit override for compatibility bridges. Reserved identifiers are `'mraid'` and `'safeframe'`. Pass `[]` to suppress all bridge loading. |
+| `creativeMeta` | object | `undefined` | Forward-compatible metadata bag. `creativeMeta.apis` accepts AdCOM `APIFramework` integer codes from bid metadata and drives bridge selection plus `container.apiFramework`. |
+
+### Observability Accessors
+
+Frozen instance properties are available for callbacks, dashboards, and validator tooling.
+
+| Accessor | Type | Description |
+|---|---|---|
+| `container.apiFramework` | `number \| null` | AdCOM `APIFramework` integer code for the declared container runtime, resolved at construction through the three-layer picker. `null` means no recognized runtime declaration. Added in 0.7.2. |
+| `container.hasSharcSession` | boolean | `true` once the SHARC `createSession` handshake has been accepted; `false` until then. Added in 0.7.2. |
+| `container.bridges` | `ReadonlyArray<string>` | Compatibility bridges selected for this load. Empty when none are selected or when bridge loading is suppressed. Added in 0.7.1. |
+| `container.placementSessionId` | string | UUID v4 generated at construction for placement correlation, DOM stamping, and diagnostics. |
+
 ## Distribution and URL Guidance
 
 SHARC is packaged as one npm package with versioned subpath exports:
@@ -83,9 +132,9 @@ All public entry points build into `dist/` as ESM (`.mjs`) plus browser/IIFE bun
 
 After the package is published, public CDN URL patterns should mirror the current `dist/` filenames:
 
-- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.1/dist/sharc-container.js`
-- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.1/dist/sharc-creative.js`
-- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.1/dist/sharc-protocol.js`
+- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.2/dist/sharc-container.js`
+- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.2/dist/sharc-creative.js`
+- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.2/dist/sharc-protocol.js`
 
 Versioning guidance:
 
@@ -102,6 +151,8 @@ Start with the curated index, then dive into specifics:
 - **[Docs index](docs/README.md)** — curated guide to authoritative, maintainer, and archive material
 - **[Current status](docs/current-status.md)** — what's stable, what's pre-publish, current package version
 - **[API reference](docs/api-reference.md)** — detailed protocol and public API reference
+- **[Operator cookbook](docs/operator-cookbook.md)** — recipes for legacy adm lift, mixed-inventory containers, and SDK-injection composition
+- **[Creative cookbook](docs/creative-cookbook.md)** — creative-side SHARC authoring patterns
 
 The [docs index](docs/README.md) lists everything else (architecture overview, bridge designs, change log, reviews, proposals).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ These are the best starting points for external readers and implementers:
 - [api-reference.md](./api-reference.md)
 - [architecture-design.md](./architecture-design.md)
 - [distribution-design.md](./distribution-design.md)
+- [operator-cookbook.md](./operator-cookbook.md) — practical operator integration patterns
 - [creative-cookbook.md](./creative-cookbook.md) — practical creative implementation patterns
 - [design/mraid-bridge-design.md](./design/mraid-bridge-design.md)
 - [design/safeframe-bridge-design.md](./design/safeframe-bridge-design.md)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,8 +1,8 @@
 # SHARC API Reference
 
-**Version:** 1.1 (Reference Implementation, current through package v0.7.0)  
-**Status:** Authoritative for v1 implementation  
-**Last Updated:** 2026-05-02  
+**Version:** 1.1 (Reference Implementation, current through package v0.7.2)
+**Status:** Authoritative for v1 implementation
+**Last Updated:** 2026-05-18
 
 This document is the definitive developer-facing reference for the SHARC protocol. It reflects all decisions approved by Jeffrey Carlson, including the MessageChannel transport, Page Lifecycle state machine, Structured Clone serialization, and the Enhanced Placement Change System (v0.4.0).
 
@@ -46,6 +46,7 @@ new SHARCContainer(options)
 | `extensions` | `Object[]` | No | Extension plugin instances (e.g. `OmidCompatBridge`, `MRAIDCompatBridge`). Default: `[]`. |
 | `supportedFeatures` | `Array<string\|{name,version?}>` | No | Explicit feature descriptors. Extensions contribute their feature names automatically. Default: `[]`. |
 | `placementPolicy` | `Object` | No | Constrains creative-driven placement requests. When omitted, placement requests bypass policy validation. See [requestPlacementChange](#sharccreativersequestplacementchange). |
+| `requireSharcInit` | `boolean` | No | When `false`, skips the `createSession` fatal-timeout so non-SHARC creatives load to a stable container instance. Useful for mixed inventory, validator tooling, and generic HTML banners. Default: `true`. Added in 0.7.2. |
 | `timeouts` | `Object` | No | Override default timeout values. Markup variant adds `rendererLoad` (default 5000ms) and `rendererReply` (default 2000ms). |
 | `onStateChange` | `Function` | No | Called with `(newState, previousState)` on every state transition. |
 | `onClose` | `Function` | No | Called when the container has fully closed. |
@@ -61,7 +62,10 @@ new SHARCContainer(options)
 | `allowModals` | `boolean` | No | When `true`, the Markup renderer iframe sandbox includes `allow-modals`. Default `false`. Added in 0.7.0. |
 | `allowDownloads` | `boolean` | No | When `true`, the Markup renderer iframe sandbox includes `allow-downloads`. Default `false`. Added in 0.7.0. |
 | `bridges` | `string[] \| null` | No | Creative Markup variant only. Explicit list of compatibility-bridge identifiers the renderer should load alongside the creative HTML. Reserved identifiers in 0.7.1: `'mraid'`, `'safeframe'`. Pass `[]` to suppress all bridge loading (static-image creative). Pass `null` (or omit) for auto-detection via `creativeMeta.apis` → adm content scan. Unknown identifiers throw at construction (stricter than renderer-side handling). Resolved value is reflected on `container.bridges` and on the `bridges` field of the `SHARC:Renderer:render` message. Added in 0.7.1. See [Bridges field](#bridges-and-creativemeta-0-7-1). |
-| `creativeMeta` | `{ apis?: number[] }` | No | Creative Markup variant only. Bid-side metadata bag. `creativeMeta.apis` is the array of AdCOM `APIFramework` integer codes from the bid response (OpenRTB 2.6's `bid.apis` references AdCOM enums directly). Recognized in 0.7.1: `3` / `5` / `6` (MRAID 1.0 / 2.0 / 3.0) → `'mraid'`. Code `7` (OMID 1.0) is deferred to 0.7.2. Vendor-specific codes (500+) are ignored. Forward-compatible — future bid-side fields land in this same object. Added in 0.7.1. See [Bridges field](#bridges-and-creativemeta-0-7-1). |
+| `creativeMeta` | `{ apis?: number[] }` | No | Creative Markup variant only. Bid-side metadata bag. `creativeMeta.apis` is the array of AdCOM `APIFramework` integer codes from the bid response (OpenRTB 2.6's `bid.apis` references AdCOM enums directly). Drives bridge selection plus `container.apiFramework`. Recognized for bridge loading in 0.7.2: `3` / `5` / `6` (MRAID 1.0 / 2.0 / 3.0) → `'mraid'`; `SAFEFRAME_API_CODE` → `'safeframe'`. `SHARC_API_CODE` resolves `container.apiFramework` but does not load a bridge. Code `7` (OMID 1.0) and vendor-specific codes (500+) are ignored by the container-runtime picker. Forward-compatible — future bid-side fields land in this same object. Added in 0.7.1. See [Bridges field](#bridges-and-creativemeta-0-7-1). |
+| `creativeSdkUrl` | `string` | No | URL of the operator-hosted `sharc-creative.js` bundle. Creative Markup variant only in 0.7.2. Auto-injects a `<script src>` tag into creative HTML at load time. Default: `undefined`. Added in 0.7.2. |
+| `creativeSdkSkipIfPresent` | `boolean` | No | Idempotency guard for `creativeSdkUrl`. When `true`, markup already containing a real `<script src="...sharc-creative.js">` tag is left alone. Default: `true`. Added in 0.7.2. |
+| `creativeSdkScriptAttrs` | `Object` | No | Additional `<script>` attributes for the auto-injected tag (e.g. `{ integrity: "sha384-..." }`, `{ nonce: "abc" }`). Default `{}` emits a bare parser-blocking synchronous tag. Added in 0.7.2. |
 | `autoStart` | `boolean` | No | If `true`, calls `startCreative` automatically after `init` resolves. Default: `true`. |
 | `visible` | `boolean` | No | Initial iframe visibility. Set to `false` to preload silently. Default: `false`. |
 | `useMarkupInjection` | `boolean` | No | Opt-in (Creative URL only): fetch the creative HTML, pipe it through extension injectors, and load via `srcdoc`. Default: `false`. Markup variant ALWAYS runs registered injectors (independent of this flag). |
@@ -75,6 +79,7 @@ After construction, the following properties are readable on any `SHARCContainer
 |----------|------|-------------|
 | `placementSessionId` | `string` | UUID v4 generated at construction time. Unique per `SHARCContainer` instance. Used for DOM stamping and diagnostics. Never `null`. |
 | `sessionId` | `string\|null` | The creative's session ID. Set during the `createSession` handshake. `null` before the handshake completes. |
+| `hasSharcSession` | `boolean` | `true` once the SHARC `createSession` handshake has been accepted; `false` until then. Added in 0.7.2. |
 | `placementId` | `string\|null` | As passed to the constructor, normalized: `''` is stored as `null`. |
 | `placementName` | `string\|null` | As passed to the constructor, normalized: `''` is stored as `null`. |
 | `creativeUrl` | `string\|null` | The creative URL as provided at construction. `null` when constructed via the Creative Markup variant. |
@@ -83,6 +88,7 @@ After construction, the following properties are readable on any `SHARCContainer
 | `creativeRendered` | `boolean` | `true` once the renderer's envelope-validated `:rendered` arrives (Markup variant). `false` for Creative URL (no renderer protocol step). Added in 0.7.0. |
 | `creativeInjected` | `boolean` | `true` once any registered extension's `injectIntoMarkup(html)` ran AND modified the markup. Independent of variant. |
 | `bridges` | `ReadonlyArray<string>` | Frozen array of compatibility-bridge identifiers the renderer will load. Resolved at construction via the three-layer detection pipeline (explicit `bridges` option → `creativeMeta.apis` AdCOM codes → adm content scan). Always `[]` in Creative URL variant. Added in 0.7.1. |
+| `apiFramework` | `number\|null` | AdCOM `APIFramework` integer code for the declared container runtime, resolved at construction via the three-layer picker. `null` means no recognized runtime. Added in 0.7.2. |
 | `placementElement` | `HTMLElement` | The DOM element passed at construction. |
 
 ### DOM Stamping

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -4,7 +4,7 @@
 
 SHARC is an IAB Tech Lab reference implementation in active **pre-1.0** development.
 
-- Repository package version: `0.7.0`
+- Repository package version: `0.7.2`
 - npm publication status: **not yet published**
 - Current implementation scope: **web iframe**, **iOS WKWebView**, **Android WebView**
 - Current repo posture: suitable for technical evaluation and standards review; not yet presented here as a broadly adopted production release line
@@ -20,7 +20,7 @@ The following are the most reliable descriptions of the present implementation:
 - [proposals/creative-sources.md](./proposals/creative-sources.md) — design rationale, threat model, and decision log for the 0.7.0 Creative Sources work
 - bridge design docs under [`docs/design/`](./design)
 - the current source and generated `dist/` artifacts
-- [CHANGELOG.md](../CHANGELOG.md) — what shipped in `0.7.0` and earlier
+- [CHANGELOG.md](../CHANGELOG.md) — what shipped in `0.7.2` and earlier
 
 As of `0.6.0`, every public package subpath ships generated TypeScript declaration files (`.d.ts`) alongside its `.mjs` bundle. TypeScript consumers get full IntelliSense and compile-time argument validation when importing any subpath. 0.7.0 expands the typedef surface to cover the Creative Markup variant — `creativeUrl` is optional, `creativeHtml` / `creativeRendererUrl` / `onSecurityEvent` are added, and `SHARCSecurityEvent` is a discriminated union over five reserved variants.
 

--- a/docs/operator-cookbook.md
+++ b/docs/operator-cookbook.md
@@ -1,0 +1,212 @@
+# SHARC Operator Cookbook
+
+**Audience:** Ad-tech engineers integrating `SHARCContainer` in DSPs, SSPs,
+ad servers, publisher SDKs, and validator tooling.
+
+This cookbook focuses on operator-side integration patterns introduced in
+0.7.2. Creative-side authoring patterns live in
+[creative-cookbook.md](./creative-cookbook.md), and the full API surface is in
+[api-reference.md](./api-reference.md).
+
+---
+
+## Table of Contents
+
+1. [Lift Legacy OpenRTB adm into SHARC](#1-lift-legacy-openrtb-adm-into-sharc)
+2. [Render Non-SHARC Creatives in a SHARC Container](#2-render-non-sharc-creatives-in-a-sharc-container)
+3. [Combine SDK Injection with Operator Extensions](#3-combine-sdk-injection-with-operator-extensions)
+4. [Migration from the PR #103 Preview Injector](#4-migration-from-the-pr-103-preview-injector)
+
+---
+
+## 1. Lift Legacy OpenRTB adm into SHARC
+
+Use `creativeSdkUrl` when the operator receives plain HTML, MRAID, or
+SafeFrame adm from a third-party DSP and wants to lift it into SHARC at load
+time.
+
+```javascript
+// Operator receives bid.adm from a third-party DSP. The adm is plain
+// HTML / MRAID / SafeFrame, not necessarily SHARC-aware. The operator hosts
+// sharc-creative.js and lets the container inject it at render time.
+
+import { SHARCContainer } from '@iabtechlab/sharc/sharc-container';
+
+const container = new SHARCContainer({
+  creativeHtml: bid.adm,
+  creativeRendererUrl: 'https://renderer.operator.example/r/',
+  placementElement: document.getElementById('ad-slot'),
+  creativeSdkUrl: 'https://cdn.operator.example/sharc-creative.js',
+  bridges: ['mraid'], // or let the container detect from bid metadata / adm
+});
+
+container.load();
+```
+
+The container injects a real parser-visible script tag into the Markup variant
+before the renderer writes the creative. Injection uses a four-position anchor
+contract: after `<head>`, otherwise after `<html>`, otherwise after
+`<!DOCTYPE>`, otherwise prepended to the markup. The script is never inserted
+before the doctype, which avoids forcing standards-mode markup into quirks
+mode.
+
+`creativeSdkSkipIfPresent` defaults to `true`. When the markup already includes
+a real `<script src="...sharc-creative.js">` tag, the container leaves it
+unchanged. Set it to `false` only for deliberate forced-injection cases, such
+as versioned-SDK coexistence tests or controlled debug overlays.
+
+The default `creativeSdkScriptAttrs: {}` emits a bare synchronous script tag.
+That parser-blocking default is intentional for legacy MRAID: inline creative
+code can call `mraid.*` immediately after the SDK and bridge load, so adding
+`async`, `defer`, or a module type can reintroduce an inline-call race.
+
+When `creativeSdkUrl` is active, the container advertises
+`com.iabtechlab.sharc.creative-injector` in `supportedFeatures`. SHARC-aware
+creatives can read the feature list and skip their own SDK-load shim.
+
+Creative URL variant note: `creativeSdkUrl` is Markup-variant-only in 0.7.2.
+Setting it on a Creative URL container does not inject the SDK and does not
+advertise the feature flag. URL-variant parity is tracked in
+[issue #106](https://github.com/jeffreycarlson/SHARC/issues/106).
+
+Known limit: if your inventory contains malformed HTML with embedded quotes,
+entity-encoded URLs, or pathologically long repeated `<script` tokens, the
+built-in `skipIfPresent` detector can behave imperfectly. The catalog is in
+[issue #104](https://github.com/jeffreycarlson/SHARC/issues/104).
+
+## 2. Render Non-SHARC Creatives in a SHARC Container
+
+Use `requireSharcInit: false` for mixed inventory pipelines and validators
+that need the container's lifecycle, observability, and security boundaries
+even when the creative never handshakes.
+
+```javascript
+// Operator wants container lifecycle and observability for a creative that
+// does not speak SHARC. The missing handshake should not be fatal.
+
+const container = new SHARCContainer({
+  creativeHtml: legacyHtmlBanner,
+  creativeRendererUrl: 'https://renderer.operator.example/r/',
+  placementElement: document.getElementById('ad-slot'),
+  requireSharcInit: false,
+});
+
+container.load();
+
+// No handshake will arrive for plain HTML:
+// container.hasSharcSession === false
+// container.apiFramework === null when no recognized runtime is declared
+```
+
+`container.apiFramework` is declaration-driven and available immediately after
+construction. It reflects the runtime declaration resolved from explicit
+options, `creativeMeta.apis`, or adm scanning. `container.hasSharcSession` is
+outcome-driven and should be read from `onStateChange`, `onError`, or after an
+operator-owned lifecycle observation window.
+
+```javascript
+const declaredFramework = container.apiFramework;
+
+const containerWithCallbacks = new SHARCContainer({
+  creativeHtml: legacyHtmlBanner,
+  creativeRendererUrl: rendererUrl,
+  placementElement: slot,
+  requireSharcInit: false,
+  onStateChange(state) {
+    if (state === 'active') {
+      reportInventoryShape({
+        declaredFramework,
+        hasSharcSession: containerWithCallbacks.hasSharcSession,
+      });
+    }
+  },
+});
+```
+
+If a creative declared as non-SHARC still completes a SHARC handshake while
+`requireSharcInit: false` is set, the container accepts the handshake but logs
+a confused-deputy warning. Treat that as a declaration mismatch signal: the
+creative behavior and bid metadata disagree.
+
+Do not use `requireSharcInit: false` for pipelines where every creative is
+expected to be SHARC-aware. Leave the default `true` so a missing handshake
+remains a loud integration error.
+
+## 3. Combine SDK Injection with Operator Extensions
+
+Use this pattern when the operator needs the built-in SHARC SDK injection plus
+custom markup transforms such as analytics tags, CSP nonce stamping, or
+operator diagnostics.
+
+```javascript
+// Operator uses creativeSdkUrl for SDK injection and a custom extension for
+// analytics injection.
+
+const container = new SHARCContainer({
+  creativeHtml: bid.adm,
+  creativeRendererUrl: rendererUrl,
+  placementElement: slot,
+  creativeSdkUrl: 'https://cdn.operator.example/sharc-creative.js',
+  extensions: [
+    new OperatorAnalyticsExtension({ pixelUrl: analyticsPixelUrl }),
+  ],
+});
+```
+
+Execution order is fixed: built-in SDK injection runs first, then operator
+extensions run in registration order. Extensions see markup with the SDK
+already present.
+
+Idempotency responsibility is split by owner. The built-in
+`creativeSdkSkipIfPresent` guard prevents the container from injecting its own
+SDK tag twice. Operator extensions that also inject `sharc-creative.js` are
+responsible for their own deduplication. The recommended pattern is for the
+extension to read `supportedFeatures` and skip SDK injection when
+`com.iabtechlab.sharc.creative-injector` is present. This cookbook note closes
+[issue #108](https://github.com/jeffreycarlson/SHARC/issues/108).
+
+The common mistake is wiring both `creativeSdkUrl` and a custom
+`SHARCCreativeInjector`-style extension. That creates two SDK loads and two
+`SHARCCreativeProtocol` instances racing in the same iframe.
+
+## 4. Migration from the PR #103 Preview Injector
+
+The standalone `SHARCCreativeInjector` extension from the closed PR
+[#103](https://github.com/jeffreycarlson/SHARC/pull/103) was never released.
+The 0.7.2 API folds that capability into `SHARCContainer`.
+
+Before:
+
+```javascript
+import { SHARCContainer } from '@iabtechlab/sharc/sharc-container';
+import { SHARCCreativeInjector } from '@iabtechlab/sharc/sharc-creative-injector';
+
+const container = new SHARCContainer({
+  // ...
+  extensions: [
+    new SHARCCreativeInjector({
+      creativeSdkUrl: 'https://cdn.operator.example/sharc-creative.js',
+      skipIfPresent: true,
+      scriptAttrs: { async: true },
+    }),
+  ],
+});
+```
+
+After:
+
+```javascript
+import { SHARCContainer } from '@iabtechlab/sharc/sharc-container';
+
+const container = new SHARCContainer({
+  // ...
+  creativeSdkUrl: 'https://cdn.operator.example/sharc-creative.js',
+  creativeSdkSkipIfPresent: true,
+  creativeSdkScriptAttrs: { async: true },
+});
+```
+
+Remove any import from `@iabtechlab/sharc/sharc-creative-injector`; that subpath
+does not exist in 0.7.2. If the preview extension also carried unrelated
+operator behavior, keep that behavior in a separate extension and make it
+idempotent against `com.iabtechlab.sharc.creative-injector`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iabtechlab/sharc",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol",
   "type": "module",
   "files": [

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -26,7 +26,7 @@
  * container.load();
  * ```
  *
- * @version 0.7.1
+ * @version 0.7.2
  */
 
 'use strict';

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -34,7 +34,7 @@
  * </script>
  * ```
  *
- * @version 0.7.1
+ * @version 0.7.2
  */
 
 'use strict';

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -14,7 +14,7 @@
  *   3. sharc-mraid-bridge.js → window.mraid (this file)
  *   4. <MRAID creative>
  *
- * @version 0.7.1
+ * @version 0.7.2
  * @see mraid-bridge-design.md
  */
 

--- a/src/sharc-navigation-bridge.js
+++ b/src/sharc-navigation-bridge.js
@@ -78,7 +78,7 @@
  *
  * Spec: docs/proposals/creative-sources.md § Click-through enforcement.
  *
- * @version 0.7.1
+ * @version 0.7.2
  */
 
 'use strict';

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -28,7 +28,7 @@
  *   - creativeType and impressionType MUST be set before impressionOccurred()
  *   - AdSession must be started before any events are fired
  *
- * @version 0.7.1
+ * @version 0.7.2
  * @see https://iabtechlab.com/standards/open-measurement-sdk/
  * @see https://github.com/IABTechLab/SHARC
  */

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -13,7 +13,7 @@
  *
  * Both extend SHARCProtocolBase which provides the shared message bus.
  *
- * @version 0.7.1
+ * @version 0.7.2
  * @see https://github.com/IABTechLab/SHARC
  */
 
@@ -27,7 +27,7 @@
 // ---------------------------------------------------------------------------
 
 /** Current SHARC spec version this implementation conforms to. */
-const SHARC_VERSION = '0.7.1';
+const SHARC_VERSION = '0.7.2';
 
 /**
  * Placeholder AdCOM `APIFramework` integer code for SHARC.

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -19,7 +19,7 @@
  *   - exp-push (push expand) — deferred to v2; fires 'failed' callback
  *   - $sf.ext.cookie() — permanently excluded; fires 'failed' callback
  *
- * @version 0.7.1
+ * @version 0.7.2
  * @see safeframe-bridge-design.md
  */
 


### PR DESCRIPTION
PR #3 of the 0.7.2 first-half release. Documentation, operator cookbook, version bump, and migration breadcrumb.

Closes #89 and #97.
Closes #108 (cookbook idempotency documentation).

Cross-references:
- #106 — URL-variant SDK injection parity (follow-up)
- #107 — Hardening for non-string-coercible attribute values
- #109 — Static-helper relocation

Acceptance criteria verified against PR #3 bootstrap spec:
- ✅ CHANGELOG.md [0.7.2] section covers all shipped items
- ✅ README constructor options table (requireSharcInit, creativeSdkUrl, creativeSdkSkipIfPresent, creativeSdkScriptAttrs)
- ✅ README accessors (apiFramework, hasSharcSession)
- ✅ README transition-vs-steady-state framing
- ✅ Cookbook recipes (3) with working code samples
- ✅ Migration breadcrumb from closed #103
- ✅ Version bumped to 0.7.2 (package.json + src/\* @version JSDoc)
- ✅ docs/api-reference.md updated with 0.7.2 surface
- ✅ No stale 0.7.1 references
- ✅ npm run check passes clean