### PR TITLE
docs: 0.7.3 quick wins from post-0.7.3 audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1486,7 +1486,8 @@ messages are sent at additional transition points; no new message types.
 - `supportedFeatures` extension mechanism
 
 <!-- Version compare links (Update when new tags are pushed) -->
-[Unreleased]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.2...main
+[Unreleased]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.3...main
+[0.7.3]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/jeffreycarlson/SHARC/compare/v0.6.2...v0.7.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported Versions
 
-SHARC is currently in pre-1.0 development at package version `0.5.3` and is not yet publicly published to npm.
+SHARC is currently in pre-1.0 development at package version `0.7.3` and is not yet publicly published to npm.
 
-Until the first public release, the project supports the current development line on `main` / the latest `0.5.x` source state in this repository. Earlier snapshots are not maintained as supported release lines, and there is no backport commitment yet.
+Until the first public release, the project supports the current development line on `main` / the latest `0.7.x` source state in this repository. Earlier snapshots are not maintained as supported release lines, and there is no backport commitment yet.
 
 | Version / state | Supported |
 | ------- | --------- |
-| Current `main` / `0.5.x` development line | :white_check_mark: |
+| Current `main` / `0.7.x` development line | :white_check_mark: |
 | Earlier pre-release snapshots | :x: |
 
 ## Reporting a Vulnerability

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -103,7 +103,7 @@ On `load()`, `SHARCContainer` stamps `data-sharc-*` attributes onto the placemen
 | `data-sharc-placement-session-id` | Yes | Value is `placementSessionId`. Unique per instance. |
 | `data-sharc-placement-id` | Only when `placementId` is non-null | Publisher-supplied placement identifier. |
 | `data-sharc-placement-name` | Only when `placementName` is non-null | Human-readable placement name. |
-| `data-sharc-version` | Yes | SHARC version string (e.g. `"0.7.2"`). |
+| `data-sharc-version` | Yes | SHARC version string (e.g. `"0.7.3"`). |
 | `data-sharc-state` | Yes | Live-reflected container state (e.g. `"active"`). Updates on every state transition. |
 | `data-sharc-intent` | Only when an intent is active | Live-reflected active intent: `"resize"`, `"expand"`, or `"fullscreen"`. Absent after `collapse` or when no intent is active. |
 
