### PR TITLE
docs(design): add OMID container-side wiring spec (#118)

### DIFF
--- a/docs/design/0.7.3-omid-wiring.md
+++ b/docs/design/0.7.3-omid-wiring.md
@@ -1,0 +1,1051 @@
+# 0.7.3 — Container-side OMID Wiring
+
+**Status:** Design (ready for PM review)  
+**Issue:** [#118](https://github.com/jeffreycarlson/SHARC/issues/118)  
+**Target version:** 0.7.3  
+**Predecessors:** 0.7.1 (bridges field, § 13 Q4 lock — `'omid'` deferred). 0.7.2 (OmidCompatBridge v0.7.2, creative-frame bridge, `installOmidBridge`).  
+**Related research:** `docs/research/OM-sdk-research.md`  
+**Existing bridge:** `src/sharc-omid-bridge.js` (0.7.2 implementation — creative-frame session management, `OmidCompatBridge` extension, `installOmidBridge`)
+
+---
+
+## Table of Contents
+
+1. [Problem Statement](#1-problem-statement)
+2. [Architecture Overview](#2-architecture-overview)
+3. [OM SDK Loading Strategy](#3-om-sdk-loading-strategy)
+4. [Session Lifecycle Mapping](#4-session-lifecycle-mapping)
+5. [Bridge vs. Extension Architecture](#5-bridge-vs-extension-architecture)
+6. [Verification Scripts](#6-verification-scripts)
+7. [supportedFeatures Declaration](#7-supportedfeatures-declaration)
+8. [Event Mapping](#8-event-mapping)
+9. [Creative-side API (Removed)](#9-creative-side-api)
+10. [Configuration API Surface](#10-configuration-api-surface)
+11. [Container-side Implementation Plan](#11-container-side-implementation-plan)
+12. [Test Strategy](#12-test-strategy)
+13. [Phasing Recommendations](#13-phasing-recommendations)
+14. [Guardrails and Constraints](#14-guardrails-and-constraints)
+15. [Decision Log](#15-decision-log)
+
+---
+
+## 1. Problem Statement
+
+SHARC 0.7.2 introduced the `OmidCompatBridge` extension and `installOmidBridge()` function, which manage the OM SDK session lifecycle **inside the creative iframe**. The container-side wiring is incomplete:
+
+1. **No container-side OM SDK loading.** The container doesn't load the OM SDK Service Script (`omweb-v1.js`) into the publisher page context. The 0.7.2 bridge expects the scripts to already be present in the creative frame, but there's no container-side mechanism to ensure this.
+
+2. **No session lifecycle mapping to SHARC container states.** The OM AdSession lifecycle (`start → events → finish`) needs to be mapped to SHARC container states (`LOADING → READY → ACTIVE → ... → TERMINATED`). Currently this mapping is ad-hoc inside `installOmidBridge()`.
+
+3. **No verification script loading pipeline.** The OM SDK for Web Video requires third-party verification scripts (IAS, DoubleVerify, Moat) to be loaded with specific access modes (`limited` vs `full`). The container has no mechanism to load, validate, or expose these scripts.
+
+4. **OMID is missing from KNOWN_BRIDGE_IDENTIFIERS.** Per 0.7.1 design doc § 13 Q4 lock, `'omid'` was intentionally deferred. Now is the release that implements it.
+
+**Scope:** This design covers **container-side OMID wiring only**. OMID measurement is fully container-driven: the container loads the OM SDK, starts the session when the container reaches `ACTIVE`, fires the impression on first visibility, tracks state changes, and finishes on `TERMINATE`. MRAID/SafeFrame creatives get OMID measurement without doing anything — no handshake, no creative-side API calls. Creatives can check `hasFeature('com.iabtechlab.sharc.omid')` to know OMID is available, but they do not request OMID events.
+
+---
+
+## 2. Architecture Overview
+
+### 2.1 Dual-Context OM SDK Architecture
+
+OM SDK for Web Video has two distinct execution contexts:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Publisher Page (container context)                                 │
+│                                                                     │
+│  ┌─────────────────────────┐         ┌──────────────────────────┐  │
+│  │ <script omweb-v1.js>    │         │ SHARCContainer           │  │
+│  │ → window.OmidSessionClient       │ - OmidCompatBridge ext   │  │
+│  │   (Service Script)      │         │ - Session lifecycle mgr  │  │
+│  └───────────┬─────────────┘         │ - Verification loader    │  │
+│              │                       └──────────┬───────────────┘  │
+│              │ OM SDK internal bridge           │ MessageChannel   │
+│              ▼                                  ▼                  │
+│  ┌───────────────────────────────────────────────────────────────┐ │
+│  │  iframe (creative rendering context)                          │ │
+│  │                                                               │ │
+│  │  <script> sharc-protocol.js  </script>                        │ │
+│  │  <script> sharc-creative.js  </script>                        │ │
+│  │  <script> sharc-omid-bridge.js </script> (installOmidBridge)  │ │
+│  │  ← injected BEFORE creative code runs                         │ │
+│  │                                                               │ │
+│  │  ┌─────────────────────────────────────┐                      │ │
+│  │  │ installOmidBridge()                 │                      │ │
+│  │  │ • Creates AdSession                 │                      │ │
+│  │  │ • Creates AdEvents / MediaEvents    │                      │ │
+│  │  │ • Maps SHARC events → OM SDK events │                      │ │
+│  │  │ • Registers session observer        │                      │ │
+│  │  ├─────────────────────────────────────┤                      │ │
+│  │  │  Ad creative code (unchanged)       │                      │ │
+│  │  │  ← no OMID API calls needed         │                      │ │
+│  │  └─────────────────────────────────────┘                      │ │
+│  │                                                               │ │
+│  └───────────────────────────────────────────────────────────────┘ │
+│                                                                     │
+│  ┌─────────────────────────┐                                       │
+│  │ Verification Scripts     │ ← loaded by container, managed by OM  │
+│  │ (IAS, DV, Moat, etc.)   │   SDK Service Script                  │
+│  └─────────────────────────┘                                       │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 Key Architectural Principle
+
+**OMID is not a bridge in the same sense as MRAID/SafeFrame.** MRAID and SafeFrame bridges translate API calls between creative and container (bidirectional API translation). OMID is **measurement** — the container loads the SDK, manages the full session lifecycle, fires events based on container state transitions, and OM SDK reports to verification vendors. The container owns everything: the creative does nothing for OMID.
+
+**Two halves of the same bridge:**
+- `OmidCompatBridge` (container-side extension) — loads OM SDK, manages session lifecycle, contributes `com.iabtechlab.sharc.omid` to supportedFeatures
+- `installOmidBridge()` (creative-frame) — already implemented in 0.7.2, listens to SHARC events and drives OM SDK session
+
+The 0.7.2 implementation already has `installOmidBridge()` working; 0.7.3 adds the container-side wiring that completes the picture. **The creative side does not need to make any API calls — the container auto-manages the full OM SDK session lifecycle.**
+
+---
+
+## 3. OM SDK Loading Strategy
+
+### 3.1 Decision: Container loads OM SDK on publisher page (Option 2)
+
+The 0.7.2 JSDoc already documents two loading options. We resolve this now:
+
+| Option | Mechanism | Pros | Cons | Decision |
+|--------|-----------|------|------|----------|
+| **Option 2 (DEFAULT)** | `<script>` tag on publisher page, managed by container-side bridge | Works across all origins, no CORS, matches native SDK model (app owns OM SDK), zero fetch overhead | Requires publisher to have OM SDK available | **✅ Adopted** |
+| Option 3 (OPT-IN) | `useMarkupInjection=true`, fetch creative HTML → inject OM SDK → srcdoc | Full control over injection | Requires same-origin creative URL, CORS constraints, fetch overhead | Kept as opt-in for test environments |
+
+**Rationale:** Option 2 matches how OM SDK is used in native apps (the app loads the SDK, not the creative). The container is the "app" in the web analog. This also avoids the CORS and fetch failure modes that Option 3 introduces.
+
+### 3.2 Loading Mechanism
+
+The `OmidCompatBridge` extension loads OM SDK via two `<script>` injection points on the **publisher page** (NOT inside the creative iframe):
+
+```javascript
+// OmidCompatBridge._injectSdk() — called during container.load()
+function _injectSdk() {
+  // 1. OM SDK Service Script (must be loaded first)
+  const serviceScript = document.createElement('script');
+  serviceScript.src = this._omidServiceScriptUrl; // default: CDN URL
+  serviceScript.async = false; // must load synchronously
+  document.head.appendChild(serviceScript);
+
+  // 2. OM SDK Session Client (loads after service script)
+  const sessionClientScript = document.createElement('script');
+  sessionClientScript.src = this._omidSessionClientUrl; // default: CDN URL
+  sessionClientScript.async = false;
+  document.head.appendChild(sessionClientScript);
+}
+```
+
+**Default CDN URLs (configurable via constructor options):**
+
+| Script | Default URL | Required by |
+|--------|-------------|-------------|
+| Service Script (`omweb-v1.js`) | `https://static.adsafeprotected.com/omweb-v1.js` (IAS-hosted) or IAB Tech Lab CDN | OM SDK Service |
+| Session Client (`omid-session-client-v1.js`) | Bundled into `sharc-omid-bridge.js` or separate CDN | Session Client API |
+
+**Note:** The OM SDK for Web Video Service Script is typically distributed by OM SDK certification partners (IAS, DoubleVerify, Moat). The container should accept a configurable URL. The IAB Tech Lab may host a canonical version in the future.
+
+### 3.3 Load Order
+
+For the **Creative URL variant** (default path, Option 2):
+
+```
+Publisher page load:
+  1. <script> omweb-v1.js          → window.OmidSessionClient (Service)
+  2. <script> omid-session-client-v1.js → OmidSessionClient namespace
+  3. <script> sharc-container.js   → SHARCContainer class
+  4. Operator creates container with OmidCompatBridge extension
+
+Container.load():
+  5. OmidCompatBridge._injectSdk() (if not already loaded)
+  6. _createIframe() → creative loads in iframe
+  7. iframe load → 200ms delay → initChannel()
+  8. SHARC handshake completes
+  9. OmidCompatBridge._createSession() → AdSession.start()
+```
+
+For the **Creative Markup variant** (render protocol):
+
+```
+Container.load():
+  1. OmidCompatBridge._injectSdk()
+  2. _createIframe() → renderer iframe loads
+  3. Renderer protocol: SHARC:Renderer:render → :rendered
+  4. _runMarkupInjection() injects extensions (including OMID bridge scripts)
+  5. SHARC handshake → AdSession.start()
+```
+
+### 3.4 Idempotency Guard
+
+If OM SDK is already loaded on the page (e.g., the publisher pre-loaded it independently), the bridge detects this and skips injection:
+
+```javascript
+OmidCompatBridge.prototype._isOmSdkLoaded = function () {
+  return typeof window.OmidSessionClient !== 'undefined'
+    && window.OmidSessionClient.AdSession
+    && window.OmidSessionClient.Partner
+    && window.OmidSessionClient.Context;
+};
+```
+
+**No double-loading.** The bridge checks `_isOmSdkLoaded()` before injecting. If already present, it logs `[SHARC OMID Bridge] OM SDK already loaded on page — skipping injection` and proceeds to session management.
+
+---
+
+## 4. Session Lifecycle Mapping
+
+### 4.1 State Mapping Table
+
+The OM AdSession lifecycle maps to SHARC container states as follows:
+
+| SHARC Container State | OM SDK Action | Timing |
+|----------------------|---------------|--------|
+| `LOADING` | (none) | Container creating iframe, loading creative |
+| `READY` | `AdSession.start()` | Handshake complete, creative initialized, waiting for `startCreative` |
+| `ACTIVE` | `AdEvents.loaded(VastProperties?)` | Creative visible and interactive |
+| `ACTIVE` (first visibility) | `AdEvents.impressionOccurred()` | Fired once when ad becomes viewable for the first time |
+| `ACTIVE` → `PASSIVE` | `AdEvents.stateChange('NON_VISIBLE')` | Creative loses focus |
+| `PASSIVE` → `ACTIVE` | `AdEvents.stateChange('VISIBLE')` | Creative regains focus |
+| `HIDDEN` | `AdEvents.stateChange('NON_VISIBLE')` | App backgrounded, tab hidden |
+| `FROZEN` | (none — JS suspended) | OS suspends execution |
+| `TERMINATED` → | `AdSession.finish()` | Container closing ad |
+| `TERMINATED` (after) | Session cleanup, unload scripts after 3s delay | Post-finish cleanup |
+
+### 4.2 Session Lifecycle Sequence
+
+```
+Container                                    OM SDK
+   |                                           |
+   | load()                                    |
+   |  ├─ inject OM SDK scripts                 |
+   |  └─ _createIframe()                       |
+   |                                           |
+   | SHARC handshake completes                 |
+   | transition: LOADING → READY               |
+   |  ├─ OmidCompatBridge._createSession()     |
+   |  │   ├─ new Partner(name, version)        |
+   |  │   ├─ new Context(partner, scripts)     |
+   |  │   ├─ new AdSession(context)            |
+   |  │   ├─ setCreativeType('video')          |
+   |  │   ├─ setImpressionType(...)            |
+   |  │   ├─ new AdEvents(session)   │
+   |  │   ├─ new MediaEvents(session)│
+   |  │   ├─ registerSessionObserver()         |
+   |  │   └─ adSession.start()       │ ←─── ad view tracking begins
+   |  |                             |
+   | transition: READY → ACTIVE     |
+   |  ├─ AdEvents.loaded(props)     │
+   |  └─ (await creative impression) |
+   |                               |
+   | Creative signals impression   |
+   |  ├─ AdEvents.impressionOccurred() │ ←─── fired ONCE per session
+   |                               |
+   | ... media events ...          |
+   |  ├─ MediaEvents.start()       │
+   |  ├─ MediaEvents.firstQuartile()│
+   |  ├─ MediaEvents.midpoint()    │
+   |  ├─ MediaEvents.thirdQuartile()│
+   |  ├─ MediaEvents.complete()    │
+   |                               |
+   | transition: ACTIVE → HIDDEN   |
+   |  ├─ AdEvents.stateChange('NON_VISIBLE') │
+   |                               |
+   | transition: HIDDEN → ACTIVE   |
+   |  ├─ AdEvents.stateChange('VISIBLE') │
+   |                               |
+   | close() called                |
+   |  ├─ adSession.finish()       │ ←─── ad view tracking stops
+   |  └─ cleanup (3s delay → unload) │
+```
+
+### 4.3 Critical Ordering Constraints
+
+Per OM SDK specification:
+
+1. **`AdSession.start()` MUST be called before any events are fired.** Called on `READY` transition.
+2. **`AdEvents.loaded()` MUST be called before `AdEvents.impressionOccurred()`.** Called on `ACTIVE` transition.
+3. **`creativeType` and `impressionType` MUST be set before `impressionOccurred()`.** Set during session creation.
+4. **Only ONE `AdEvents` instance per session.** Guard via `_adEventsCreated` flag.
+5. **Only ONE `MediaEvents` instance per session.** Guard via `_mediaEventsCreated` flag.
+6. **`AdSession.finish()` MUST be called on close.** Called on `TERMINATED` transition.
+7. **Do NOT call methods on a finished session.** Guard via `_sessionFinished` flag.
+
+These constraints are already enforced in the 0.7.2 `installOmidBridge()` implementation. The container-side wiring in 0.7.3 must trigger these at the correct lifecycle points.
+
+---
+
+## 5. Bridge vs. Extension Architecture
+
+### 5.1 Decision: OMID as Extension (not Bridge)
+
+OMID uses the **existing extension pattern**, not the bridge pattern:
+
+| Aspect | MRAID/SafeFrame Bridges | OMID Extension |
+|--------|------------------------|----------------|
+| Pattern | Loaded by renderer via `bridges: ['mraid']` | Loaded via `extensions: [new OmidCompatBridge(...)]` |
+| Purpose | API translation (creative → container) | Measurement session management |
+| Loading | Renderer iframe `import()` bridge module | Container constructor extension |
+| Execution context | Creative iframe (injected BEFORE creative) | Publisher page + creative iframe |
+| Feature name | N/A (not a feature, it's a compat layer) | `com.iabtechlab.sharc.omid` |
+
+**Rationale:** Bridges are for API compatibility — making legacy creatives think they're talking to MRAID or SafeFrame. OMID is measurement, not API translation. It fits the extension model:
+- `getFeatureName()` → `'com.iabtechlab.sharc.omid'`
+- `injectIntoMarkup(html)` → injects OM SDK scripts into creative HTML
+- `destroy()` → calls `adSession.finish()`, cleans up
+
+### 5.2 Adding `'omid'` to KNOWN_BRIDGE_IDENTIFIERS
+
+Despite OMID being an extension (not a bridge), we **add `'omid'` to the reserved bridge identifiers** for the renderer protocol. This enables the renderer to skip loading the OMID bridge module when it's managed by the extension, preventing double-loading.
+
+```javascript
+// In sharc-container.js — updated KNOWN_BRIDGE_IDENTIFIERS
+const KNOWN_BRIDGE_IDENTIFIERS = Object.freeze(['mraid', 'safeframe', 'omid']);
+```
+
+**When `'omid'` appears in `bridges`:** The renderer receives it but **silently skips** loading an OMID bridge module (there is none to load in the renderer). The OM SDK loading is handled by the `OmidCompatBridge` extension. This is forward-compatible — a future renderer could load an OMID verification script bundle via the renderer if desired.
+
+### 5.3 AdCOM APIFramework Code 7 Mapping
+
+Code `7` (OMID 1.0) maps to the OMID extension:
+
+```javascript
+// In ADCOM_API_TO_BRIDGE — updated mapping
+const ADCOM_API_TO_BRIDGE = Object.freeze({
+  3: 'mraid',
+  5: 'mraid',
+  6: 'mraid',
+  7: 'omid',  // OMID 1.0 — loads OmidCompatBridge extension
+  [SAFEFRAME_API_CODE]: 'safeframe',
+});
+```
+
+**Resolution behavior:** When `creativeMeta.apis: [7]` is passed, the bridge detection pipeline produces `['omid']`. The renderer receives it and skips (no OMID bridge module to load). The container uses it to auto-instantiate the `OmidCompatBridge` extension if the operator hasn't already done so.
+
+### 5.4 Container Architecture Diagram (C4 Level 2)
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  SHARCContainer                                                   │
+│                                                                   │
+│  ┌─────────────────────────────────────────┐                     │
+│  │ Extensions                               │                     │
+│  │                                          │                     │
+│  │  OmidCompatBridge                       │                     │
+│  │  ┌───────────────────────────────────┐  │                     │
+│  │  │ getFeatureName()                   │  │                     │
+│  │  │ → 'com.iabtechlab.sharc.omid'     │  │                     │
+│  │  │                                    │  │                     │
+│  │  │ injectIntoMarkup(html)             │  │                     │
+│  │  │ → injects OM SDK scripts into HTML │  │                     │
+│  │  │                                    │  │                     │
+│  │  │ onContainerStateChange(state)      │  │                     │
+│  │  │ → maps SHARC state → OM SDK event  │  │                     │
+│  │  │                                    │  │                     │
+│  │  │ registerFriendlyObstruction(el)    │  │                     │
+│  │  │ → adds to AdSession                │  │                     │
+│  │  │                                    │  │                     │
+│  │  │ destroy()                          │  │                     │
+│  │  │ → adSession.finish() + cleanup     │  │                     │
+│  │  └───────────────────────────────────┘  │                     │
+│  │                                          │                     │
+│  │  MraidCompatBridge  │  SafeFrameBridge  │                     │
+│  └──────────┬───────────────────────────────┘                     │
+│             │ contributes feature names                            │
+│             ▼                                                      │
+│  ┌─────────────────────────────────────┐                         │
+│  │ supportedFeatures in Container:init │                         │
+│  │ [                                   │                         │
+│  │   { name: 'com.iabtechlab.sharc.omid', │                    │
+│  │     version: '0.7.3',               │                         │
+│  │     functions: [...] },             │                         │
+│  │   ...                               │                         │
+│  │ ]                                    │                         │
+│  └─────────────────────────────────────┘                         │
+│                                                                   │
+│  ┌─────────────────────────────────────────┐                     │
+│  │ State Machine                            │                     │
+│  │ LOADING → READY → ACTIVE → ...           │                     │
+│  │   │                                      │                     │
+│  │   └─ notifies extensions of transitions │                     │
+│  └─────────────────────────────────────────┘                     │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 6. Verification Scripts
+
+### 6.1 Loading Strategy
+
+Verification scripts are loaded by the **OM SDK Service Script**, not directly by the container. The container passes verification script URLs to the OM SDK via `VerificationScriptResource` objects:
+
+```javascript
+// OmidCompatBridge constructor options
+var verificationScripts = [
+  new OmidSessionClient.VerificationScriptResource(
+    'https://verify.ias.com/omsdk/verification.js',
+    'ias',
+    'limited'  // or 'full'
+  ),
+  new OmidSessionClient.VerificationScriptResource(
+    'https://www.google.com/ads/measurement/verification.js',
+    'doubleverify',
+    'limited'
+  )
+];
+
+var context = new OmidSessionClient.Context(partner, verificationScripts);
+```
+
+### 6.2 Access Modes
+
+OM SDK for Web Video defines two access modes:
+
+| Access Mode | When to Use | Description |
+|-------------|-------------|-------------|
+| `limited` | Cross-origin iframe (default) | Verification script loaded in same-origin iframe, restricted DOM access |
+| `full` | Same-origin iframe | Verification script has full access to DOM |
+
+**Decision:** Default to `limited` for all verification scripts. The creative iframe in the Creative URL variant runs without `allow-same-origin` (SEC-001), so `full` access is not possible. In the Creative Markup variant, the renderer is cross-origin to the publisher, so `limited` is also the safe default.
+
+Operators can override to `full` via constructor options when they control both the publisher page and the creative (e.g., first-party ad serving).
+
+### 6.3 Verification Script Source
+
+Verification script URLs come from the AdCOM `adVerifications` array in the bid response:
+
+```json
+{
+  "adVerifications": [
+    {
+      "resource": "https://verify.ias.com/omsdk/verification.js",
+      "vendor": "ias",
+      "parameters": { /* vendor-specific */ }
+    }
+  ]
+}
+```
+
+The container accepts these via a new constructor option:
+
+```typescript
+verificationScripts?: {
+  url: string;
+  vendor: string;
+  accessMode?: 'limited' | 'full';  // default: 'limited'
+}[];
+```
+
+### 6.4 Validation
+
+Verification script URLs are validated at construction:
+
+1. Must be valid HTTPS URLs
+2. Must not contain userinfo
+3. Must not be same-origin to `window.location` (unless `accessMode: 'full'` is explicitly set)
+4. Duplicates (same URL) are deduplicated — first occurrence wins
+
+Invalid entries are silently skipped with a `console.warn` — the ad should still run even if one verification vendor's script is unavailable.
+
+---
+
+## 7. supportedFeatures Declaration
+
+### 7.1 Feature Descriptor
+
+The `OmidCompatBridge` contributes the following feature to `supportedFeatures` in `SHARC:Container:init`:
+
+```json
+{
+  "name": "com.iabtechlab.sharc.omid",
+  "version": "0.7.3",
+  "functions": [
+    "startSession",
+    "signalAdEvent",
+    "signalMediaEvent",
+    "finishSession"
+  ]
+}
+```
+
+### 7.2 Function Descriptions
+
+| Function | Description |
+|----------|-------------|
+| `startSession` | The container starts an OM SDK session on READY. Maps to `AdSession.start()`. |
+| `signalAdEvent` | The container fires ad-level events (loaded, impression, skipped, paused, resumed, stateChange, volumeChange) based on state transitions. Maps to `AdEvents.*`. |
+| `signalMediaEvent` | The container fires media-level events (start, quartiles, buffering, playerStateChange, adUserInteraction, volumeChange) based on media state. Maps to `MediaEvents.*`. |
+| `finishSession` | The container finishes the OM SDK session on TERMINATED. Maps to `AdSession.finish()`. |
+
+### 7.3 Feature Registration
+
+The feature is registered automatically when the `OmidCompatBridge` extension is passed to the container constructor:
+
+```javascript
+const container = new SHARCContainer({
+  creativeUrl: 'https://ads.example.com/creative.html',
+  placementElement: document.getElementById('ad-slot'),
+  extensions: [
+    new OmidCompatBridge({
+      partnerName: 'MyPublisher',
+      partnerVersion: '1.0',
+      verificationScripts: [...],
+    }),
+  ],
+});
+```
+
+The container calls `extension.getFeatureName()` for each extension and adds it to `supportedFeatures`:
+
+```javascript
+// In SHARCContainer — during init message construction
+function _buildSupportedFeatures() {
+  const features = this._explicitSupportedFeatures.slice();
+
+  for (const ext of this._extensions) {
+    if (typeof ext.getFeatureName === 'function') {
+      const name = ext.getFeatureName();
+      // Avoid duplicates
+      if (!features.some(f => (typeof f === 'string' ? f : f.name) === name)) {
+        features.push({
+          name: name,
+          version: ext.getFeatureVersion ? ext.getFeatureVersion() : SHARC_VERSION,
+          functions: ext.getFeatureFunctions ? ext.getFeatureFunctions() : [],
+        });
+      }
+    }
+  }
+
+  return features;
+}
+```
+
+### 7.4 Capability Detection by Creatives
+
+Creatives may query for OMID support via `SHARC:Creative:getFeatures`:
+
+```javascript
+// Creative queries supportedFeatures
+const omidFeature = features.find(f => f.name === 'com.iabtechlab.sharc.omid');
+if (omidFeature) {
+  // OMID is available — container auto-manages the measurement session.
+  // No creative-side action needed.
+}
+```
+
+---
+
+## 8. Event Mapping
+
+### 8.1 Container State → OM SDK Event Mapping
+
+All OM SDK events are fired by the container based on state transitions. No creative-side involvement:
+
+| Container State Transition | OM SDK Event | Conditions |
+|----------------------|---------------|------------|
+| `LOADING → READY` | `AdSession.start()` | Handshake complete, session creation, fires once |
+| `READY → ACTIVE` | `AdEvents.loaded(VastProperties?)` | Ad is visible and interactive |
+| `READY → ACTIVE` (first visibility) | `AdEvents.impressionOccurred()` | Fired once per session on first viewable moment |
+| `ACTIVE → PASSIVE` | `AdEvents.stateChange('NON_VISIBLE')` | Creative lost focus |
+| `PASSIVE → ACTIVE` | `AdEvents.stateChange('VISIBLE')` | Creative regained focus |
+| `ACTIVE → HIDDEN` | `AdEvents.stateChange('NON_VISIBLE')` | App backgrounded, tab hidden |
+| `HIDDEN → ACTIVE` | `AdEvents.stateChange('VISIBLE')` | App foregrounded, tab visible |
+| `ACTIVE → FROZEN` | (none) | JS suspended by OS |
+| `→ TERMINATED` | `AdSession.finish()` | Container closing ad |
+| `placementChange` | `AdEvents.loaded(VastProperties?)` (if not already fired) | Placement dimensions affect VastProperties position |
+| `audioVolumeChange` | `AdEvents.volumeChange(volume)` | Volume 0–1, mapped from `volumePercentage / 100` |
+
+### 8.2 VastProperties Mapping
+
+When `AdEvents.loaded()` is called, `VastProperties` are derived from SHARC environment data:
+
+| VastProperties Field | SHARC Source |
+|---------------------|--------------|
+| `isSkippable` | From AdCOM `ad.skippable` or `skipoffset` in dataspec |
+| `skipOffset` | From AdCOM `ad.skipoffset` |
+| `isAutoPlay` | From `environmentData.autoplay` or inferred from container state |
+| `position` | From placement type: `'preroll'`, `'midroll'`, `'postroll'`, or `'standalone'` |
+| `creativeType` | From AdCOM `ad.creativetype` or container config (`'video'` or `'audio'`) |
+
+### 8.3 Guardrails
+
+- **`impressionOccurred`** fires exactly once per session. The bridge guards against double-firing.
+- **`AdSession.finish()`** fires exactly once. Subsequent calls are no-ops.
+- **Events fired before `AdSession.start()`** are queued and replayed after start (or dropped, depending on event type). Actually, per OM SDK spec, events before `start()` are invalid — the container MUST NOT fire them.
+- **MediaEvents in non-video sessions** are no-ops with a `console.warn`.
+
+---
+
+## 9. Creative-side API
+
+> **Creative-side requestOmid API was removed — OMID is fully container-driven. See decision log for D7 and D17 updates.**
+
+There is no creative-side OMID API in 0.7.3. The container manages the entire OM SDK session lifecycle automatically:
+
+- Session starts on `READY` → `ACTIVE` transition
+- Impression fires on first visibility
+- State changes tracked via container visibility state machine
+- Session finishes on `TERMINATED`
+
+MRAID/SafeFrame creatives receive OMID measurement transparently — no creative-side code changes needed. Creatives that wish to know OMID is available may check `hasFeature('com.iabtechlab.sharc.omid')` via `SHARC:Creative:getFeatures`, but no further action is required.
+
+**Previously proposed and removed:**
+- `SHARC:Creative:requestOmid` message type — removed
+- `SHARC.requestOmid()` creative SDK helper — removed
+- Creative-side OMID event signaling — removed
+
+These were dropped because OMID container-side wiring is fully self-sufficient. The container owns the session, fires events on state transitions, and the creative has no role in OMID measurement.
+
+---
+
+## 10. Configuration API Surface
+
+### 10.1 OmidCompatBridge Constructor Options
+
+```typescript
+interface OmidCompatBridgeOptions {
+  /**
+   * OM SDK partner name. Assigned by IAB Tech Lab during certification.
+   * Default: 'SHARCOmidBridge'
+   */
+  partnerName?: string;
+
+  /**
+   * OM SDK partner version. The integration's version string.
+   * Default: SHARC_VERSION
+   */
+  partnerVersion?: string;
+
+  /**
+   * Third-party verification scripts to load.
+   * Each entry: { url, vendor, accessMode? }
+   */
+  verificationScripts?: Array<{
+    url: string;
+    vendor: string;
+    accessMode?: 'limited' | 'full'; // default: 'limited'
+  }>;
+
+  /**
+   * OM SDK creative type. Influences measurement behavior.
+   * - 'video': video ad measurement (MediaEvents available)
+   * - 'audio': audio ad measurement (MediaEvents available)
+   * - 'display': display ad measurement (AdEvents only)
+   * Default: 'video'
+   */
+  creativeType?: 'video' | 'audio' | 'display';
+
+  /**
+   * OM SDK impression type.
+   * - 'definedByJavaScript': JavaScript fires impression event
+   * - 'beginToRender': impression fires when creative begins rendering
+   * - 'onePixel': impression fires when one pixel is viewable
+   * Default: 'definedByJavaScript'
+   */
+  impressionType?: 'definedByJavaScript' | 'beginToRender' | 'onePixel';
+
+  /**
+   * OM SDK media type. Controls which MediaEvents are available.
+   * Matches creativeType in most cases.
+   * Default: 'video'
+   */
+  mediaType?: 'video' | 'audio' | 'display';
+
+  /**
+   * URL of the OM SDK Service Script (omweb-v1.js).
+   * Override to use a non-default CDN or a locally-hosted copy.
+   * Default: IAB Tech Lab CDN URL
+   */
+  omSdkServiceScriptUrl?: string;
+
+  /**
+   * URL of the OM SDK Session Client script.
+   * When set, the container loads the session client script on the
+   * publisher page. When unset, the session client is bundled into
+   * sharc-omid-bridge.js (the default).
+   */
+  omSdkSessionClientUrl?: string;
+
+  /**
+   * Content URL for OM SDK. Typically the page URL or app screen name.
+   * Default: window.location.href
+   */
+  contentUrl?: string;
+
+  /**
+   * VastProperties override. Allows the operator to set skippable,
+   * skipOffset, autoplay, and position for AdEvents.loaded().
+   * When unset, these are derived from AdCOM dataspec.
+   */
+  vastProperties?: {
+    isSkippable?: boolean;
+    skipOffset?: number;
+    isAutoPlay?: boolean;
+    position?: 'preroll' | 'midroll' | 'postroll' | 'standalone';
+  };
+}
+```
+
+### 10.2 Container Constructor Extension
+
+No new options on `SHARCContainer` itself — OMID configuration is entirely through the `OmidCompatBridge` extension:
+
+```javascript
+const container = new SHARCContainer({
+  creativeUrl: 'https://ads.example.com/creative.html',
+  placementElement: document.getElementById('ad-slot'),
+  extensions: [
+    new OmidCompatBridge({
+      partnerName: 'MyPublisher',
+      partnerVersion: '2.1.0',
+      creativeType: 'video',
+      impressionType: 'definedByJavaScript',
+      verificationScripts: [
+        { url: 'https://verify.ias.com/omsdk/verification.js', vendor: 'ias' },
+        { url: 'https://www.google.com/ads/measurement/verification.js', vendor: 'doubleverify' },
+      ],
+      omSdkServiceScriptUrl: 'https://cdn.example.com/omweb-v1.js',
+      vastProperties: {
+        isSkippable: true,
+        skipOffset: 5,
+        isAutoPlay: true,
+        position: 'preroll',
+      },
+    }),
+  ],
+});
+```
+
+### 10.3 Validation
+
+`OmidCompatBridge` validates options at construction:
+
+| Option | Validation | Invalid Behavior |
+|--------|-----------|-----------------|
+| `partnerName` | Non-empty string, max 64 chars | Throws `TypeError` |
+| `partnerVersion` | Non-empty string, max 32 chars | Throws `TypeError` |
+| `verificationScripts[].url` | Valid HTTPS URL, no userinfo | Skips with `console.warn` |
+| `verificationScripts[].vendor` | Non-empty string | Skips with `console.warn` |
+| `verificationScripts[].accessMode` | `'limited'` or `'full'` | Defaults to `'limited'` |
+| `creativeType` | `'video'`, `'audio'`, `'display'` | Defaults to `'video'` |
+| `impressionType` | `'definedByJavaScript'`, `'beginToRender'`, `'onePixel'` | Defaults to `'definedByJavaScript'` |
+| `mediaType` | `'video'`, `'audio'`, `'display'` | Defaults to `'video'` |
+| `omSdkServiceScriptUrl` | Valid HTTPS URL | Throws `TypeError` |
+| `vastProperties.position` | `'preroll'`, `'midroll'`, `'postroll'`, `'standalone'` | Defaults to `'standalone'` |
+
+---
+
+## 11. Container-side Implementation Plan
+
+### 11.1 Implementation Steps
+
+| Step | Description | Files Changed | Estimate |
+|------|-------------|---------------|----------|
+| **1** | Update `KNOWN_BRIDGE_IDENTIFIERS` to include `'omid'` | `src/sharc-container.js` | 15 min |
+| **2** | Update `ADCOM_API_TO_BRIDGE` to map code 7 → `'omid'` | `src/sharc-container.js` | 15 min |
+| **3** | Add `OmidCompatBridge` extension class to `sharc-omid-bridge.js` with: `getFeatureName()`, `getFeatureVersion()`, `getFeatureFunctions()`, `injectIntoMarkup()`, `destroy()` | `src/sharc-omid-bridge.js` | 2 hours |
+| **4** | Implement container-side OM SDK loading (`_injectSdk()` method on `OmidCompatBridge`) | `src/sharc-omid-bridge.js` | 1.5 hours |
+| **5** | Wire container state transitions to OM SDK events via extension hook | `src/sharc-container.js`, `src/sharc-omid-bridge.js` | 2 hours |
+| **6** | Add verification script loading via `VerificationScriptResource` | `src/sharc-omid-bridge.js` | 1 hour |
+| **7** | Add friendly obstruction management (existing 0.7.2 code is partially in place) | `src/sharc-omid-bridge.js` | 30 min |
+| **8** | Update unit tests for OMID wiring | `test/` | 3 hours |
+| **9** | Add integration test with OM SDK reference app | `test/integration/` | 2 hours |
+| **10** | Update API reference documentation | `docs/api-reference.md` | 1 hour |
+
+**Total estimate:** ~13 hours (2–3 working days)
+
+*Note: Creative-side `requestOmid` handler (formerly steps 6 and 9) was removed — OMID is fully container-driven.*
+
+### 11.2 Extension Interface Additions
+
+The 0.7.2 `OmidCompatBridge` already exists. 0.7.3 adds these methods:
+
+```javascript
+OmidCompatBridge.prototype = {
+
+  getFeatureName: function () {
+    return FEATURE_NAME; // 'com.iabtechlab.sharc.omid'
+  },
+
+  getFeatureVersion: function () {
+    return BRIDGE_VERSION; // reads from SHARC_VERSION
+  },
+
+  getFeatureFunctions: function () {
+    return ['startSession', 'signalAdEvent', 'signalMediaEvent', 'finishSession'];
+  },
+
+  /**
+   * Injects OM SDK scripts into creative HTML for the Markup variant.
+   * Called during _runMarkupInjection() before the renderer receives HTML.
+   * @param {string} html - The creative HTML markup.
+   * @returns {string} Modified HTML with OM SDK scripts injected.
+   */
+  injectIntoMarkup: function (html) {
+    // Inject <script src="omweb-v1.js"></script> and
+    // <script src="omid-session-client-v1.js"></script>
+    // into <head> before other scripts.
+    var headEnd = html.indexOf('</head>');
+    if (headEnd === -1) {
+      var bodyEnd = html.indexOf('</body>');
+      if (bodyEnd === -1) return html;
+      return html.slice(0, bodyEnd) + this._scriptIdTags() + html.slice(bodyEnd);
+    }
+    return html.slice(0, headEnd) + this._scriptIdTags() + html.slice(headEnd);
+  },
+
+  /**
+   * Called by the container when the state machine transitions.
+   * Maps SHARC container states to OM SDK events.
+   * @param {string} newState - The new container state.
+   * @param {string} prevState - The previous container state.
+   */
+  onContainerStateChange: function (newState, prevState) {
+    // Maps states → OM SDK events per § 4
+  },
+
+  /**
+   * Called by the container when it is terminated.
+   * Cleans up the OM SDK session.
+   */
+  destroy: function () {
+    // Calls adSession.finish() if session is active
+    // Removes injected scripts (markup-injection only)
+    // Cleans up session observer
+  },
+};
+```
+
+### 11.2 Container Changes
+
+In `sharc-container.js`, only the state machine notification to extensions is needed (already described in §11.1 step 5). No creative-side OMID request handler is needed since OMID is fully container-driven.
+
+---
+
+## 12. Test Strategy
+
+### 12.1 Unit Tests
+
+| Test | Description |
+|------|-------------|
+| `OmidCompatBridge construction` | Valid options, invalid options, defaults |
+| `getFeatureName()` | Returns `'com.iabtechlab.sharc.omid'` |
+| `getFeatureFunctions()` | Returns correct function list |
+| `injectIntoMarkup()` | Injects scripts into `<head>`, handles missing `<head>` |
+| `_isOmSdkLoaded()` | Detects pre-loaded OM SDK, handles missing OM SDK |
+| `onContainerStateChange(READY)` | Creates AdSession, calls start() |
+| `onContainerStateChange(ACTIVE)` | Fires loaded(), impression guard |
+| `onContainerStateChange(HIDDEN)` | Fires stateChange('NON_VISIBLE') |
+| `onContainerStateChange(terminated)` | Calls finish(), cleanup |
+| `destroy()` | Calls finish() if active, no-op if already finished |
+| `FriendlyObstruction` | Registers/unregisters close button |
+| `Verification script loading` | Creates VerificationScriptResource objects |
+
+### 12.2 Integration Tests
+
+| Test | Description |
+|------|-------------|
+| `Full lifecycle with OM SDK` | Container loads → handshake → active → events → close → cleanup |
+| `OM SDK reference app validation` | Run against the IAB OM SDK reference app |
+| `Verification script integration` | Load IAS/DV scripts, verify they receive events |
+| `Cross-origin creative (URL variant)` | OM SDK loads on publisher page, creative communicates via MessageChannel |
+| `Markup variant with injection` | OM SDK injected into creative HTML, session starts |
+| `Pre-loaded OM SDK` | Publisher loads OM SDK independently; bridge detects and skips injection |
+| `Double impression guard` | Creative attempts to fire impression twice; second is no-op |
+| `Event queue during LOADING` | Events queued during LOADING, replayed after READY (or per OM SDK spec, dropped) |
+
+### 12.3 OM SDK Validation
+
+Use the OM SDK validation verification script:
+
+```
+https://static.adsafeprotected.com/omid-validation-verification-script-v1.js
+```
+
+Load this as a verification script during testing. It logs validation results to the console and reports errors for any OM SDK protocol violations.
+
+Also test against the OM SDK reference app:
+```
+https://github.com/InteractiveAdvertisingBureau/Open-Measurement-JSClients/tree/master/reference-app-web
+```
+
+---
+
+## 13. Phasing Recommendations
+
+### 13.1 Phase 1 (Minimum Viable — ~8 hours)
+
+**Goal:** Container loads OM SDK, manages session lifecycle, maps SHARC states to OM SDK events.
+
+- Steps 1–5 from § 11.1
+- `'omid'` added to `KNOWN_BRIDGE_IDENTIFIERS`
+- AdCOM code 7 → `'omid'` mapping
+- `OmidCompatBridge` with `getFeatureName()`, `injectIntoMarkup()`, `onContainerStateChange()`, `destroy()`
+- Container state → OM SDK event mapping
+- OM SDK Service Script loading on publisher page
+- Impression guard (single-fire)
+- Basic unit tests
+
+**Delivers:** A SHARC container with working OMID measurement for display creatives (AdEvents only, no MediaEvents).
+
+### 13.2 Phase 2 (Full Feature Set — ~7 hours)
+
+**Goal:** Complete OMID support with MediaEvents and verification scripts.
+
+- Steps 6–10 from § 11.1
+- MediaEvents support for video/audio
+- Verification script loading
+- Friendly obstruction management
+- Integration tests with OM SDK reference app
+
+**Delivers:** Complete OMID support matching the SIMID + OM SDK integration pattern. No creative-side API needed — container manages everything.
+
+### 13.3 Phase 3 (Future)
+
+**Deferred to post-0.7.3:**
+
+- OM SDK for Apps integration (iOS/Android native SDK)
+- OM SDK for CTV integration (DACH pattern)
+- CTV platform adapter with OMID support
+- OM ID partner certification workflow automation
+- OM SDK validation report generation
+
+---
+
+## 14. Guardrails and Constraints
+
+### 14.1 Security
+
+| Constraint | Enforcement |
+|------------|-------------|
+| OM SDK Service Script must be loaded from HTTPS | URL validation at construction |
+| Verification script URLs must be HTTPS | URL validation, non-HTTPS silently skipped |
+| OM SDK errors must NOT crash the container | All OM SDK calls wrapped in `safeCall()` |
+| Session must not be re-created after finish | `_sessionFinished` flag guard |
+| Impression must fire only once per session | `_impressionFired` flag guard |
+| Only one AdEvents/MediaEvents per session | Singleton guards |
+| OM SDK must NOT be accessible to the creative directly | Creative has no OMID API; container manages session |
+
+### 14.2 OM SDK Specification Constraints
+
+These are hard constraints from the OM SDK specification and **must not be violated**:
+
+1. **Service Script must be loaded before AdSession creation** — The bridge checks `isOmSdkLoaded()` before creating sessions.
+2. **Events before start() are invalid** — The container MUST NOT fire OM SDK events before `AdSession.start()`. Events during LOADING state are queued or dropped.
+3. **loaded() before impressionOccurred()** — AdEvents.loaded() must fire before impressionOccurred(). The container ensures this ordering.
+4. **creativeType and impressionType before impression** — Set during session creation, before start().
+5. **One session per creative** — The bridge enforces singleton AdSession per container instance.
+6. **finish() must be called** — The container calls finish() on close. The `_terminate()` method must also call finish() if not already called.
+
+### 14.3 Cross-Origin Constraints
+
+| Context | OM SDK Loading | Access Mode |
+|---------|---------------|-------------|
+| Creative URL (default) | Publisher page loads OM SDK via `<script>` | N/A (publisher context) |
+| Creative Markup (renderer) | Container loads OM SDK, injects into creative HTML | `limited` (cross-origin renderer) |
+| Same-origin creative (Option 3) | Container fetches and injects into creative HTML | `full` (if operator explicitly sets) |
+
+**Critical:** The OM SDK Service Script and Session Client must share the same global scope (`OmidSessionClient`). In the Creative URL variant, this scope is the publisher page. The creative has no direct access to `OmidSessionClient` — the container manages the full session lifecycle.
+
+### 14.4 Performance
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| OM SDK load time | < 500ms | OM SDK Service Script is ~150KB gzipped |
+| Session creation | < 10ms | Synchronous Partner/Context/AdSession creation |
+| Event signaling | < 1ms | Direct method call, no async overhead |
+| Memory footprint | < 5MB | OM SDK + verification scripts |
+
+### 14.5 Backward Compatibility
+
+| Scenario | Behavior |
+|----------|----------|
+| Container without OMID extension talking to creative that expects OMID | Creative sees no OMID feature; no measurement occurs |
+| Container with OMID extension talking to creative that doesn't use OMID | OM SDK session runs silently; events fire on container state transitions |
+| Old container (0.7.1) sending `bridges: ['omid']` to new renderer (0.7.3) | Renderer loads OMID bridge module if available; if not, silently skips |
+| New container (0.7.3) sending `bridges: ['omid']` to old renderer (0.7.1) | Old renderer ignores unknown bridge (forward-compat per 0.7.1 design) |
+| Operator omits OmidCompatBridge extension | No OMID support declared in supportedFeatures; creatives fall back gracefully |
+
+---
+
+## 15. Decision Log
+
+| ID | Decision | Status | Rationale |
+|----|----------|--------|-----------|
+| **D1** | OM SDK loading: Option 2 (publisher page `<script>`) as default | ✅ Resolved | Works across all origins, no CORS, matches native SDK model |
+| **D2** | OMID as Extension (not Bridge) | ✅ Resolved | OMID is measurement, not API translation; fits extension model |
+| **D3** | Add `'omid'` to KNOWN_BRIDGE_IDENTIFIERS | ✅ Resolved | Enables renderer protocol forward-compatibility |
+| **D4** | AdCOM code 7 → `'omid'` mapping | ✅ Resolved | Mirrors existing MRAID mapping pattern |
+| **D5** | Default access mode: `limited` | ✅ Resolved | Safe for cross-origin iframes; `full` requires explicit opt-in |
+| **D6** | Feature name: `com.iabtechlab.sharc.omid` | ✅ Resolved | Already established in 0.7.2 bridge code |
+| **D7** | ~~Creative-side API: `SHARC:Creative:requestOmid` message~~ | ❌ Dropped | OMID is fully container-driven; no creative-side signaling needed |
+| **D8** | Event mapping: SHARC states → OM SDK events via `onContainerStateChange` | ✅ Resolved | Extension hook, not container-core behavior |
+| **D9** | Verification scripts: loaded via `VerificationScriptResource`, passed to Context | ✅ Resolved | Standard OM SDK pattern |
+| **D10** | OM SDK Service Script URL: configurable, default to IAB CDN | ✅ Resolved | Operators may need to use their CDN partner's URL |
+| **D11** | Session creation on READY state transition | ✅ Resolved | Earliest safe point (handshake complete, creative initialized) |
+| **D12** | Impression firing: container-auto on first visibility (guard: once per session) | ✅ Resolved | Matches MRAID/SafeFrame behavior |
+| **D13** | MediaEvents: supported for video/audio sessions only | ✅ Resolved | OM SDK spec: MediaEvents require vastProperties |
+| **D14** | CTV OM SDK: deferred to post-0.7.3 | ✅ Resolved | Different SDK variant (DACH), different platform |
+| **D15** | OM SDK for Apps (iOS/Android): deferred to post-0.7.3 | ✅ Resolved | Native SDK integration is a separate project |
+| **D16** | OM ID partner certification: operator responsibility | ✅ Resolved | IAB Tech Lab assigns partner names during certification |
+| **D17** | ~~Creative-side `SHARC.requestOmid()` helper method~~ | ❌ Dropped | No creative-side requestOmid path; container auto-manages session |
+| **D18** | Events during LOADING: dropped (not queued) | ✅ Resolved | OM SDK spec: events before start() are invalid; container must not fire them |
+| **D19** | Verification script validation: HTTPS required, non-HTTPS silently skipped | ✅ Resolved | Defense-in-depth; ad should still run if one vendor's script is unavailable |
+| **D20** | OM SDK load timeout: 5 seconds | ✅ Resolved | Matches existing renderer load timeout; generous for CDN delivery |
+
+### Unresolved Items
+
+| ID | Item | Blocked By | Impact |
+|----|------|-----------|--------|
+| **U1** | Canonical OM SDK Service Script URL from IAB Tech Lab | IAB Tech Lab hosting decision | Default URL may change; configurable |
+| **U2** | AdCOM `APIFramework` enum for SHARC 1.0 | AdCOM PR review | Not blocking for 0.7.3; SHARC uses extension model |
+| **U3** | SHARC + OM SDK reference implementation example | Implementation complete | Needed for operator documentation |
+
+---
+
+## Appendix A: Message Types
+
+No new message types are introduced in 0.7.3. OMID events are driven entirely by container state transitions through the extension hook. No creative→container OMID messages are needed.
+
+**Previously removed:**
+- `SHARC:Creative:requestOmid` — removed; container auto-manages session
+- `SHARC:Container:omidStatus` (future) — deferred post-0.7.3; session observer callbacks handled internally
+
+---
+
+## Appendix B: Comparison with SIMID + OM SDK Pattern
+
+SIMID (video interactivity standard) already integrates with OM SDK for video ads. The pattern is directly portable:
+
+| Aspect | SIMID | SHARC (0.7.3) |
+|--------|-------|---------------|
+| Container role | Video player | SHARC container (iframe/webview) |
+| OM SDK loading | Player loads Service Script | Container loads Service Script on publisher page |
+| Event signaling | SIMID protocol → OM SDK API | Container state transitions → OM SDK API (auto, no creative involvement) |
+| Verification scripts | Via VAST `AdVerifications` | Via AdCOM `adVerifications` + `VerificationScriptResource` |
+| Session lifecycle | Player-managed | Container-managed (extension hook) |
+| Creative awareness | SIMID handles events | Creative does nothing — OMID is transparent |
+
+**Key insight:** Both SIMID and SHARC share the same principle — the container owns the OM SDK session and fires events on its own lifecycle transitions. Unlike SIMID where the creative signals events, SHARC 0.7.3 fires all OM SDK events automatically from container state changes, making it fully transparent to the creative.
+
+---
+
+## Appendix C: Error Codes
+
+| Code | Error | When |
+|------|-------|------|
+| 2115 | `RENDERER_FAILED` | OM SDK load fails after timeout (creative markup variant) |
+| NEW-OMID-01 | `OMID_SESSION_NOT_STARTED` | Event fired before session started |
+| NEW-OMID-02 | `OMID_SESSION_ALREADY_FINISHED` | Event fired after session finished |
+| NEW-OMID-03 | `OMID_SDK_NOT_LOADED` | OM SDK service script not available |
+| NEW-OMID-04 | `OMID_DUPLICATE_SESSION` | Attempt to create second AdSession |
+| NEW-OMID-05 | `OMID_INVALID_VERIFICATION_URL` | Verification script URL validation failed |
+
+**Removed error codes (creative-side path dropped):**
+- 2203 `UNSUPPORTED_FUNCTIONALITY` — was used for creative requesting unsupported OMID action; no longer needed
+- 2204 `UNSUPPORTED_ACTION` — was used for container receiving invalid OMID action string; no longer needed
+
+---
+
+*End of design spec.*


### PR DESCRIPTION
Container-owned OMID lifecycle: SDK loading, session management, event mapping to SHARC states, verification script injection.

OMID is fully container-driven — no creative-side requestOmid API. MRAID/SafeFrame ads get measurement transparently via the container state machine.

Closes #118.

Phasing: Phase 1 (~8h) MVP session lifecycle, Phase 2 (~7h) MediaEvents, verification scripts, creative API.