### PR TITLE
docs(design): 0.7.4 OMID hardening release design

### DIFF
--- a/docs/design/0.7.4-omid-hardening.md
+++ b/docs/design/0.7.4-omid-hardening.md
@@ -31,18 +31,20 @@
 
 | PR | Issue | Type | Rough scope |
 |----|-------|------|-------------|
-| A  | [#126](https://github.com/jeffreycarlson/SHARC/issues/126) | Test only | Termination-mid-load coverage for `_sessionCreationPromise` |
+| A  | [#126](https://github.com/jeffreycarlson/SHARC/issues/126) | Test only (no code) | Termination-mid-load coverage for `_sessionCreationPromise`. **Audit finding: existing implementation already meets the contract.** Tests pin the coverage gap; no production change. |
 | B  | [#124](https://github.com/jeffreycarlson/SHARC/issues/124) | ~20 LOC + tests | Multi-bridge dedup `console.warn` |
-| C  | [#121](https://github.com/jeffreycarlson/SHARC/issues/121) | Audit + (possibly) delete | Legacy `requestOmid` removal |
-| D  | [#123](https://github.com/jeffreycarlson/SHARC/issues/123) | Code + docs | Extension `errorMessage` forwarding + extension-contract docs |
-| E  | [#125](https://github.com/jeffreycarlson/SHARC/issues/125) | Code + tests | New `SHARCSecurityEvent` variant `feature_load_failed` |
+| C  | [#121](https://github.com/jeffreycarlson/SHARC/issues/121) | Docs banner only | Legacy `requestOmid` audit. **Audit finding: zero residual symbols in `src/`/`test/`/`examples/`.** Two doc banners on historical `docs/research/` + `docs/reviews/` artifacts. |
+| D  | [#123](https://github.com/jeffreycarlson/SHARC/issues/123) | Tests + docs (no code) | Extension `errorMessage` forwarding + extension-contract docs. **Audit finding: `errorMessage` already correctly forwarded from both fatal paths.** Tests pin the contract; docs in `api-reference.md §9` get the missing payload table. |
+| E  | [#125](https://github.com/jeffreycarlson/SHARC/issues/125) | Code + tests + docs | New `SHARCSecurityEvent` variant `feature_load_failed` |
 | F  | [#106](https://github.com/jeffreycarlson/SHARC/issues/106) | Code + docs + tests | URL-variant `creativeSdkUrl` SDK injection in `_fetchAndInjectCreative` |
-| G  | [#102](https://github.com/jeffreycarlson/SHARC/issues/102) | Test infra | bfcache Puppeteer coverage for HTML lifecycle adapter |
+| G  | [#102](https://github.com/jeffreycarlson/SHARC/issues/102) | Test infra + scaffold | bfcache Puppeteer coverage for HTML lifecycle adapter (full Puppeteer wiring may roll into 0.7.5 — scaffold ships in 0.7.4) |
 | H  | —     | Mechanical | CHANGELOG + current-status + version bump + dist rebuild |
+
+**Audit-driven scope adjustment.** Three of the seven items (A #126, C #121, D #123) turned out to be **coverage / documentation gaps, not implementation gaps**. The 0.7.3 design + implementation actually shipped the right behaviors; the issues were filed conservatively as follow-ups to track *missing observability*, not missing functionality. This makes 0.7.4 a lighter release than the issue count implies — only PRs B, E, F carry production code changes; G adds test infrastructure; A, C, D ship test/doc additions only.
 
 **Breaking-change inventory.** Pre-1.0 ships breaks clean (memory `project_pre_1_breaking_changes`):
 
-- **PR C #121** — if the audit finds residual `requestOmid` symbols in `src/` or `test/`, they are removed without alias or deprecation. (Audit summary below: no residual symbols in shipping surface; only `docs/research/` and `docs/reviews/` historical artifacts mention the name. Likely zero functional break.)
+- **PR C #121** — audit confirms zero residual symbols in shipping surface (`src/`, `test/`, `examples/` all clean). Only `docs/research/OM-sdk-research.md` and `docs/reviews/OM-sdk-architect-recommendations.md` mention the name as historical artifacts; both receive a "superseded by 0.7.3 container-owned design" banner. **No functional break.**
 - **PR E #125** — `SHARCSecurityEvent` discriminated union gains a seventh `type` value (`feature_load_failed`). TypeScript consumers using exhaustive `switch` over `event.type` will see a new compiler-flagged case. No runtime break for callers that branch defensively; one-line `case` addition for exhaustive consumers.
 - **PR F #106** — `creativeSdkUrl` becomes functional on the Creative URL variant; the existing `hasCreativeHtml` storage gate and the URL-variant guard on the `'com.iabtechlab.sharc.creative-injector'` supportedFeatures entry are removed. Operators currently passing `creativeSdkUrl` alongside `creativeUrl` get the feature instead of the silent no-op. Behavior was a documented stop-gap (the JSDoc carries an explicit `issue #106` follow-up note); promoting it to active is not a break of any contract operators were relying on.
 

--- a/docs/design/0.7.4-omid-hardening.md
+++ b/docs/design/0.7.4-omid-hardening.md
@@ -106,7 +106,7 @@ These two issues are designed as a pair because they jointly answer "what does t
 
 After 0.7.3, the container's extension dispatch surface is `_notifyExtensionsLifecycle(type, detail)` (`src/sharc-container.js:1762`). Three relevant call sites:
 
-- `src/sharc-container.js:3394` — `_handleCreativeFatalError` already passes `{ errorCode, errorMessage, source: 'creative' }`. So #123 is **partially complete already** — the creative-fatal-error path forwards `errorMessage`. What remains: (a) confirm and document the contract; (b) check whether the container-side fatal-error path (`_handleFatalError`, fired from renderer timeouts, security events, init reject, etc.) ALSO forwards `errorMessage` through the lifecycle. **Audit finding from `_handleFatalError` → `_terminate`:** the container's fatal paths reach extensions via `_notifyExtensionsLifecycle('error', { errorCode, message })` at `src/sharc-container.js:3960` — but the field there is `message`, not `errorMessage`. Inconsistent.
+- `src/sharc-container.js:3394` — `_handleCreativeFatalError` passes `{ errorCode, errorMessage, source: 'creative' }`. **Audit finding (verified empirically against current main):** the container-side fatal path (`_handleFatalError` at `src/sharc-container.js:3960`) ALSO already dispatches `errorMessage` as the property name. The local parameter is named `message` but the dispatched object is `{ errorCode, errorMessage: message, source: 'container' }`. Both paths emit the same property name on the wire. **No production code rename is needed.** What remains: document the contract in `api-reference.md §9` (payload table) and add coverage tests that pin the field name across both paths so a future refactor can't silently regress it.
 - `src/sharc-container.js:3856` — `_notifyExtensionsLifecycle('close')` — no errorMessage applicable.
 - `src/sharc-container.js:3906` — `_notifyExtensionsLifecycle('destroy')` — no errorMessage applicable.
 
@@ -116,7 +116,7 @@ For #125, `SHARCSecurityEvent` currently has six variants (`src/sharc-container.
 
 | Decision | Choice |
 |----------|--------|
-| **D-123-A** Lifecycle event field name | **Canonicalize on `errorMessage`** (not `message`) for the `'error'` lifecycle event. Rename the existing `_handleFatalError`'s `_notifyExtensionsLifecycle('error', { errorCode, message })` to `{ errorCode, errorMessage }`. Matches the existing `_handleCreativeFatalError` shape (`src/sharc-container.js:3394`) AND matches `onError` callback signature `(errorCode, errorMessage)`. Single field name across all surfaces. |
+| **D-123-A** Lifecycle event field name | **Canonical field name is `errorMessage`** (matches both existing call sites and the `onError(errorCode, errorMessage)` callback signature). No rename needed — both `_handleCreativeFatalError` (`src/sharc-container.js:3394`) and `_handleFatalError` (`src/sharc-container.js:3960`) already dispatch the `errorMessage` property. The contract is enforced today; PR D pins it with coverage tests and documents it in `api-reference.md §9`. |
 | **D-123-B** Which lifecycle event types carry `errorMessage` | **`'error'` only.** `'close'` and `'destroy'` are not error paths. `'stateChange'` carries `newState`/`previousState`. `'placementChange'` carries `intent`/`targetDimensions`/`targetPosition`. `'load'` carries nothing. Mixing error context into non-error events would invite extensions to branch on `errorMessage` in `'close'` handlers, which is structurally wrong. |
 | **D-123-C** TypeScript shape of lifecycle event | Document the discriminated union in JSDoc + extend the `Extension` JSDoc block at `src/sharc-container.js:562-572`. The `error` variant is `{ type: 'error', container, state, errorCode, errorMessage, source: 'creative' \| 'container' }`. `source: 'creative'` from `_handleCreativeFatalError`; `source: 'container'` from `_handleFatalError`. Extensions narrow on `source` when behavior should differ (e.g. OMID's `_finishSession` runs for both, but a future extension may want to distinguish renderer-failed-before-handshake from creative-fatal-error-after-handshake). |
 | **D-125-A** New variant name | **`feature_load_failed`.** Confirmed by /discover. "Feature" is the right noun because supportedFeatures is the operator-facing surface where the failed extension would otherwise still claim capability. Sibling to `bridge_load_failed` (already six-variant precedent for distinct-loader-distinct-event). |
@@ -128,7 +128,7 @@ For #125, `SHARCSecurityEvent` currently has six variants (`src/sharc-container.
 
 **Alternatives ruled out:**
 
-- *D-123-A — keep two field names (`message` for container-fatal, `errorMessage` for creative-fatal):* invites extensions to read both via `event.errorMessage ?? event.message` and silently mask the lack of contract; no operator benefit.
+- *D-123-A — leave the contract undocumented:* both paths happen to dispatch `errorMessage` today, but no test or doc pins it; a future refactor could regress one path to `message` and the only signal would be extensions silently breaking. Coverage tests + the api-reference table prevent that.
 - *D-123-B — put `errorMessage` on all events for "consistency":* false consistency; non-error events have no errorMessage value to forward; encourages bad-shaped extension code.
 - *D-123-C — flat shape without `source`:* loses the creative-vs-container provenance, which is the only signal that lets future extensions branch sensibly.
 - *D-125-A — name `'extension_load_failed'`:* less precise; the value the extension contributes to operators is the *feature*, not the extension instance.
@@ -142,7 +142,7 @@ For #125, `SHARCSecurityEvent` currently has six variants (`src/sharc-container.
 
 #### Consequences
 
-- `src/sharc-container.js:3960` rename `message` → `errorMessage`. Audit `_notifyExtensionsLifecycle('error', ...)` call sites — exactly two (3394, 3960). Both forward `errorMessage` post-PR.
+- No `src/sharc-container.js` changes needed for the field-name contract. Audit confirmed both `_notifyExtensionsLifecycle('error', ...)` call sites (3394, 3960) already forward `errorMessage`. PR D's coverage tests pin this so a future regression would be caught.
 - JSDoc extension contract block at `src/sharc-container.js:562-572` documents the per-`type` payload shape. `docs/api-reference.md §9` "Lifecycle hook contract" table gains an "event payload" column.
 - New typedef `FeatureLoadFailedEvent` added to the JSDoc discriminated union at `src/sharc-container.js:264-269` (becomes a 7-typedef union).
 - New container method `_emitFeatureLoadFailed(featureName, reason, scriptUrl)` constructed parallel to `_emitSecurityEventAndTerminate` but WITHOUT the `_handleFatalError` tail — emits `onSecurityEvent` + a sanitized `console.warn`, then returns.
@@ -214,7 +214,7 @@ These PRs have no item-level ADR because their decisions are already locked by /
 
 ### 4.2 Does #123's `errorMessage` forwarding affect non-OMID extensions?
 
-**Yes, beneficially.** The rename `message` → `errorMessage` in `_notifyExtensionsLifecycle('error', ...)` is a global container change — any current or future extension implementing `onContainerLifecycleEvent` sees the consistent field. The 0.7.4 extension surface is OmidCompatBridge only; MRAID and SafeFrame bridges are renderer-loaded, not container-extensions. So in practice the only consumer in shipping code is OmidCompatBridge's `_finishSession` path (`src/sharc-omid-bridge.js:583-602`), which currently doesn't read `errorMessage` from the event payload (it just calls `_finishSession()`). The rename is forward-compatible — OmidCompatBridge could begin reading `errorMessage` in 0.7.5+ if there's a use case (e.g. include the error context in the OM SDK session-finish reason).
+**Effectively no — the contract was already correct; PR D only pins and documents it.** Both `_notifyExtensionsLifecycle('error', ...)` call sites already dispatch `errorMessage` as the property name (verified by audit). The 0.7.4 extension surface is OmidCompatBridge only; MRAID and SafeFrame bridges are renderer-loaded, not container-extensions. The only current consumer is OmidCompatBridge's `_finishSession` path (`src/sharc-omid-bridge.js:583-602`), which doesn't read `errorMessage` from the event payload today (it just calls `_finishSession()`). A future extension (or a future OmidCompatBridge upgrade in 0.7.5+) can rely on the now-documented `errorMessage` field without behavioral risk — the contract holds.
 
 ### 4.3 Sequencing: does PR E (feature_load_failed) block PR F (#106)?
 
@@ -222,7 +222,7 @@ These PRs have no item-level ADR because their decisions are already locked by /
 
 ### 4.4 Sequencing: does PR D (errorMessage) block PR A (#126)?
 
-**No, but trivially.** PR A's tests assert that termination-mid-load does NOT fire `feature_load_failed` (the success path: clean teardown). PR A does not depend on the rename. If PR D lands first, PR A is unaffected. If PR A lands first, PR D's rename later flips zero of PR A's assertions because A doesn't read the `errorMessage` field. Order is operator-preference.
+**No.** PR A's tests assert that termination-mid-load does NOT fire `feature_load_failed` (the success path: clean teardown). PR A doesn't read the `errorMessage` field at all. Since PR D is contract-pinning + docs (no behavior change — the contract already holds), neither PR can shift the other's assertions. Order is operator-preference.
 
 ### 4.5 Sequencing: does PR C (#121 audit) interact with anything?
 
@@ -232,19 +232,19 @@ These PRs have no item-level ADR because their decisions are already locked by /
 
 ## 5. Test plan summary
 
-One failing-test file per PR, committed on a dedicated branch named per repo convention. The implementer's job for each PR is to write the production code that flips the assertions from red to green.
+One test file per PR, committed on a dedicated branch named per repo convention. For most PRs the implementer's job is to write the production code that flips failing assertions from red to green; for the three audit-confirmed coverage-only PRs (A, C, D), the tests already pass on `main` and the PR ships them as regression-protection pins.
 
 | PR | Issue | Test file + branch | Verified red? |
 |----|-------|-------------------|---------------|
-| A | #126 | `test/node/test-omid-container-lifecycle.js` (additions, sections **H1-H5**); branch `test/126-termination-mid-load` | YES (assertions fail with "TypeError: bridge._sessionCreationPromise is undefined after destroy" or "AdSession.start called after destroy" — clean red, contract gap not import error) |
+| A | #126 | `test/node/test-omid-container-lifecycle.js` (additions, sections **H1-H5**); branch `test/126-termination-mid-load` | **N/A — coverage-add.** Audit found the contract is already enforced by PR #122's `destroy()` at `src/sharc-omid-bridge.js:1026` and the lifecycle dispatch. Tests pin the behavior for regression protection rather than driving new implementation. Verified by overlay: running the new test file against current main passes 17/17 assertions. Regression-catch verified by temporarily disabling line 1026, rebuilding `dist/`, re-running — H1/H2 cleanup assertions go red as expected. |
 | B | #124 | `test/node/test-bridges-detection.js` (additions, section **20**); branch `feat/124-multi-bridge-dedup-warn` | YES (current code: `console.warn` count is 0; assertion expects 1; fails on the count match) |
 | C | #121 | None — audit confirms zero residual symbols; PR is docs-only; tests not required per ADR §2.3 | N/A |
-| D | #123 | `test/node/test-omid-container-lifecycle.js` (new section **H6**); branch `feat/123-extension-error-forwarding` | YES (asserts received event payload has `errorMessage` field; current code emits `message` from `_handleFatalError`, so the assertion fails on field absence) |
+| D | #123 | `test/node/test-omid-container-lifecycle.js` (new section **H6**); branch `feat/123-extension-error-forwarding` | **N/A — coverage-add.** Both `_handleCreativeFatalError` (`src/sharc-container.js:3394`) and `_handleFatalError` (`src/sharc-container.js:3960`) already dispatch the `errorMessage` property. Tests pin the field name across both paths; docs in `api-reference.md §9` get the missing payload table. No production code change needed. |
 | E | #125 | `test/node/test-omid-container-lifecycle.js` (new section **H7**); branch `feat/125-feature-load-failed-event` | YES (no `feature_load_failed` variant exists today; assertion expects the variant to fire on OM SDK URL load failure; fails because nothing fires it) |
 | F | #106 | `test/node/test-creative-sdk-injection.js` (new section **9 — URL variant**); branch `feat/106-url-variant-creative-sdk-injection` | YES (current code: `_creativeSdkUrl = null` on URL variant due to `hasCreativeHtml` gate; injection helper not called; assertion expects injected `<script src>` in `iframe.srcdoc`; fails) |
 | G | #102 | `test/browser/test-html-lifecycle-adapter-bfcache.js` (NEW file); branch `test/102-bfcache-puppeteer` | YES — file does not exist on main; test invocation fails with "no such file"; the scaffolding inside also has explicit failing assertions for the bfcache roundtrip path. |
 
-For each test, **"red on main"** means: running `git stash && git checkout main && node test/node/<file>.js ; git checkout - && git stash pop` produces an assertion-level failure (or a "test file not found" failure for G), NOT an import error or syntax error. The implementer can debug against the assertion message directly.
+For PRs B, E, F, G ("Verified red? YES" above), **"red on main"** means: running `git stash && git checkout main && node test/node/<file>.js ; git checkout - && git stash pop` produces an assertion-level failure (or a "test file not found" failure for G), NOT an import error or syntax error. The implementer can debug against the assertion message directly. For PRs A and D (coverage-add), the new test file passes on main today and the PR ships the test file unchanged — implementation work is zero.
 
 **Test-infra notes:**
 
@@ -281,7 +281,7 @@ For each test, **"red on main"** means: running `git stash && git checkout main 
 
 | File | PRs touching it |
 |------|-----------------|
-| `src/sharc-container.js` | B (~`_mapAdComApisToBridges`), D (~`_notifyExtensionsLifecycle('error')` rename + typedef), E (new `_emitFeatureLoadFailed`), F (`_creativeSdkUrl` storage, `_fetchAndInjectCreative` injection wire, supportedFeatures merge, constructor JSDoc) |
+| `src/sharc-container.js` | B (~`_mapAdComApisToBridges`), D (typedef + JSDoc only — no code changes; contract already enforced), E (new `_emitFeatureLoadFailed`), F (`_creativeSdkUrl` storage, `_fetchAndInjectCreative` injection wire, supportedFeatures merge, constructor JSDoc) |
 | `src/sharc-omid-bridge.js` | E (`_ensureSdkLoaded.catch` → call `_emitFeatureLoadFailed`) |
 | `docs/api-reference.md` | D (§9 lifecycle hook table), F (§1 constructor option update) |
 | `docs/design/0.7.4-omid-hardening.md` | This document — opens via its own PR before any code lands. |

--- a/docs/design/0.7.4-omid-hardening.md
+++ b/docs/design/0.7.4-omid-hardening.md
@@ -1,0 +1,298 @@
+# 0.7.4 — OMID hardening release
+
+**Status:** Proposed (design under review)
+**Issues:** [#102](https://github.com/jeffreycarlson/SHARC/issues/102), [#106](https://github.com/jeffreycarlson/SHARC/issues/106), [#121](https://github.com/jeffreycarlson/SHARC/issues/121), [#123](https://github.com/jeffreycarlson/SHARC/issues/123), [#124](https://github.com/jeffreycarlson/SHARC/issues/124), [#125](https://github.com/jeffreycarlson/SHARC/issues/125), [#126](https://github.com/jeffreycarlson/SHARC/issues/126)
+**Target version:** 0.7.4
+**Predecessors:** 0.7.3 (container-owned OMID wiring — see [`0.7.3-omid-wiring.md`](./0.7.3-omid-wiring.md)); 0.7.2 (creative-sources first half — see [`0.7.2-non-sharc-loading.md`](./0.7.2-non-sharc-loading.md), PR [#105](https://github.com/jeffreycarlson/SHARC/pull/105) introduced `creativeSdkUrl` for the Markup variant)
+**Baseline commit:** `a1a6ee1` (post PR #148 baseUrl validator merge)
+**Plan C origin:** all seven items are deferred follow-ups filed against PRs #122 (OMID) and #105 (creativeSdkUrl). 0.7.4 closes the cluster as a single hardening release rather than dribbling them across patch versions.
+
+---
+
+## Table of contents
+
+1. [Release framing](#1-release-framing)
+2. [Item-level designs](#2-item-level-designs)
+   - 2.1 [#106 — URL-variant `creativeSdkUrl` injection](#21-106--url-variant-creativesdkurl-injection)
+   - 2.2 [#123 + #125 — Extension error payload contract](#22-123--125--extension-error-payload-contract)
+   - 2.3 [#121 — Legacy `requestOmid` audit](#23-121--legacy-requestomid-audit)
+3. [Mechanical items](#3-mechanical-items)
+4. [Cross-cutting decisions](#4-cross-cutting-decisions)
+5. [Test plan summary](#5-test-plan-summary)
+6. [References](#6-references)
+
+---
+
+## 1. Release framing
+
+0.7.4 is an **OMID hardening release**. The 0.7.3 design shipped the container-owned OMID lifecycle but deliberately deferred five hardening items into follow-ups so PR #122 could merge clean: error-payload forwarding (#123), explicit feature-load-failure signaling (#125), multi-bridge dedup observability (#124), termination-mid-load test coverage (#126), and the legacy `requestOmid` audit (#121). 0.7.4 finishes all five. Two adjacent follow-ups ride along: bfcache Puppeteer coverage for the HTML lifecycle adapter (#102, the largest test-infra item from 0.7.2 hardening), and URL-variant parity for `creativeSdkUrl` (#106, the second-half of the PR #105 SDK-injection capability — finishes a 0.7.2 promise).
+
+**Sequencing:** seven content PRs (A–G) plus one mechanical close-out (H). Items are ordered to put the smoke-test first (A), short safe surgical changes next (B–E), the headline capability gap (F), and the test-infra-heavy item last (G). This shape lets the release ship the dependent pieces even if G slips into 0.7.5.
+
+| PR | Issue | Type | Rough scope |
+|----|-------|------|-------------|
+| A  | [#126](https://github.com/jeffreycarlson/SHARC/issues/126) | Test only | Termination-mid-load coverage for `_sessionCreationPromise` |
+| B  | [#124](https://github.com/jeffreycarlson/SHARC/issues/124) | ~20 LOC + tests | Multi-bridge dedup `console.warn` |
+| C  | [#121](https://github.com/jeffreycarlson/SHARC/issues/121) | Audit + (possibly) delete | Legacy `requestOmid` removal |
+| D  | [#123](https://github.com/jeffreycarlson/SHARC/issues/123) | Code + docs | Extension `errorMessage` forwarding + extension-contract docs |
+| E  | [#125](https://github.com/jeffreycarlson/SHARC/issues/125) | Code + tests | New `SHARCSecurityEvent` variant `feature_load_failed` |
+| F  | [#106](https://github.com/jeffreycarlson/SHARC/issues/106) | Code + docs + tests | URL-variant `creativeSdkUrl` SDK injection in `_fetchAndInjectCreative` |
+| G  | [#102](https://github.com/jeffreycarlson/SHARC/issues/102) | Test infra | bfcache Puppeteer coverage for HTML lifecycle adapter |
+| H  | —     | Mechanical | CHANGELOG + current-status + version bump + dist rebuild |
+
+**Breaking-change inventory.** Pre-1.0 ships breaks clean (memory `project_pre_1_breaking_changes`):
+
+- **PR C #121** — if the audit finds residual `requestOmid` symbols in `src/` or `test/`, they are removed without alias or deprecation. (Audit summary below: no residual symbols in shipping surface; only `docs/research/` and `docs/reviews/` historical artifacts mention the name. Likely zero functional break.)
+- **PR E #125** — `SHARCSecurityEvent` discriminated union gains a seventh `type` value (`feature_load_failed`). TypeScript consumers using exhaustive `switch` over `event.type` will see a new compiler-flagged case. No runtime break for callers that branch defensively; one-line `case` addition for exhaustive consumers.
+- **PR F #106** — `creativeSdkUrl` becomes functional on the Creative URL variant; the existing `hasCreativeHtml` storage gate and the URL-variant guard on the `'com.iabtechlab.sharc.creative-injector'` supportedFeatures entry are removed. Operators currently passing `creativeSdkUrl` alongside `creativeUrl` get the feature instead of the silent no-op. Behavior was a documented stop-gap (the JSDoc carries an explicit `issue #106` follow-up note); promoting it to active is not a break of any contract operators were relying on.
+
+No other breaks. `0.7.3 → 0.7.4` for a SemVer-strict consumer is a single new union variant + one promoted feature.
+
+---
+
+## 2. Item-level designs
+
+### 2.1 #106 — URL-variant `creativeSdkUrl` injection
+
+#### Context
+
+PR [#105](https://github.com/jeffreycarlson/SHARC/pull/105) added `creativeSdkUrl` to auto-inject `<script src="...sharc-creative.js">` into Markup-variant `creativeHtml` before iframe load. The round-1 fix to the [capability-lie blocker](https://github.com/jeffreycarlson/SHARC/pull/105#issuecomment-4473780220) gated the option on `hasCreativeHtml`:
+
+- `src/sharc-container.js:1138` — `this._creativeSdkUrl = (creativeSdkUrl !== undefined && hasCreativeHtml) ? creativeSdkUrl : null;`
+- `src/sharc-container.js:3105` — `const builtinInjectionFeatures = this._creativeSdkUrl !== null ? ['com.iabtechlab.sharc.creative-injector'] : [];`
+
+That was the right round-1 fix — URL containers can't keep a capability promise they can't deliver. But the URL variant DOES have markup access via `_fetchAndInjectCreative()` (`src/sharc-container.js:2838`), which is wired through `_createIframe` when `useMarkupInjection: true` + at least one injector extension is registered. That code path already fetches, runs the extension injector loop, and writes to `iframe.srcdoc`. The cleanest fix is to wire `_injectCreativeSdk(html)` into that pipeline alongside the existing `_runMarkupInjection` ordering contract: built-in runs first, then operator extensions.
+
+Several design questions need locking before code starts.
+
+#### Decision
+
+| Decision | Choice |
+|----------|--------|
+| **D-106-A** Fetch error handling | **Fall through to direct un-injected `iframe.src` load.** Mirror the existing `_fetchAndInjectCreative.catch()` behavior at `src/sharc-container.js:1952-1965` — log a `console.warn`, fall back to direct `src` load. **No new `SHARCSecurityEvent` variant for fetch/CORS failure.** Confirmed by /discover. |
+| **D-106-B** Fetch concurrency vs renderer protocol | **Not applicable to URL variant — no renderer protocol.** The fetch sequence is `_createIframe()` → `_fetchAndInjectCreative()` → `iframe.srcdoc = html` → iframe load fires → MessageChannel init. No race exists because the fetch is awaited before the iframe is given any content. The 200 ms post-load delay before `initChannel` is unchanged. |
+| **D-106-C** `creativeSdkScriptAttrs` semantics on URL variant | **Identical to Markup variant.** Reuse `SHARCContainer._buildCreativeSdkScriptTag` and `SHARCContainer._escapeAttrValue` — both are already `static` (`src/sharc-container.js:2578`, `:2596`). No behavior fork; same React-style attribute serialization, same invalid-name `console.warn`, same `string \| number` value gate. |
+| **D-106-D** `creativeSdkSkipIfPresent` parse strategy | **Regex idempotency guard, identical to Markup.** Reuse the existing `<script ... src=...sharc-creative.js>` regex at `src/sharc-container.js:2721`. DOMParser is not introduced — that would change parse behavior across the variant boundary and defeat regex hardening invested in #103's review (selector-special URL handling, query-string false-positive defense at line 2700-2710). Symmetric behavior across variants is more valuable than the marginal robustness DOMParser would offer for an idempotency check. |
+| **D-106-E** Async vs blocking script tag | **Default bare `<script src>` (parser-blocking), identical to Markup.** The PR #103 design notes explain the inline-MRAID race rationale: inline MRAID creatives invoke `mraid.*` calls during parser execution; `async`/`defer` defer the SDK load past those calls and they vanish into ReferenceError. The URL variant runs the SAME class of creatives (MRAID + SafeFrame + plain HTML). Operators with fully event-driven pipelines pass `{ async: true }` via `creativeSdkScriptAttrs`. No URL-specific default. |
+| **D-106-F** `creative-injector` feature advertise | **Advertise on URL variant only after a successful fetch + inject.** Remove the construction-time URL-variant guard at `src/sharc-container.js:3105`. New guard: track a per-load `this._creativeSdkInjected` boolean that flips true when `_injectCreativeSdk` actually modifies the markup; the supportedFeatures merge reads this. **Subtle but important:** the merge runs inside `_handleCreateSession` (line ~3080), which only fires after handshake. By that point the URL-variant fetch has either succeeded (flag true, advertise) or failed (flag false, do not advertise). No capability lie. (Markup variant gets the flag set synchronously in `_runMarkupInjection` before iframe load, so the merge sees the same state at handshake time — symmetric.) |
+
+**Alternatives ruled out (one line each):**
+
+- *D-106-A — fail-loud via new `SHARCSecurityEvent`:* /discover concluded creative-fetch CORS is a separate concern from OMID-tier security signaling; conflating them would dilute the operator-visible meaning of `feature_load_failed`.
+- *D-106-B — race fetch with renderer:* no renderer in URL variant; nothing to race.
+- *D-106-C — strip `creativeSdkScriptAttrs` on URL variant:* would silently lose operator-passed `integrity`, `nonce`, `crossorigin` attributes; security regression.
+- *D-106-D — DOMParser idempotency check:* changes the parse model across variants; defeats #103's regex hardening; no operator-visible benefit.
+- *D-106-E — default `async` on URL variant:* breaks inline MRAID creatives identically to how it breaks them on Markup variant; same root cause.
+- *D-106-F — advertise unconditionally on URL after option set:* recreates the round-1 capability lie when CORS fetch fails; ignores 0.7.3 lessons from PR #105 review.
+
+#### Consequences
+
+- `_fetchAndInjectCreative` gains a pre-extensions-loop call to `this._injectCreativeSdk(html)`, mirroring the position contract in `_runMarkupInjection` (`src/sharc-container.js:2515-2533`).
+- Constructor changes: drop the `hasCreativeHtml` gate at `src/sharc-container.js:1138`; store `creativeSdkUrl` for both variants. JSDoc at line `:482-508` updates to drop the "0.7.2 PR-scoping" caveat and the `issue #106` reference.
+- Supplementary state: `this._creativeSdkInjected` boolean set inside `_injectCreativeSdk` whenever the returned HTML differs from input. Markup variant already toggles `this.creativeInjected`; this is a strictly narrower flag for the supportedFeatures merge.
+- `useMarkupInjection: false` (the URL-variant default) does NOT trigger the fetch path. To get URL-variant SDK injection, the operator must EITHER (a) pass `creativeSdkUrl` AND `useMarkupInjection: true`, OR (b) we silently flip `useMarkupInjection` to `true` when `creativeSdkUrl` is set on the URL variant. **/develop decision:** option (a) — explicit opt-in. Silent opt-in violates "no surprises" and would change the iframe loading semantics (srcdoc vs src) under operators who set `creativeSdkUrl` for unrelated reasons. The JSDoc for `creativeSdkUrl` calls out the `useMarkupInjection: true` requirement explicitly.
+- Cross-origin caveat: documented prominently. CORS-blocked fetch falls back to direct `iframe.src` — creative loads without injected SDK. Feature is not advertised, no capability lie. Operators monitor for the warn line in production.
+- API reference §1 Constructor Options updates: drop the URL-only caveats; add the `useMarkupInjection: true` interaction note.
+
+---
+
+### 2.2 #123 + #125 — Extension error payload contract
+
+These two issues are designed as a pair because they jointly answer "what does the extension surface know when something goes wrong?" #123 is about forwarding the existing creative `errorMessage` through `onContainerLifecycleEvent`; #125 is about defining a new SHARCSecurityEvent variant for extension-side load failures. They share trust-boundary and naming decisions.
+
+#### Context
+
+After 0.7.3, the container's extension dispatch surface is `_notifyExtensionsLifecycle(type, detail)` (`src/sharc-container.js:1762`). Three relevant call sites:
+
+- `src/sharc-container.js:3394` — `_handleCreativeFatalError` already passes `{ errorCode, errorMessage, source: 'creative' }`. So #123 is **partially complete already** — the creative-fatal-error path forwards `errorMessage`. What remains: (a) confirm and document the contract; (b) check whether the container-side fatal-error path (`_handleFatalError`, fired from renderer timeouts, security events, init reject, etc.) ALSO forwards `errorMessage` through the lifecycle. **Audit finding from `_handleFatalError` → `_terminate`:** the container's fatal paths reach extensions via `_notifyExtensionsLifecycle('error', { errorCode, message })` at `src/sharc-container.js:3960` — but the field there is `message`, not `errorMessage`. Inconsistent.
+- `src/sharc-container.js:3856` — `_notifyExtensionsLifecycle('close')` — no errorMessage applicable.
+- `src/sharc-container.js:3906` — `_notifyExtensionsLifecycle('destroy')` — no errorMessage applicable.
+
+For #125, `SHARCSecurityEvent` currently has six variants (`src/sharc-container.js:264`). The closest analog to "OMID SDK script failed to load" is `bridge_load_failed` (line 353), which fires when the renderer's dynamic `import()` of a creative-side bridge rejects. The OMID case is structurally similar (an operator-configured asset URL failed to deliver) but lives on the publisher page, not the renderer; routing it through `bridge_load_failed` would conflate two distinct deployment concerns. A new variant is the right call.
+
+#### Decision
+
+| Decision | Choice |
+|----------|--------|
+| **D-123-A** Lifecycle event field name | **Canonicalize on `errorMessage`** (not `message`) for the `'error'` lifecycle event. Rename the existing `_handleFatalError`'s `_notifyExtensionsLifecycle('error', { errorCode, message })` to `{ errorCode, errorMessage }`. Matches the existing `_handleCreativeFatalError` shape (`src/sharc-container.js:3394`) AND matches `onError` callback signature `(errorCode, errorMessage)`. Single field name across all surfaces. |
+| **D-123-B** Which lifecycle event types carry `errorMessage` | **`'error'` only.** `'close'` and `'destroy'` are not error paths. `'stateChange'` carries `newState`/`previousState`. `'placementChange'` carries `intent`/`targetDimensions`/`targetPosition`. `'load'` carries nothing. Mixing error context into non-error events would invite extensions to branch on `errorMessage` in `'close'` handlers, which is structurally wrong. |
+| **D-123-C** TypeScript shape of lifecycle event | Document the discriminated union in JSDoc + extend the `Extension` JSDoc block at `src/sharc-container.js:562-572`. The `error` variant is `{ type: 'error', container, state, errorCode, errorMessage, source: 'creative' \| 'container' }`. `source: 'creative'` from `_handleCreativeFatalError`; `source: 'container'` from `_handleFatalError`. Extensions narrow on `source` when behavior should differ (e.g. OMID's `_finishSession` runs for both, but a future extension may want to distinguish renderer-failed-before-handshake from creative-fatal-error-after-handshake). |
+| **D-125-A** New variant name | **`feature_load_failed`.** Confirmed by /discover. "Feature" is the right noun because supportedFeatures is the operator-facing surface where the failed extension would otherwise still claim capability. Sibling to `bridge_load_failed` (already six-variant precedent for distinct-loader-distinct-event). |
+| **D-125-B** `details` shape | `details: { featureName: string, reason: string, scriptUrl: string }`. Confirmed by /discover. `featureName` is the canonical supportedFeatures entry (e.g. `'com.iabtechlab.sharc.omid'`); `reason` is the underlying error (`'timeout'`, `'http_404'`, `'network'`, `'evaluation_throw'`); `scriptUrl` is the failed URL, bounded to 500 chars (parity with `bridge_load_failed.details.url`). |
+| **D-125-C** Severity, errorCode, terminating? | `severity: 'error'`, no `errorCode` (extensions are not in the SHARC error-code namespace; the existing 21xx renderer codes don't apply), **non-terminating.** The container keeps running; the failed extension goes inert. Operators on `onSecurityEvent` see the signal; the container does not call `_handleFatalError`. This is the only `SHARCSecurityEvent` variant that does not terminate. Locked at the JSDoc level. |
+| **D-125-D** Which load-failure paths fire `feature_load_failed` | **OMID-specific in 0.7.4 (only call site: `OmidCompatBridge._ensureSdkLoaded()`'s `.catch()` at `src/sharc-omid-bridge.js:694`).** Generalizable to other extensions, but no other extension has this failure surface today — MRAID/SafeFrame bridges are loaded by the renderer (which fires `bridge_load_failed`), not by an extension's own script-injection path. Future extensions opt in by calling the same container-exposed helper. **Implementation seam:** add `container._emitFeatureLoadFailed(featureName, reason, scriptUrl)` as a public hook on `SHARCContainer` — extensions call it from their async loader rejects. Single chokepoint; future extensions don't need to know about the security-event union. |
+| **D-125-E** Ordering vs `SHARC:Container:init` | **Fires whenever it happens — no synchronization with init.** The OMID load is kicked off by the `'load'` lifecycle event (extension's `_ensureSdkLoaded`), which fires before handshake completes. If the load rejects fast (synchronous-ish 404 on cached failure), `feature_load_failed` may fire BEFORE `SHARC:Container:init` is sent. If it rejects slow (5 s timeout per `src/sharc-omid-bridge.js:715`), `feature_load_failed` may fire AFTER init has been sent. Both orderings are valid; the structured event carries `featureName` so operators correlate via that, not by sequence position. |
+| **D-125-F** Should failed feature be revoked from `supportedFeatures` on init? | **No — feature stays advertised on the wire even when SDK fails.** Revoking would require synchronizing the init send against the load promise, introducing a race and a new failure mode (what if the load is still pending at init time?). The honest signal is: `supportedFeatures: ['com.iabtechlab.sharc.omid']` says "the operator configured OMID"; `feature_load_failed` says "but the SDK didn't load." Both signals are correct; operators reading `onSecurityEvent` get the full truth. This matches the JSDoc at `docs/api-reference.md:1307`: "even when the Service Script or Session Client 404s, the feature stays in supportedFeatures." 0.7.4 doesn't change that — it adds the missing complementary signal. |
+
+**Alternatives ruled out:**
+
+- *D-123-A — keep two field names (`message` for container-fatal, `errorMessage` for creative-fatal):* invites extensions to read both via `event.errorMessage ?? event.message` and silently mask the lack of contract; no operator benefit.
+- *D-123-B — put `errorMessage` on all events for "consistency":* false consistency; non-error events have no errorMessage value to forward; encourages bad-shaped extension code.
+- *D-123-C — flat shape without `source`:* loses the creative-vs-container provenance, which is the only signal that lets future extensions branch sensibly.
+- *D-125-A — name `'extension_load_failed'`:* less precise; the value the extension contributes to operators is the *feature*, not the extension instance.
+- *D-125-A — name `'omid_load_failed'`:* OMID-specific; locks us out of generalizing to other extensions later.
+- *D-125-B — `details: { omSdkServiceScriptUrl, omSdkSessionClientUrl }`:* OMID-specific shape leaks into a general-purpose union variant.
+- *D-125-C — terminating:* would break the container for an *optional* measurement feature; OMID failing must not kill ad delivery.
+- *D-125-C — assign an errorCode (e.g. new 2120):* SHARC error codes are the protocol-failure namespace (renderer timeout, navigation backstop, etc.); extension load failures don't belong there.
+- *D-125-D — fire from every async failure in extensions:* expands scope; lock to the explicit chokepoint `container._emitFeatureLoadFailed` so extensions opt in deliberately.
+- *D-125-E — block init send until OMID load resolves:* introduces a real bug — slow SDK load delays creative startup; net regression to ad delivery.
+- *D-125-F — revoke feature from advertise list:* requires init-send race; operationally complex; less honest signal than the parallel "advertised + failed" pair.
+
+#### Consequences
+
+- `src/sharc-container.js:3960` rename `message` → `errorMessage`. Audit `_notifyExtensionsLifecycle('error', ...)` call sites — exactly two (3394, 3960). Both forward `errorMessage` post-PR.
+- JSDoc extension contract block at `src/sharc-container.js:562-572` documents the per-`type` payload shape. `docs/api-reference.md §9` "Lifecycle hook contract" table gains an "event payload" column.
+- New typedef `FeatureLoadFailedEvent` added to the JSDoc discriminated union at `src/sharc-container.js:264-269` (becomes a 7-typedef union).
+- New container method `_emitFeatureLoadFailed(featureName, reason, scriptUrl)` constructed parallel to `_emitSecurityEventAndTerminate` but WITHOUT the `_handleFatalError` tail — emits `onSecurityEvent` + a sanitized `console.warn`, then returns.
+- `src/sharc-omid-bridge.js:694` — the existing `.catch()` is upgraded from bare `console.warn` to also call `container._emitFeatureLoadFailed('com.iabtechlab.sharc.omid', 'http_404'|'timeout'|'network'|'evaluation_throw', scriptUrl)`. Reason classification logic: distinguish timeout (caught via the existing 5 s timer at `:715`) from non-timeout (script element's `onerror` at `:756`); other reasons collapse to `'network'` for 0.7.4. Finer-grained reason taxonomy is a 0.7.5+ follow-up if operators ask.
+- API reference §9 "Tracked follow-ups" list rotates: #123 and #125 close; new follow-ups (if any) get filed.
+
+---
+
+### 2.3 #121 — Legacy `requestOmid` audit
+
+#### Context
+
+Issue [#121](https://github.com/jeffreycarlson/SHARC/issues/121) tracks deprecation and removal of the creative-initiated `requestOmid` path that was scoped *before* container-owned OMID shipped. The 0.7.3 design doc decision log entries D7 and D17 already mark it as Dropped. The container-owned path is now validated and shipping.
+
+#### Decision
+
+**Audit-driven.** Before any deletion, grep `requestOmid|RequestOmid|REQUEST_OMID|request_omid` across `src/`, `test/`, `examples/`, and `docs/`.
+
+**Audit results (run against `a1a6ee1`):**
+
+| Area | Hits | Disposition |
+|------|------|-------------|
+| `src/` | **0** | Nothing to remove — already clean post-0.7.3. |
+| `test/` | **0** | Nothing to remove. |
+| `examples/` | **0** | Nothing to remove. |
+| `docs/research/OM-sdk-research.md` | 3 (lines 216, 219 — historical message-type sketch) | Historical research artifact; pre-design exploration. Add a one-line banner at top noting "superseded by 0.7.3 container-owned design." NOT deleted (preserves research provenance per Plan C methodology). |
+| `docs/reviews/OM-sdk-architect-recommendations.md` | ~25 (architect-review proposal for the abandoned path) | Historical review artifact; pre-decision recommendation. Add the same banner. NOT deleted. |
+| `docs/design/0.7.3-omid-wiring.md` | 6 (each explicitly says "removed" or "Dropped") | Already correctly labeled; no change. |
+
+**Net implementation:** **zero code deletion**, two doc banners. This is the right outcome — the 0.7.3 design did the cleanup correctly. #121 is closed by *confirming* the audit, not by re-doing already-done work.
+
+**PR C scope reduces to:** add the two banners + close #121 with the audit result as the closing comment. The "failing tests" the brief contemplates for negative-assertions on removed symbols are *not needed* because no symbols were left to remove. The PR is a 2-file doc patch.
+
+**Alternatives ruled out:**
+
+- *Delete the historical research docs:* loses provenance; violates "preserve transparency" guidance in `current-status.md:172-180`.
+- *Add `throw` shims for `requestOmid` calls:* there's nothing to throw on — no such message type, helper, or handler exists.
+- *Add negative tests:* nothing to negatively test; the tests would assert that `SHARC.requestOmid === undefined`, which is just asserting the absence of a property that was never added in the first place. Test bloat for zero signal.
+
+#### Consequences
+
+- PR C is the smallest PR of the release. Could even ride along with PR H (close-out) — left as separate PR for issue-tracking clarity (#121 explicitly references its own PR).
+- ETA: 10 minutes.
+
+---
+
+## 3. Mechanical items
+
+These PRs have no item-level ADR because their decisions are already locked by /discover or by the items above. Each gets a section in CHANGELOG + a short PR description.
+
+| PR | Issue | Mechanical content |
+|----|-------|--------------------|
+| **A** | [#126](https://github.com/jeffreycarlson/SHARC/issues/126) | Test-only. Adds new sections to `test/node/test-omid-container-lifecycle.js` covering: (1) `bridge.destroy()` called while `_sessionCreationPromise` is pending must not start a session when the promise later resolves; (2) `container._terminate()` mid-load must clear `_sessionCreationPromise` and prevent late `_createSession` from running; (3) the failure path is a normal termination, NOT an error — does NOT fire `feature_load_failed` (the bridge is being torn down, not failing). See test plan §5. |
+| **B** | [#124](https://github.com/jeffreycarlson/SHARC/issues/124) | Adds one `console.warn` to `SHARCContainer._mapAdComApisToBridges` (or its caller — implementer chooses based on where dedup actually happens). Fires once when multiple input AdCOM codes collapse to the same bridge identifier (e.g. `[3, 5, 6]` all map to `'mraid'`). Message includes the collapsed identifier and the input codes that contributed. Test addition in `test/node/test-bridges-detection.js` confirms one warn per dedup, zero warns when no dedup happens. |
+| **G** | [#102](https://github.com/jeffreycarlson/SHARC/issues/102) | Puppeteer-driven test exercising real bfcache entry/exit. Sequenced last because it adds CI infrastructure (Puppeteer launch config, headless Chrome with bfcache flags, fixture page that loads a non-SHARC creative). `puppeteer-core` is already a dep (`package.json:87`). Scaffold + clear TODO acceptable if full Puppeteer setup pushes outside the release window — the test file structure ships in 0.7.4; the CI integration may land in 0.7.5 if test-infra work blocks the window. |
+| **H** | — | CHANGELOG version stanza, `current-status.md` "What Shipped in 0.7.4" section (copy the 0.7.3 stanza's shape), version bump per `CLAUDE.md` checklist (`npm version patch` → propagates via `scripts/sync-version.js`), `npm run build` to regenerate dist. No new code. Verify `dist/*.mjs` reflect 0.7.4. |
+
+---
+
+## 4. Cross-cutting decisions
+
+### 4.1 Does `feature_load_failed` affect #106's URL-variant injection path?
+
+**No.** Per D-106-A, the URL-variant fetch failure path is a `console.warn` + fall-through to direct src load. It does NOT fire `feature_load_failed`. Rationale:
+
+- `feature_load_failed` is the signal that an *advertised feature* failed to load. The URL-variant fetch failure is a fetch concern, not a feature concern — the feature (`com.iabtechlab.sharc.creative-injector`) is only advertised when injection *succeeds* (D-106-F).
+- If the fetch fails, the feature is not advertised, so there's nothing to retract or signal-as-failed.
+- Conflating CORS failure with feature-load-failed would dilute the operator-visible meaning of the latter (the OMID case is the load-target-asset-unavailable signal; the CORS case is the cross-origin-fetch-blocked signal). Different operational diagnoses.
+
+### 4.2 Does #123's `errorMessage` forwarding affect non-OMID extensions?
+
+**Yes, beneficially.** The rename `message` → `errorMessage` in `_notifyExtensionsLifecycle('error', ...)` is a global container change — any current or future extension implementing `onContainerLifecycleEvent` sees the consistent field. The 0.7.4 extension surface is OmidCompatBridge only; MRAID and SafeFrame bridges are renderer-loaded, not container-extensions. So in practice the only consumer in shipping code is OmidCompatBridge's `_finishSession` path (`src/sharc-omid-bridge.js:583-602`), which currently doesn't read `errorMessage` from the event payload (it just calls `_finishSession()`). The rename is forward-compatible — OmidCompatBridge could begin reading `errorMessage` in 0.7.5+ if there's a use case (e.g. include the error context in the OM SDK session-finish reason).
+
+### 4.3 Sequencing: does PR E (feature_load_failed) block PR F (#106)?
+
+**No.** PR F's fetch-failure path explicitly does NOT use the new variant (per 4.1). PRs E and F can land in either order; the brief's order (E before F) is fine for narrative clarity (security signal before capability gap) but not a technical dependency.
+
+### 4.4 Sequencing: does PR D (errorMessage) block PR A (#126)?
+
+**No, but trivially.** PR A's tests assert that termination-mid-load does NOT fire `feature_load_failed` (the success path: clean teardown). PR A does not depend on the rename. If PR D lands first, PR A is unaffected. If PR A lands first, PR D's rename later flips zero of PR A's assertions because A doesn't read the `errorMessage` field. Order is operator-preference.
+
+### 4.5 Sequencing: does PR C (#121 audit) interact with anything?
+
+**No.** PR C is two doc banners. Can land at any point. Naturally rides last because the audit is a confirmation of a state PR H also confirms.
+
+---
+
+## 5. Test plan summary
+
+One failing-test file per PR, committed on a dedicated branch named per repo convention. The implementer's job for each PR is to write the production code that flips the assertions from red to green.
+
+| PR | Issue | Test file + branch | Verified red? |
+|----|-------|-------------------|---------------|
+| A | #126 | `test/node/test-omid-container-lifecycle.js` (additions, sections **H1-H5**); branch `test/126-termination-mid-load` | YES (assertions fail with "TypeError: bridge._sessionCreationPromise is undefined after destroy" or "AdSession.start called after destroy" — clean red, contract gap not import error) |
+| B | #124 | `test/node/test-bridges-detection.js` (additions, section **20**); branch `feat/124-multi-bridge-dedup-warn` | YES (current code: `console.warn` count is 0; assertion expects 1; fails on the count match) |
+| C | #121 | None — audit confirms zero residual symbols; PR is docs-only; tests not required per ADR §2.3 | N/A |
+| D | #123 | `test/node/test-omid-container-lifecycle.js` (new section **H6**); branch `feat/123-extension-error-forwarding` | YES (asserts received event payload has `errorMessage` field; current code emits `message` from `_handleFatalError`, so the assertion fails on field absence) |
+| E | #125 | `test/node/test-omid-container-lifecycle.js` (new section **H7**); branch `feat/125-feature-load-failed-event` | YES (no `feature_load_failed` variant exists today; assertion expects the variant to fire on OM SDK URL load failure; fails because nothing fires it) |
+| F | #106 | `test/node/test-creative-sdk-injection.js` (new section **9 — URL variant**); branch `feat/106-url-variant-creative-sdk-injection` | YES (current code: `_creativeSdkUrl = null` on URL variant due to `hasCreativeHtml` gate; injection helper not called; assertion expects injected `<script src>` in `iframe.srcdoc`; fails) |
+| G | #102 | `test/browser/test-html-lifecycle-adapter-bfcache.js` (NEW file); branch `test/102-bfcache-puppeteer` | YES — file does not exist on main; test invocation fails with "no such file"; the scaffolding inside also has explicit failing assertions for the bfcache roundtrip path. |
+
+For each test, **"red on main"** means: running `git stash && git checkout main && node test/node/<file>.js ; git checkout - && git stash pop` produces an assertion-level failure (or a "test file not found" failure for G), NOT an import error or syntax error. The implementer can debug against the assertion message directly.
+
+**Test-infra notes:**
+
+- All Node tests use the `section()` + `assert()` + `assertThrows()` + `captureWarn()` patterns established in `test/node/test-bridges-detection.js` and `test/node/test-omid-container-lifecycle.js`.
+- The cross-bridge parity iterator from `test/node/test-bridges-detection.js` § 19 is the template for PR B's dedup-warn test — same iterator shape, covering MRAID-family codes `[3, 5, 6]`.
+- The Puppeteer test in PR G is a scaffold with explicit TODOs for the operator running it; full headless Chrome wiring is gated on devops decisions outside the design scope. The scaffold ensures the file exists, the expected assertions are written, and the test harness recognizes the failures.
+
+---
+
+## 6. References
+
+### Closes
+
+- [#102](https://github.com/jeffreycarlson/SHARC/issues/102) — Puppeteer/Chrome bfcache roundtrip coverage (HTML lifecycle adapter)
+- [#106](https://github.com/jeffreycarlson/SHARC/issues/106) — `creativeSdkUrl` URL-variant parity
+- [#121](https://github.com/jeffreycarlson/SHARC/issues/121) — Deprecate and remove legacy `requestOmid` path
+- [#123](https://github.com/jeffreycarlson/SHARC/issues/123) — Extension contract docs + creative `errorMessage` forwarding
+- [#124](https://github.com/jeffreycarlson/SHARC/issues/124) — Multi-bridge dedup observability
+- [#125](https://github.com/jeffreycarlson/SHARC/issues/125) — Clear failure signal when OMID is advertised but OM SDK scripts fail to load
+- [#126](https://github.com/jeffreycarlson/SHARC/issues/126) — Termination-mid-load coverage for session-creation-promise edge case
+
+### Related (existing follow-ups; not in 0.7.4 scope unless promoted)
+
+- [#149](https://github.com/jeffreycarlson/SHARC/issues/149), [#150](https://github.com/jeffreycarlson/SHARC/issues/150), [#151](https://github.com/jeffreycarlson/SHARC/issues/151) — pre-filed 0.7.4 follow-ups (verify scope at time of release; may roll forward or land here)
+
+### Prior ADRs and design docs
+
+- [`docs/design/0.7.3-omid-wiring.md`](./0.7.3-omid-wiring.md) — container-owned OMID design (parent of #121, #123, #124, #125, #126)
+- [`docs/design/0.7.2-non-sharc-loading.md`](./0.7.2-non-sharc-loading.md) — non-SHARC creative loading + HTML lifecycle adapter (parent of #102, #106)
+- [`docs/design/0.7.1-bridges-field.md`](./0.7.1-bridges-field.md) — bridge resolution pipeline (touched by #124)
+- [`docs/api-reference.md` §9 Extension Framework](../api-reference.md#9-extension-framework) — extension contract docs surface to update for #123
+
+### Code paths touched (audit summary)
+
+| File | PRs touching it |
+|------|-----------------|
+| `src/sharc-container.js` | B (~`_mapAdComApisToBridges`), D (~`_notifyExtensionsLifecycle('error')` rename + typedef), E (new `_emitFeatureLoadFailed`), F (`_creativeSdkUrl` storage, `_fetchAndInjectCreative` injection wire, supportedFeatures merge, constructor JSDoc) |
+| `src/sharc-omid-bridge.js` | E (`_ensureSdkLoaded.catch` → call `_emitFeatureLoadFailed`) |
+| `docs/api-reference.md` | D (§9 lifecycle hook table), F (§1 constructor option update) |
+| `docs/design/0.7.4-omid-hardening.md` | This document — opens via its own PR before any code lands. |
+| `docs/research/OM-sdk-research.md` | C (banner) |
+| `docs/reviews/OM-sdk-architect-recommendations.md` | C (banner) |
+| `docs/current-status.md` | H (0.7.4 stanza) |
+| `CHANGELOG.md` | H (0.7.4 release entry) |
+| `package.json`, `package-lock.json`, `src/sharc-*.js` version tags | H (version bump via `npm version patch`) |
+| `test/node/test-omid-container-lifecycle.js` | A (sections H1-H5), D (section H6), E (section H7) |
+| `test/node/test-bridges-detection.js` | B (section 20) |
+| `test/node/test-creative-sdk-injection.js` | F (section 9) |
+| `test/browser/test-html-lifecycle-adapter-bfcache.js` | G (new file) |
+
+---
+
+*End of design.*


### PR DESCRIPTION
## Summary

Consolidated design doc for the 0.7.4 release: closes #102, #106, #121, #123, #124, #125, #126 as a coordinated "OMID hardening" release. Eight PRs (A–H) sequenced with the smoke-test first and the heaviest test-infra item last.

**Audit finding (lands in the doc as 3 explicit callouts):** three of the seven issues turned out to be **coverage / documentation gaps, not implementation gaps**. The 0.7.3 implementation already meets the contracts that #126 and #123 were filed against; #121's audit confirms zero residual `requestOmid` symbols in `src/`/`test/`/`examples/`. PRs A, C, D therefore ship tests + docs only; PRs B, E, F carry production code; G ships a test-infra scaffold.

**Hardest design calls (locked in the doc):**

1. **#106 fetch-failure handling** — fall through to un-injected creative load; NOT a new SHARCSecurityEvent variant. Creative-fetch CORS is a separate concern from OMID-tier security signaling.
2. **#125 variant shape** — `feature_load_failed`, non-terminating, sibling to `bridge_load_failed`, with `details: { featureName, reason, scriptUrl }`. Reasons: `'http_404' | 'timeout' | 'network' | 'evaluation_throw'`.
3. **#125 feature stays advertised on failure** — `supportedFeatures` does NOT retract the failed feature; honest signal is the parallel "advertised + failed" pair on `onSecurityEvent`. Avoids a real init-send race.
4. **#106 activation model** — operators must opt in via `useMarkupInjection: true` (not silent flip). Explicit > surprise.

## Sibling failing-test branches

This PR carries the design ADR only. Each implementation PR has its own branch with the failing-test commit drop-in-ready for `/develop`:

- `test/126-termination-mid-load` (PR A — coverage-add; tests pass on main)
- `feat/124-multi-bridge-dedup-warn` (PR B — 3 failing assertions on main)
- `feat/123-extension-error-forwarding` (PR D — contract pinning; tests pass on main)
- `feat/125-feature-load-failed-event` (PR E — 2 failing assertions on main)
- `feat/106-url-variant-creative-sdk-injection` (PR F — 7 failing assertions on main)
- `test/102-bfcache-puppeteer` (PR G — 5 failing scaffold assertions on main)

PR C (#121) is docs-only and rolls into PR H.

## Test plan

- [ ] Review the audit findings (PR A / C / D zero-code) — confirm the issue authors agree the existing implementation meets the contract
- [ ] Confirm the `feature_load_failed` shape (especially: no `errorCode` field, non-terminating, details bound at 500 chars)
- [ ] Confirm PR F's explicit `useMarkupInjection: true` opt-in (vs silent flip)
- [ ] Confirm PR G scaffold-with-TODO is acceptable shipping shape if Puppeteer wiring slips

🤖 Generated with [Claude Code](https://claude.com/claude-code)