### PR TITLE
docs: address lint/cleanup findings from 0.7.2 audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1455,7 +1455,10 @@ messages are sent at additional transition points; no new message types.
 - `supportedFeatures` extension mechanism
 
 <!-- Version compare links (Update when new tags are pushed) -->
-[Unreleased]: https://github.com/InteractiveAdvertisingBureau/SHARC/compare/v0.6.2...main
+[Unreleased]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.2...main
+[0.7.2]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.1...v0.7.2
+[0.7.1]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/jeffreycarlson/SHARC/compare/v0.6.2...v0.7.0
 [0.6.2]: https://github.com/InteractiveAdvertisingBureau/SHARC/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/InteractiveAdvertisingBureau/SHARC/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/InteractiveAdvertisingBureau/SHARC/compare/v0.5.4...v0.6.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Package status](https://img.shields.io/badge/package-v0.7.2%20(pre--publish)-informational)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![CI](https://github.com/InteractiveAdvertisingBureau/SHARC/actions/workflows/ci.yml/badge.svg)](https://github.com/InteractiveAdvertisingBureau/SHARC/actions/workflows/ci.yml)
+[![CI](https://github.com/jeffreycarlson/SHARC/actions/workflows/ci.yml/badge.svg)](https://github.com/jeffreycarlson/SHARC/actions/workflows/ci.yml)
 
 Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol reference implementation.
 
@@ -22,7 +22,7 @@ The current v1 reference implementation targets web iframes, iOS WKWebView, and 
 
 In the steady state, SHARC creatives handshake directly with the container via `createSession`. The container observes the full SHARC lifecycle, installs bridges, and audits navigation through the protocol.
 
-In the transition state, operators have inventory that does not yet speak SHARC: legacy plain HTML, MRAID, and SafeFrame adm from mixed supply. SHARC 0.7.2 ships two operator-side options for that path: `requireSharcInit: false` lets the container accept non-SHARC creatives without fatal-erroring, and `creativeSdkUrl` lets the container auto-inject the SHARC creative-side SDK so legacy adm becomes SHARC-compatible at load time.
+In the transition state, operators have inventory that does not yet speak SHARC: legacy plain HTML, MRAID, and SafeFrame adm from mixed supply. SHARC 0.7.2 ships the current legacy-adm path through `SHARCContainer`: set `requireSharcInit: false` to keep non-SHARC creatives from fatal-erroring on the missing `createSession` handshake, and set `creativeSdkUrl` on Markup-variant loads to auto-inject the SHARC creative-side SDK so legacy adm becomes SHARC-compatible at load time.
 
 See the [operator cookbook](docs/operator-cookbook.md) for concrete integration recipes.
 
@@ -126,6 +126,7 @@ SHARC is packaged as one npm package with versioned subpath exports:
 - Container: `@iabtechlab/sharc/sharc-container`
 - Creative: `@iabtechlab/sharc/sharc-creative`
 - Protocol: `@iabtechlab/sharc/sharc-protocol`
+- Navigation bridge: `@iabtechlab/sharc/sharc-navigation-bridge`
 - Bridges: `@iabtechlab/sharc/sharc-mraid-bridge`, `@iabtechlab/sharc/sharc-safeframe-bridge`, `@iabtechlab/sharc/sharc-omid-bridge`
 
 All public entry points build into `dist/` as ESM (`.mjs`) plus browser/IIFE bundles (`.js`).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # SHARC API Reference
 
-**Version:** 1.1 (Reference Implementation, current through package v0.7.2)
+**Document revision:** 1.1 (Reference Implementation, current through package v0.7.2)
 **Status:** Authoritative for v1 implementation
 **Last Updated:** 2026-05-18
 
@@ -45,7 +45,7 @@ new SHARCContainer(options)
 | `placementName` | `string\|null` | No | Human-readable placement name. Same null normalization as `placementId`. |
 | `extensions` | `Object[]` | No | Extension plugin instances (e.g. `OmidCompatBridge`, `MRAIDCompatBridge`). Default: `[]`. |
 | `supportedFeatures` | `Array<string\|{name,version?}>` | No | Explicit feature descriptors. Extensions contribute their feature names automatically. Default: `[]`. |
-| `placementPolicy` | `Object` | No | Constrains creative-driven placement requests. When omitted, placement requests bypass policy validation. See [requestPlacementChange](#sharccreativersequestplacementchange). |
+| `placementPolicy` | `Object` | No | Constrains creative-driven placement requests. When omitted, placement requests bypass policy validation. See [requestPlacementChange](#sharccreativerequestplacementchange). |
 | `requireSharcInit` | `boolean` | No | When `false`, skips the `createSession` fatal-timeout so non-SHARC creatives load to a stable container instance. Useful for mixed inventory, validator tooling, and generic HTML banners. Default: `true`. Added in 0.7.2. |
 | `timeouts` | `Object` | No | Override default timeout values. Markup variant adds `rendererLoad` (default 5000ms) and `rendererReply` (default 2000ms). |
 | `onStateChange` | `Function` | No | Called with `(newState, previousState)` on every state transition. |
@@ -103,7 +103,7 @@ On `load()`, `SHARCContainer` stamps `data-sharc-*` attributes onto the placemen
 | `data-sharc-placement-session-id` | Yes | Value is `placementSessionId`. Unique per instance. |
 | `data-sharc-placement-id` | Only when `placementId` is non-null | Publisher-supplied placement identifier. |
 | `data-sharc-placement-name` | Only when `placementName` is non-null | Human-readable placement name. |
-| `data-sharc-version` | Yes | SHARC version string (e.g. `"0.7.0"`). |
+| `data-sharc-version` | Yes | SHARC version string (e.g. `"0.7.2"`). |
 | `data-sharc-state` | Yes | Live-reflected container state (e.g. `"active"`). Updates on every state transition. |
 | `data-sharc-intent` | Only when an intent is active | Live-reflected active intent: `"resize"`, `"expand"`, or `"fullscreen"`. Absent after `collapse` or when no intent is active. |
 
@@ -810,7 +810,7 @@ interface CreateSessionArgs {
 ```
 
 - `placementType` — the creative's self-declared placement type. `"inline"` (default) means the ad is anchored in page content. `"interstitial"` means the ad overlays content. Omitting the field is equivalent to `"inline"`.
-- `version` — the SHARC spec version the creative SDK conforms to (e.g. `"0.7.0"`). Used by the container for version compatibility checks.
+- `version` — the SHARC spec version the creative SDK conforms to (e.g. `"0.7.2"`). Used by the container for version compatibility checks.
 
 The creative generates a unique `sessionId` (UUID) and includes it in this message. All subsequent messages in the session use this same `sessionId`.
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -22,7 +22,19 @@ The following are the most reliable descriptions of the present implementation:
 - the current source and generated `dist/` artifacts
 - [CHANGELOG.md](../CHANGELOG.md) — what shipped in `0.7.2` and earlier
 
-As of `0.6.0`, every public package subpath ships generated TypeScript declaration files (`.d.ts`) alongside its `.mjs` bundle. TypeScript consumers get full IntelliSense and compile-time argument validation when importing any subpath. 0.7.0 expands the typedef surface to cover the Creative Markup variant — `creativeUrl` is optional, `creativeHtml` / `creativeRendererUrl` / `onSecurityEvent` are added, and `SHARCSecurityEvent` is a discriminated union over five reserved variants.
+As of `0.6.0`, every public package subpath ships generated TypeScript declaration files (`.d.ts`) alongside its `.mjs` bundle. TypeScript consumers get full IntelliSense and compile-time argument validation when importing any subpath. 0.7.0 expands the typedef surface to cover the Creative Markup variant — `creativeUrl` is optional, `creativeHtml` / `creativeRendererUrl` / `onSecurityEvent` are added, and `SHARCSecurityEvent` is a discriminated union that now covers six reserved variants after 0.7.1 added `bridge_load_failed`.
+
+## What Shipped in 0.7.2
+
+0.7.2 closes the first transition-state path for operators loading mixed inventory. `requireSharcInit: false` lets a container load non-SHARC creatives without fatal-erroring on the missing `createSession` handshake, while keeping the default SHARC-aware path strict. `creativeSdkUrl` lets operators auto-inject the creative-side SDK into Markup-variant adm so legacy plain HTML, MRAID, and SafeFrame markup can be lifted toward SHARC without per-creative edits.
+
+0.7.2 also adds the declaration/outcome diagnostics operators need while evaluating that path: `container.apiFramework` reports the declared AdCOM `APIFramework` runtime resolved at construction, and `container.hasSharcSession` reports whether the SHARC handshake actually completed.
+
+## What Shipped in 0.7.1
+
+0.7.1 adds container-driven compatibility bridge loading for the Creative Markup variant. `bridges` provides an explicit override, `creativeMeta.apis` lets the container select MRAID or SafeFrame bridges from bid metadata, and `container.bridges` exposes the resolved bridge list for dashboards and diagnostics.
+
+The renderer imports requested bridges before writing creative HTML and reports bridge import failures through the structured `bridge_load_failed` security-event variant. That brings `SHARCSecurityEvent` to six reserved `type` values.
 
 ## What Shipped in 0.7.0
 
@@ -95,7 +107,7 @@ The guard runs after rule 7 (cross-origin) succeeds, so it only fires when the U
 
 ### Structured `onSecurityEvent` callback
 
-Production observability hook fired with a `SHARCSecurityEvent` discriminated-union payload. Five reserved `type` values:
+Production observability hook fired with a `SHARCSecurityEvent` discriminated-union payload. Six reserved `type` values:
 
 | `type` | `severity` | `errorCode` | When |
 |---|---|---|---|
@@ -103,6 +115,7 @@ Production observability hook fired with a `SHARCSecurityEvent` discriminated-un
 | `renderer_origin_mismatch` | `'error'` | `2116` | Post-load origin echo found a redirect-chain origin |
 | `renderer_protocol_error` | `'error'` | `2114` \| `2117` \| `2119` | Timeout, malformed payload, or postMessage threw — `details.subtype` discriminates |
 | `renderer_failed` | `'error'` | `2115` | Renderer sent `SHARC:Renderer:failed` |
+| `bridge_load_failed` | `'error'` | `2115` | Renderer failed to dynamically import a requested compatibility bridge; payload includes the failed `bridge` identifier |
 | `unauthorized_navigation` | `'error'` | `2118` | Load-event backstop fired (`details.variant: 'markup' \| 'url'`) |
 
 Callbacks are synchronous; throws are caught and logged. For terminating events, `onSecurityEvent` fires BEFORE `onError` — operators that hook both rely on the sequence. Console output continues regardless of whether the callback is provided. Console-log prefix format now includes a `[<placementSessionId>]` segment (`[SHARCContainer] [<placementSessionId>] [<internalType>] <message>`); operators with log-grep regexes / dashboard parsers must update for the new format.

--- a/docs/design/0.7.2-NEXT-SESSION-PROMPT.md
+++ b/docs/design/0.7.2-NEXT-SESSION-PROMPT.md
@@ -1,3 +1,5 @@
+> **Historical artifact:** This session-handoff prompt is preserved for audit context only. It is not current implementation guidance for 0.7.2.
+
 # Next-session bootstrap prompt for SHARC 0.7.2 Stage 3
 
 **Copy/paste the prompt below into a fresh Claude Code session to pick up Stage 3 (spike comparison) cleanly.**

--- a/docs/design/0.7.2-WORK-IN-PROGRESS.md
+++ b/docs/design/0.7.2-WORK-IN-PROGRESS.md
@@ -1,3 +1,5 @@
+> **Historical artifact:** This work-in-progress snapshot is preserved for audit context only. It is not current implementation guidance for 0.7.2.
+
 # SHARC 0.7.2 — Work In Progress Snapshot
 
 **Date:** 2026-05-15

--- a/docs/design/0.7.2-non-sharc-loading.md
+++ b/docs/design/0.7.2-non-sharc-loading.md
@@ -1,6 +1,6 @@
 # 0.7.2 — Loading non-SHARC creatives without `createSession` fatal-timeout
 
-**Status:** Design (ready for implementation — Q1–Q9 locked, see § 13)
+**Status:** Implemented in 0.7.2
 **Issue:** [#89](https://github.com/jeffreycarlson/SHARC/issues/89)
 **Branch:** `feat/89-non-sharc-loading`
 **Target version:** 0.7.2 (patch — first half; OMID container-side wiring is the second half, separately scoped)
@@ -940,4 +940,4 @@ Larger than the prior estimate (~13.5 h) because of two scope additions: (a) the
 
 ---
 
-*This design doc moves from "Status: Design" to "Status: Design (ready for implementation)" with Q1–Q9 locked per § 13 (including G12 D supersession and the HTML lifecycle adapter scope-C lock). Stage 3 of the design-first methodology (comparison against the parallel spike workstream) is downstream of this revision.*
+*This design doc is preserved as the implemented 0.7.2 design record with Q1–Q9 locked per § 13 (including G12 D supersession and the HTML lifecycle adapter scope-C lock). Stage 3 of the design-first methodology (comparison against the parallel spike workstream) is historical context for this revision.*

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,24 +6,32 @@
 
 SHARC is currently in active pre-1.0 development:
 
-- Current package version in this repo: `0.7.0`
+- Current package version in this repo: `0.7.2`
 - npm package: **not yet published**
 - Current supported implementation scope: **web iframe**, **iOS WKWebView**, **Android WebView**
 
 Today, the practical way to evaluate SHARC is to build from this repository and use the generated `dist/` artifacts or the local browser harness.
 
-## What's New in 0.7.0
+## What's New in 0.7.2
 
-0.7.0 ships the **Creative Markup variant** — a second creative-payload path alongside Creative URL. Operators that have markup in hand (RTB pipelines, header bidding wrappers, Prebid Universal Creative scenarios) can pass `creativeHtml` + `creativeRendererUrl` instead of `creativeUrl`. The container posts the markup to an operator-hosted renderer page that writes it into its own document, giving the creative a real cross-origin origin (so measurement SDKs work) without forcing operators to pre-host every markup blob as a URL.
+0.7.2 keeps the 0.7.0 Creative Markup path and adds the transition-state tools operators need for mixed inventory. Operators can still pass `creativeHtml` + `creativeRendererUrl` instead of `creativeUrl`; when the markup is legacy adm that does not yet speak SHARC, set `requireSharcInit: false` so the container does not fatal-error on a missing `createSession` handshake. If the operator hosts `sharc-creative.js`, set `creativeSdkUrl` to inject that SDK into Markup-variant creative HTML at load time.
 
 For the architecture, see [architecture-design.md §14](./architecture-design.md#14-renderer-protocol--creative-markup-variant). For the wire-level reference, see [api-reference.md §10](./api-reference.md#10-renderer-protocol). For practical recipes, see [creative-cookbook.md §8–10](./creative-cookbook.md#8-creative-markup-variant-070).
 
-This release also adds:
+The current first-run path is:
 
-- Structured `onSecurityEvent` callback (discriminated union over five reserved event types)
+1. Build the repo locally with `npm install` and `npm run build`.
+2. Open the local harness or Creative Markup demo through `npm run dev` / `node server.cjs`.
+3. For SHARC-aware creatives, use the default `requireSharcInit: true` handshake path.
+4. For legacy adm evaluation, use the Markup variant with `requireSharcInit: false`; add `creativeSdkUrl` when you want the container to lift the adm into SHARC by injecting the creative SDK.
+
+Recent releases also add:
+
+- Structured `onSecurityEvent` callback, now a discriminated union over six reserved event types after 0.7.1 added `bridge_load_failed`
+- Container-driven MRAID/SafeFrame bridge loading via `bridges`, `creativeMeta.apis`, and `container.bridges`
+- `container.apiFramework` and `container.hasSharcSession` accessors for declaration-vs-outcome diagnostics
 - SDK-auto-installed `sharc-navigation-bridge` (auto-installs at SDK init for Creative URL; renderer installs for Creative Markup) — operators get unified click-through audit across both variants
 - Load-event navigation backstop (`RENDERER_UNAUTHORIZED_NAVIGATION` 2118) for both variants
-- Six new error codes (2114–2119) for renderer protocol failures
 - A reference renderer at `examples/renderer/index.html` (hosted at `https://jeffreycarlson.github.io/SHARC/renderer/` for SDK evaluation only)
 - A local Creative Markup demo at `examples/demos/creative-markup/index.html`
 
@@ -62,15 +70,15 @@ Then open:
 
 Use `?build=dist` on the core harness to validate the built artifacts.
 
-The 0.7.0 dev server listens on **two ports**: 8765 (publisher pages) and 8766 (renderer pages). Browsers treat the two ports as distinct origins, satisfying validation rule 7's cross-origin requirement for local Creative Markup testing.
+The dev server listens on **two ports**: 8765 (publisher pages) and 8766 (renderer pages). Browsers treat the two ports as distinct origins, satisfying validation rule 7's cross-origin requirement for local Creative Markup testing.
 
 ## TypeScript Support
 
 As of `0.6.0`, every public package subpath ships a generated `.d.ts` declaration alongside its `.mjs` bundle. TypeScript consumers get IntelliSense and compile-time argument validation on `new SHARCContainer({...})`, every bridge constructor, and the creative API surface — no `@types/sharc` needed.
 
-0.7.0 expands the typedef surface: `creativeUrl` is now optional, `creativeHtml` / `creativeRendererUrl` / `onSecurityEvent` are added, and `SHARCSecurityEvent` is a discriminated union — five reserved variants in 0.7.0 (`wrapper_top_frame_inaccessible`, `renderer_origin_mismatch`, `renderer_protocol_error`, `renderer_failed`, `unauthorized_navigation`), extended to six in 0.7.1 with `bridge_load_failed` (bridge-module import failure, error code 2115 same as `renderer_failed` but distinct event.type for operator observability). 0.7.1 also adds `bridges` and `creativeMeta` constructor options for compatibility-bridge loading on the Markup variant, plus a `container.bridges` instance accessor. Consumers should narrow via `switch (event.type)` rather than treating `details` as `any`.
+The current typedef surface covers both creative-payload variants, bridge loading, and the 0.7.2 transition-state path. `creativeUrl` is optional when `creativeHtml` / `creativeRendererUrl` are provided; `onSecurityEvent` is a discriminated union over six reserved variants; `bridges` and `creativeMeta` drive compatibility-bridge loading; and `requireSharcInit`, `creativeSdkUrl`, `container.apiFramework`, and `container.hasSharcSession` are typed for mixed-inventory diagnostics. Consumers should narrow via `switch (event.type)` rather than treating `details` as `any`.
 
-## Container Constructor — 0.7.0 Options
+## Container Constructor — 0.7.2 Options
 
 The most-used `SHARCContainer` constructor options. See [api-reference.md §1](./api-reference.md#1-sharccontainer-javascript-api) for the full surface.
 
@@ -88,13 +96,19 @@ The most-used `SHARCContainer` constructor options. See [api-reference.md §1](.
 | `onClose` | `Function` | No | Fires when the container has fully closed |
 | `onError` | `Function` | No | Fires with `(errorCode, errorMessage)` on fatal errors |
 | `onNavigation` | `Function` | No | Fires when the creative requests navigation. Observation-only hook for click telemetry; return value is ignored (see issue #75) |
-| `onSecurityEvent` | `(event) => void` | No | Production observability hook; discriminated-union payload over five reserved variants. Added in 0.7.0 |
+| `onSecurityEvent` | `(event) => void` | No | Production observability hook; discriminated-union payload over six reserved variants. Added in 0.7.0; `bridge_load_failed` added in 0.7.1 |
 | `wrapperPolicy` | `'warn' \| 'block'` | No | Validation-rule-7 wrapper-cross-origin carve-out policy. `'warn'` (default) emits warning + `onSecurityEvent` and proceeds; `'block'` throws synchronously. Added in 0.7.0 |
 | `allowPopups` | `boolean` | No | Default `true`. When `false`, removes `allow-popups` and `allow-popups-to-escape-sandbox` from the Markup renderer iframe sandbox. Added in 0.7.0 |
 | `allowTopNavigationByUserActivation` | `boolean` | No | Default `true`. The unsafe `allow-top-navigation` (no-gesture) variant is never exposed. Added in 0.7.0 |
 | `allowStorageAccessByUserActivation` | `boolean` | No | Default `true`. Added in 0.7.0 |
 | `allowModals` | `boolean` | No | Default **`false`** (asymmetric — operators opt in for age gates, etc.). Added in 0.7.0 |
 | `allowDownloads` | `boolean` | No | Default **`false`** (asymmetric). Added in 0.7.0 |
+| `bridges` | `string[] \| null` | No | Markup-variant compatibility bridges. Reserved identifiers are `'mraid'` and `'safeframe'`; pass `[]` to suppress bridge loading. Added in 0.7.1 |
+| `creativeMeta` | `{ apis?: number[] }` | No | Bid-side AdCOM `APIFramework` metadata used for bridge selection and `container.apiFramework`. Added in 0.7.1 |
+| `requireSharcInit` | `boolean` | No | Default `true`. Set `false` for legacy adm or generic HTML that should load without a SHARC `createSession` handshake. Added in 0.7.2 |
+| `creativeSdkUrl` | `string` | No | Operator-hosted `sharc-creative.js` URL. Markup variant only in 0.7.2; auto-injects a SDK `<script>` tag into creative HTML. Added in 0.7.2 |
+| `creativeSdkSkipIfPresent` | `boolean` | No | Default `true`. Leaves markup unchanged when a real `sharc-creative.js` script tag is already present. Added in 0.7.2 |
+| `creativeSdkScriptAttrs` | `Object` | No | Additional attributes for the auto-injected SDK tag, such as `integrity` or `nonce`. Added in 0.7.2 |
 | `placementPolicy` | `Object` | No | Constrains creative-driven placement requests (`resize` / `expand` / `collapse` / `fullscreen`); when omitted, placement requests bypass policy validation |
 | `closeButtonStyles` | `Object` | No | CSS overrides for the auto-rendered close button |
 | `useMarkupInjection` | `boolean` | No | Creative URL only. Default `false`. Markup variant ALWAYS runs registered injectors |
@@ -113,6 +127,9 @@ After construction, the following instance properties are readable:
 | `creativeSource` | `'url' \| 'html'` | Variant discriminator. Added in 0.7.0 |
 | `creativeRendered` | `boolean` | `true` once renderer's `:rendered` arrives. `false` for Creative URL. Added in 0.7.0 |
 | `creativeInjected` | `boolean` | `true` once any extension `injectIntoMarkup` ran AND modified markup |
+| `bridges` | `ReadonlyArray<string>` | Compatibility bridges selected for this Markup-variant load. Added in 0.7.1 |
+| `apiFramework` | `number \| null` | AdCOM `APIFramework` integer code for the declared container runtime. Added in 0.7.2 |
+| `hasSharcSession` | `boolean` | `true` after the SHARC `createSession` handshake is accepted; `false` until then. Added in 0.7.2 |
 
 ## Creative URL Hello-World
 
@@ -150,7 +167,7 @@ The container opens an iframe pointing at `creativeUrl`, runs the standard SHARC
 
   const container = new SHARCContainer({
     creativeHtml: CREATIVE_HTML,
-    creativeRendererUrl: 'https://renderer.your-operator.com/0.7.0/',
+    creativeRendererUrl: 'https://renderer.your-operator.com/0.7.2/',
     placementElement: document.getElementById('ad-slot'),
     placementId: 'inline-300x250',
 
@@ -284,7 +301,7 @@ SHARC runs on iOS WKWebView and Android WebView in addition to web iframes. Nati
 
 ## Recommended Next Reading
 
-- [docs/current-status.md](./current-status.md) — project maturity and 0.7.0 status snapshot
+- [docs/current-status.md](./current-status.md) — project maturity and current status snapshot
 - [docs/api-reference.md](./api-reference.md) — authoritative public API and protocol details
 - [docs/api-reference.md §10](./api-reference.md#10-renderer-protocol) — renderer protocol wire-level reference
 - [docs/architecture-design.md §14](./architecture-design.md#14-renderer-protocol--creative-markup-variant) — renderer protocol architecture

--- a/docs/research/mraid-migration.md
+++ b/docs/research/mraid-migration.md
@@ -460,5 +460,5 @@ mraid.addEventListener('error')      →  catch on SHARC promises; SHARC.on('err
 
 ## Questions?
 
-See [api-reference.md](./api-reference.md) for the full SHARC API spec.  
-See [getting-started.md](./getting-started.md) for complete creative and container examples.
+See [api-reference.md](../api-reference.md) for the full SHARC API spec.
+See [getting-started.md](../getting-started.md) for complete creative and container examples.

--- a/docs/reviews/OM-sdk-architect-recommendations.md
+++ b/docs/reviews/OM-sdk-architect-recommendations.md
@@ -2,7 +2,7 @@
 
 **Author:** Software Architect (Dev Team)
 **Date:** 2026-04-05
-**Input:** [OM SDK Research](./OM-sdk-research.md) + review of `examples/` reference implementation
+**Input:** [OM SDK Research](../research/OM-sdk-research.md) + review of `examples/` reference implementation
 **Status:** Draft for Working Group discussion
 
 ---


### PR DESCRIPTION
Fixes all 12 findings from the SHARC docs audit (branch docs/audit-cleanup).

Closes #111 (getting-started stale version)
Closes #112 (broken relative links)
Closes #113 (stale status + design docs)
Closes #114 (api-reference typos and examples)
Closes #115 (README nav bridge + CI badge)
Closes #116 (CHANGELOG compare links)

Changes:
- **CHANGELOG.md** — Added compare links for 0.7.0, 0.7.1, 0.7.2; updated [Unreleased]
- **docs/getting-started.md** — Updated version refs from 0.7.0 to 0.7.2
- **docs/api-reference.md** — Fixed anchor typo, updated examples to 0.7.2, renamed document revision label
- **README.md** — Added sharc-navigation-bridge to distribution list
- **docs/current-status.md** — Updated event count to 6, clarified stable current
- **docs/reviews/OM-sdk-architect-recommendations.md** — Fixed relative link
- **docs/research/mraid-migration.md** — Fixed two broken relative links
- **docs/design/0.7.2-non-sharc-loading.md** — Marked as implemented in 0.7.2
- **docs/design/0.7.2-NEXT-SESSION-PROMPT.md** and **0.7.2-WORK-IN-PROGRESS.md** — Added historical artifact banners

Verified: npm run build passes, git diff --check clean.