### PR TITLE
fix(security): validate bridge baseUrl across MRAID/SafeFrame/OMID

### DIFF
--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -34,13 +34,18 @@
  *   - `undefined` / `null` are accepted (caller falls back to `'/sharc'`)
  *   - Must be a string
  *   - Must NOT be empty or whitespace-only after trim
- *   - Must NOT contain embedded C0 control characters (would survive a future
- *     WHATWG-parser sink and rehydrate as a dangerous scheme — e.g.
- *     `'jav\tascript:alert(1)'`)
+ *   - Must NOT contain embedded control / Unicode-whitespace / zero-width
+ *     characters (would survive a future WHATWG-parser or ES2019-trim sink
+ *     and rehydrate as a dangerous scheme — e.g. `'jav\tascript:alert(1)'`
+ *     or `' javascript:alert(1)'` with NBSP)
  *   - Must NOT be protocol-relative (`//host/…` or `\\host\…`) — would resolve
  *     against the page's protocol in an href/srcdoc sink and fetch from an
  *     attacker-controlled origin
+ *   - Must NOT contain `%3A` (percent-encoded colon) anywhere or lead with
+ *     `%2F` / `%5C` (percent-encoded slash / backslash) — defends a future
+ *     decoding sink against scheme-injection and protocol-relative rehydration
  *   - Must NOT start with a dangerous scheme (`javascript:`, `data:`, `vbscript:`, `file:`, `blob:`)
+ *     in any letter case
  *   - If absolute (has a scheme), must be HTTPS
  *   - No userinfo allowed
  *
@@ -61,10 +66,15 @@ function validateBridgeBaseUrl(baseUrl) {
   }
 
   // Trim leading/trailing whitespace before scheme detection. The WHATWG URL
-  // parser strips leading C0 control + space, so `'\tjavascript:alert(1)'`
-  // would parse as a `javascript:` URL — reject those forms explicitly.
-  // eslint-disable-next-line no-control-regex -- intentional: C0 controls + space are the bypass surface this trim defends
-  var trimmed = baseUrl.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '');
+  // parser strips leading C0 control + space, and ES2019 `String.prototype.trim`
+  // additionally strips Unicode whitespace — so `'\tjavascript:alert(1)'`,
+  // `'<NBSP>javascript:alert(1)'`, and `'<ZWSP>javascript:alert(1)'`
+  // would all rehydrate as `javascript:` if forwarded to such a sink
+  // without pre-trimming. Strip the full ES2019-trim set plus zero-width chars
+  // (ZWSP / ZWNJ / ZWJ / BOM) which are not in the spec set but are stripped
+  // by some parsers / normalizers and could mask scheme detection here.
+  // eslint-disable-next-line no-control-regex -- intentional: C0 controls + space + Unicode whitespace are the bypass surface this trim defends
+  var trimmed = baseUrl.replace(/^[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]+|[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]+$/g, '');
 
   // Empty / whitespace-only baseUrl. Without this check, `'   '` would
   // bypass scheme detection (empty `trimmed` matches no scheme) and be
@@ -77,12 +87,17 @@ function validateBridgeBaseUrl(baseUrl) {
     throw new TypeError(emptyMsg);
   }
 
