### PR TITLE
chore: tidy renderer payload and release checklist

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,14 +23,19 @@ git push && git push --tags
 
 `scripts/sync-version.js` (run by the `npm version` lifecycle hook) propagates the version to:
 
+This list is for verification after the bump; do not edit these entries manually unless the sync script fails and you are following the troubleshooting path below.
+
 | File | What is updated |
 |------|-----------------|
 | `src/sharc-protocol.js` | `SHARC_VERSION` constant + `@version` JSDoc |
 | `src/sharc-container.js` | `@version` JSDoc |
+| `src/lifecycle-adapters/base-adapter.js` | `@version` JSDoc |
+| `src/lifecycle-adapters/html-adapter.js` | `@version` JSDoc |
 | `src/sharc-creative.js` | `@version` JSDoc |
 | `src/sharc-mraid-bridge.js` | `@version` JSDoc |
 | `src/sharc-safeframe-bridge.js` | `@version` JSDoc |
 | `src/sharc-omid-bridge.js` | `@version` JSDoc |
+| `src/sharc-navigation-bridge.js` | `@version` JSDoc |
 | `README.md` | Version badge + CDN example URLs |
 | `package.json` / `package-lock.json` | `version` field (via `npm version` itself) |
 

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -2198,12 +2198,12 @@ class SHARCContainer {
         // `knownBridges` allowlist (`['mraid', 'safeframe']` in 0.7.1)
         // before importing. See docs/design/0.7.1-bridges-field.md § 2.
         bridges: this.bridges.slice(),
+        containerOrigin: containerOrigin,
         creativeHtml: html,
         placementSessionId: this.placementSessionId,
+        rendererProtocolVersion: RENDERER_PROTOCOL_VERSION,
         sharcNonce: this._sharcNonce,
         sharcVersion: SHARC_VERSION,
-        rendererProtocolVersion: RENDERER_PROTOCOL_VERSION,
-        containerOrigin: containerOrigin,
       };
       try {
         iframe.contentWindow.postMessage(renderMsg, this._rendererOrigin);


### PR DESCRIPTION
## Summary
- order the SHARC:Renderer:render payload fields alphabetically after the leading type discriminator
- update the tracked release version-sync checklist in RELEASING.md to match scripts/sync-version.js
- note that the checklist is verification-only unless using the manual troubleshooting path

## Tests
- npm run lint
- npm run test:creative-sources-load
- npm run check

Closes #85
Refs #86

Note: #86 explicitly names CLAUDE.md, but CLAUDE.md is ignored and not tracked in this fork. This PR updates the tracked release checklist in RELEASING.md only, and intentionally leaves issue 86 open.