@@ -810,7 +810,7 @@ interface CreateSessionArgs {
 ```
 
 - `placementType` — the creative's self-declared placement type. `"inline"` (default) means the ad is anchored in page content. `"interstitial"` means the ad overlays content. Omitting the field is equivalent to `"inline"`.
-- `version` — the SHARC spec version the creative SDK conforms to (e.g. `"0.7.2"`). Used by the container for version compatibility checks.
+- `version` — the SHARC spec version the creative SDK conforms to (e.g. `"0.7.3"`). Used by the container for version compatibility checks.
 
 The creative generates a unique `sessionId` (UUID) and includes it in this message. All subsequent messages in the session use this same `sessionId`.
 

--- a/docs/architecture-design.md
+++ b/docs/architecture-design.md
@@ -890,7 +890,7 @@ Container-driven compatibility bridge loading on the Creative Markup variant. Th
 **Container-side detection** is a three-layer pipeline, most-specific wins:
 
 1. **Layer 1 — explicit constructor `bridges` option.** Operator override. Array of reserved identifiers (`'mraid'`, `'safeframe'` in 0.7.1). Pass `[]` to explicitly suppress all bridge loading; `null` / omit to use auto-detection.
-2. **Layer 2 — `creativeMeta.apis` AdCOM `APIFramework` integer codes.** OpenRTB 2.6's `bid.apis` references AdCOM enums directly. 0.7.1 mapping: `3` / `5` / `6` (MRAID 1.0 / 2.0 / 3.0) → `'mraid'`. Code `7` (OMID 1.0) deferred to 0.7.2. Vendor-specific codes (500+) ignored. Empty mapping falls through to layer 3.
+2. **Layer 2 — `creativeMeta.apis` AdCOM `APIFramework` integer codes.** OpenRTB 2.6's `bid.apis` references AdCOM enums directly. 0.7.1 mapping: `3` / `5` / `6` (MRAID 1.0 / 2.0 / 3.0) → `'mraid'`. Code `7` (OMID 1.0) is **intentionally excluded from the renderer bridge picker** — 0.7.3 cemented OMID as extension-owned (container-side `OmidCompatBridge`), not a renderer-loaded compatibility bridge. See [`docs/design/0.7.3-omid-wiring.md`](./design/0.7.3-omid-wiring.md) § 5. Vendor-specific codes (500+) ignored. Empty mapping falls through to layer 3.
 3. **Layer 3 — adm content scan.** Last-resort heuristic on `creativeHtml`. Tightened substrings: `indexOf('mraid.js')` for MRAID, `indexOf('$sf.ext')` for SafeFrame. False positives (extra bridge loads) are tolerable; false negatives break the creative and require the operator to pass an explicit `bridges`.
 
 Result is sorted, deduplicated, frozen, and exposed as `container.bridges` (diagnostic surface) and on the `bridges` field of the outgoing `:render` message.
@@ -905,7 +905,7 @@ Result is sorted, deduplicated, frozen, and exposed as `container.bridges` (diag
 4. **CSP `script-src 'self'`** is recommended operator-fork guidance — browser-level belt for the JS-level same-origin defense.
 5. **`bridge_load_failed`** is a distinct `onSecurityEvent` variant (error code `2115`, same as `renderer_failed`, but a separate `event.type` discriminator). Operators see bridge import failures separately from creative-side render failures.
 
-**Forward compatibility.** An old container omitting the `bridges` field is treated identically to `bridges: []` by a new renderer. An old renderer receiving `bridges` from a new container silently ignores the unknown field (legacy load path predates the field). A new renderer receiving an identifier it doesn't know (`'omid'` from a 0.7.2+ container on a 0.7.1 renderer) silently skips it via `customSecurityLog`. The protocol degrades gracefully across the version skew without protocol-version bumps. Per design doc § 13 Q4 lock, `'omid'` is NOT in 0.7.1's vocabulary — it lands with 0.7.2.
+**Forward compatibility.** An old container omitting the `bridges` field is treated identically to `bridges: []` by a new renderer. An old renderer receiving `bridges` from a new container silently ignores the unknown field (legacy load path predates the field). A new renderer receiving an identifier it doesn't know silently skips it via `customSecurityLog`. The protocol degrades gracefully across the version skew without protocol-version bumps. Per design doc § 13 Q4 lock, `'omid'` is NOT in 0.7.1's vocabulary — and 0.7.3 cemented OMID as extension-owned rather than bringing it into the renderer bridge vocabulary at all. The renderer bridge picker stays `['mraid', 'safeframe']` going forward.
 
 ---
 

--- a/docs/creative-cookbook.md
+++ b/docs/creative-cookbook.md
@@ -382,7 +382,7 @@ The architectural rationale lives in [architecture-design.md §14](./architectur
     const container = new SHARCContainer({
       // Creative Markup variant — TWO inputs in place of `creativeUrl`
       creativeHtml: CREATIVE_HTML,
-      creativeRendererUrl: 'https://renderer.your-operator.com/0.7.0/',
+      creativeRendererUrl: 'https://renderer.your-operator.com/0.7.3/',
 
       placementElement: document.getElementById('ad-slot'),
       placementId: 'inline-300x250',
@@ -507,7 +507,7 @@ new SHARCContainer({ /* ... */, bridges: ['mraid', 'safeframe'] }); // force bot
 
 The resolved bridge list is exposed as `container.bridges` (frozen array) for operator dashboards correlating "this `placementSessionId` had MRAID bridge loaded" — useful when investigating creative-rendering bugs.
 
-What's NOT in 0.7.1's bridge vocabulary: `'omid'` (OMID viewability). That lands in 0.7.2 as a separate scope per the [0.7.1 bridges design](./design/0.7.1-bridges-field.md) § 13 Q4 lock. A 0.7.2+ container shipping `bridges: ['omid']` to a 0.7.1 renderer will have `'omid'` silently skipped via the renderer's `KNOWN_BRIDGES` allowlist (forward-compat tolerance, not pre-reservation).
+What's NOT in 0.7.1's bridge vocabulary: `'omid'` (OMID viewability). 0.7.3 decided OMID stays **extension-owned**, not in the renderer bridge vocabulary — see [`docs/design/0.7.3-omid-wiring.md`](./design/0.7.3-omid-wiring.md) § 5 (Bridge vs. Extension Architecture). The `bridges` array stays `['mraid', 'safeframe']`; OMID measurement is wired via the container-owned `OmidCompatBridge` extension. A container passing `bridges: ['omid']` throws synchronously at construction.
 
 The hosted reference renderer is **SDK evaluation only**. The container's `KNOWN_TEST_RENDERERS` guard refuses to load it from non-dev origins and throws synchronously at construction. See § 9 for the production setup.
 
@@ -622,7 +622,7 @@ The bridge is **best-effort**. Adversarial creative HTML can re-override `window
 ```javascript
 const container = new SHARCContainer({
   creativeHtml: CREATIVE_HTML,
-  creativeRendererUrl: 'https://renderer.your-operator.com/0.7.0/',
+  creativeRendererUrl: 'https://renderer.your-operator.com/0.7.3/',
   placementElement: document.getElementById('ad-slot'),
 
   onNavigation: (req) => {

--- a/docs/design/0.7.3-omid-wiring.md
+++ b/docs/design/0.7.3-omid-wiring.md
@@ -1,6 +1,6 @@
 # 0.7.3 — Container-side OMID Wiring
 
-**Status:** Design (ready for PM review)  
+**Status:** Shipped in 0.7.3 (PR [#122](https://github.com/jeffreycarlson/SHARC/pull/122))  
 **Issue:** [#118](https://github.com/jeffreycarlson/SHARC/issues/118)  
 **Target version:** 0.7.3  
 **Predecessors:** 0.7.1 (bridges field, § 13 Q4 lock — `'omid'` deferred). 0.7.2 (OmidCompatBridge v0.7.2, creative-frame bridge, `installOmidBridge`, removed from the 0.7.3 design).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -167,7 +167,7 @@ The container opens an iframe pointing at `creativeUrl`, runs the standard SHARC
 
   const container = new SHARCContainer({
     creativeHtml: CREATIVE_HTML,
-    creativeRendererUrl: 'https://renderer.your-operator.com/0.7.2/',
+    creativeRendererUrl: 'https://renderer.your-operator.com/0.7.3/',
     placementElement: document.getElementById('ad-slot'),
     placementId: 'inline-300x250',
 


### PR DESCRIPTION
## Summary

Eight mechanical doc fixes surfaced by the 2026-05-22 post-0.7.3 audit. File-scope edits only — no behavioral changes, no content writing.

## Fixes

| # | File | Change |
|---|---|---|
| 1 | `SECURITY.md` | Version drift `0.5.3` → `0.7.3` (eleven versions stale). Highest-trust file for vuln reporters. |
| 2 | `CHANGELOG.md` | `[Unreleased]` compare-link `v0.7.2...main` → `v0.7.3...main`; add missing `[0.7.3]: ...v0.7.2...v0.7.3` entry |
| 3 | `docs/getting-started.md:170` | Example renderer URL `/0.7.2/` → `/0.7.3/` |
| 4 | `docs/creative-cookbook.md:385,625` | Example renderer URLs `/0.7.0/` → `/0.7.3/` (two locations) |
| 5 | `docs/creative-cookbook.md:510` | Rewrite "OMID lands in 0.7.2" sentence to reflect 0.7.3's extension-owned decision; cross-link to OMID design doc |
| 6 | `docs/architecture-design.md:893,908` | Same OMID rewrite in the bridge-detection-layer description and forward-compat section |
| 7 | `docs/api-reference.md:106,813` | Example `"0.7.2"` version strings → `"0.7.3"` |
| 8 | `docs/design/0.7.3-omid-wiring.md:3` | Status "Design (ready for PM review)" → "Shipped in 0.7.3 (PR #122)" |

## Out of scope (tracked separately)

Content-writing follow-ups landed as separate issues:
- #133 `docs/current-status.md` 0.7.3 section (currently denies 0.7.3 exists)
- #134 `docs/operator-cookbook.md` OMID integration recipe
- #135 `docs/api-reference.md` `OmidCompatBridge` API surface subsection
- #136 `docs/distribution-design.md` sample-vs-actual decision

Already-tracked from prior audits: #129 (repo origin attribution), #130 (getting-started identity), #131 (README OMID framing).

## Test plan

- [x] `git diff --stat` → 7 files changed, 14 insertions, 13 deletions
- [x] `grep -rn "renderer.your-operator.com/0\.7\.[02]/" docs/` → no remaining hardcoded stale URLs
- [x] All edits read-verified (no logic, no formatting drift)
- [x] CI green (Build, Size, and Pack Test passed per OpenClaw review)