### PR TITLE
chore: OMID + creativeSdkUrl LOW cleanup sweep

### DIFF
--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -5351,7 +5351,9 @@ class SHARCContainer {
    * thread user-derived data (RTB macros, A/B config) through `creativeSdkUrl`
    * or string `creativeSdkScriptAttrs` values.
    *
-   * @param {string} value - Raw attribute value (already coerced to string).
+   * @param {string|number} value - Raw attribute value. Internal `String(value)`
+   *   coercion handles numbers (`creativeSdkScriptAttrs: { 'data-rtb-id': 42 }`);
+   *   other non-string types are gated upstream in `_buildCreativeSdkScriptTag`.
    * @returns {string} HTML-attribute-safe escaped value.
    * @private
    */
@@ -5404,8 +5406,22 @@ class SHARCContainer {
         if (value === false || value === null || value === undefined) continue;
         if (value === true) {
           serialized += ' ' + name;
-        } else {
+        } else if (typeof value === 'string' || typeof value === 'number') {
+          // 0.7.3 follow-up (#107): explicitly gate on string|number rather than
+          // String(value) on arbitrary types. `Symbol` throws on `String(Symbol)`;
+          // objects with throwing `toString` throw; plain objects silently
+          // coerce to `"[object Object]"`. Throwing values were caught by the
+          // outer try/catch in _runMarkupInjection, but the failure mode was
+          // silent re: cause. Plain objects produced corrupt markup with no
+          // warning. Now: unsupported value types skipped + warned (same
+          // pattern as the attribute-name validation above).
           serialized += ' ' + name + '="' + SHARCContainer._escapeAttrValue(value) + '"';
+        } else {
+          console.warn(
+            '[SHARCContainer] Skipping creativeSdkScriptAttrs[' + JSON.stringify(name) + '] '
+            + 'with unsupported value type ' + typeof value
+            + ' (expected boolean | string | number | null | undefined)'
+          );
         }
       }
     }

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -2561,6 +2561,92 @@ class SHARCContainer {
   }
 
   /**
+   * HTML-escapes a string for safe insertion inside a double-quoted attribute
+   * value. Replaces in order: `&` → `&amp;` (first, so we don't double-escape),
+   * `"` → `&quot;`, `<` → `&lt;` (defense-in-depth — `<` inside an attribute
+   * is legal but escaping removes any chance an upstream HTML scanner mistakes
+   * the boundary). Defense against attribute-injection when operator pipelines
+   * thread user-derived data (RTB macros, A/B config) through `creativeSdkUrl`
+   * or string `creativeSdkScriptAttrs` values.
+   *
+   * @param {string|number} value - Raw attribute value. Internal `String(value)`
+   *   coercion handles numbers (`creativeSdkScriptAttrs: { 'data-rtb-id': 42 }`);
+   *   other non-string types are gated upstream in `_buildCreativeSdkScriptTag`.
+   * @returns {string} HTML-attribute-safe escaped value.
+   * @private
+   */
+  static _escapeAttrValue(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;');
+  }
+
+  /**
+   * Builds the `<script src="...">` tag for the auto-injected creative SDK.
+   * Serializes `attrs` with React-style conventions: `true` → bare attribute,
+   * `false`/`null`/`undefined` → omitted, strings/coercible → quoted +
+   * HTML-escaped via `_escapeAttrValue`.
+   *
+   * @param {string} url - The validated `creativeSdkUrl`.
+   * @param {Object} attrs - The `creativeSdkScriptAttrs` option.
+   * @returns {string} A complete `<script ...></script>` tag.
+   * @private
+   */
+  static _buildCreativeSdkScriptTag(url, attrs) {
+    let serialized = '';
+    if (attrs && typeof attrs === 'object') {
+      const keys = Object.keys(attrs);
+      for (let i = 0; i < keys.length; i++) {
+        const name = keys[i];
+        // 0.7.2 PR 4.1 round-1 fix: validate each name against a deliberately
+        // strict subset of the HTML5 attribute-name grammar — letter first,
+        // then letters/digits/hyphen/underscore/colon/period. Tighter than the
+        // formal HTML5 spec (which also allows leading `_`, `:`, or digits)
+        // but adequate for the operator-common attribute-name shapes used on
+        // <script> tags (async, defer, integrity, nonce, type, data-*, aria-*,
+        // etc.). Operators who hit this can rename. The value path is
+        // HTML-escaped via _escapeAttrValue, but the name path emits verbatim
+        // — a hostile key like `'></script><img src=x onerror=alert(1)'` would
+        // break out of the <script> tag despite the value being escaped.
+        // Operators threading user-derived data through
+        // Object.keys(creativeSdkScriptAttrs) get a loud console.warn rather
+        // than silent HTML injection. Rejects whitespace, quotes, angle
+        // brackets, `=`, `/`.
+        if (!/^[a-zA-Z][a-zA-Z0-9_:.-]*$/.test(name)) {
+          console.warn(
+            '[SHARCContainer] Skipping invalid attribute name in creativeSdkScriptAttrs: '
+            + JSON.stringify(name)
+          );
+          continue;
+        }
+        const value = attrs[name];
+        if (value === false || value === null || value === undefined) continue;
+        if (value === true) {
+          serialized += ' ' + name;
+        } else if (typeof value === 'string' || typeof value === 'number') {
+          // 0.7.3 follow-up (#107): explicitly gate on string|number rather than
+          // String(value) on arbitrary types. `Symbol` throws on `String(Symbol)`;
+          // objects with throwing `toString` throw; plain objects silently
+          // coerce to `"[object Object]"`. Throwing values were caught by the
+          // outer try/catch in _runMarkupInjection, but the failure mode was
+          // silent re: cause. Plain objects produced corrupt markup with no
+          // warning. Now: unsupported value types skipped + warned (same
+          // pattern as the attribute-name validation above).
+          serialized += ' ' + name + '="' + SHARCContainer._escapeAttrValue(value) + '"';
+        } else {
+          console.warn(
+            '[SHARCContainer] Skipping creativeSdkScriptAttrs[' + JSON.stringify(name) + '] '
+            + 'with unsupported value type ' + typeof value
+            + ' (expected boolean | string | number | null | undefined)'
+          );
+        }
+      }
+    }
+    return '<script src="' + SHARCContainer._escapeAttrValue(url) + '"' + serialized + '></script>';
+  }
+
+  /**
    * Built-in injection: inserts a `<script src="creativeSdkUrl"></script>` tag
    * into Markup-variant creative HTML at the most-specific position present.
    * Runs FIRST in `_runMarkupInjection` (before any operator extensions), so
@@ -5340,92 +5426,6 @@ class SHARCContainer {
    */
   static _sortDedupBridges(ids) {
     return [...new Set(ids)].sort();
-  }
-
-  /**
-   * HTML-escapes a string for safe insertion inside a double-quoted attribute
-   * value. Replaces in order: `&` → `&amp;` (first, so we don't double-escape),
-   * `"` → `&quot;`, `<` → `&lt;` (defense-in-depth — `<` inside an attribute
-   * is legal but escaping removes any chance an upstream HTML scanner mistakes
-   * the boundary). Defense against attribute-injection when operator pipelines
-   * thread user-derived data (RTB macros, A/B config) through `creativeSdkUrl`
-   * or string `creativeSdkScriptAttrs` values.
-   *
-   * @param {string|number} value - Raw attribute value. Internal `String(value)`
-   *   coercion handles numbers (`creativeSdkScriptAttrs: { 'data-rtb-id': 42 }`);
-   *   other non-string types are gated upstream in `_buildCreativeSdkScriptTag`.
-   * @returns {string} HTML-attribute-safe escaped value.
-   * @private
-   */
-  static _escapeAttrValue(value) {
-    return String(value)
-      .replace(/&/g, '&amp;')
-      .replace(/"/g, '&quot;')
-      .replace(/</g, '&lt;');
-  }
-
-  /**
-   * Builds the `<script src="...">` tag for the auto-injected creative SDK.
-   * Serializes `attrs` with React-style conventions: `true` → bare attribute,
-   * `false`/`null`/`undefined` → omitted, strings/coercible → quoted +
-   * HTML-escaped via `_escapeAttrValue`.
-   *
-   * @param {string} url - The validated `creativeSdkUrl`.
-   * @param {Object} attrs - The `creativeSdkScriptAttrs` option.
-   * @returns {string} A complete `<script ...></script>` tag.
-   * @private
-   */
-  static _buildCreativeSdkScriptTag(url, attrs) {
-    let serialized = '';
-    if (attrs && typeof attrs === 'object') {
-      const keys = Object.keys(attrs);
-      for (let i = 0; i < keys.length; i++) {
-        const name = keys[i];
-        // 0.7.2 PR 4.1 round-1 fix: validate each name against a deliberately
-        // strict subset of the HTML5 attribute-name grammar — letter first,
-        // then letters/digits/hyphen/underscore/colon/period. Tighter than the
-        // formal HTML5 spec (which also allows leading `_`, `:`, or digits)
-        // but adequate for the operator-common attribute-name shapes used on
-        // <script> tags (async, defer, integrity, nonce, type, data-*, aria-*,
-        // etc.). Operators who hit this can rename. The value path is
-        // HTML-escaped via _escapeAttrValue, but the name path emits verbatim
-        // — a hostile key like `'></script><img src=x onerror=alert(1)'` would
-        // break out of the <script> tag despite the value being escaped.
-        // Operators threading user-derived data through
-        // Object.keys(creativeSdkScriptAttrs) get a loud console.warn rather
-        // than silent HTML injection. Rejects whitespace, quotes, angle
-        // brackets, `=`, `/`.
-        if (!/^[a-zA-Z][a-zA-Z0-9_:.-]*$/.test(name)) {
-          console.warn(
-            '[SHARCContainer] Skipping invalid attribute name in creativeSdkScriptAttrs: '
-            + JSON.stringify(name)
-          );
-          continue;
-        }
-        const value = attrs[name];
-        if (value === false || value === null || value === undefined) continue;
-        if (value === true) {
-          serialized += ' ' + name;
-        } else if (typeof value === 'string' || typeof value === 'number') {
-          // 0.7.3 follow-up (#107): explicitly gate on string|number rather than
-          // String(value) on arbitrary types. `Symbol` throws on `String(Symbol)`;
-          // objects with throwing `toString` throw; plain objects silently
-          // coerce to `"[object Object]"`. Throwing values were caught by the
-          // outer try/catch in _runMarkupInjection, but the failure mode was
-          // silent re: cause. Plain objects produced corrupt markup with no
-          // warning. Now: unsupported value types skipped + warned (same
-          // pattern as the attribute-name validation above).
-          serialized += ' ' + name + '="' + SHARCContainer._escapeAttrValue(value) + '"';
-        } else {
-          console.warn(
-            '[SHARCContainer] Skipping creativeSdkScriptAttrs[' + JSON.stringify(name) + '] '
-            + 'with unsupported value type ' + typeof value
-            + ' (expected boolean | string | number | null | undefined)'
-          );
-        }
-      }
-    }
-    return '<script src="' + SHARCContainer._escapeAttrValue(url) + '"' + serialized + '></script>';
   }
 
   /**

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -190,10 +190,15 @@ function validateVerificationScripts(verificationScripts) {
     var dedupeKey = parsedUrl;
     if (seen[dedupeKey]) continue;
     seen[dedupeKey] = true;
+    // 0.7.3 follow-up (#127 sub-3b): push a shallow copy with the normalized
+    // resourceUrl rather than mutating the operator's input object. The legacy
+    // `url` alias caller may not expect a validation function to write
+    // resourceUrl back onto their input.
     if (typeof script.resourceUrl !== 'string') {
-      script.resourceUrl = resourceUrl;
+      validated.push(Object.assign({}, script, { resourceUrl: resourceUrl }));
+    } else {
+      validated.push(script);
     }
-    validated.push(script);
   }
   return validated;
 }
@@ -386,6 +391,13 @@ OmidCompatBridge.prototype = /** @type {any} */ ({
    * owns the AdSession lifecycle. No OMID or SHARC scripts are injected into
    * creative markup.
    *
+   * **Status (#127 sub-3c):** no-op stub. Exists for bridge-interface parity
+   * with `MRAIDCompatBridge.injectScripts` and `SafeFrameCompatBridge.injectScripts`
+   * (which DO transform markup in their respective legacy-bridge flows).
+   * Retirement of this method across all three bridges is a separate decision
+   * not scoped to 0.7.3 — the wrapper/injector pattern may still be relevant
+   * for MRAID/SafeFrame even if OMID has moved past it.
+   *
    * @param {string} html    - The original creative HTML markup.
    * @returns {string}       The original creative HTML markup, unchanged.
    */
@@ -410,11 +422,18 @@ OmidCompatBridge.prototype = /** @type {any} */ ({
   },
 
   /**
-   * Returns the wrapper URL for a given creative URL.
+   * Returns a wrapper URL for a given creative URL.
    *
-   * The container should load this URL in the ad iframe instead of the
-   * creative directly. OMID remains container-owned; this legacy helper only
-   * constructs the wrapper URL.
+   * **Status (#127 sub-3c):** legacy compatibility stub. The container-owned
+   * OMID model (0.7.3, PR #122) does NOT use a wrapper-page approach — OM
+   * SDK runs on the publisher page and the creative iframe loads the
+   * creative directly. This method exists for bridge-interface parity with
+   * `MRAIDCompatBridge.getWrapperUrl` and `SafeFrameCompatBridge.getWrapperUrl`
+   * (where the wrapper page is still part of the legacy flow). Operators
+   * should NOT call this method for OMID setup; OMID lifecycle is driven by
+   * the container directly via `OmidCompatBridge` as an extension. Retirement
+   * of `getWrapperUrl` across all three bridges is a separate decision not
+   * scoped to 0.7.3.
    *
    * @param {string} creativeUrl - Original creative URL.
    * @returns {string} The wrapper URL.
@@ -887,6 +906,21 @@ OmidCompatBridge.prototype = /** @type {any} */ ({
 
   /**
    * Public cleanup hook called by SHARCContainer.
+   *
+   * Multi-instance contract (0.7.3 follow-up #127): each bridge instance
+   * owns and removes ONLY the `<script>` tags IT actually injected.
+   * `_injectScript` skips DOM injection (and the push to `_loadedScripts`)
+   * when it finds an existing matching tag — that tag remains owned by
+   * whoever appended it. If two `OmidCompatBridge` instances configured
+   * with the same OM SDK URL coexist on a page, instance B sees A's tag
+   * and resolves early without tracking it; A.destroy() removes the
+   * shared tag while B's `_loadedScripts` stays empty. OM SDK globals
+   * (`window.omid`, `window.OmidSessionClient`) persist after the script
+   * element is removed, so B's existing AdSession keeps working — but
+   * no instance will re-inject the SDK after that. Operators running
+   * multiple OMID bridges on one page should expect at-most-one cleanup
+   * pass to fire; long-lived multi-instance setups are out of scope for
+   * the 0.7.3 cleanup model.
    */
   destroy: function () {
     this.unregisterFriendlyObstruction();

--- a/test/node/test-creative-sdk-injection.js
+++ b/test/node/test-creative-sdk-injection.js
@@ -51,6 +51,9 @@
  *      - creativeSdkUrl with `&` → src value escaped
  *      - 4i–4k: round-1 attribute-name validation (PR #105 review Fix 3)
  *      - 4l–4m: round-1 adversarial creativeSdkUrl content escape
+ *      - 4n–4q: 0.7.3 follow-up — attribute-VALUE type gating; only
+ *               string|number emitted, Symbol/throwing-toString/plain Object
+ *               skipped with warn (issue #107)
  *
  *   5. SHARCContainer integration
  *      - creativeInjected flag flips true after _runMarkupInjection()
@@ -753,6 +756,67 @@ const SDK_URL = 'https://op.example/sharc-creative.js';
       '4k. data-rtb-id passes through unchanged (namespaced name allowed)');
     assert(out.indexOf('aria-label="Ad"') !== -1,
       '4k (sanity). aria-label passes through unchanged (namespaced name allowed)');
+  }
+
+  // ─── 0.7.3 follow-up (#107): attribute-value type gating ──────────────
+  // _buildCreativeSdkScriptTag previously called String(value) for any
+  // non-boolean/null/undefined value. Symbols and throwing-Object values
+  // threw (caught silently by the outer try/catch); plain objects produced
+  // "[object Object]". Now: only string|number are emitted; other types
+  // skipped + console.warn.
+
+  // 4n — Symbol value → skipped + warn
+  {
+    let out;
+    const warns = captureWarn(() => {
+      out = injectWithAttrs({ 'data-x': Symbol('foo') });
+    });
+    assert(out !== null && out.indexOf('data-x') === -1,
+      '4n. Symbol value → attribute omitted from output');
+    assert(warns.length === 1 && /unsupported value type symbol/.test(String(warns[0][0])),
+      '4n (sanity). console.warn fires once with "unsupported value type symbol"');
+  }
+
+  // 4o — throwing-toString Object value → skipped + warn (no exception)
+  {
+    let out;
+    let threw = false;
+    const warns = captureWarn(() => {
+      try {
+        out = injectWithAttrs({ 'data-x': { toString() { throw new Error('boom'); } } });
+      } catch (_) { threw = true; }
+    });
+    assert(!threw, '4o. throwing-toString Object → does NOT throw (gated before coercion)');
+    assert(out !== null && out.indexOf('data-x') === -1,
+      '4o (sanity). attribute omitted from output');
+    assert(warns.length === 1 && /unsupported value type object/.test(String(warns[0][0])),
+      '4o (further). console.warn fires once with "unsupported value type object"');
+  }
+
+  // 4p — plain Object value → skipped + warn (no "[object Object]" leak)
+  {
+    let out;
+    const warns = captureWarn(() => {
+      out = injectWithAttrs({ 'data-x': { a: 1, b: 2 } });
+    });
+    assert(out !== null && out.indexOf('[object Object]') === -1,
+      '4p. plain Object value → no "[object Object]" string leaks into output');
+    assert(out !== null && out.indexOf('data-x') === -1,
+      '4p (sanity). attribute omitted from output');
+    assert(warns.length === 1 && /unsupported value type object/.test(String(warns[0][0])),
+      '4p (further). console.warn fires for plain Object value');
+  }
+
+  // 4q — Number value → ACCEPTED (regression guard against over-tightening)
+  {
+    let out;
+    const warns = captureWarn(() => {
+      out = injectWithAttrs({ 'data-rtb-id': 42 });
+    });
+    assert(out !== null && out.indexOf('data-rtb-id="42"') !== -1,
+      '4q. Number value (42) → emitted as quoted attribute');
+    assert(warns.length === 0,
+      '4q (sanity). no warning for valid Number value');
   }
 
   // ─── PR #105 review: adversarial creativeSdkUrl content ───────────────

--- a/test/node/test-omid-container-lifecycle.js
+++ b/test/node/test-omid-container-lifecycle.js
@@ -1360,10 +1360,9 @@ section('G11f. Edge cases — multi-instance destroy contract (each bridge owns 
   // B sees the existing tag — call _injectScript and verify it resolves
   // without pushing to B's _loadedScripts (matching the production dedup
   // path inside _injectScript at sharc-omid-bridge.js:629-650).
-  bridgeB._injectScript(sharedUrl).then(() => {
-    assert(bridgeB._loadedScripts.length === 0,
-      'B._injectScript finds existing tag → does NOT push to B._loadedScripts');
-  });
+  await bridgeB._injectScript(sharedUrl);
+  assert(bridgeB._loadedScripts.length === 0,
+    'B._injectScript finds existing tag → does NOT push to B._loadedScripts');
 
   // A.destroy() removes the shared tag.
   bridgeA.destroy();

--- a/test/node/test-omid-container-lifecycle.js
+++ b/test/node/test-omid-container-lifecycle.js
@@ -503,8 +503,13 @@ section('B5. Container lifecycle — session idempotent: ready fired twice does 
     const bridge = new OmidCompatBridge({ creativeType: 'display', mediaType: 'display' });
     const c = createContainerWithOmid(bridge);
 
+    // 0.7.3 cleanup (#127 sub-3d): setState() already triggers
+    // _notifyExtensionsLifecycle via the state-machine onChange listener,
+    // so the manual call that used to follow each setState was a redundant
+    // double-fire. Dropped — the test now exercises the documented
+    // "spurious duplicate" path with one explicit manual call after the
+    // natural setState dispatch.
     c.setState('ready');
-    c._notifyExtensionsLifecycle('stateChange', { newState: 'ready', previousState: 'loading' });
     // Dispatch ready again (e.g. spurious duplicate event)
     c._notifyExtensionsLifecycle('stateChange', { newState: 'ready', previousState: 'ready' });
 
@@ -523,10 +528,10 @@ section('B6. Container lifecycle — active fired twice does NOT double-fire loa
     const bridge = new OmidCompatBridge({ creativeType: 'display', mediaType: 'display' });
     const c = createContainerWithOmid(bridge);
 
+    // 0.7.3 cleanup (#127 sub-3d): drop redundant manual fires after each
+    // setState. setState() already dispatches via the onChange listener.
     c.setState('ready');
-    c._notifyExtensionsLifecycle('stateChange', { newState: 'ready', previousState: 'loading' });
     c.setState('active');
-    c._notifyExtensionsLifecycle('stateChange', { newState: 'active', previousState: 'ready' });
     // Spurious second active
     c._notifyExtensionsLifecycle('stateChange', { newState: 'active', previousState: 'active' });
 
@@ -546,10 +551,10 @@ section('B7. Container lifecycle — session-finished state persists after bridg
     const bridge = new OmidCompatBridge({ creativeType: 'display', mediaType: 'display' });
     const c = createContainerWithOmid(bridge);
 
+    // 0.7.3 cleanup (#127 sub-3d): drop redundant manual fires after each
+    // setState. setState() already dispatches via the onChange listener.
     c.setState('ready');
-    c._notifyExtensionsLifecycle('stateChange', { newState: 'ready', previousState: 'loading' });
     c.setState('active');
-    c._notifyExtensionsLifecycle('stateChange', { newState: 'active', previousState: 'ready' });
 
     bridge.destroy();
     assert(bridge._omid.sessionStarted === false, 'after destroy: sessionStarted = false');
@@ -1182,6 +1187,16 @@ section('G10b. Edge cases — verificationScripts validation and deduplication')
     'verificationScripts keeps first duplicate descriptor');
   assert(bridge.options.verificationScripts[1].resourceUrl === 'https://legacy.example/v.js',
     'verificationScripts normalizes legacy url alias to resourceUrl');
+
+  // 0.7.3 cleanup (#127 sub-3b): legacy-url-alias normalization MUST NOT
+  // mutate the operator's input object. Validator now pushes a shallow
+  // copy with the normalized resourceUrl.
+  const operatorInput = [{ url: 'https://op-input.example/v.js', vendor: 'op-vendor' }];
+  new OmidCompatBridge({ verificationScripts: operatorInput });
+  assert(operatorInput[0].url === 'https://op-input.example/v.js',
+    'legacy-url-alias: operator input.url preserved (not mutated)');
+  assert(!('resourceUrl' in operatorInput[0]),
+    'legacy-url-alias: resourceUrl NOT written onto operator input object');
 }
 
 section('G10c. Edge cases — OM SDK script URLs use HTTPS validation');
@@ -1316,6 +1331,52 @@ section('G11d. Edge cases — destroy removes scripts injected by the bridge');
 
   assert(!script.parentNode, 'destroy(): injected OM SDK script node is removed');
   assert(bridge._loadedScripts.length === 0, 'destroy(): _loadedScripts is cleared');
+}
+
+section('G11f. Edge cases — multi-instance destroy contract (each bridge owns only what it injected)');
+{
+  // 0.7.3 follow-up (#127 sub-3a): when two OmidCompatBridge instances share
+  // an OM SDK URL, instance B's _injectScript finds A's existing tag and
+  // resolves early WITHOUT pushing to its own _loadedScripts. A.destroy()
+  // removes the shared tag (it's in A's _loadedScripts); B's _loadedScripts
+  // stays empty because B never owned the tag. This test documents that
+  // contract so a future maintainer can't quietly change it.
+  const sharedUrl = 'https://omid.example/omweb-shared.js';
+  const bridgeA = new OmidCompatBridge({
+    omSdkServiceScriptUrl: sharedUrl,
+    omSdkSessionClientUrl: 'https://omid.example/omid-session-client-v1.js',
+  });
+  const bridgeB = new OmidCompatBridge({
+    omSdkServiceScriptUrl: sharedUrl,
+    omSdkSessionClientUrl: 'https://omid.example/omid-session-client-v1.js',
+  });
+
+  // A "injects" by pushing into _loadedScripts (simulates the post-onload path).
+  const sharedScript = document.createElement('script');
+  sharedScript.src = sharedUrl;
+  document.head.appendChild(sharedScript);
+  bridgeA._loadedScripts.push(sharedScript);
+
+  // B sees the existing tag — call _injectScript and verify it resolves
+  // without pushing to B's _loadedScripts (matching the production dedup
+  // path inside _injectScript at sharc-omid-bridge.js:629-650).
+  bridgeB._injectScript(sharedUrl).then(() => {
+    assert(bridgeB._loadedScripts.length === 0,
+      'B._injectScript finds existing tag → does NOT push to B._loadedScripts');
+  });
+
+  // A.destroy() removes the shared tag.
+  bridgeA.destroy();
+  assert(!sharedScript.parentNode,
+    'A.destroy(): A removes the shared script it owned');
+  assert(bridgeB._loadedScripts.length === 0,
+    'B._loadedScripts stays empty after A.destroy() (B never owned the tag)');
+
+  // B.destroy() must not throw even though its _loadedScripts is empty.
+  let bDestroyThrew = false;
+  try { bridgeB.destroy(); } catch (_) { bDestroyThrew = true; }
+  assert(!bDestroyThrew,
+    'B.destroy() does not throw with empty _loadedScripts (clean idempotent cleanup)');
 }
 
 section('G11e. Edge cases — friendly obstruction lifecycle follows container close button changes');


### PR DESCRIPTION
## Summary

Three LOW-severity follow-ups from the 0.7.2 + 0.7.3 review backlog landed as one focused PR. All mechanical, all small. No behavioral changes to the public API surface.

Closes #107
Closes #109
Closes #127

## Commits

| # | Commit | Closes |
|---|---|---|
| 1 | \`fix(creativeSdkUrl): gate attribute serialization on string\|number types\` | #107 |
| 2 | \`refactor(creativeSdkUrl): relocate static helpers adjacent to _injectCreativeSdk\` | #109 |
| 3 | \`chore(omid): low-priority lifecycle hardening\` | #127 |

## Commit 1 — #107 attribute-value type gating

\`_buildCreativeSdkScriptTag\` previously called \`String(value)\` for any non-boolean/null/undefined value. Three edge-case failures:
- **Symbol value**: \`String(Symbol)\` throws \`TypeError\` (caught silently by the outer try/catch in \`_runMarkupInjection\` — failure was opaque re: cause)
- **Object with throwing toString**: same silent failure
- **Plain Object**: produced \`\"[object Object]\"\` — silent markup corruption

Now: explicit gate on \`typeof value === 'string' || typeof value === 'number'\`. Other types skipped + \`console.warn\` (mirrors the attribute-name validation pattern from PR #105 review).

\`_escapeAttrValue\` JSDoc widened from \`string\` to \`string|number\` to match the gated input. Internal \`String(value)\` coercion unchanged.

**+10 test assertions** in \`test-creative-sdk-injection.js\` § 4 (cases 4n–4q): Symbol, throwing-Object, plain-Object skipped + warn; Number value accepted (regression guard).

## Commit 2 — #109 static helpers relocation

Move \`static _escapeAttrValue\` + \`static _buildCreativeSdkScriptTag\` from near \`_generateUUID\` (~line 5358) to immediately precede \`_injectCreativeSdk\` (~line 2578). The ~2700-line gap between the helpers and their only caller made the injection path harder to read.

\`_generateUUID\` is a pure-string utility with ~30 callers across the class — appropriate for \"general utilities\" placement. The two SDK-injection helpers are used in exactly one place. Co-locating them with their caller improves discoverability without affecting behavior.

**Pure refactor.** Zero diff to function bodies. \`git diff --stat\` shows \`1 file changed, 86 insertions(+), 86 deletions(-)\` — exact move.

## Commit 3 — #127 OMID low-priority bucket (4 sub-items)

**3a — Multi-instance destroy contract** (\`sharc-omid-bridge.js\` \`destroy()\`): documented that each instance owns and removes only the scripts IT injected. When two \`OmidCompatBridge\` instances share an OM SDK URL, instance B's \`_injectScript\` skips the push to \`_loadedScripts\` (existing tag found, resolves early). \`A.destroy()\` removes the shared tag; B keeps working via sticky OM SDK globals (\`window.omid\`, \`window.OmidSessionClient\`). Long-lived multi-instance setups out of scope. **+3 assertions in new G11f test** exercise + document the contract.

**3b — verificationScripts legacy-url-alias non-mutation**: validator was writing \`resourceUrl\` back onto the operator's input object when the legacy \`url\` alias was used. Now pushes a shallow copy with the normalized \`resourceUrl\`. **+2 assertions in G10b** verify the operator's input object stays untouched.

**3c — injectScripts / getWrapperUrl**: documented, **not deleted**. Both methods exist in all 3 bridges (mraid + safeframe + omid) as a shared interface — not OMID-specific dead code. MRAID's and SafeFrame's are still part of their respective legacy-bridge flows. Strengthened JSDoc on OMID's versions to clearly mark them no-op stubs preserved for bridge-interface parity; retirement across all three is a separate decision out of scope for this PR.

**3d — B5/B6/B7 test cleanup**: \`setState()\` already triggers \`_notifyExtensionsLifecycle\` via the state-machine \`onChange\` listener. Manual \`_notifyExtensionsLifecycle\` calls that immediately followed \`setState()\` were redundant double-fires. Dropped. Tests now exercise the documented \"natural setState + spurious duplicate manual fire\" path. The other ~35 occurrences of manual \`_notifyExtensionsLifecycle\` elsewhere in the test file serve different purposes and stay.

## Verification

\`\`\`
$ npm run check
> build → lint clean → 13 test suites green → size budgets pass
\`\`\`

**Test deltas:**
- \`test-creative-sdk-injection.js\`: +10 assertions (§ 4 attr-value type gating)
- \`test-omid-container-lifecycle.js\`: +5 assertions (G10b non-mutation + G11f multi-instance), B5/B6/B7 cleanup

## Out of scope (still tracked)

- #106 — URL-variant OMID parity (capability extension, headline feature)
- #123 — Extension contract docs + creative errorMessage forwarding
- #124 — Multi-bridge dedup warn
- #125 — Advertised-but-SDK-fails clear signaling
- #126 — Termination-mid-load test coverage

## Test plan

- [x] \`npm run check\` green (build + lint + 13 suites + size)
- [x] +15 new test assertions across two test files
- [x] B5/B6/B7 still pass under cleaned-up shape (idempotency contract preserved)
- [x] G11f multi-instance destroy contract documented + tested
- [x] No public API surface changes