### PR TITLE
test: cover bridge auto-install diagnostics

### DIFF
--- a/docs/design/0.7.2-non-sharc-loading.md
+++ b/docs/design/0.7.2-non-sharc-loading.md
@@ -539,7 +539,7 @@ The Security Engineer pressure-test surfaced eight MUST-rules (G1–G8) that loc
 
 - **G8.** OMID 0.7.2 second-half work MUST be compatible with `requireSharcInit: false`. The OMID design pass must verify its container-side wiring does not introduce a new "must-handshake" dependency.
 
-- **G9.** Bridge auto-install timeout (when `window.SHARC` never appears) MUST emit `console.warn` per bridge with a specific message. The bridge module emits the warn; the container does not intervene. The warn template MUST report the **strict integer cap value** (the cap-hit elapsed time at which the polling stopped), not an approximate "~Nms" string. See § 10.1 for the bridge-side spec.
+- **G9.** Bridge auto-install timeout (when `window.SHARC` never appears) MUST emit `console.warn` per bridge with a specific message. The bridge module emits the warn; the container does not intervene. The warn template MUST report the **strict integer tick cap value** and conservative wall-clock cap, not an approximate "~Nms" string. The warn includes `placementSessionId` when the renderer threads it, with `unknown` as the fallback for direct bridge loads and older renderers. See § 10.1 for the bridge-side spec.
 
 - **G10.** `container.apiFramework` MUST be frozen at construction and MUST NOT be mutated by any subsequent operation including late handshake, `creativeMeta` field re-reads, or extension callbacks. Implement as a getter returning `this._apiFramework`, where `this._apiFramework` is set exactly once in the constructor body alongside `this._bridges`. No setter; no mutation path. This guardrail prevents a class of "the framework changed after I read it" bugs that would silently break operator dashboards.
 
@@ -554,16 +554,17 @@ The Security Engineer pressure-test surfaced eight MUST-rules (G1–G8) that loc
 When `requireSharcInit: false` + `bridges: ['mraid']` (Markup variant; URL variant blocked by Rule 3b from 0.7.1) + the creative does NOT load `sharc-creative.js`:
 
 - The bridge module's auto-install polling (the `setTimeout(0)` pattern from 0.7.1, capped at a strict integer tick count) eventually hits the cap without finding `window.SHARC.onReady`.
-- At cap-hit, the bridge install **MUST** emit a `console.warn` with the structure below. The warn reports the **strict integer cap value** (the configured cap-hit elapsed time, e.g. `16000` if the cap is 1000 ticks × ≈16 ms), not an approximate "~Nms" string. The warn includes `placementSessionId` for forensic correlation:
+- At cap-hit, the bridge install **MUST** emit a `console.warn` with the structure below. The warn reports the **strict integer tick cap value** plus the conservative wall-clock cap (e.g. `1000 ticks (cap 16000ms)`), not an approximate "~Nms" string. The warn includes `placementSessionId` for forensic correlation when available and `unknown` otherwise:
 
 ```
-[SHARC MRAID bridge] Auto-install failed for placement <placementSessionId>:
-  window.SHARC not available after <CAP_MS>ms. window.mraid will not be wired.
+[SHARC MRAID bridge] Auto-install failed: placementSessionId=<placementSessionId>;
+  window.SHARC not available after <CAP_TICKS> ticks (cap <CAP_MS>ms).
+  window.mraid will not be wired.
   Consider removing 'mraid' from bridges, or loading sharc-creative.js in your
   creative so the bridge can install on top of the SHARC SDK.
 ```
 
-Where `<CAP_MS>` is the bridge module's `BRIDGE_AUTOINSTALL_CAP_MS` constant. Same pattern for the `'safeframe'` bridge with `[SHARC SafeFrame bridge]` prefix and corresponding suggestion. Implementer adjusts the bridge prefix per module.
+Where `<CAP_TICKS>` and `<CAP_MS>` are the bridge module's exported auto-install cap constants. Same pattern for the `'safeframe'` bridge with `[SHARC SafeFrame bridge]` prefix, `window.$sf`, and the corresponding suggestion. Implementer adjusts the bridge prefix per module.
 
 - Bridge install does **NOT** proceed — `window.mraid` (or `window.$sf`) stays undefined.
 - Any subsequent `mraid.foo()` / `$sf.ext.bar()` call from the creative throws `ReferenceError` as today. **No change to this throw behavior.** The warn surfaces the failure at timeout-time, not just at call-time, so operators see the diagnostic earlier in the lifecycle.
