### PR TITLE
chore: rebuild dev dist after size so post-check individual tests pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "test:all": "npm run test:smoke && npm run test:treeshake && npm run test:placement && npm run test:placement-stamping && npm run test:creative-sources && npm run test:creative-sources-load && npm run test:navigation-bridge && npm run test:creative-sdk-autoinstall && npm run test:creative-sdk-injection && npm run test:bridges-detection && npm run test:non-sharc-loading && npm run test:html-lifecycle-adapter && npm run test:omid-container-lifecycle && npm run test:renderer-fallback",
     "regen:baseline": "node scripts/regen-mraid3-baseline.js",
     "lint": "eslint src/*.js --max-warnings=0",
-    "check": "npm run build && npm run test:all && npm run size"
+    "check": "npm run build && npm run test:all && npm run size && npm run build"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",


### PR DESCRIPTION
## Summary

Closes #139 — captureWarn-based test assertions failed when dist was in production-build state after \`npm run check\`.

### Root cause

\`npm run check\` chains \`build → test:all → size\`. The \`size\` step calls \`build:prod\` which runs rollup with \`NODE_ENV=production\`, applying terser's \`drop_console: true\`. After check completes, \`dist/sharc-container.mjs\` has zero \`console.warn\` calls — terser stripped them.

Five assertions in \`test/node/test-creative-sdk-injection.js\` (sections 4i, 4n, 4o, 4p, 9b) use \`captureWarn\` and fail when an operator runs the test directly after \`npm run check\`:

\`\`\`bash
npm run check                                # green
node test/node/test-creative-sdk-injection.js   # 5 failures (before this PR)
\`\`\`

CI and the standard check workflow were never affected — \`test:all\` ran on the dev build before \`size\` overwrote it. Only post-check individual test runs hit the stripped dist.

### Fix

One-line append to the \`check\` script in \`package.json\`:

\`\`\`diff
- "check": "npm run build && npm run test:all && npm run size"
+ "check": "npm run build && npm run test:all && npm run size && npm run build"
\`\`\`

Post-check dist is always dev-built. Individual test runs work without developers needing to remember to rebuild.

Issue body offered four paths (A: brittle detection, B: reorder check, C: tests build their own dist, D: document the constraint). Took **Path B** as the issue recommended. Tradeoff vs the issue's specific suggestion (\`build → size → build → test:all\`): I put the rebuild at the *end* of check rather than the middle, which is one fewer rollup invocation and preserves the existing test:all-position. Same effect on post-check dist state.

### Cost

Adds ~1-2 seconds to \`npm run check\` (one extra rollup + tsc pass). Negligible vs the ~30-60s the full check already takes.

## Verification before commit

\`\`\`bash
$ npm run check                                  # green
$ node test/node/test-creative-sdk-injection.js  # green (was 5 failures pre-fix)
\`\`\`

Reproduced the failure on main first, applied the fix, confirmed individual test runs cleanly. The fix actually changes the symptom rather than just suppressing the assertion.

## Test plan

- [x] \`npm run check\` green end-to-end
- [x] Individual \`test-creative-sdk-injection.js\` run passes after check completes
- [x] No changes to test logic — only the build-state contract changed

Closes #139