-  // Embedded C0 control characters. A future WHATWG-parser-backed sink would
-  // strip these and rehydrate `'jav\tascript:alert(1)'` as `javascript:`.
-  // Catch the bypass at the validator regardless of where the value flows.
-  // eslint-disable-next-line no-control-regex -- intentional: embedded C0 controls are the bypass surface this check defends
-  if (/[\x00-\x1F]/.test(trimmed)) {
-    var ctrlMsg = 'baseUrl must not contain embedded control characters';
+  // Embedded control / Unicode-whitespace / zero-width characters. A future
+  // WHATWG-parser-backed sink would strip C0 controls and rehydrate
+  // `'jav\tascript:alert(1)'` as `javascript:`; an ES2019-trim sink would
+  // additionally strip NBSP / line-separator / ZWSP / BOM. Catch all of these
+  // bypass shapes at the validator regardless of where the value flows.
+  // ASCII space (0x20) is intentionally allowed mid-string so legitimate
+  // path-relative values containing spaces still pass — leading/trailing
+  // spaces are already removed by the trim above.
+  // eslint-disable-next-line no-control-regex -- intentional: embedded C0 controls + DEL + Unicode whitespace + zero-width chars are the bypass surface this check defends
+  if (/[\x00-\x1F\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]/.test(trimmed)) {
+    var ctrlMsg = 'baseUrl must not contain embedded control or whitespace characters';
     if (typeof console !== 'undefined' && console.warn) {
       console.warn('[SHARC MRAID Bridge] ' + ctrlMsg);
     }
@@ -94,13 +109,28 @@ function validateBridgeBaseUrl(baseUrl) {
   // "path-relative — accept", but in an href/srcdoc sink the browser
   // resolves `//host/…` against the page protocol and fetches from
   // attacker-controlled origin. Backslash variants are normalized to
-  // forward slashes by browsers in special-scheme contexts.
-  if (/^[\\/]{2}/.test(trimmed)) {
+  // forward slashes by browsers in special-scheme contexts. Also reject
+  // the percent-encoded leading form (`%2F%2F…`, `%5C%5C…`, mixed) so a
+  // downstream decoding sink can't rehydrate the bypass.
+  if (/^[\\/]{2}/.test(trimmed) || /^%(?:2[Ff]|5[Cc])/.test(trimmed)) {
     var protoRelMsg = 'baseUrl must not be protocol-relative';
     if (typeof console !== 'undefined' && console.warn) {
       console.warn('[SHARC MRAID Bridge] ' + protoRelMsg);
     }
     throw new TypeError(protoRelMsg);
+  }
+
+  // Percent-encoded scheme separator (`%3A`). Today the scheme regex requires
+  // a literal `:`, so this isn't an active bypass — but if a future code path
+  // URL-decodes `baseUrl` before validation (or hands it to a sink that does),
+  // `'javascript%3Aalert(1)'` rehydrates as `javascript:`. Lock the bypass
+  // shape at the validator. Case-insensitive per RFC 3986 §2.1.
+  if (/%3[Aa]/.test(trimmed)) {
+    var pctColonMsg = 'baseUrl must not contain percent-encoded scheme separator (%3A)';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC MRAID Bridge] ' + pctColonMsg);
+    }
+    throw new TypeError(pctColonMsg);
   }
 
   // Scheme detection: `scheme:` per RFC 3986 (ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )).

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -74,7 +74,7 @@ function validateBridgeBaseUrl(baseUrl) {
   // (ZWSP / ZWNJ / ZWJ / BOM) which are not in the spec set but are stripped
   // by some parsers / normalizers and could mask scheme detection here.
   // eslint-disable-next-line no-control-regex -- intentional: C0 controls + space + Unicode whitespace are the bypass surface this trim defends
-  var trimmed = baseUrl.replace(/^[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]+|[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]+$/g, '');
+  var trimmed = baseUrl.replace(/^[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F-\u2060\u3000\uFEFF]+|[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F-\u2060\u3000\uFEFF]+$/g, '');
 
   // Empty / whitespace-only baseUrl. Without this check, `'   '` would
   // bypass scheme detection (empty `trimmed` matches no scheme) and be
@@ -96,7 +96,7 @@ function validateBridgeBaseUrl(baseUrl) {
   // path-relative values containing spaces still pass — leading/trailing
   // spaces are already removed by the trim above.
   // eslint-disable-next-line no-control-regex -- intentional: embedded C0 controls + DEL + Unicode whitespace + zero-width chars are the bypass surface this check defends
-  if (/[\x00-\x1F\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]/.test(trimmed)) {
+  if (/[\x00-\x1F\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F-\u2060\u3000\uFEFF]/.test(trimmed)) {
     var ctrlMsg = 'baseUrl must not contain embedded control or whitespace characters';
     if (typeof console !== 'undefined' && console.warn) {
       console.warn('[SHARC MRAID Bridge] ' + ctrlMsg);
@@ -124,7 +124,9 @@ function validateBridgeBaseUrl(baseUrl) {
   // a literal `:`, so this isn't an active bypass — but if a future code path
   // URL-decodes `baseUrl` before validation (or hands it to a sink that does),
   // `'javascript%3Aalert(1)'` rehydrates as `javascript:`. Lock the bypass
-  // shape at the validator. Case-insensitive per RFC 3986 §2.1.
+  // shape at the validator. Case-insensitive per RFC 3986 §2.1. Matched
+  // anywhere (vs leading-only for `%2F`/`%5C` above) — a decoded `:` mid-path
+  // can still influence URL parsing downstream.
   if (/%3[Aa]/.test(trimmed)) {
     var pctColonMsg = 'baseUrl must not contain percent-encoded scheme separator (%3A)';
     if (typeof console !== 'undefined' && console.warn) {

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -33,6 +33,13 @@
  * Rules:
  *   - `undefined` / `null` are accepted (caller falls back to `'/sharc'`)
  *   - Must be a string
+ *   - Must NOT be empty or whitespace-only after trim
+ *   - Must NOT contain embedded C0 control characters (would survive a future
+ *     WHATWG-parser sink and rehydrate as a dangerous scheme — e.g.
+ *     `'jav\tascript:alert(1)'`)
+ *   - Must NOT be protocol-relative (`//host/…` or `\\host\…`) — would resolve
+ *     against the page's protocol in an href/srcdoc sink and fetch from an
+ *     attacker-controlled origin
  *   - Must NOT start with a dangerous scheme (`javascript:`, `data:`, `vbscript:`, `file:`, `blob:`)
  *   - If absolute (has a scheme), must be HTTPS
  *   - No userinfo allowed
@@ -56,7 +63,45 @@ function validateBridgeBaseUrl(baseUrl) {
   // Trim leading/trailing whitespace before scheme detection. The WHATWG URL
   // parser strips leading C0 control + space, so `'\tjavascript:alert(1)'`
   // would parse as a `javascript:` URL — reject those forms explicitly.
+  // eslint-disable-next-line no-control-regex -- intentional: C0 controls + space are the bypass surface this trim defends
   var trimmed = baseUrl.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '');
+
+  // Empty / whitespace-only baseUrl. Without this check, `'   '` would
+  // bypass scheme detection (empty `trimmed` matches no scheme) and be
+  // returned verbatim — leading whitespace would propagate into the URL.
+  if (trimmed === '') {
+    var emptyMsg = 'baseUrl must not be empty or whitespace';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC MRAID Bridge] ' + emptyMsg);
+    }
+    throw new TypeError(emptyMsg);
+  }
+
+  // Embedded C0 control characters. A future WHATWG-parser-backed sink would
+  // strip these and rehydrate `'jav\tascript:alert(1)'` as `javascript:`.
+  // Catch the bypass at the validator regardless of where the value flows.
+  // eslint-disable-next-line no-control-regex -- intentional: embedded C0 controls are the bypass surface this check defends
+  if (/[\x00-\x1F]/.test(trimmed)) {
+    var ctrlMsg = 'baseUrl must not contain embedded control characters';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC MRAID Bridge] ' + ctrlMsg);
+    }
+    throw new TypeError(ctrlMsg);
+  }
+
+  // Protocol-relative URLs (`//host/…` or `\\host\…`). The scheme regex
+  // returns no match, so without this check these fall through to
+  // "path-relative — accept", but in an href/srcdoc sink the browser
+  // resolves `//host/…` against the page protocol and fetches from
+  // attacker-controlled origin. Backslash variants are normalized to
+  // forward slashes by browsers in special-scheme contexts.
+  if (/^[\\/]{2}/.test(trimmed)) {
+    var protoRelMsg = 'baseUrl must not be protocol-relative';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC MRAID Bridge] ' + protoRelMsg);
+    }
+    throw new TypeError(protoRelMsg);
+  }
 
   // Scheme detection: `scheme:` per RFC 3986 (ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )).
   var schemeMatch = trimmed.match(/^([a-zA-Z][a-zA-Z0-9+\-.]*):/);

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -24,6 +24,85 @@
 // -------------------------------------------------------------------------
 
 /**
+ * Defense-in-depth validation for the operator-supplied `baseUrl` option
+ * (issue #140). The bridge `baseUrl` differs from OMID's strict HTTPS URLs
+ * because the default (`'/sharc'`) is path-relative, so this validator
+ * accepts path-relative URLs while still rejecting dangerous schemes and
+ * insecure / userinfo-bearing absolute URLs.
+ *
+ * Rules:
+ *   - `undefined` / `null` are accepted (caller falls back to `'/sharc'`)
+ *   - Must be a string
+ *   - Must NOT start with a dangerous scheme (`javascript:`, `data:`, `vbscript:`, `file:`, `blob:`)
+ *   - If absolute (has a scheme), must be HTTPS
+ *   - No userinfo allowed
+ *
+ * Throws `TypeError` on invalid input, mirroring the shape of OMID's
+ * `validateOmidHttpsUrl` (logs via `console.warn` then throws).
+ *
+ * @param {*} baseUrl
+ * @returns {string|undefined} the input string when valid, or `undefined` for null/undefined input
+ */
+function validateBridgeBaseUrl(baseUrl) {
+  if (baseUrl == null) return undefined;
+  if (typeof baseUrl !== 'string') {
+    var typeMsg = 'baseUrl must be a string';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC MRAID Bridge] ' + typeMsg);
+    }
+    throw new TypeError(typeMsg);
+  }
+
+  // Trim leading/trailing whitespace before scheme detection. The WHATWG URL
+  // parser strips leading C0 control + space, so `'\tjavascript:alert(1)'`
+  // would parse as a `javascript:` URL — reject those forms explicitly.
+  var trimmed = baseUrl.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '');
+
+  // Scheme detection: `scheme:` per RFC 3986 (ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )).
+  var schemeMatch = trimmed.match(/^([a-zA-Z][a-zA-Z0-9+\-.]*):/);
+  if (!schemeMatch) {
+    // Path-relative URL (e.g. '/sharc', './sharc', 'sharc'). Accept.
+    return baseUrl;
+  }
+
+  var scheme = schemeMatch[1].toLowerCase();
+  var dangerousSchemes = { 'javascript': 1, 'data': 1, 'vbscript': 1, 'file': 1, 'blob': 1 };
+  if (dangerousSchemes[scheme]) {
+    var dangerMsg = 'baseUrl must not use the ' + scheme + ': scheme';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC MRAID Bridge] ' + dangerMsg);
+    }
+    throw new TypeError(dangerMsg);
+  }
+
+  var parsed;
+  try {
+    parsed = new URL(trimmed);
+  } catch (e) {
+    var parseMsg = 'baseUrl must be a valid URL';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC MRAID Bridge] ' + parseMsg);
+    }
+    throw new TypeError(parseMsg);
+  }
+  if (parsed.protocol !== 'https:') {
+    var httpsMsg = 'baseUrl must use HTTPS when absolute';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC MRAID Bridge] ' + httpsMsg);
+    }
+    throw new TypeError(httpsMsg);
+  }
+  if (parsed.username || parsed.password) {
+    var userinfoMsg = 'baseUrl must not include userinfo';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC MRAID Bridge] ' + userinfoMsg);
+    }
+    throw new TypeError(userinfoMsg);
+  }
+  return baseUrl;
+}
+
+/**
  * Computes the screen-space bounding rect of the MRAID close button zone.
  * @param {number} adX - Default position X of the ad
  * @param {number} adY - Default position Y of the ad
@@ -913,6 +992,9 @@ function installMRAIDBridge(SHARC) {
 function MRAIDCompatBridge(options) {
   this.name = 'com.iabtechlab.sharc.mraid';
   this.options = options || {};
+  if (this.options.baseUrl != null) {
+    validateBridgeBaseUrl(this.options.baseUrl);
+  }
 }
 
 MRAIDCompatBridge.prototype = {

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -138,10 +138,15 @@ function getVerificationScriptResourceUrl(script) {
  * path-relative URLs because the default (`'/sharc'`) is path-relative —
  * strict HTTPS-only would break the default.
  *
- * Rules:
+ * Rules (mirror sharc-mraid-bridge.js — see there for full rationale):
  *   - `undefined` / `null` are accepted (caller falls back to `'/sharc'`)
  *   - Must be a string
+ *   - Must NOT be empty or whitespace-only after trim
+ *   - Must NOT contain embedded control / Unicode-whitespace / zero-width chars
+ *   - Must NOT be protocol-relative (literal `//`, `\\`, or percent-encoded `%2F%2F` / `%5C%5C`)
+ *   - Must NOT contain `%3A` (percent-encoded colon — gates a future decoding-sink bypass)
  *   - Must NOT start with a dangerous scheme (`javascript:`, `data:`, `vbscript:`, `file:`, `blob:`)
+ *     in any letter case
  *   - If absolute (has a scheme), must be HTTPS
  *   - No userinfo allowed
  *
@@ -156,27 +161,35 @@ function validateBridgeBaseUrl(baseUrl) {
     throwOmidConfigError('baseUrl must be a string');
   }
 
-  // Trim leading/trailing whitespace before scheme detection. The WHATWG URL
-  // parser strips leading C0 control + space, so `'\tjavascript:alert(1)'`
-  // would parse as a `javascript:` URL — reject those forms explicitly.
-  // eslint-disable-next-line no-control-regex -- intentional: C0 controls + space are the bypass surface this trim defends
-  var trimmed = baseUrl.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '');
+  // Trim leading/trailing whitespace before scheme detection — see
+  // sharc-mraid-bridge.js for full rationale on the Unicode-whitespace +
+  // zero-width character set.
+  // eslint-disable-next-line no-control-regex -- intentional: C0 controls + space + Unicode whitespace are the bypass surface this trim defends
+  var trimmed = baseUrl.replace(/^[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]+|[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]+$/g, '');
 
   // Empty / whitespace-only baseUrl — see sharc-mraid-bridge.js for rationale.
   if (trimmed === '') {
     throwOmidConfigError('baseUrl must not be empty or whitespace');
   }
 
-  // Embedded C0 control characters — see sharc-mraid-bridge.js for rationale.
-  // eslint-disable-next-line no-control-regex -- intentional: embedded C0 controls are the bypass surface this check defends
-  if (/[\x00-\x1F]/.test(trimmed)) {
-    throwOmidConfigError('baseUrl must not contain embedded control characters');
+  // Embedded control / Unicode-whitespace / zero-width characters — see
+  // sharc-mraid-bridge.js for rationale.
+  // eslint-disable-next-line no-control-regex -- intentional: embedded C0 controls + DEL + Unicode whitespace + zero-width chars are the bypass surface this check defends
+  if (/[\x00-\x1F\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]/.test(trimmed)) {
+    throwOmidConfigError('baseUrl must not contain embedded control or whitespace characters');
   }
 
-  // Protocol-relative URLs (`//host/…` or `\\host\…`) — see
-  // sharc-mraid-bridge.js for rationale.
-  if (/^[\\/]{2}/.test(trimmed)) {
+  // Protocol-relative URLs (`//host/…`, `\\host\…`, or the percent-encoded
+  // leading form `%2F%2F…` / `%5C%5C…` / mixed) — see sharc-mraid-bridge.js
+  // for rationale.
+  if (/^[\\/]{2}/.test(trimmed) || /^%(?:2[Ff]|5[Cc])/.test(trimmed)) {
     throwOmidConfigError('baseUrl must not be protocol-relative');
+  }
+
+  // Percent-encoded scheme separator (`%3A`) — see sharc-mraid-bridge.js
+  // for rationale.
+  if (/%3[Aa]/.test(trimmed)) {
+    throwOmidConfigError('baseUrl must not contain percent-encoded scheme separator (%3A)');
   }
 
   // Scheme detection: `scheme:` per RFC 3986 (ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )).

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -133,6 +133,63 @@ function getVerificationScriptResourceUrl(script) {
 }
 
 /**
+ * Defense-in-depth validation for the operator-supplied `baseUrl` option
+ * (issue #140). Unlike `validateOmidHttpsUrl`, this validator accepts
+ * path-relative URLs because the default (`'/sharc'`) is path-relative —
+ * strict HTTPS-only would break the default.
+ *
+ * Rules:
+ *   - `undefined` / `null` are accepted (caller falls back to `'/sharc'`)
+ *   - Must be a string
+ *   - Must NOT start with a dangerous scheme (`javascript:`, `data:`, `vbscript:`, `file:`, `blob:`)
+ *   - If absolute (has a scheme), must be HTTPS
+ *   - No userinfo allowed
+ *
+ * Throws `TypeError` via `throwOmidConfigError` on invalid input.
+ *
+ * @param {*} baseUrl
+ * @returns {string|undefined} the input string when valid, or `undefined` for null/undefined input
+ */
+function validateBridgeBaseUrl(baseUrl) {
+  if (baseUrl == null) return undefined;
+  if (typeof baseUrl !== 'string') {
+    throwOmidConfigError('baseUrl must be a string');
+  }
+
+  // Trim leading/trailing whitespace before scheme detection. The WHATWG URL
+  // parser strips leading C0 control + space, so `'\tjavascript:alert(1)'`
+  // would parse as a `javascript:` URL — reject those forms explicitly.
+  var trimmed = baseUrl.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '');
+
+  // Scheme detection: `scheme:` per RFC 3986 (ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )).
+  var schemeMatch = trimmed.match(/^([a-zA-Z][a-zA-Z0-9+\-.]*):/);
+  if (!schemeMatch) {
+    // Path-relative URL (e.g. '/sharc', './sharc', 'sharc'). Accept.
+    return baseUrl;
+  }
+
+  var scheme = schemeMatch[1].toLowerCase();
+  var dangerousSchemes = { 'javascript': 1, 'data': 1, 'vbscript': 1, 'file': 1, 'blob': 1 };
+  if (dangerousSchemes[scheme]) {
+    throwOmidConfigError('baseUrl must not use the ' + scheme + ': scheme');
+  }
+
+  var parsed;
+  try {
+    parsed = new URL(trimmed);
+  } catch (e) {
+    throwOmidConfigError('baseUrl must be a valid URL');
+  }
+  if (parsed.protocol !== 'https:') {
+    throwOmidConfigError('baseUrl must use HTTPS when absolute');
+  }
+  if (parsed.username || parsed.password) {
+    throwOmidConfigError('baseUrl must not include userinfo');
+  }
+  return baseUrl;
+}
+
+/**
  * Validates an OMID-managed script URL using the same hygiene rules as
  * verification script resource URLs.
  *
@@ -248,6 +305,9 @@ function validateVerificationScripts(verificationScripts) {
 function OmidCompatBridge(options) {
   this.name    = FEATURE_NAME;
   this.options = options ? Object.assign({}, options) : {};
+  if (this.options.baseUrl != null) {
+    validateBridgeBaseUrl(this.options.baseUrl);
+  }
   if (this.options.omSdkServiceScriptUrl != null) {
     this.options.omSdkServiceScriptUrl = validateOmidHttpsUrl(
       this.options.omSdkServiceScriptUrl,

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -165,7 +165,7 @@ function validateBridgeBaseUrl(baseUrl) {
   // sharc-mraid-bridge.js for full rationale on the Unicode-whitespace +
   // zero-width character set.
   // eslint-disable-next-line no-control-regex -- intentional: C0 controls + space + Unicode whitespace are the bypass surface this trim defends
-  var trimmed = baseUrl.replace(/^[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]+|[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]+$/g, '');
+  var trimmed = baseUrl.replace(/^[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F-\u2060\u3000\uFEFF]+|[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F-\u2060\u3000\uFEFF]+$/g, '');
 
   // Empty / whitespace-only baseUrl — see sharc-mraid-bridge.js for rationale.
   if (trimmed === '') {
@@ -175,7 +175,7 @@ function validateBridgeBaseUrl(baseUrl) {
   // Embedded control / Unicode-whitespace / zero-width characters — see
   // sharc-mraid-bridge.js for rationale.
   // eslint-disable-next-line no-control-regex -- intentional: embedded C0 controls + DEL + Unicode whitespace + zero-width chars are the bypass surface this check defends
-  if (/[\x00-\x1F\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]/.test(trimmed)) {
+  if (/[\x00-\x1F\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F-\u2060\u3000\uFEFF]/.test(trimmed)) {
     throwOmidConfigError('baseUrl must not contain embedded control or whitespace characters');
   }
 

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -159,7 +159,25 @@ function validateBridgeBaseUrl(baseUrl) {
   // Trim leading/trailing whitespace before scheme detection. The WHATWG URL
   // parser strips leading C0 control + space, so `'\tjavascript:alert(1)'`
   // would parse as a `javascript:` URL — reject those forms explicitly.
+  // eslint-disable-next-line no-control-regex -- intentional: C0 controls + space are the bypass surface this trim defends
   var trimmed = baseUrl.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '');
+
+  // Empty / whitespace-only baseUrl — see sharc-mraid-bridge.js for rationale.
+  if (trimmed === '') {
+    throwOmidConfigError('baseUrl must not be empty or whitespace');
+  }
+
+  // Embedded C0 control characters — see sharc-mraid-bridge.js for rationale.
+  // eslint-disable-next-line no-control-regex -- intentional: embedded C0 controls are the bypass surface this check defends
+  if (/[\x00-\x1F]/.test(trimmed)) {
+    throwOmidConfigError('baseUrl must not contain embedded control characters');
+  }
+
+  // Protocol-relative URLs (`//host/…` or `\\host\…`) — see
+  // sharc-mraid-bridge.js for rationale.
+  if (/^[\\/]{2}/.test(trimmed)) {
+    throwOmidConfigError('baseUrl must not be protocol-relative');
+  }
 
   // Scheme detection: `scheme:` per RFC 3986 (ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )).
   var schemeMatch = trimmed.match(/^([a-zA-Z][a-zA-Z0-9+\-.]*):/);

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -32,6 +32,70 @@
 // -------------------------------------------------------------------------
 
 /**
+ * Defense-in-depth validation for the operator-supplied `baseUrl` option
+ * (issue #140). See `sharc-mraid-bridge.js` for the rationale — the same
+ * validator is inlined here (rather than shared) because each bridge file
+ * is intentionally self-contained and rollup builds them as independent
+ * IIFE bundles.
+ *
+ * @param {*} baseUrl
+ * @returns {string|undefined} the input string when valid, or `undefined` for null/undefined input
+ */
+function validateBridgeBaseUrl(baseUrl) {
+  if (baseUrl == null) return undefined;
+  if (typeof baseUrl !== 'string') {
+    var typeMsg = 'baseUrl must be a string';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC SafeFrame Bridge] ' + typeMsg);
+    }
+    throw new TypeError(typeMsg);
+  }
+
+  var trimmed = baseUrl.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '');
+
+  var schemeMatch = trimmed.match(/^([a-zA-Z][a-zA-Z0-9+\-.]*):/);
+  if (!schemeMatch) {
+    return baseUrl;
+  }
+
+  var scheme = schemeMatch[1].toLowerCase();
+  var dangerousSchemes = { 'javascript': 1, 'data': 1, 'vbscript': 1, 'file': 1, 'blob': 1 };
+  if (dangerousSchemes[scheme]) {
+    var dangerMsg = 'baseUrl must not use the ' + scheme + ': scheme';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC SafeFrame Bridge] ' + dangerMsg);
+    }
+    throw new TypeError(dangerMsg);
+  }
+
+  var parsed;
+  try {
+    parsed = new URL(trimmed);
+  } catch (e) {
+    var parseMsg = 'baseUrl must be a valid URL';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC SafeFrame Bridge] ' + parseMsg);
+    }
+    throw new TypeError(parseMsg);
+  }
+  if (parsed.protocol !== 'https:') {
+    var httpsMsg = 'baseUrl must use HTTPS when absolute';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC SafeFrame Bridge] ' + httpsMsg);
+    }
+    throw new TypeError(httpsMsg);
+  }
+  if (parsed.username || parsed.password) {
+    var userinfoMsg = 'baseUrl must not include userinfo';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC SafeFrame Bridge] ' + userinfoMsg);
+    }
+    throw new TypeError(userinfoMsg);
+  }
+  return baseUrl;
+}
+
+/**
  * Computes the in-view percentage (0–100) from SHARC state and cached geometry.
  * Returns 0 when hidden, frozen, or pre-init.
  * @param {string} sharcState - Current SHARC container state (e.g. 'active', 'hidden').
@@ -585,6 +649,9 @@ function installSafeFrameBridge(SHARC) {
 function SafeFrameCompatBridge(options) {
   this.name    = 'com.iabtechlab.sharc.safeframe';
   this.options = options || {};
+  if (this.options.baseUrl != null) {
+    validateBridgeBaseUrl(this.options.baseUrl);
+  }
 }
 
 SafeFrameCompatBridge.prototype = {

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -51,7 +51,37 @@ function validateBridgeBaseUrl(baseUrl) {
     throw new TypeError(typeMsg);
   }
 
+  // eslint-disable-next-line no-control-regex -- intentional: C0 controls + space are the bypass surface this trim defends
   var trimmed = baseUrl.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '');
+
+  // Empty / whitespace-only baseUrl — see sharc-mraid-bridge.js for rationale.
+  if (trimmed === '') {
+    var emptyMsg = 'baseUrl must not be empty or whitespace';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC SafeFrame Bridge] ' + emptyMsg);
+    }
+    throw new TypeError(emptyMsg);
+  }
+
+  // Embedded C0 control characters — see sharc-mraid-bridge.js for rationale.
+  // eslint-disable-next-line no-control-regex -- intentional: embedded C0 controls are the bypass surface this check defends
+  if (/[\x00-\x1F]/.test(trimmed)) {
+    var ctrlMsg = 'baseUrl must not contain embedded control characters';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC SafeFrame Bridge] ' + ctrlMsg);
+    }
+    throw new TypeError(ctrlMsg);
+  }
+
+  // Protocol-relative URLs (`//host/…` or `\\host\…`) — see
+  // sharc-mraid-bridge.js for rationale.
+  if (/^[\\/]{2}/.test(trimmed)) {
+    var protoRelMsg = 'baseUrl must not be protocol-relative';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC SafeFrame Bridge] ' + protoRelMsg);
+    }
+    throw new TypeError(protoRelMsg);
+  }
 
   var schemeMatch = trimmed.match(/^([a-zA-Z][a-zA-Z0-9+\-.]*):/);
   if (!schemeMatch) {

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -54,7 +54,7 @@ function validateBridgeBaseUrl(baseUrl) {
   // Trim — see sharc-mraid-bridge.js for full rationale on the Unicode-whitespace
   // + zero-width character set.
   // eslint-disable-next-line no-control-regex -- intentional: C0 controls + space + Unicode whitespace are the bypass surface this trim defends
-  var trimmed = baseUrl.replace(/^[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]+|[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]+$/g, '');
+  var trimmed = baseUrl.replace(/^[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F-\u2060\u3000\uFEFF]+|[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F-\u2060\u3000\uFEFF]+$/g, '');
 
   // Empty / whitespace-only baseUrl — see sharc-mraid-bridge.js for rationale.
   if (trimmed === '') {
@@ -68,7 +68,7 @@ function validateBridgeBaseUrl(baseUrl) {
   // Embedded control / Unicode-whitespace / zero-width characters — see
   // sharc-mraid-bridge.js for rationale.
   // eslint-disable-next-line no-control-regex -- intentional: embedded C0 controls + DEL + Unicode whitespace + zero-width chars are the bypass surface this check defends
-  if (/[\x00-\x1F\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]/.test(trimmed)) {
+  if (/[\x00-\x1F\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F-\u2060\u3000\uFEFF]/.test(trimmed)) {
     var ctrlMsg = 'baseUrl must not contain embedded control or whitespace characters';
     if (typeof console !== 'undefined' && console.warn) {
       console.warn('[SHARC SafeFrame Bridge] ' + ctrlMsg);

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -51,8 +51,10 @@ function validateBridgeBaseUrl(baseUrl) {
     throw new TypeError(typeMsg);
   }
 
-  // eslint-disable-next-line no-control-regex -- intentional: C0 controls + space are the bypass surface this trim defends
-  var trimmed = baseUrl.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '');
+  // Trim — see sharc-mraid-bridge.js for full rationale on the Unicode-whitespace
+  // + zero-width character set.
+  // eslint-disable-next-line no-control-regex -- intentional: C0 controls + space + Unicode whitespace are the bypass surface this trim defends
+  var trimmed = baseUrl.replace(/^[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]+|[\x00-\x20\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]+$/g, '');
 
   // Empty / whitespace-only baseUrl — see sharc-mraid-bridge.js for rationale.
   if (trimmed === '') {
@@ -63,24 +65,36 @@ function validateBridgeBaseUrl(baseUrl) {
     throw new TypeError(emptyMsg);
   }
 
-  // Embedded C0 control characters — see sharc-mraid-bridge.js for rationale.
-  // eslint-disable-next-line no-control-regex -- intentional: embedded C0 controls are the bypass surface this check defends
-  if (/[\x00-\x1F]/.test(trimmed)) {
-    var ctrlMsg = 'baseUrl must not contain embedded control characters';
+  // Embedded control / Unicode-whitespace / zero-width characters — see
+  // sharc-mraid-bridge.js for rationale.
+  // eslint-disable-next-line no-control-regex -- intentional: embedded C0 controls + DEL + Unicode whitespace + zero-width chars are the bypass surface this check defends
+  if (/[\x00-\x1F\x7F\u00A0\u1680\u2000-\u200D\u2028\u2029\u202F\u205F\u3000\uFEFF]/.test(trimmed)) {
+    var ctrlMsg = 'baseUrl must not contain embedded control or whitespace characters';
     if (typeof console !== 'undefined' && console.warn) {
       console.warn('[SHARC SafeFrame Bridge] ' + ctrlMsg);
     }
     throw new TypeError(ctrlMsg);
   }
 
-  // Protocol-relative URLs (`//host/…` or `\\host\…`) — see
-  // sharc-mraid-bridge.js for rationale.
-  if (/^[\\/]{2}/.test(trimmed)) {
+  // Protocol-relative URLs (`//host/…`, `\\host\…`, or the percent-encoded
+  // leading form `%2F%2F…` / `%5C%5C…` / mixed) — see sharc-mraid-bridge.js
+  // for rationale.
+  if (/^[\\/]{2}/.test(trimmed) || /^%(?:2[Ff]|5[Cc])/.test(trimmed)) {
     var protoRelMsg = 'baseUrl must not be protocol-relative';
     if (typeof console !== 'undefined' && console.warn) {
       console.warn('[SHARC SafeFrame Bridge] ' + protoRelMsg);
     }
     throw new TypeError(protoRelMsg);
+  }
+
+  // Percent-encoded scheme separator (`%3A`) — see sharc-mraid-bridge.js
+  // for rationale.
+  if (/%3[Aa]/.test(trimmed)) {
+    var pctColonMsg = 'baseUrl must not contain percent-encoded scheme separator (%3A)';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[SHARC SafeFrame Bridge] ' + pctColonMsg);
+    }
+    throw new TypeError(pctColonMsg);
   }
 
   var schemeMatch = trimmed.match(/^([a-zA-Z][a-zA-Z0-9+\-.]*):/);

--- a/test/node/test-bridges-detection.js
+++ b/test/node/test-bridges-detection.js
@@ -1253,14 +1253,95 @@ console.log('\n19. baseUrl validation — defense-in-depth on MRAID / SafeFrame 
     // future WHATWG-parser sink strips them and rehydrates as javascript:.
     assertThrows(
       () => new ctor({ baseUrl: 'jav\tascript:alert(1)' }),
-      /embedded control characters/,
+      /embedded (?:control|control or whitespace) characters/,
       `${label}: rejects embedded-tab scheme bypass`,
       TypeError,
     );
     assertThrows(
       () => new ctor({ baseUrl: 'Java\tScript:alert(1)' }),
-      /embedded control characters/,
+      /embedded (?:control|control or whitespace) characters/,
       `${label}: rejects embedded-tab + case-variant scheme bypass`,
+      TypeError,
+    );
+
+    // -- Unicode-whitespace / zero-width bypass (round-3 hardening) ----------
+    // ES2019 `String.prototype.trim` strips Unicode whitespace (NBSP, LSEP,
+    // PSEP, ideographic space, BOM, etc.) and some parsers strip zero-width
+    // chars too — so without broadening trim + embedded-check, a future sink
+    // would rehydrate `'<NBSP>javascript:alert(1)'` (NBSP-leading) as
+    // `javascript:`. Lock the bypass surface at the validator.
+    assertThrows(
+      () => new ctor({ baseUrl: ' javascript:alert(1)' }),
+      /javascript: scheme/,
+      `${label}: rejects NBSP-leading javascript: bypass`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: ' javascript:alert(1)' }),
+      /javascript: scheme/,
+      `${label}: rejects LSEP-leading javascript: bypass`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: '​javascript:alert(1)' }),
+      /javascript: scheme/,
+      `${label}: rejects ZWSP-leading javascript: bypass`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: '﻿javascript:alert(1)' }),
+      /javascript: scheme/,
+      `${label}: rejects BOM-leading javascript: bypass`,
+      TypeError,
+    );
+    // Embedded NBSP mid-string — would survive an ES2019-trim sink and
+    // rehydrate as `javascript:` if also folded out by the URL parser.
+    assertThrows(
+      () => new ctor({ baseUrl: 'jav ascript:alert(1)' }),
+      /embedded control or whitespace characters/,
+      `${label}: rejects embedded-NBSP scheme bypass`,
+      TypeError,
+    );
+
+    // -- Pure-case scheme variants (round-3 hardening) -----------------------
+    // The validator already lowercases the scheme before the dangerous-set
+    // check, but no test asserted the all-caps / mixed-case form was
+    // rejected. Lock the `toLowerCase()` contract explicitly so a future
+    // refactor can't accidentally make the scheme check case-sensitive.
+    assertThrows(
+      () => new ctor({ baseUrl: 'JAVASCRIPT:alert(1)' }),
+      /javascript: scheme/,
+      `${label}: rejects all-caps JAVASCRIPT: baseUrl`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: 'JavaScript:alert(1)' }),
+      /javascript: scheme/,
+      `${label}: rejects mixed-case JavaScript: baseUrl`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: 'DATA:text/html,foo' }),
+      /data: scheme/,
+      `${label}: rejects all-caps DATA: baseUrl`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: 'VBSCRIPT:msgbox("x")' }),
+      /vbscript: scheme/,
+      `${label}: rejects all-caps VBSCRIPT: baseUrl`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: 'FILE:///etc/passwd' }),
+      /file: scheme/,
+      `${label}: rejects all-caps FILE: baseUrl`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: 'BLOB:https://x/y' }),
+      /blob: scheme/,
+      `${label}: rejects all-caps BLOB: baseUrl`,
       TypeError,
     );
 
@@ -1282,6 +1363,50 @@ console.log('\n19. baseUrl validation — defense-in-depth on MRAID / SafeFrame 
       TypeError,
     );
 
+    // -- Percent-encoded bypass surface (round-3 hardening, Option C) --------
+    // Not an active bypass today (current scheme regex requires literal `:`
+    // and protocol-relative regex requires literal `/` or `\`), but if a
+    // future code path URL-decodes `baseUrl` before validation or hands it
+    // to a sink that does, these shapes rehydrate as `javascript:` (via %3A)
+    // or `//evil/` (via %2F%2F) / `\\evil\` (via %5C%5C). Lock the bypass
+    // surface at the validator. Case-insensitive per RFC 3986 §2.1.
+    assertThrows(
+      () => new ctor({ baseUrl: 'javascript%3Aalert(1)' }),
+      /percent-encoded scheme separator/,
+      `${label}: rejects %3A (percent-encoded colon) bypass`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: 'data%3Atext/html,foo' }),
+      /percent-encoded scheme separator/,
+      `${label}: rejects %3A on data: scheme bypass`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: 'javascript%3aalert(1)' }),
+      /percent-encoded scheme separator/,
+      `${label}: rejects lowercase %3a bypass`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: '%2F%2Fevil.example/sharc' }),
+      /protocol-relative/,
+      `${label}: rejects %2F%2F protocol-relative bypass`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: '%5C%5Cevil.test/x' }),
+      /protocol-relative/,
+      `${label}: rejects %5C%5C protocol-relative bypass`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: '%2f%2fevil.example/sharc' }),
+      /protocol-relative/,
+      `${label}: rejects lowercase %2f%2f bypass`,
+      TypeError,
+    );
+
     // -- Whitespace-only baseUrl (must-fix #3) -------------------------------
     // `'   '` trims to empty; without the empty-check it would bypass scheme
     // detection and be returned verbatim, propagating whitespace into the URL.
@@ -1289,6 +1414,13 @@ console.log('\n19. baseUrl validation — defense-in-depth on MRAID / SafeFrame 
       () => new ctor({ baseUrl: '   ' }),
       /empty or whitespace/,
       `${label}: rejects whitespace-only baseUrl`,
+      TypeError,
+    );
+    // Unicode-whitespace-only (round-3) — must also trim to empty.
+    assertThrows(
+      () => new ctor({ baseUrl: '  ﻿' }),
+      /empty or whitespace/,
+      `${label}: rejects Unicode-whitespace-only baseUrl`,
       TypeError,
     );
 
@@ -1303,6 +1435,13 @@ console.log('\n19. baseUrl validation — defense-in-depth on MRAID / SafeFrame 
     try { new ctor({ baseUrl: 'sharc' }); }                          catch (e) { ok = false; }
     try { new ctor({ baseUrl: './sharc' }); }                        catch (e) { ok = false; }
     try { new ctor({ baseUrl: 'https://cdn.example/sharc' }); }      catch (e) { ok = false; }
+    // Legitimate non-dangerous percent-encoding (e.g. URL-encoded space) MUST
+    // still pass — Option C only locks %3A, %2F (leading), %5C (leading).
+    try { new ctor({ baseUrl: '/sharc%20path' }); }                  catch (e) { ok = false; }
+    try { new ctor({ baseUrl: 'https://cdn.example/sharc%20path' }); } catch (e) { ok = false; }
+    // Mid-string %2F (e.g. URL-encoded path separator) is not the protocol-
+    // relative bypass shape — only leading %2F%2F / %5C%5C is rejected.
+    try { new ctor({ baseUrl: '/sharc/seg%2Fwith%2Fslashes' }); }    catch (e) { ok = false; }
     assert(ok, `${label}: accepts undefined / null / path-relative / valid HTTPS baseUrl`);
   }
 }

--- a/test/node/test-bridges-detection.js
+++ b/test/node/test-bridges-detection.js
@@ -1253,13 +1253,13 @@ console.log('\n19. baseUrl validation — defense-in-depth on MRAID / SafeFrame 
     // future WHATWG-parser sink strips them and rehydrates as javascript:.
     assertThrows(
       () => new ctor({ baseUrl: 'jav\tascript:alert(1)' }),
-      /embedded (?:control|control or whitespace) characters/,
+      /embedded control or whitespace characters/,
       `${label}: rejects embedded-tab scheme bypass`,
       TypeError,
     );
     assertThrows(
       () => new ctor({ baseUrl: 'Java\tScript:alert(1)' }),
-      /embedded (?:control|control or whitespace) characters/,
+      /embedded control or whitespace characters/,
       `${label}: rejects embedded-tab + case-variant scheme bypass`,
       TypeError,
     );
@@ -1292,6 +1292,12 @@ console.log('\n19. baseUrl validation — defense-in-depth on MRAID / SafeFrame 
       () => new ctor({ baseUrl: '﻿javascript:alert(1)' }),
       /javascript: scheme/,
       `${label}: rejects BOM-leading javascript: bypass`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: '\u2060javascript:alert(1)' }),
+      /javascript: scheme/,
+      `${label}: rejects WORD JOINER-leading javascript: bypass`,
       TypeError,
     );
     // Embedded NBSP mid-string — would survive an ES2019-trim sink and

--- a/test/node/test-bridges-detection.js
+++ b/test/node/test-bridges-detection.js
@@ -55,6 +55,8 @@ window.SHARC.Protocol = protoMod;
 
 const { SHARCContainer } = await import('../../dist/sharc-container.mjs');
 const { OmidCompatBridge } = await import('../../dist/sharc-omid-bridge.mjs');
+const { MRAIDCompatBridge } = await import('../../dist/sharc-mraid-bridge.mjs');
+const { SafeFrameCompatBridge } = await import('../../dist/sharc-safeframe-bridge.mjs');
 
 // ── Tiny assertion harness ────────────────────────────────────────────────
 let failures = 0;
@@ -1157,6 +1159,77 @@ function makeMarkupOpts(extra) {
     'OMID bridge contract: AdCOM APIFramework 7 remains unmapped to renderer bridges');
   assertDeepEqual(SHARCContainer._resolveBridges({ creativeMeta: { apis: [7] }, creativeHtml: 'plain' }), [],
     'OMID bridge contract: creativeMeta.apis=[7] resolves to no renderer bridge');
+}
+
+// -- 19. baseUrl validation — defense-in-depth (issue #140) ──────────────────
+console.log('\n19. baseUrl validation — defense-in-depth on MRAIDCompatBridge / SafeFrameCompatBridge');
+{
+  // Cases identical for both bridges; iterate to lock parity.
+  const cases = [
+    { ctor: MRAIDCompatBridge,    label: 'MRAIDCompatBridge' },
+    { ctor: SafeFrameCompatBridge, label: 'SafeFrameCompatBridge' },
+  ];
+
+  for (const { ctor, label } of cases) {
+    // Rejection cases.
+    assertThrows(
+      () => new ctor({ baseUrl: 'javascript:alert(1)//' }),
+      /javascript: scheme/,
+      `${label}: rejects javascript: baseUrl`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: 'data:text/html,<script>alert(1)</script>' }),
+      /data: scheme/,
+      `${label}: rejects data: baseUrl`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: 'vbscript:msgbox("x")' }),
+      /vbscript: scheme/,
+      `${label}: rejects vbscript: baseUrl`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: 'https://user:pw@cdn.example/' }),
+      /userinfo/,
+      `${label}: rejects userinfo in absolute baseUrl`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: 'http://cdn.example/' }),
+      /HTTPS/,
+      `${label}: rejects non-HTTPS absolute baseUrl`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: 42 }),
+      /must be a string/,
+      `${label}: rejects non-string baseUrl`,
+      TypeError,
+    );
+    // Leading-whitespace bypass attempt — WHATWG URL parser strips C0+space,
+    // so '\tjavascript:alert(1)' would otherwise parse as javascript:.
+    assertThrows(
+      () => new ctor({ baseUrl: '\tjavascript:alert(1)' }),
+      /javascript: scheme/,
+      `${label}: rejects leading-whitespace javascript: bypass`,
+      TypeError,
+    );
+
+    // Acceptance cases — must not throw.
+    let ok = true;
+    try { new ctor(); }                                              catch (e) { ok = false; }
+    try { new ctor({}); }                                            catch (e) { ok = false; }
+    try { new ctor({ baseUrl: undefined }); }                        catch (e) { ok = false; }
+    try { new ctor({ baseUrl: null }); }                             catch (e) { ok = false; }
+    try { new ctor({ baseUrl: '/sharc' }); }                         catch (e) { ok = false; }
+    try { new ctor({ baseUrl: '/custom/path' }); }                   catch (e) { ok = false; }
+    try { new ctor({ baseUrl: 'sharc' }); }                          catch (e) { ok = false; }
+    try { new ctor({ baseUrl: './sharc' }); }                        catch (e) { ok = false; }
+    try { new ctor({ baseUrl: 'https://cdn.example/sharc' }); }      catch (e) { ok = false; }
+    assert(ok, `${label}: accepts undefined / null / path-relative / valid HTTPS baseUrl`);
+  }
 }
 
 // ── Summary ───────────────────────────────────────────────────────────────

--- a/test/node/test-bridges-detection.js
+++ b/test/node/test-bridges-detection.js
@@ -1162,16 +1162,20 @@ function makeMarkupOpts(extra) {
 }
 
 // -- 19. baseUrl validation — defense-in-depth (issue #140) ──────────────────
-console.log('\n19. baseUrl validation — defense-in-depth on MRAIDCompatBridge / SafeFrameCompatBridge');
+console.log('\n19. baseUrl validation — defense-in-depth on MRAID / SafeFrame / OMID bridges');
 {
-  // Cases identical for both bridges; iterate to lock parity.
+  // Cross-bridge parity: all three bridges must enforce identical baseUrl
+  // contract. Iterating here (rather than copy-pasting the matrix into
+  // test-omid-container-lifecycle.js §G10d) ensures any future security fix
+  // that lands in one validator can't silently miss the others.
   const cases = [
-    { ctor: MRAIDCompatBridge,    label: 'MRAIDCompatBridge' },
+    { ctor: MRAIDCompatBridge,     label: 'MRAIDCompatBridge' },
     { ctor: SafeFrameCompatBridge, label: 'SafeFrameCompatBridge' },
+    { ctor: OmidCompatBridge,      label: 'OmidCompatBridge' },
   ];
 
   for (const { ctor, label } of cases) {
-    // Rejection cases.
+    // -- Scheme-based rejections ---------------------------------------------
     assertThrows(
       () => new ctor({ baseUrl: 'javascript:alert(1)//' }),
       /javascript: scheme/,
@@ -1190,6 +1194,23 @@ console.log('\n19. baseUrl validation — defense-in-depth on MRAIDCompatBridge 
       `${label}: rejects vbscript: baseUrl`,
       TypeError,
     );
+    // Direct file:/blob: scheme rejection — covered by the validator's
+    // dangerousSchemes set, asserted explicitly here so the contract is
+    // visible at the test layer (not just inferred from the rule docs).
+    assertThrows(
+      () => new ctor({ baseUrl: 'file:///etc/passwd' }),
+      /file: scheme/,
+      `${label}: rejects file: baseUrl`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: 'blob:https://example/uuid' }),
+      /blob: scheme/,
+      `${label}: rejects blob: baseUrl`,
+      TypeError,
+    );
+
+    // -- Userinfo / non-HTTPS / non-string -----------------------------------
     assertThrows(
       () => new ctor({ baseUrl: 'https://user:pw@cdn.example/' }),
       /userinfo/,
@@ -1208,16 +1229,70 @@ console.log('\n19. baseUrl validation — defense-in-depth on MRAIDCompatBridge 
       `${label}: rejects non-string baseUrl`,
       TypeError,
     );
-    // Leading-whitespace bypass attempt — WHATWG URL parser strips C0+space,
-    // so '\tjavascript:alert(1)' would otherwise parse as javascript:.
+
+    // -- Leading-whitespace scheme bypass ------------------------------------
+    // WHATWG URL parser strips C0+space, so `'\tjavascript:alert(1)'` would
+    // otherwise parse as javascript:.
     assertThrows(
       () => new ctor({ baseUrl: '\tjavascript:alert(1)' }),
       /javascript: scheme/,
-      `${label}: rejects leading-whitespace javascript: bypass`,
+      `${label}: rejects leading-tab javascript: bypass`,
+      TypeError,
+    );
+    // Null-byte leading-whitespace variant — locks the same contract for the
+    // \x00 case that the existing trim regex (`[\x00-\x20]`) already covers.
+    assertThrows(
+      () => new ctor({ baseUrl: '\x00javascript:alert(1)' }),
+      /javascript: scheme/,
+      `${label}: rejects leading-null-byte javascript: bypass`,
       TypeError,
     );
 
-    // Acceptance cases — must not throw.
+    // -- Embedded-whitespace scheme bypass (must-fix #2) ---------------------
+    // After trim, embedded tab/control chars must be rejected — otherwise a
+    // future WHATWG-parser sink strips them and rehydrates as javascript:.
+    assertThrows(
+      () => new ctor({ baseUrl: 'jav\tascript:alert(1)' }),
+      /embedded control characters/,
+      `${label}: rejects embedded-tab scheme bypass`,
+      TypeError,
+    );
+    assertThrows(
+      () => new ctor({ baseUrl: 'Java\tScript:alert(1)' }),
+      /embedded control characters/,
+      `${label}: rejects embedded-tab + case-variant scheme bypass`,
+      TypeError,
+    );
+
+    // -- Protocol-relative URLs (must-fix #1) --------------------------------
+    // `//host/…` resolves against the page protocol in an href/srcdoc sink,
+    // fetching from attacker-controlled origin.
+    assertThrows(
+      () => new ctor({ baseUrl: '//evil.example/sharc' }),
+      /protocol-relative/,
+      `${label}: rejects protocol-relative // baseUrl`,
+      TypeError,
+    );
+    // Backslash-prefix variant — browsers normalize backslashes to forward
+    // slashes in special-scheme contexts.
+    assertThrows(
+      () => new ctor({ baseUrl: '\\\\evil.test/x' }),
+      /protocol-relative/,
+      `${label}: rejects protocol-relative \\\\ baseUrl`,
+      TypeError,
+    );
+
+    // -- Whitespace-only baseUrl (must-fix #3) -------------------------------
+    // `'   '` trims to empty; without the empty-check it would bypass scheme
+    // detection and be returned verbatim, propagating whitespace into the URL.
+    assertThrows(
+      () => new ctor({ baseUrl: '   ' }),
+      /empty or whitespace/,
+      `${label}: rejects whitespace-only baseUrl`,
+      TypeError,
+    );
+
+    // -- Acceptance cases — must not throw -----------------------------------
     let ok = true;
     try { new ctor(); }                                              catch (e) { ok = false; }
     try { new ctor({}); }                                            catch (e) { ok = false; }

--- a/test/node/test-omid-container-lifecycle.js
+++ b/test/node/test-omid-container-lifecycle.js
@@ -1224,6 +1224,68 @@ section('G10c. Edge cases — OM SDK script URLs use HTTPS validation');
     'omSdkSessionClientUrl preserves validated HTTPS URL');
 }
 
+section('G10d. Edge cases — baseUrl validation (issue #140 defense-in-depth)');
+{
+  // Rejection cases.
+  assertThrows(
+    () => new OmidCompatBridge({ baseUrl: 'javascript:alert(1)//' }),
+    /javascript: scheme/,
+    'baseUrl rejects javascript: scheme',
+    TypeError,
+  );
+  assertThrows(
+    () => new OmidCompatBridge({ baseUrl: 'data:text/html,<script>alert(1)</script>' }),
+    /data: scheme/,
+    'baseUrl rejects data: scheme',
+    TypeError,
+  );
+  assertThrows(
+    () => new OmidCompatBridge({ baseUrl: 'vbscript:msgbox("x")' }),
+    /vbscript: scheme/,
+    'baseUrl rejects vbscript: scheme',
+    TypeError,
+  );
+  assertThrows(
+    () => new OmidCompatBridge({ baseUrl: 'https://user:pw@cdn.example/' }),
+    /userinfo/,
+    'baseUrl rejects userinfo in absolute URL',
+    TypeError,
+  );
+  assertThrows(
+    () => new OmidCompatBridge({ baseUrl: 'http://cdn.example/' }),
+    /HTTPS/,
+    'baseUrl rejects non-HTTPS absolute URL',
+    TypeError,
+  );
+  assertThrows(
+    () => new OmidCompatBridge({ baseUrl: 42 }),
+    /must be a string/,
+    'baseUrl rejects non-string value',
+    TypeError,
+  );
+  // Leading-whitespace bypass attempt — WHATWG URL parser strips C0+space,
+  // so '\tjavascript:alert(1)' would otherwise parse as javascript:.
+  assertThrows(
+    () => new OmidCompatBridge({ baseUrl: '\tjavascript:alert(1)' }),
+    /javascript: scheme/,
+    'baseUrl rejects leading-whitespace javascript: bypass',
+    TypeError,
+  );
+
+  // Acceptance cases — must not throw.
+  let ok = true;
+  try { new OmidCompatBridge(); }                                              catch (e) { ok = false; }
+  try { new OmidCompatBridge({}); }                                            catch (e) { ok = false; }
+  try { new OmidCompatBridge({ baseUrl: undefined }); }                        catch (e) { ok = false; }
+  try { new OmidCompatBridge({ baseUrl: null }); }                             catch (e) { ok = false; }
+  try { new OmidCompatBridge({ baseUrl: '/sharc' }); }                         catch (e) { ok = false; }
+  try { new OmidCompatBridge({ baseUrl: '/custom/path' }); }                   catch (e) { ok = false; }
+  try { new OmidCompatBridge({ baseUrl: 'sharc' }); }                          catch (e) { ok = false; }
+  try { new OmidCompatBridge({ baseUrl: './sharc' }); }                        catch (e) { ok = false; }
+  try { new OmidCompatBridge({ baseUrl: 'https://cdn.example/sharc' }); }      catch (e) { ok = false; }
+  assert(ok, 'baseUrl accepts undefined / null / path-relative / valid HTTPS');
+}
+
 section('G11. Edge cases — getFeatureDescriptor mediaEvents flag for video vs display');
 {
   const sdkUrls = {

--- a/test/node/test-omid-container-lifecycle.js
+++ b/test/node/test-omid-container-lifecycle.js
@@ -1224,67 +1224,12 @@ section('G10c. Edge cases — OM SDK script URLs use HTTPS validation');
     'omSdkSessionClientUrl preserves validated HTTPS URL');
 }
 
-section('G10d. Edge cases — baseUrl validation (issue #140 defense-in-depth)');
-{
-  // Rejection cases.
-  assertThrows(
-    () => new OmidCompatBridge({ baseUrl: 'javascript:alert(1)//' }),
-    /javascript: scheme/,
-    'baseUrl rejects javascript: scheme',
-    TypeError,
-  );
-  assertThrows(
-    () => new OmidCompatBridge({ baseUrl: 'data:text/html,<script>alert(1)</script>' }),
-    /data: scheme/,
-    'baseUrl rejects data: scheme',
-    TypeError,
-  );
-  assertThrows(
-    () => new OmidCompatBridge({ baseUrl: 'vbscript:msgbox("x")' }),
-    /vbscript: scheme/,
-    'baseUrl rejects vbscript: scheme',
-    TypeError,
-  );
-  assertThrows(
-    () => new OmidCompatBridge({ baseUrl: 'https://user:pw@cdn.example/' }),
-    /userinfo/,
-    'baseUrl rejects userinfo in absolute URL',
-    TypeError,
-  );
-  assertThrows(
-    () => new OmidCompatBridge({ baseUrl: 'http://cdn.example/' }),
-    /HTTPS/,
-    'baseUrl rejects non-HTTPS absolute URL',
-    TypeError,
-  );
-  assertThrows(
-    () => new OmidCompatBridge({ baseUrl: 42 }),
-    /must be a string/,
-    'baseUrl rejects non-string value',
-    TypeError,
-  );
-  // Leading-whitespace bypass attempt — WHATWG URL parser strips C0+space,
-  // so '\tjavascript:alert(1)' would otherwise parse as javascript:.
-  assertThrows(
-    () => new OmidCompatBridge({ baseUrl: '\tjavascript:alert(1)' }),
-    /javascript: scheme/,
-    'baseUrl rejects leading-whitespace javascript: bypass',
-    TypeError,
-  );
-
-  // Acceptance cases — must not throw.
-  let ok = true;
-  try { new OmidCompatBridge(); }                                              catch (e) { ok = false; }
-  try { new OmidCompatBridge({}); }                                            catch (e) { ok = false; }
-  try { new OmidCompatBridge({ baseUrl: undefined }); }                        catch (e) { ok = false; }
-  try { new OmidCompatBridge({ baseUrl: null }); }                             catch (e) { ok = false; }
-  try { new OmidCompatBridge({ baseUrl: '/sharc' }); }                         catch (e) { ok = false; }
-  try { new OmidCompatBridge({ baseUrl: '/custom/path' }); }                   catch (e) { ok = false; }
-  try { new OmidCompatBridge({ baseUrl: 'sharc' }); }                          catch (e) { ok = false; }
-  try { new OmidCompatBridge({ baseUrl: './sharc' }); }                        catch (e) { ok = false; }
-  try { new OmidCompatBridge({ baseUrl: 'https://cdn.example/sharc' }); }      catch (e) { ok = false; }
-  assert(ok, 'baseUrl accepts undefined / null / path-relative / valid HTTPS');
-}
+// G10d. baseUrl validation (issue #140 defense-in-depth) — moved to the
+// cross-bridge parity matrix in test/node/test-bridges-detection.js §19, which
+// runs the same accept/reject contract against MRAID + SafeFrame +
+// OmidCompatBridge in one place. Keeping the matrix in one file ensures any
+// future security fix that lands in one bridge's validator can't silently
+// miss the others.
 
 section('G11. Edge cases — getFeatureDescriptor mediaEvents flag for video vs display');
 {


### PR DESCRIPTION
## Summary

Closes #140 — defense-in-depth validation of operator-supplied \`baseUrl\` across all three SHARC bridges (\`MRAIDCompatBridge\`, \`SafeFrameCompatBridge\`, \`OmidCompatBridge\`). \`getWrapperUrl\` isn't currently consumed by any production sink, but locks the validator down before a future feature wires the wrapper URL into a navigation/href/srcdoc sink.

## Cumulative diff

**5 files, +650/-0 (post-rebase) across 4 commits.** Each commit is a distinct hardening round driven by the 3-reviewer pass + spot-checks.

| Commit | Round | Scope |
|---|---|---|
| `f5db25e` | 1 | Initial validator: HTTPS-only for absolute URLs, no userinfo, reject `javascript:`/`data:`/`vbscript:`/`file:`/`blob:` schemes, allow path-relative defaults, leading-whitespace bypass defense (trim-then-detect for `\\x00-\\x20`) |
| `0e627cb` | 2 | Closed must-fix gaps: protocol-relative `//host` + backslash `\\\\host` rejection, embedded C0-control bypass (`jav\\tascript:`), whitespace-only rejection. Moved OMID into the cross-bridge parameterized iterator in `test-bridges-detection.js` §19. Added ESLint disable for `no-control-regex` (intentional bypass-surface match) |
| `b3008bd` | 3 | Broadened Unicode coverage (NBSP/LSEP/PSEP/ZWSP/ZWNJ/ZWJ/BOM/Ogham/NNBSP/MMSP/ideographic). Added pure-case scheme tests locking the `.toLowerCase()` contract. Percent-encoded scheme separator `%3A` rejection (anywhere) + leading `%2F`/`%5C` (Option C — surgical block of bypass shapes, preserves legitimate `%20`/`%2F` in paths). Rebased onto main |
| `e80a41b` | 4 | Review-pass nits: U+2060 WORD JOINER added to regex (same speculative-future-sink class as existing zero-width set), asymmetry comment on `%3A`-anywhere check, tightened test alternation, contract-lock test for U+2060-leading bypass |

## Validator contract (post-round 4)

Checks run cheapest-first:

1. `typeof !== 'string'` → `TypeError`
2. Trim per ES2019 (`String.prototype.trim`) set + zero-width chars
3. Empty / whitespace-only → `TypeError`
4. Embedded control / Unicode whitespace / zero-width → `TypeError`
5. Protocol-relative `//`, `\\\\`, or leading `%2F`/`%5C` (case-insensitive) → `TypeError`
6. Percent-encoded scheme separator `%3A` / `%3a` anywhere → `TypeError`
7. Scheme regex (RFC 3986)
8. Dangerous-set lowercase: `javascript`/`data`/`vbscript`/`file`/`blob` → `TypeError`
9. `URL()` parse; require `https:` for absolute → `TypeError`
10. Reject userinfo → `TypeError`

Path-relative inputs (`/sharc`, `sharc`, `./sharc`, `/sharc%20path`) and absolute HTTPS (`https://cdn.example/sharc`) pass.

## Tests

**Cross-bridge parameterized iterator** at `test/node/test-bridges-detection.js` §19 runs every assertion against all three bridges (MRAID + SafeFrame + OMID). 260+ cross-bridge assertions across the 4 rounds. Contract-lock verified: new tests fail on \`main\` (no validator), pass on this branch. \`npm run check\` green end-to-end.

## Design decisions worth knowing

- **Option B (per-bridge inline duplication, not shared helper).** Each bridge file is built as an independent IIFE bundle; a shared 20-line validator wouldn't earn the shared surface. Cross-bridge parity is locked structurally via the §19 iterator.
- **Option C (percent-encoded scheme bypass).** Picked over A (reject any `%`) which would break legitimate `%20` paths, and B (URL-decode-then-validate) which would create scheme-vs-decoded ambiguity. C is surgical: lock the literal bytes that decode to known-dangerous chars (`:`, `//`, `\\\\`).
- **Explicit Unicode codepoint set, not `\\s`.** `\\s` semantics are V8-version-dependent (Mongolian VS bounced in/out across Unicode versions). Explicit is deterministic.

## Deferred to post-merge follow-up issue

Speculative future-sink concerns that don't fit any current threat model:

- NFKC fullwidth fold (\`ｊａｖａｓｃｒｉｐｔ：\` → \`javascript:\` if sink applies \`.normalize('NFKC')\`)
- Bidi formatting marks (LRM/RLM/LRO/RLO/LRI-PDI, soft hyphen U+00AD)
- Mongolian Vowel Separator U+180E (theoretical — bounced in/out of \`\\s\` across Unicode versions)
- Double percent-encoding (\`%253A\` → \`%3A\` → \`:\` — multi-stage decoder)
- Percent-encoded ASCII controls (\`%00\`-\`%1F\`, \`%7F\` — future single-stage decoder)
- Asymmetric leading \`\\\\%2F\` (vs caught \`%2F\\\\\`)

All gated on a future sink ingesting \`getWrapperUrl\` output that applies normalization the current validator doesn't anticipate. Will be filed as a single round-5 issue post-merge per Security Engineer recommendation.

## Out-of-scope follow-ups already filed

- [#149](https://github.com/jeffreycarlson/SHARC/issues/149) — Retire \`getWrapperUrl\` across all three bridges (currently dead code)
- [#150](https://github.com/jeffreycarlson/SHARC/issues/150) — Validate \`creativeUrl\` argument when wrapper consumption is revived

## Test plan

- [x] \`npm run check\` green — build + 13 test suites + size budget
- [x] Cross-bridge parity verified — all assertions run against MRAID + SafeFrame + OMID via §19 iterator
- [x] Contract-lock verified — new tests fail on \`main\`, pass on branch
- [x] Three-reviewer pass (Reality Checker / Code Reviewer / Security Engineer) consensus: **READY / APPROVE / READY**
- [x] All review-pass should-fixes folded into rounds 2 and 3
- [x] Review-pass nits addressed in round 4
- [ ] Squash-merge with subject ≤72 chars and body summarizing all 4 rounds (this PR's commit history)

Closes #140