@@ -894,7 +895,7 @@ Optional: a simple grep-style CI check could assert that the cookbook contains t
 
 ### 15.6 Bridge timeout warn (G9)
 
-Add to `test/node/test-bridges-detection.js` (or new file): assertions that the MRAID and SafeFrame bridge modules emit the specified `console.warn` after auto-install timeout when `window.SHARC` is not present. Mock the bridge's polling cap to a small value for test speed. Verify the warn message reports the strict integer cap value (not an approximate "~Nms" string).
+Add to `test/node/test-bridges-detection.js` (or new file): assertions that the MRAID and SafeFrame bridge modules emit the specified `console.warn` after auto-install timeout when `window.SHARC` is not present. Control timer scheduling for test speed without changing the production cap constants. Verify the warn message reports the strict integer tick cap, conservative wall-clock cap, renderer-threaded `placementSessionId`, `unknown` fallback, and no timeout warn when `window.SHARC.onReady` is already present.
 
 ### 15.7 Regression coverage for the SHARC handshake path
 

--- a/examples/renderer/index.html
+++ b/examples/renderer/index.html
@@ -1028,6 +1028,10 @@
     }
 
     if (allowedBridges.length > 0) {
+      // Thread :render session context to compatibility bridges before
+      // dynamic import so auto-install timeout diagnostics identify the
+      // placement that failed to load SHARC SDK.
+      window.__sharcPlacementSessionId__ = placementSessionId;
       try {
         // Promise.all: concurrent load. Each rejection bubbles up to the
         // catch below and we surface the FIRST failure via :failed

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -19,6 +19,10 @@
  */
 
 'use strict';
+
+const MRAID_BRIDGE_AUTOINSTALL_CAP_TICKS = 1000;
+const MRAID_BRIDGE_AUTOINSTALL_CAP_MS = 16000;
+
 // -------------------------------------------------------------------------
 // Internal helpers
 // -------------------------------------------------------------------------
@@ -1113,7 +1117,12 @@ MRAIDCompatBridge.prototype = {
 // ESM exports
 // ---------------------------------------------------------------------------
 
-export { MRAIDCompatBridge, installMRAIDBridge };
+export {
+  MRAIDCompatBridge,
+  installMRAIDBridge,
+  MRAID_BRIDGE_AUTOINSTALL_CAP_TICKS,
+  MRAID_BRIDGE_AUTOINSTALL_CAP_MS,
+};
 
 // Browser auto-install — two distinct paths.
 //
@@ -1158,8 +1167,8 @@ if (typeof window !== 'undefined') {
     // (~4 ms in modern browsers, ~16 ms in older). We report the integer
     // tick count and the conservative wall-clock upper bound for operator
     // forensics. See 0.7.2 design § 10.1.
-    var _mraidWireMax = 1000;
-    var _mraidWireCapMs = 16000; // conservative upper bound: 1000 × 16 ms
+    var _mraidWireMax = MRAID_BRIDGE_AUTOINSTALL_CAP_TICKS;
+    var _mraidWireCapMs = MRAID_BRIDGE_AUTOINSTALL_CAP_MS; // conservative upper bound: 1000 × 16 ms
     function _trySharcMraidWire() {
       if (anyWin.__sharcMraidBridgeInstalled) return;
       if (anyWin.SHARC && typeof anyWin.SHARC.onReady === 'function') {
@@ -1173,13 +1182,17 @@ if (typeof window !== 'undefined') {
         // G9: surface the auto-install failure at timeout-time, not just
         // when the creative eventually calls `mraid.*`. The bridge stays
         // uninstalled (correct failure mode); the warn gives operators a
-        // ~16s-earlier diagnostic. PlacementSessionId is intentionally
-        // omitted in 0.7.2 first half — the bridge runs in the renderer
-        // iframe and has no direct handle to the container's session ID.
-        // Follow-up issue tracks threading it via the :render envelope.
+        // ~16s-earlier diagnostic. The reference renderer threads
+        // placementSessionId before importing the bridge; unknown covers
+        // direct bridge loads and older renderers.
         if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+          var placementSessionId = (typeof anyWin.__sharcPlacementSessionId__ === 'string'
+            && anyWin.__sharcPlacementSessionId__.length > 0)
+            ? anyWin.__sharcPlacementSessionId__
+            : 'unknown';
           console.warn(
-            '[SHARC MRAID bridge] Auto-install failed: '
+            '[SHARC MRAID bridge] Auto-install failed: placementSessionId='
+            + placementSessionId + '; '
             + 'window.SHARC not available after ' + _mraidWireMax + ' ticks '
             + '(cap ' + _mraidWireCapMs + 'ms). window.mraid will not be wired. '
             + 'Consider removing "mraid" from bridges, or loading sharc-creative.js '

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -25,6 +25,9 @@
 
 'use strict';
 
+const SAFEFRAME_BRIDGE_AUTOINSTALL_CAP_TICKS = 1000;
+const SAFEFRAME_BRIDGE_AUTOINSTALL_CAP_MS = 16000;
+
 // ---------------------------------------------------------------------------
 
 // -------------------------------------------------------------------------
@@ -749,7 +752,12 @@ SafeFrameCompatBridge.prototype = {
 // ESM exports
 // ---------------------------------------------------------------------------
 
-export { SafeFrameCompatBridge, installSafeFrameBridge };
+export {
+  SafeFrameCompatBridge,
+  installSafeFrameBridge,
+  SAFEFRAME_BRIDGE_AUTOINSTALL_CAP_TICKS,
+  SAFEFRAME_BRIDGE_AUTOINSTALL_CAP_MS,
+};
 
 // Browser auto-install — two distinct paths. See sharc-mraid-bridge.js for
 // full design notes; the same pattern applies here.
@@ -779,8 +787,8 @@ if (typeof window !== 'undefined') {
     // (~4 ms in modern browsers, ~16 ms in older). At cap-hit, emit
     // operator-visible `console.warn` with the integer tick count and the
     // conservative wall-clock upper bound. See 0.7.2 design § 10.1.
-    var _sfWireMax = 1000;
-    var _sfWireCapMs = 16000; // conservative upper bound: 1000 × 16 ms
+    var _sfWireMax = SAFEFRAME_BRIDGE_AUTOINSTALL_CAP_TICKS;
+    var _sfWireCapMs = SAFEFRAME_BRIDGE_AUTOINSTALL_CAP_MS; // conservative upper bound: 1000 × 16 ms
     function _trySharcSafeFrameWire() {
       if (anyWin.__sharcSafeFrameBridgeInstalled) return;
       if (anyWin.SHARC && typeof anyWin.SHARC.onReady === 'function') {
@@ -794,11 +802,17 @@ if (typeof window !== 'undefined') {
         // G9: surface the auto-install failure at timeout-time, not just
         // when the creative eventually calls `$sf.ext.*`. The bridge stays
         // uninstalled (correct failure mode); the warn gives operators a
-        // ~16s-earlier diagnostic. PlacementSessionId is intentionally
-        // omitted in 0.7.2 first half — see MRAID bridge for rationale.
+        // ~16s-earlier diagnostic. The reference renderer threads
+        // placementSessionId before importing the bridge; unknown covers
+        // direct bridge loads and older renderers.
         if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+          var placementSessionId = (typeof anyWin.__sharcPlacementSessionId__ === 'string'
+            && anyWin.__sharcPlacementSessionId__.length > 0)
+            ? anyWin.__sharcPlacementSessionId__
+            : 'unknown';
           console.warn(
-            '[SHARC SafeFrame bridge] Auto-install failed: '
+            '[SHARC SafeFrame bridge] Auto-install failed: placementSessionId='
+            + placementSessionId + '; '
             + 'window.SHARC not available after ' + _sfWireMax + ' ticks '
             + '(cap ' + _sfWireCapMs + 'ms). window.$sf will not be wired. '
             + 'Consider removing "safeframe" from bridges, or loading sharc-creative.js '
@@ -817,4 +831,3 @@ if (typeof window !== 'undefined') {
 if (typeof window !== 'undefined' && typeof window.SHARC !== 'undefined' && !window.SHARC.SafeFrameCompatBridge) {
   window.SHARC.SafeFrameCompatBridge = SafeFrameCompatBridge;
 }
-

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -220,6 +220,13 @@ declare global {
      * precise install point (BEFORE document.write(creativeHtml)).
      */
     __sharcNavBridgeAutoInstall?: boolean;
+
+    /**
+     * Renderer-threaded placement session context used by compatibility
+     * bridge auto-install timeout warnings.
+     */
+    __sharcPlacementSessionId__?: string;
+
   }
 }
 

--- a/test/node/test-bridges-detection.js
+++ b/test/node/test-bridges-detection.js
@@ -55,8 +55,16 @@ window.SHARC.Protocol = protoMod;
 
 const { SHARCContainer } = await import('../../dist/sharc-container.mjs');
 const { OmidCompatBridge } = await import('../../dist/sharc-omid-bridge.mjs');
-const { MRAIDCompatBridge } = await import('../../dist/sharc-mraid-bridge.mjs');
-const { SafeFrameCompatBridge } = await import('../../dist/sharc-safeframe-bridge.mjs');
+const {
+  MRAIDCompatBridge,
+  MRAID_BRIDGE_AUTOINSTALL_CAP_TICKS,
+  MRAID_BRIDGE_AUTOINSTALL_CAP_MS,
+} = await import('../../dist/sharc-mraid-bridge.mjs');
+const {
+  SafeFrameCompatBridge,
+  SAFEFRAME_BRIDGE_AUTOINSTALL_CAP_TICKS,
+  SAFEFRAME_BRIDGE_AUTOINSTALL_CAP_MS,
+} = await import('../../dist/sharc-safeframe-bridge.mjs');
 
 // ── Tiny assertion harness ────────────────────────────────────────────────
 let failures = 0;
@@ -95,6 +103,97 @@ function assertThrows(fn, msgPattern, message, ErrorCtor) {
       return;
     }
     console.log('  ✓', message);
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+let freshImportCounter = 0;
+function freshBridgeUrl(file, label) {
+  const url = new URL('../../dist/' + file, import.meta.url);
+  url.searchParams.set('case', String(Date.now()) + '-' + String(freshImportCounter++) + '-' + label);
+  return url.href;
+}
+
+function createMinimalSharcStub() {
+  return {
+    onReady() {},
+    onStart() {},
+    on() {},
+    hasFeature() { return false; },
+    requestPlacementChange() { return Promise.resolve(); },
+    requestClose() { return Promise.resolve(); },
+    requestNavigation() { return Promise.resolve(); },
+    requestFeature() { return Promise.resolve(); },
+  };
+}
+
+async function captureBridgeAutoInstallWarnings(options) {
+  const savedWarn = console.warn;
+  const savedSharc = window.SHARC;
+  const savedMraid = window.mraid;
+  const savedMraidEnv = window.MRAID_ENV;
+  const savedSf = window.$sf;
+  const savedPlacementSessionId = window.__sharcPlacementSessionId__;
+  const savedSetTimeout = global.setTimeout;
+  const warnings = [];
+  console.warn = function (...args) {
+    warnings.push(args.map(String).join(' '));
+  };
+
+  try {
+    delete window.mraid;
+    delete window.MRAID_ENV;
+    delete window.$sf;
+    delete window.__sharcMraidBridgeInstalled;
+    delete window.__sharcSafeFrameBridgeInstalled;
+    delete window.__sharcMraidBridgeAutoInstall;
+    delete window.__sharcSafeFrameBridgeAutoInstall;
+    delete window.__sharcPlacementSessionId__;
+
+    if (options.placementSessionId !== undefined) {
+      window.__sharcPlacementSessionId__ = options.placementSessionId;
+    }
+    if (options.withSharc) {
+      window.SHARC = createMinimalSharcStub();
+    } else {
+      delete window.SHARC;
+    }
+    if (!options.withSharc) {
+      global.setTimeout = function (fn) {
+        fn();
+        return 0;
+      };
+    }
+
+    if (options.bridge === 'mraid') {
+      window.__sharcMraidBridgeAutoInstall = true;
+      await import(freshBridgeUrl('sharc-mraid-bridge.mjs', options.label));
+    } else {
+      window.__sharcSafeFrameBridgeAutoInstall = true;
+      await import(freshBridgeUrl('sharc-safeframe-bridge.mjs', options.label));
+    }
+
+    await sleep(options.withSharc ? 50 : 0);
+    return warnings;
+  } finally {
+    console.warn = savedWarn;
+    global.setTimeout = savedSetTimeout;
+    window.SHARC = savedSharc;
+    if (savedMraid === undefined) delete window.mraid; else window.mraid = savedMraid;
+    if (savedMraidEnv === undefined) delete window.MRAID_ENV; else window.MRAID_ENV = savedMraidEnv;
+    if (savedSf === undefined) delete window.$sf; else window.$sf = savedSf;
+    if (savedPlacementSessionId === undefined) {
+      delete window.__sharcPlacementSessionId__;
+    } else {
+      window.__sharcPlacementSessionId__ = savedPlacementSessionId;
+    }
+    delete window.__sharcMraidBridgeInstalled;
+    delete window.__sharcSafeFrameBridgeInstalled;
+    delete window.__sharcMraidBridgeAutoInstall;
+    delete window.__sharcSafeFrameBridgeAutoInstall;
   }
 }
 
@@ -1614,6 +1713,70 @@ console.log('\n20. Multi-bridge dedup observability (#124) — collapsing AdCOM 
     assert(dedupWarns.length === 0,
       '20h. [6, 9002] (MRAID 3.0 + SafeFrame, two distinct bridges) → ZERO dedup warns');
   }
+}
+
+// -- 21. Bridge auto-install timeout diagnostics (#91/#93) ───────────────
+{
+  console.log('21. Bridge auto-install timeout diagnostics (#91/#93)');
+
+  assert(MRAID_BRIDGE_AUTOINSTALL_CAP_TICKS === 1000,
+    'MRAID auto-install cap ticks exported as strict integer 1000');
+  assert(MRAID_BRIDGE_AUTOINSTALL_CAP_MS === 16000,
+    'MRAID auto-install cap milliseconds exported as 16000');
+  assert(SAFEFRAME_BRIDGE_AUTOINSTALL_CAP_TICKS === 1000,
+    'SafeFrame auto-install cap ticks exported as strict integer 1000');
+  assert(SAFEFRAME_BRIDGE_AUTOINSTALL_CAP_MS === 16000,
+    'SafeFrame auto-install cap milliseconds exported as 16000');
+
+  const mraidWarnings = await captureBridgeAutoInstallWarnings({
+    bridge: 'mraid',
+    placementSessionId: 'sid-g9-mraid',
+    label: 'mraid-threaded-session',
+  });
+  const mraidWarning = mraidWarnings.find((msg) => msg.includes('[SHARC MRAID bridge] Auto-install failed'));
+  assert(!!mraidWarning,
+    'MRAID auto-install cap emits timeout warning');
+  assert(mraidWarning && mraidWarning.includes('placementSessionId=sid-g9-mraid'),
+    'MRAID timeout warning includes renderer-threaded placementSessionId');
+  assert(mraidWarning && mraidWarning.includes('after 1000 ticks'),
+    'MRAID timeout warning reports exported tick cap');
+  assert(mraidWarning && mraidWarning.includes('(cap 16000ms)'),
+    'MRAID timeout warning reports exported wall-clock cap');
+  assert(mraidWarning && mraidWarning.includes('window.mraid will not be wired'),
+    'MRAID timeout warning names the missing compatibility surface');
+
+  const safeframeWarnings = await captureBridgeAutoInstallWarnings({
+    bridge: 'safeframe',
+    placementSessionId: 'sid-g9-sf',
+    label: 'safeframe-threaded-session',
+  });
+  const sfWarning = safeframeWarnings.find((msg) => msg.includes('[SHARC SafeFrame bridge] Auto-install failed'));
+  assert(!!sfWarning,
+    'SafeFrame auto-install cap emits timeout warning');
+  assert(sfWarning && sfWarning.includes('placementSessionId=sid-g9-sf'),
+    'SafeFrame timeout warning includes renderer-threaded placementSessionId');
+  assert(sfWarning && sfWarning.includes('after 1000 ticks'),
+    'SafeFrame timeout warning reports exported tick cap');
+  assert(sfWarning && sfWarning.includes('(cap 16000ms)'),
+    'SafeFrame timeout warning reports exported wall-clock cap');
+  assert(sfWarning && sfWarning.includes('window.$sf will not be wired'),
+    'SafeFrame timeout warning names the missing compatibility surface');
+
+  const unknownSessionWarnings = await captureBridgeAutoInstallWarnings({
+    bridge: 'mraid',
+    label: 'mraid-unknown-session',
+  });
+  const unknownSessionWarning = unknownSessionWarnings.find((msg) => msg.includes('[SHARC MRAID bridge] Auto-install failed'));
+  assert(unknownSessionWarning && unknownSessionWarning.includes('placementSessionId=unknown'),
+    'auto-install timeout warning falls back to placementSessionId=unknown without renderer context');
+
+  const sharcPresentWarnings = await captureBridgeAutoInstallWarnings({
+    bridge: 'mraid',
+    withSharc: true,
+    label: 'mraid-sharc-present',
+  });
+  assert(!sharcPresentWarnings.some((msg) => msg.includes('Auto-install failed')),
+    'auto-install timeout warning does not fire when window.SHARC.onReady is already present');
 }
 
 // ── Summary ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- thread renderer placementSessionId into bridge auto-install timeout warnings
- export MRAID/SafeFrame auto-install cap constants and include them in warnings
- add node coverage for timeout warnings, unknown fallback, and SHARC-present no-warning path

## Tests
- npm run lint
- npm run check

Closes #91
Closes #93