### PR TITLE
test: cover lifecycle stateChange gating

### DIFF
--- a/test/node/test-html-lifecycle-adapter.js
+++ b/test/node/test-html-lifecycle-adapter.js
@@ -631,6 +631,61 @@ flushContainers();
 }
 flushContainers();
 
+// -- 18. Issue #95: pre-session LOADING → ACTIVE sends no stateChange ------
+//    The HTML adapter may promote a permissive, non-handshake creative from
+//    LOADING → ACTIVE before any SHARC session exists. That local state
+//    transition must not emit Container:stateChange with sessionId === ''.
+{
+  console.log('\n18. Issue #95: adapter LOADING → ACTIVE before session sends no stateChange');
+  const sentMessages = [];
+  const { c, io } = makeContainer();
+  c._protocol._sendMessage = (type, args) => {
+    sentMessages.push({ type, args });
+    return Promise.resolve({});
+  };
+
+  dispatchIframeLoad(c);
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.9 });
+  await sleep(5);
+
+  assert(c.getState() === ContainerStates.ACTIVE,
+    'pre-session adapter path advanced LOADING → ACTIVE locally');
+  assert(c.hasSharcSession === false,
+    'pre-session adapter path still has no SHARC session');
+  assert(sentMessages.filter((m) => m.type === 'SHARC:Container:stateChange').length === 0,
+    'pre-session adapter LOADING → ACTIVE did NOT send Container:stateChange');
+}
+flushContainers();
+
+// -- 19. Issue #95: session-backed transition does send stateChange --------
+//    Positive control for § 18: once a session exists, an adapter-driven
+//    creative-queryable state transition should still notify the creative.
+{
+  console.log('\n19. Issue #95: adapter state transition after session sends stateChange');
+  const sentMessages = [];
+  const { c, io } = makeContainer();
+
+  // Simulate a completed handshake without exercising MessageChannel in jsdom.
+  c._protocol.sessionId = 'test-session-id';
+  c._protocol._sendMessage = (type, args) => {
+    sentMessages.push({ type, args });
+    return Promise.resolve({});
+  };
+
+  dispatchIframeLoad(c);
+  trigger(io, { isIntersecting: true, intersectionRatio: 0.9 });
+  await sleep(5);
+
+  assert(c.hasSharcSession === true,
+    'session-backed path reports an established SHARC session');
+  assert(c.getState() === ContainerStates.ACTIVE,
+    'session-backed adapter path advanced LOADING → ACTIVE');
+  const stateMessages = sentMessages.filter((m) => m.type === 'SHARC:Container:stateChange');
+  assert(stateMessages.length === 1 && stateMessages[0].args.containerState === ContainerStates.ACTIVE,
+    'session-backed adapter transition sent Container:stateChange(active)');
+}
+flushContainers();
+
 // ── Summary ───────────────────────────────────────────────────────────────
 console.log('');
 if (failures > 0) {


### PR DESCRIPTION
## Summary

Closes #95 — adds explicit regression coverage for the remaining HTML lifecycle adapter state-change gating question.

Current main already guards the runtime path: `SHARCContainerProtocol.sendStateChange()` no-ops when `sessionId === ''`. This PR locks that behavior with focused tests in `test/node/test-html-lifecycle-adapter.js`.

### What changed

- Added a pre-session adapter test: `LOADING -> ACTIVE` advances local container state, keeps `hasSharcSession === false`, and does **not** send `SHARC:Container:stateChange`.
- Added a session-backed positive control: with `sessionId` present, the same adapter-driven transition still sends `SHARC:Container:stateChange(active)`.

No production code changes.

## Verification

- [x] `npm run build && node test/node/test-html-lifecycle-adapter.js`
- [x] `node test/node/test-non-sharc-loading.js`
- [x] `npm run lint`
- [x] `git diff --check`

## Review notes

This is intentionally test-only. The spy sits below `sendStateChange()` at `_sendMessage()` so the existing no-session guard remains under test rather than being bypassed by the test harness.

Closes #95
