### PR TITLE
chore: sync lifecycle adapter versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "./dist/*.js"
   ],
   "scripts": {
-    "version": "node scripts/sync-version.js && git add src/sharc-protocol.js src/sharc-container.js src/sharc-creative.js src/sharc-mraid-bridge.js src/sharc-safeframe-bridge.js src/sharc-omid-bridge.js src/sharc-navigation-bridge.js README.md",
+    "version": "node scripts/sync-version.js && git add src/sharc-protocol.js src/sharc-container.js src/lifecycle-adapters/base-adapter.js src/lifecycle-adapters/html-adapter.js src/sharc-creative.js src/sharc-mraid-bridge.js src/sharc-safeframe-bridge.js src/sharc-omid-bridge.js src/sharc-navigation-bridge.js README.md",
     "dev": "node server.cjs",
     "build": "rollup -c && npm run build:types",
     "build:types": "tsc -p tsconfig.types.json",

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -37,6 +37,16 @@ const replacements = [
     replacement: `$1${version}`,
   },
   {
+    file: 'src/lifecycle-adapters/base-adapter.js',
+    pattern: /(@version )\S+/,
+    replacement: `$1${version}`,
+  },
+  {
+    file: 'src/lifecycle-adapters/html-adapter.js',
+    pattern: /(@version )\S+/,
+    replacement: `$1${version}`,
+  },
+  {
     file: 'src/sharc-creative.js',
     pattern: /(@version )\S+/,
     replacement: `$1${version}`,

--- a/src/lifecycle-adapters/base-adapter.js
+++ b/src/lifecycle-adapters/base-adapter.js
@@ -22,7 +22,7 @@
  * for the rationale that picked the adapter-class shape over inline-switch
  * or registry alternatives.
  *
- * @version 0.7.1
+ * @version 0.7.3
  */
 
 'use strict';

--- a/src/lifecycle-adapters/html-adapter.js
+++ b/src/lifecycle-adapters/html-adapter.js
@@ -30,7 +30,7 @@
  *   - jsdom does NOT ship an IntersectionObserver implementation. Tests
  *     stub `global.IntersectionObserver` with a manually-triggerable mock.
  *
- * @version 0.7.1
+ * @version 0.7.3
  */
 
 'use strict';


### PR DESCRIPTION
## Summary

Closes #100 — includes the lifecycle adapter source files in version propagation.

### What changed

- Added `src/lifecycle-adapters/base-adapter.js` and `src/lifecycle-adapters/html-adapter.js` to `scripts/sync-version.js`.
- Added both adapter files to the npm `version` lifecycle script's `git add` list so release bumps stage them with the rest of the synced files.
- Ran `node scripts/sync-version.js`, updating both adapter `@version` tags from `0.7.1` to the current package version, `0.7.3`.

`CLAUDE.md` is referenced in the issue body, but that file is not present on current `main`; no checklist doc was updated.

## Verification

- [x] `node scripts/sync-version.js`
- [x] `npm run version` verified the expanded staging list includes both adapter files
- [x] `rg -n "@version 0\\.7\\.1|@version" src/lifecycle-adapters src/*.js`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`

Closes #100
