### PR TITLE
docs: post-0.7.3 sweep — current-status, design banner, README shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ const omidBridge = new OmidCompatBridge({
   impressionType: 'definedByJavaScript',
   mediaType: 'video',             // 'video' | 'audio' | 'display'
   verificationScripts: [
-    { url: 'https://verify.ias.com/omsdk/verification.js', vendor: 'ias' },
+    { resourceUrl: 'https://verify.ias.com/omsdk/verification.js', vendorKey: 'ias' },
   ],
 });
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -4,7 +4,7 @@
 
 SHARC is an IAB Tech Lab reference implementation in active **pre-1.0** development.
 
-- Repository package version: `0.7.2`
+- Repository package version: `0.7.3`
 - npm publication status: **not yet published**
 - Current implementation scope: **web iframe**, **iOS WKWebView**, **Android WebView**
 - Current repo posture: suitable for technical evaluation and standards review; not yet presented here as a broadly adopted production release line
@@ -20,9 +20,19 @@ The following are the most reliable descriptions of the present implementation:
 - [proposals/creative-sources.md](./proposals/creative-sources.md) — design rationale, threat model, and decision log for the 0.7.0 Creative Sources work
 - bridge design docs under [`docs/design/`](./design)
 - the current source and generated `dist/` artifacts
-- [CHANGELOG.md](../CHANGELOG.md) — what shipped in `0.7.2` and earlier
+- [CHANGELOG.md](../CHANGELOG.md) — what shipped in `0.7.3` and earlier
 
 As of `0.6.0`, every public package subpath ships generated TypeScript declaration files (`.d.ts`) alongside its `.mjs` bundle. TypeScript consumers get full IntelliSense and compile-time argument validation when importing any subpath. 0.7.0 expands the typedef surface to cover the Creative Markup variant — `creativeUrl` is optional, `creativeHtml` / `creativeRendererUrl` / `onSecurityEvent` are added, and `SHARCSecurityEvent` is a discriminated union that now covers six reserved variants after 0.7.1 added `bridge_load_failed`.
