### PR TITLE
test: cover renderer bridge edge cases

### DIFF
--- a/examples/renderer/index.html
+++ b/examples/renderer/index.html
@@ -293,6 +293,16 @@
     // ES module URL imported via dynamic `import()`.
     BRIDGE_URL_TEMPLATE: '../../dist/sharc-{name}-bridge.mjs'
   };
+  // TEST_ONLY harness knob: lets Puppeteer exercise fork-time renderer config
+  // mistakes without carrying a second renderer fixture. Production forks
+  // should leave this absent; it is ignored unless the query param is present.
+  try {
+    var testBridgeTemplate = new URLSearchParams(window.location.search)
+      .get('sharcTestBridgeUrlTemplate');
+    if (RENDERER_CONFIG.TEST_ONLY && testBridgeTemplate != null) {
+      RENDERER_CONFIG.BRIDGE_URL_TEMPLATE = testBridgeTemplate;
+    }
+  } catch (_) { /* keep default config */ }
   // SECURITY: freeze the config post-construction. Closes the
   // post-load-mutation surface — once set at fork time, the bridge URL
   // template (and the protocol-version allowlist, etc.) cannot be
@@ -380,6 +390,17 @@
     || function _sharcOnAfterRender(_payload) {};
   window.__sharcRenderer.customSecurityLog = window.__sharcRenderer.customSecurityLog
     || function _sharcCustomSecurityLog(message, payload) {
+      if (RENDERER_CONFIG.TEST_ONLY
+          && /\bsharcTestReportSecurityLog=1\b/.test(window.location.search)
+          && window.parent && window.parent !== window) {
+        try {
+          window.parent.postMessage({
+            type: 'SHARC:Test:rendererSecurityLog',
+            message: String(message || ''),
+            payload: payload || null,
+          }, '*');
+        } catch (_) { /* test hook only */ }
+      }
       // Default: existing '[SHARC Renderer]'-prefixed console pattern.
       // Operators override to route through their telemetry stack.
       if (payload && payload.severity === 'error') {

--- a/test/browser/test-creative-sources-puppeteer.js
+++ b/test/browser/test-creative-sources-puppeteer.js
@@ -146,7 +146,7 @@ async function withServer(body) {
 }
 
 async function run() {
-  console.log('test-creative-sources-puppeteer.js — issue #69\n');
+  console.log('test-creative-sources-puppeteer.js — issues #69, #83, #84\n');
 
   await withServer(async () => {
     const chromePath = resolveChromePath();
@@ -179,6 +179,61 @@ async function run() {
       ));
       assert(hasHarness,
         'Puppeteer loaded test/browser/test-creative-sources.html automation hooks');
+
+      console.log('\nbridge_load_failed. unparseable BRIDGE_URL_TEMPLATE');
+      {
+        const result = await page.evaluate(() =>
+          window.__sharcCreativeSourcesHarness.runBridgeLoadFailureProbe());
+        const unparseableLog = result.messages.find((m) =>
+          m.payload && m.payload.reason === 'bridge_url_unparseable'
+            && m.payload.bridge === 'mraid');
+        const bridgeFailedLog = result.messages.find((m) =>
+          m.payload && m.payload.reason === 'bridge_load_failed'
+            && m.payload.bridge === 'mraid');
+        const bridgeEvent = result.securityEvents.find((event) =>
+          event.type === 'bridge_load_failed');
+        const firstError = result.errors[0];
+
+        assert(result.terminated === true,
+          'unparseable bridge template: container terminates');
+        assert(result.creativeRendered === false,
+          'unparseable bridge template: renderer does not report :rendered');
+        assert(Boolean(unparseableLog),
+          'unparseable bridge template: renderer logs bridge_url_unparseable for mraid');
+        assert(Boolean(bridgeFailedLog),
+          'unparseable bridge template: renderer logs bridge_load_failed for mraid');
+        assert(firstError && firstError.code === 2115,
+          'unparseable bridge template: onError fires RENDERER_FAILED (2115)');
+        assert(bridgeEvent && bridgeEvent.errorCode === 2115
+            && bridgeEvent.details && bridgeEvent.details.bridge === 'mraid'
+            && bridgeEvent.details.url === 'http://[invalid',
+          'unparseable bridge template: onSecurityEvent bridge_load_failed carries bridge and substituted URL');
+      }
+
+      console.log('\nunknown_bridge_skipped. future bridge identifier');
+      {
+        const result = await page.evaluate(() =>
+          window.__sharcCreativeSourcesHarness.runUnknownBridgeProtocolProbe());
+        const rendered = result.messages.find((m) =>
+          m && m.type === 'SHARC:Renderer:rendered');
+        const failed = result.messages.find((m) =>
+          m && m.type === 'SHARC:Renderer:failed');
+        const unknownLog = result.messages.find((m) =>
+          m && m.type === 'SHARC:Test:rendererSecurityLog'
+            && m.payload && m.payload.reason === 'unknown_bridge_skipped'
+            && m.payload.bridge === 'definitely-not-a-real-bridge');
+        const mraidProbe = result.messages.find((m) =>
+          m && m.type === 'SHARC:Test:creative:mraid');
+
+        assert(Boolean(rendered),
+          'unknown bridge: renderer still posts :rendered');
+        assert(!failed,
+          'unknown bridge: renderer does not post :failed');
+        assert(Boolean(unknownLog),
+          'unknown bridge: renderer logs unknown_bridge_skipped with the identifier');
+        assert(mraidProbe && mraidProbe.hasMraid === true,
+          'unknown bridge: known mraid bridge still loads for the creative');
+      }
 
       for (const kind of ['assign', 'replace', 'href']) {
         console.log(`\n${kind}. window.location.${kind === 'href' ? 'href =' : kind + '()'} browser backstop`);

--- a/test/browser/test-creative-sources.html
+++ b/test/browser/test-creative-sources.html
@@ -421,9 +421,99 @@ window.runNavigationProbe = async function (kind) {
   }
 };
 
+window.runBridgeLoadFailureProbe = async function () {
+  const messages = [];
+  const onMessage = (event) => {
+    if (event && event.data && event.data.type === 'SHARC:Test:rendererSecurityLog') {
+      messages.push(event.data);
+    }
+  };
+  window.addEventListener('message', onMessage);
+
+  const rendererUrl = RENDERER_BASE + '/examples/renderer/'
+    + '?sharcTestReportSecurityLog=1'
+    + '&sharcTestBridgeUrlTemplate=' + encodeURIComponent('http://[invalid');
+  const c = buildContainer(rendererUrl, {
+    bridges: ['mraid'],
+    timeouts: { rendererLoad: 8000, rendererReply: 4000 },
+  });
+
+  try {
+    c.load();
+    await waitFor(() => c._terminated, 10000);
+    return {
+      messages,
+      errors: c.errors,
+      securityEvents: c.securityEvents,
+      creativeRendered: c.creativeRendered,
+      terminated: c._terminated,
+    };
+  } finally {
+    window.removeEventListener('message', onMessage);
+  }
+};
+
+window.runUnknownBridgeProtocolProbe = async function () {
+  const nonce = (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function')
+    ? crypto.randomUUID()
+    : String(Date.now()) + '-' + Math.random();
+  const placementSessionId = 'test-' + nonce;
+  const messages = [];
+  const iframe = document.createElement('iframe');
+  iframe.width = '320';
+  iframe.height = '250';
+  iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+  iframe.src = RENDERER_BASE + '/examples/renderer/?sharcTestReportSecurityLog=1'
+    + '#sharcNonce=' + encodeURIComponent(nonce);
+
+  const onMessage = (event) => {
+    if (event.source !== iframe.contentWindow) return;
+    messages.push(event.data);
+  };
+  window.addEventListener('message', onMessage);
+  slotEl.innerHTML = '';
+  slotEl.appendChild(iframe);
+
+  try {
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('renderer iframe load timeout')), 8000);
+      iframe.addEventListener('load', () => {
+        clearTimeout(timer);
+        resolve();
+      }, { once: true });
+    });
+    iframe.contentWindow.postMessage({
+      type: 'SHARC:Renderer:render',
+      placementSessionId,
+      sharcNonce: nonce,
+      sharcVersion: '0.7.3',
+      rendererProtocolVersion: '1',
+      containerOrigin: window.location.origin,
+      creativeHtml: '<!DOCTYPE html><html><body>'
+        + '<script src="/dist/sharc-creative.js"><\/script>'
+        + '<script>setTimeout(function(){window.parent.postMessage({'
+        + 'type:"SHARC:Test:creative:mraid",'
+        + 'hasMraid:typeof window.mraid==="object"},"*");},100);<\/script>'
+        + '</body></html>',
+      bridges: ['mraid', 'definitely-not-a-real-bridge'],
+    }, RENDERER_BASE);
+
+    await waitFor(() => messages.some((m) => m
+      && m.type === 'SHARC:Renderer:rendered'), 10000);
+    await waitFor(() => messages.some((m) => m
+      && m.type === 'SHARC:Test:creative:mraid'), 2000);
+    return { messages };
+  } finally {
+    window.removeEventListener('message', onMessage);
+    if (iframe.parentNode) iframe.parentNode.removeChild(iframe);
+  }
+};
+
 window.__sharcCreativeSourcesHarness = {
   runScenario: window.runScenario,
   runNavigationProbe: window.runNavigationProbe,
+  runBridgeLoadFailureProbe: window.runBridgeLoadFailureProbe,
+  runUnknownBridgeProtocolProbe: window.runUnknownBridgeProtocolProbe,
   resetAll: window.resetAll,
 };
 


### PR DESCRIPTION
## Summary
- add TEST_ONLY renderer hooks so Puppeteer can report renderer security logs and override BRIDGE_URL_TEMPLATE for failure injection
- cover unparseable BRIDGE_URL_TEMPLATE through the real SHARCContainer path, including bridge_load_failed onSecurityEvent details
- cover renderer-side unknown_bridge_skipped forward-compat behavior with a synthetic future-container :render payload, while verifying known mraid still loads

Closes #83.
Closes #84.

## Tests
- npm run build
- npm run test:browser
- npm run test:creative-sources-load
- npm run lint
- npm run test:all