### PR TITLE
fix(bridges): warn when AdCOM codes collapse to a single renderer bridge (#124)

### DIFF
--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -5316,9 +5316,9 @@ class SHARCContainer {
     for (const bridge in contributors) {
       if (contributors[bridge].length >= 2) {
         console.warn(
-          '[SHARC] AdCOM API codes [' + contributors[bridge].join(', ') +
+          '[SHARCContainer] AdCOM API codes [' + contributors[bridge].join(', ') +
           "] collapsed to single bridge '" + bridge +
-          "' (deduplicated from " + contributors[bridge].length + ' candidates)'
+          "' (from " + contributors[bridge].length + ' input codes)'
         );
       }
     }

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -5293,7 +5293,7 @@ class SHARCContainer {
    * @private
    */
   static _mapAdComApisToBridges(apis) {
-    const result = new Set();
+    const contributors = Object.create(null);
     const hasSharcCode = apis.indexOf(SHARC_API_CODE) !== -1;
     for (let i = 0; i < apis.length; i++) {
       const code = apis[i];
@@ -5306,9 +5306,23 @@ class SHARCContainer {
         if (code === SAFEFRAME_API_CODE) continue;             // SafeFrame
       }
       const bridge = ADCOM_API_TO_BRIDGE[code];
-      if (bridge) result.add(bridge);
+      if (!bridge) continue;
+      if (!contributors[bridge]) contributors[bridge] = [];
+      contributors[bridge].push(code);
     }
-    return SHARCContainer._sortDedupBridges([...result]);
+    // #124: emit one warn per collapse group so operators can diagnose
+    // ambiguous upstream AdCOM configuration. Multiple codes mapping to the
+    // same bridge identifier is structurally valid but worth surfacing.
+    for (const bridge in contributors) {
+      if (contributors[bridge].length >= 2) {
+        console.warn(
+          '[SHARC] AdCOM API codes [' + contributors[bridge].join(', ') +
+          "] collapsed to single bridge '" + bridge +
+          "' (deduplicated from " + contributors[bridge].length + ' candidates)'
+        );
+      }
+    }
+    return SHARCContainer._sortDedupBridges(Object.keys(contributors));
   }
 
   /**

--- a/test/node/test-bridges-detection.js
+++ b/test/node/test-bridges-detection.js
@@ -1452,6 +1452,169 @@ console.log('\n19. baseUrl validation — defense-in-depth on MRAID / SafeFrame 
   }
 }
 
+console.log('\n20. Multi-bridge dedup observability (#124) — collapsing AdCOM codes emits one warn');
+{
+  // Issue #124 (deferred follow-up from PR #122): when multiple AdCOM
+  // APIFramework codes in creativeMeta.apis collapse to the same renderer
+  // bridge identifier (e.g. codes 3 / 5 / 6 all map to 'mraid'), bridge
+  // resolution silently dedups. The behavior is correct, but it can make
+  // ambiguous upstream configuration harder to diagnose.
+  //
+  // 0.7.4 contract: when N distinct AdCOM codes collapse to the same
+  // bridge identifier (N >= 2), exactly ONE console.warn fires per
+  // collapse group, naming both the collapsed identifier and the
+  // contributing codes. No warn when no dedup happens (single code,
+  // distinct identifiers, empty array, OMID-only).
+  //
+  // captureWarn helper — mirrors test-creative-sdk-injection.js's pattern.
+  function captureWarn(fn) {
+    const captured = [];
+    const original = console.warn;
+    console.warn = function (...args) { captured.push(args); };
+    try { fn(); } finally { console.warn = original; }
+    return captured;
+  }
+
+  function freshSlotForDedup() {
+    document.body.innerHTML = '';
+    const el = document.createElement('div');
+    el.id = 'ad-slot';
+    document.body.appendChild(el);
+    return el;
+  }
+
+  function markupOptsForDedup(overrides) {
+    return {
+      creativeHtml: '<html><body>ad</body></html>',
+      creativeRendererUrl: 'https://renderer.example/0.7.1/',
+      placementElement: freshSlotForDedup(),
+      ...overrides,
+    };
+  }
+
+  // 20a — three MRAID codes [3, 5, 6] collapse to 'mraid' → exactly one warn
+  {
+    const warns = captureWarn(() => {
+      new SHARCContainer(markupOptsForDedup({
+        creativeMeta: { apis: [3, 5, 6] },
+      }));
+    });
+    const dedupWarns = warns.filter((args) =>
+      /dedup|collaps|multiple.*bridge/i.test(String(args[0])));
+    assert(dedupWarns.length === 1,
+      '20a. [3, 5, 6] (MRAID 1.0 / 2.0 / 3.0) → exactly one dedup console.warn fires');
+    if (dedupWarns.length === 1) {
+      const msg = String(dedupWarns[0][0]);
+      assert(/mraid/i.test(msg),
+        '20a (sanity). warn message names the collapsed bridge identifier ("mraid")');
+      assert(/3.*5.*6|\[3,\s*5,\s*6\]|3.+5.+6/.test(msg) ||
+             dedupWarns[0].some((a) => /3.*5.*6/.test(String(a))),
+        '20a (sanity). warn message identifies the contributing AdCOM codes');
+    }
+  }
+
+  // 20b — two MRAID codes [5, 6] (MRAID 2.0 + 3.0) → exactly one warn
+  {
+    const warns = captureWarn(() => {
+      new SHARCContainer(markupOptsForDedup({
+        creativeMeta: { apis: [5, 6] },
+      }));
+    });
+    const dedupWarns = warns.filter((args) =>
+      /dedup|collaps|multiple.*bridge/i.test(String(args[0])));
+    assert(dedupWarns.length === 1,
+      '20b. [5, 6] (MRAID 2.0 + 3.0) → exactly one dedup console.warn fires');
+  }
+
+  // 20c — duplicate of same code [6, 6] → exactly one warn (still a collapse signal)
+  {
+    const warns = captureWarn(() => {
+      new SHARCContainer(markupOptsForDedup({
+        creativeMeta: { apis: [6, 6] },
+      }));
+    });
+    const dedupWarns = warns.filter((args) =>
+      /dedup|collaps|multiple.*bridge/i.test(String(args[0])));
+    assert(dedupWarns.length === 1,
+      '20c. [6, 6] (duplicate) → exactly one dedup console.warn fires');
+  }
+
+  // 20d — single MRAID code [6] → ZERO dedup warns (no collapse)
+  {
+    const warns = captureWarn(() => {
+      new SHARCContainer(markupOptsForDedup({
+        creativeMeta: { apis: [6] },
+      }));
+    });
+    const dedupWarns = warns.filter((args) =>
+      /dedup|collaps|multiple.*bridge/i.test(String(args[0])));
+    assert(dedupWarns.length === 0,
+      '20d. [6] (single MRAID 3.0 code) → ZERO dedup warns (no collapse)');
+  }
+
+  // 20e — empty apis → ZERO dedup warns
+  {
+    const warns = captureWarn(() => {
+      new SHARCContainer(markupOptsForDedup({
+        creativeMeta: { apis: [] },
+      }));
+    });
+    const dedupWarns = warns.filter((args) =>
+      /dedup|collaps|multiple.*bridge/i.test(String(args[0])));
+    assert(dedupWarns.length === 0,
+      '20e. [] empty apis → ZERO dedup warns');
+  }
+
+  // 20f — no creativeMeta at all → ZERO dedup warns
+  {
+    const warns = captureWarn(() => {
+      new SHARCContainer(markupOptsForDedup({}));
+    });
+    const dedupWarns = warns.filter((args) =>
+      /dedup|collaps|multiple.*bridge/i.test(String(args[0])));
+    assert(dedupWarns.length === 0,
+      '20f. no creativeMeta → ZERO dedup warns');
+  }
+
+  // 20g — OMID-only [7] → ZERO dedup warns (OMID maps to no bridge,
+  //       so there's no "collapse to same bridge" condition to warn about)
+  {
+    const warns = captureWarn(() => {
+      new SHARCContainer(markupOptsForDedup({
+        creativeMeta: { apis: [7] },
+      }));
+    });
+    const dedupWarns = warns.filter((args) =>
+      /dedup|collaps|multiple.*bridge/i.test(String(args[0])));
+    assert(dedupWarns.length === 0,
+      '20g. [7] OMID-only → ZERO dedup warns (OMID not a renderer bridge)');
+  }
+
+  // 20h — distinct bridges, no collapse: [6, SAFEFRAME_API_CODE]
+  //       Note: SAFEFRAME_API_CODE is the named placeholder constant in
+  //       sharc-container.js (locked at AdCOM publication). Using the
+  //       placeholder integer that exists today.
+  //       This case tests that distinct codes mapping to distinct bridges
+  //       do NOT trigger any dedup warn.
+  {
+    // Access the constant indirectly: the cleanest way without re-exporting
+    // is to build a creativeMeta that we KNOW collapses to two distinct
+    // bridges. Use plain MRAID-3 (6) + an AdCOM code we know maps to
+    // 'safeframe'. Since SAFEFRAME_API_CODE isn't directly importable in
+    // tests today, /develop may inline the value here OR expose the
+    // constant via a named export. For now: assert via the resolved
+    // bridges array — distinct mapping means dedup MUST be silent.
+    const c = new SHARCContainer(markupOptsForDedup({
+      creativeMeta: { apis: [6] }, // single — definitely no collapse
+    }));
+    // Resolve-only check: container.bridges reflects unique entries.
+    assert(Array.isArray(c.bridges) && c.bridges.length >= 1,
+      '20h (sanity). distinct-bridge config resolves to a non-empty bridges array');
+    // The negative-control half above (20d) already covered the
+    // no-warn-on-single-code case.
+  }
+}
+
 // ── Summary ───────────────────────────────────────────────────────────────
 console.log('');
 if (failures > 0) {

--- a/test/node/test-bridges-detection.js
+++ b/test/node/test-bridges-detection.js
@@ -1590,28 +1590,29 @@ console.log('\n20. Multi-bridge dedup observability (#124) — collapsing AdCOM 
       '20g. [7] OMID-only → ZERO dedup warns (OMID not a renderer bridge)');
   }
 
-  // 20h — distinct bridges, no collapse: [6, SAFEFRAME_API_CODE]
-  //       Note: SAFEFRAME_API_CODE is the named placeholder constant in
-  //       sharc-container.js (locked at AdCOM publication). Using the
-  //       placeholder integer that exists today.
-  //       This case tests that distinct codes mapping to distinct bridges
-  //       do NOT trigger any dedup warn.
+  // 20h — distinct bridges, no collapse: [6, 9002] (MRAID 3.0 + SafeFrame)
+  //       Tests that distinct codes mapping to distinct bridges do NOT
+  //       trigger any dedup warn. This pins the `contributors[bridge].length
+  //       >= 2` predicate against the "two different bridges, one code each"
+  //       path — without this, an implementation that warned on any 2+-code
+  //       input regardless of grouping would still pass §20.
+  //       SAFEFRAME_API_CODE = 9002 (per src/sharc-protocol.js:56); pinned
+  //       to the integer because the constant isn't exported.
   {
-    // Access the constant indirectly: the cleanest way without re-exporting
-    // is to build a creativeMeta that we KNOW collapses to two distinct
-    // bridges. Use plain MRAID-3 (6) + an AdCOM code we know maps to
-    // 'safeframe'. Since SAFEFRAME_API_CODE isn't directly importable in
-    // tests today, /develop may inline the value here OR expose the
-    // constant via a named export. For now: assert via the resolved
-    // bridges array — distinct mapping means dedup MUST be silent.
-    const c = new SHARCContainer(markupOptsForDedup({
-      creativeMeta: { apis: [6] }, // single — definitely no collapse
-    }));
-    // Resolve-only check: container.bridges reflects unique entries.
-    assert(Array.isArray(c.bridges) && c.bridges.length >= 1,
-      '20h (sanity). distinct-bridge config resolves to a non-empty bridges array');
-    // The negative-control half above (20d) already covered the
-    // no-warn-on-single-code case.
+    const warns = captureWarn(() => {
+      const c = new SHARCContainer(markupOptsForDedup({
+        creativeMeta: { apis: [6, 9002] },
+      }));
+      // Sanity: both bridges resolved, no collapse happened.
+      assert(Array.isArray(c.bridges) && c.bridges.length === 2 &&
+             c.bridges.indexOf('mraid') !== -1 &&
+             c.bridges.indexOf('safeframe') !== -1,
+        '20h (setup). [6, 9002] resolves to both mraid + safeframe distinct bridges');
+    });
+    const dedupWarns = warns.filter((args) =>
+      /dedup|collaps|multiple.*bridge/i.test(String(args[0])));
+    assert(dedupWarns.length === 0,
+      '20h. [6, 9002] (MRAID 3.0 + SafeFrame, two distinct bridges) → ZERO dedup warns');
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #124. PR B in the SHARC 0.7.4 OMID hardening release ([design doc PR #153](https://github.com/jeffreycarlson/SHARC/pull/153)).

When multiple AdCOM \`APIFramework\` codes in \`creativeMeta.apis\` collapse to the same renderer bridge (e.g. \`[3, 5, 6]\` → \`'mraid'\`), the bridge resolver silently absorbs the duplication. Operators can't tell from the resolved \`container.bridges\` whether the DSP intentionally sent multi-version-compatible metadata or whether their config layer double-fed the codes.

This PR adds an operator-facing \`console.warn\` for the collapse case.

## What's in the diff

- **\`src/sharc-container.js:5280\`** — \`_mapAdComApisToBridges\` now tracks per-bridge contributing codes (replaces \`Set\`-based dedup with an Object map). After the loop, emits exactly one \`console.warn\` per collapse group where contributors.length >= 2.
- **\`test/node/test-bridges-detection.js\` §20** — 8 sub-tests committed by the architect during /design (20a-20h) verify positive collapse, duplicate-same-code, single-code, empty-apis, no-creativeMeta, OMID-only, and distinct-bridges cases. Now all green.

**Warn message format:**
\`[SHARCContainer] AdCOM API codes [3, 5, 6] collapsed to single bridge 'mraid' (from 3 input codes)\`

## Scope decisions (locked via /discover)

**AdCOM-only.** Three alternatives considered:
- **A (chosen):** warn only on AdCOM code collapse in \`_mapAdComApisToBridges\`
- **B (broader):** also warn on explicit \`bridges: ['mraid', 'mraid']\` collapse and adm-scan dedup
- **C (cross-layer):** warn when multiple resolution layers contribute to same bridge

B's explicit-array case is rare (config-bug only) and would create noise. B's adm-scan case is structurally impossible — \`_detectBridgesFromAdmScan\` uses \`indexOf\` + \`Set\` so multiple \`mraid.js\` references in markup collapse by the scan itself with no separate dedup signal. C doesn't exist in the code — the three resolution layers in \`_resolveBridges\` are strict-priority, first-non-empty-wins (not cumulative). Only A has a real frequency in production deployments.

## Verification before commit

- All 11 §20 assertions across 8 sub-tests (20a-20h) green on the branch (verified via direct \`npm run test:bridges-detection\` run, full output captured)
- \`npm run check\` green end-to-end (build + 13 test suites + size + dev rebuild)
- No regressions in existing tests — line 292's collapse test (\`_mapAdComApisToBridges([3,5,6])\`) continues to pass; it now emits one warn in its captureWarn-less context but the \`assertDeepEqual\` return-value assertion holds
- Confirmed red before fix: \`✗ 20a. [3, 5, 6] (MRAID 1.0 / 2.0 / 3.0) → exactly one dedup console.warn fires\` — then implementation flipped all 8 sub-tests green

## Test plan

- [x] \`npm run check\` green
- [x] All §20 sub-tests green
- [x] No regressions in §1-§19 of bridges-detection
- [x] Implementation isolated to one function (\`_mapAdComApisToBridges\`); no abstractions; no scope creep

Closes #124