+
+## What Shipped in 0.7.3
+
+0.7.3 ships container-owned OMID measurement through a new `OmidCompatBridge` extension. The publisher page loads OM SDK; the container drives the full `AdSession` lifecycle (start on `READY`, `loaded()` and impression on first `ACTIVE`, viewability tracking on state changes, finish on termination) from its own state transitions. MRAID, SafeFrame, and SHARC-native creatives all receive OMID measurement transparently — no creative-side OMID code is required.
+
+OMID is intentionally an *extension*, not a renderer-loaded bridge. The `bridges` vocabulary stays scoped to runtime API compatibility (`'mraid'`, `'safeframe'`); `bridges: ['omid']` is rejected at construction and AdCOM `APIFramework` code `7` (OMID 1.0) is intentionally excluded from the auto-instantiation picker. The 0.7.3 work also formalizes the extension dispatch surface: `_notifyExtensionsLifecycle` invokes `extension.onContainerLifecycleEvent({ type, container, ...detail })` for `'load'`, `'stateChange'`, `'placementChange'`, `'close'`, `'destroy'`, and `'error'` phases.
+
+Bridge-managed URL validation throws synchronously at construction: both `omSdkServiceScriptUrl` and `omSdkSessionClientUrl` must be valid HTTPS URLs with no userinfo, and every `verificationScripts[].resourceUrl` entry is validated and deduplicated under the same rules. Missing (vs invalid) URLs do not throw — the bridge silently goes inert, advertising no OMID feature.
+
+Architecture spec: [`docs/design/0.7.3-omid-wiring.md`](./design/0.7.3-omid-wiring.md). Operator overview: README [Open Measurement (OMID)](../README.md#open-measurement-omid). Integration recipe: [`operator-cookbook.md` §5](./operator-cookbook.md#5-wire-container-owned-omid-measurement). API reference: [`api-reference.md` §9 OmidCompatBridge](./api-reference.md#omidcompatbridge).
 
 ## What Shipped in 0.7.2
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -28,11 +28,18 @@ As of `0.6.0`, every public package subpath ships generated TypeScript declarati
 
 0.7.3 ships container-owned OMID measurement through a new `OmidCompatBridge` extension. The publisher page loads OM SDK; the container drives the full `AdSession` lifecycle (start on `READY`, `loaded()` and impression on first `ACTIVE`, viewability tracking on state changes, finish on termination) from its own state transitions. MRAID, SafeFrame, and SHARC-native creatives all receive OMID measurement transparently — no creative-side OMID code is required.
 
-OMID is intentionally an *extension*, not a renderer-loaded bridge. The `bridges` vocabulary stays scoped to runtime API compatibility (`'mraid'`, `'safeframe'`); `bridges: ['omid']` is rejected at construction and AdCOM `APIFramework` code `7` (OMID 1.0) is intentionally excluded from the auto-instantiation picker. The 0.7.3 work also formalizes the extension dispatch surface: `_notifyExtensionsLifecycle` invokes `extension.onContainerLifecycleEvent({ type, container, ...detail })` for `'load'`, `'stateChange'`, `'placementChange'`, `'close'`, `'destroy'`, and `'error'` phases.
+OMID is intentionally an *extension*, not a renderer-loaded bridge. The `bridges` vocabulary stays scoped to runtime API compatibility (`'mraid'`, `'safeframe'`); `bridges: ['omid']` is rejected at construction and AdCOM `APIFramework` code `7` (OMID 1.0) is intentionally excluded from the auto-instantiation picker.
+
+0.7.3 also formalizes the container's extension dispatch surface. Extensions receive `onContainerLifecycleEvent({ type, timestamp, container, state, ...detail })` for `'load'`, `'stateChange'`, `'placementChange'`, `'close'`, `'destroy'`, and `'error'` phases.
 
 Bridge-managed URL validation throws synchronously at construction: both `omSdkServiceScriptUrl` and `omSdkSessionClientUrl` must be valid HTTPS URLs with no userinfo, and every `verificationScripts[].resourceUrl` entry is validated and deduplicated under the same rules. Missing (vs invalid) URLs do not throw — the bridge silently goes inert, advertising no OMID feature.
 
-Architecture spec: [`docs/design/0.7.3-omid-wiring.md`](./design/0.7.3-omid-wiring.md). Operator overview: README [Open Measurement (OMID)](../README.md#open-measurement-omid). Integration recipe: [`operator-cookbook.md` §5](./operator-cookbook.md#5-wire-container-owned-omid-measurement). API reference: [`api-reference.md` §9 OmidCompatBridge](./api-reference.md#omidcompatbridge).
+Further reading:
+
+- Architecture spec: [`docs/design/0.7.3-omid-wiring.md`](./design/0.7.3-omid-wiring.md)
+- Operator overview: README [Open Measurement (OMID)](../README.md#open-measurement-omid)
+- Integration recipe: [`operator-cookbook.md` §5](./operator-cookbook.md#5-wire-container-owned-omid-measurement)
+- API reference: [`api-reference.md` §9 OmidCompatBridge](./api-reference.md#omidcompatbridge)
 
 ## What Shipped in 0.7.2
 

--- a/docs/design/0.7.2-non-sharc-loading.md
+++ b/docs/design/0.7.2-non-sharc-loading.md
@@ -1,5 +1,7 @@
 # 0.7.2 — Loading non-SHARC creatives without `createSession` fatal-timeout
 
+> **Historical design doc.** OMID container-side wiring shipped in **0.7.3**, not as a "0.7.2 second-half" as this doc anticipates. See [`0.7.3-omid-wiring.md`](./0.7.3-omid-wiring.md) for the as-shipped OMID design. This document is preserved as a snapshot of the 0.7.2 first-half design intent.
+
 **Status:** Implemented in 0.7.2
 **Issue:** [#89](https://github.com/jeffreycarlson/SHARC/issues/89)
 **Branch:** `feat/89-non-sharc-loading`

--- a/docs/design/0.7.2-non-sharc-loading.md
+++ b/docs/design/0.7.2-non-sharc-loading.md
@@ -5,7 +5,7 @@
 **Status:** Implemented in 0.7.2
 **Issue:** [#89](https://github.com/jeffreycarlson/SHARC/issues/89)
 **Branch:** `feat/89-non-sharc-loading`
-**Target version:** 0.7.2 (patch — first half; OMID container-side wiring is the second half, separately scoped)
+**Target version:** 0.7.2 (patch — first half; OMID container-side wiring was scoped as a second half here but subsequently shipped as 0.7.3 — see banner above)
 **Predecessors:** 0.7.1 GA (`bridges` field, `creativeMeta`, container-driven bridge loading)
 **Forward bridges:** 0.7.3 will extend the HTML lifecycle adapter (§ 8) with MRAID and SafeFrame variants.
 


### PR DESCRIPTION
## Summary

Three small post-0.7.3 doc-debt items bundled into one sweep PR (similar shape to PR [#138](https://github.com/jeffreycarlson/SHARC/pull/138)). Each one was filed independently but each is small enough that a separate PR per item would be more ceremony than value.

### What's in the bundle

**Closes #134** — \`docs/current-status.md\` missing 0.7.3 section
- Headline \`Repository package version\`: \`0.7.2\` → \`0.7.3\`
- "What Is Stable" CHANGELOG callout: \"shipped in \`0.7.2\` and earlier\" → \`0.7.3\`
- New "What Shipped in 0.7.3" section before the existing 0.7.2 section, covering container-owned OMID, the \`_notifyExtensionsLifecycle\` extension hook surface, bridge-managed URL validation contract, and the architectural decision to keep OMID extension-owned. Cross-links to the design spec, README, cookbook, and api-reference — closing the docs triangle from PRs #142/#143/#145.

**Closes #137** — \`docs/design/0.7.2-non-sharc-loading.md\` references nonexistent "0.7.2 second-half"
- Added a historical-artifact banner at the top of the doc per **Path A** from the issue body (the issue body lead toward A).
- Preserves the doc as a snapshot of the 0.7.2 first-half design intent rather than find-replacing body references that would blur the line between "designed at the time" and "shipped." Banner cross-links to \`0.7.3-omid-wiring.md\` for the as-shipped design.

**Closes #144** — README OMID verification-script shape mismatch
- Changed \`{ url, vendor }\` → \`{ resourceUrl, vendorKey }\` in the README OMID code sample
- Aligns with the canonical OM SDK names already used in the cookbook recipe (PR #143). Bridge accepts both at the input boundary; canonical is the preferred form. README example stays simple (2 fields, no \`verificationParameters\`) — cookbook still owns the full canonical demonstration.

### Scope

3 files, +15/-3 net:
- \`README.md\` — 1 line (#144)
- \`docs/current-status.md\` — 12 lines (#134)
- \`docs/design/0.7.2-non-sharc-loading.md\` — 2 lines (#137)

## Verification before commit

- \`Repository package version\` change verified against \`package.json\` (\`0.7.3\` confirmed)
- 0.7.3 section content verified against the just-shipped triangle (PR #142 README, PR #143 cookbook, PR #145 api-reference) — terminology, anchors, and architectural claims agree
- Banner anchor \`0.7.3-omid-wiring.md\` confirmed exists in \`docs/design/\`
- README verification-script field names verified against bridge source (\`src/sharc-omid-bridge.js:128-133, :783-792\` — same source cited in #144)

## Test plan

- [x] \`npm run check\` green — build + 13 test suites + size budget
- [x] All cross-links in the new "What Shipped in 0.7.3" section resolve
- [x] Each closing-issue reference targets the right scope

Closes #134
Closes #137
Closes #144