### PR TITLE
docs: banner legacy creative-side OMID research + recommendations (#121)

### DIFF
--- a/docs/research/OM-sdk-research.md
+++ b/docs/research/OM-sdk-research.md
@@ -1,5 +1,7 @@
 # OM SDK + SHARC Integration Research
 
+> **Historical research artifact.** This research sketched a creative-initiated `SHARC:Creative:requestOmid` message path (§ "Message Schema"). Subsequent architectural review chose a fully container-owned OMID lifecycle instead — no creative-side `requestOmid` message type or `installOmidBridge()` helper was ever shipped. See [`docs/design/0.7.3-omid-wiring.md`](../design/0.7.3-omid-wiring.md) (decision log D7/D17) for the as-shipped design and [`docs/design/0.7.4-omid-hardening.md`](../design/0.7.4-omid-hardening.md#23-121--legacy-requestomid-audit) for the 0.7.4 audit closure (issue [#121](https://github.com/jeffreycarlson/SHARC/issues/121)). This document is preserved as a snapshot of the original research.
+
 **Author:** Ad Tech Team (tracking-measurement-specialist lead)
 **Date:** 2026-04-05
 **Status:** Research draft for SHARC Working Group consideration

--- a/docs/reviews/OM-sdk-architect-recommendations.md
+++ b/docs/reviews/OM-sdk-architect-recommendations.md
@@ -1,5 +1,7 @@
 # OM SDK Integration — Architectural Recommendations
 
+> **Historical architectural recommendation.** The high-level container-resident OMID approach recommended here did ship — but the specific protocol surface this doc proposes (a creative-initiated `SHARC:Creative:requestOmid` message type wired into `CreativeMessages.REQUEST_OMID`, plus a creative-frame `installOmidBridge()` helper) was later superseded by a fully container-driven OMID lifecycle that needs no creative-side signaling. See [`docs/design/0.7.3-omid-wiring.md`](../design/0.7.3-omid-wiring.md) (decision log D7/D17) for the as-shipped design and [`docs/design/0.7.4-omid-hardening.md`](../design/0.7.4-omid-hardening.md#23-121--legacy-requestomid-audit) for the 0.7.4 audit closure (issue [#121](https://github.com/jeffreycarlson/SHARC/issues/121)) confirming zero residual symbols in `src/`/`test/`/`examples/`. This document is preserved as a snapshot of the original recommendation; treat the high-level architecture as accepted and the specific `requestOmid` protocol surface as superseded.
+
 **Author:** Software Architect (Dev Team)
 **Date:** 2026-04-05
 **Input:** [OM SDK Research](../research/OM-sdk-research.md) + review of `examples/` reference implementation


### PR DESCRIPTION
## Summary

Adds historical-artifact banners to the two pre-0.7.3 docs that propose a creative-initiated `requestOmid` measurement path:

- `docs/research/OM-sdk-research.md` — original Ad Tech research
- `docs/reviews/OM-sdk-architect-recommendations.md` — Software Architect's recommendations doc

Both banners point readers to the canonical 0.7.3 design (D7/D17 decision log) and the 0.7.4 audit closure.

The second banner is intentionally nuanced: the *high-level container-resident architecture* this doc recommends did ship, but the *specific protocol surface* (creative-initiated `SHARC:Creative:requestOmid` + `installOmidBridge()`) was superseded by a fully container-driven lifecycle that needs no creative-side signaling.

## Audit finding

Per locked /discover Q3 (2026-05-23): zero residual symbols across `src/`, `test/`, `examples/`, `dist/`, `scripts/`.

Fuzzier-grep audit broadened the architect's original pattern (`requestOmid|RequestOmid|REQUEST_OMID|request_omid`) to include:
- `installOmidBridge`
- `SHARC:Creative:requestOmid`
- `omidRequest`, `request_omid_session`, `requestOmidSession`

All clean. Banners-only PR; no production code change.

## Sibling discovery (out of scope, tracked for PR H)

`CHANGELOG.md` 0.2.0 "Added" section (lines 1458/1460/1466) documents `installOmidBridge` and `requestOmid` as shipped APIs, but neither 0.7.2 nor 0.7.3 changelog records the removal. This belongs in PR H close-out under `[0.7.4] Removed`, not here, per the focused-PR-splits convention. Tracked.

## Design context

- Issue: [#121](https://github.com/jeffreycarlson/SHARC/issues/121)
- Release design: [`docs/design/0.7.4-omid-hardening.md`](https://github.com/jeffreycarlson/SHARC/blob/main/docs/design/0.7.4-omid-hardening.md#23-121--legacy-requestomid-audit) § 2.3
- Predecessor design: [`docs/design/0.7.3-omid-wiring.md`](https://github.com/jeffreycarlson/SHARC/blob/main/docs/design/0.7.3-omid-wiring.md) D7/D17

## Test plan

- [x] Visual review of banner rendering (markdown blockquote at top of each doc, after H1)
- [x] Cross-doc links resolve (relative paths to `../design/0.7.3-...` and `../design/0.7.4-...`)
- [x] Issue link resolves
- [x] No code changed; no test suite impact

Closes #121