### PR TITLE
test(extensions)+docs: pin lifecycle error event payload contract (#123)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1238,6 +1238,7 @@ Extensions opt in to container lifecycle by implementing `onContainerLifecycleEv
 | `type` | `string` | One of `'load'`, `'stateChange'`, `'placementChange'`, `'close'`, `'destroy'`, `'error'`. |
 | `container` | `SHARCContainer` | The originating container instance. |
 | `timestamp` | `number` | `Date.now()` at dispatch. |
+| `state` | `string \| null` | Container state at dispatch (from the state machine: `'loading'`, `'ready'`, `'active'`, `'passive'`, `'hidden'`, `'frozen'`, `'terminated'`). `null` only if the state machine hasn't been instantiated yet. |
 
 **Per-type detail fields:**
 
@@ -1245,7 +1246,7 @@ Extensions opt in to container lifecycle by implementing `onContainerLifecycleEv
 |--------|-------------------|-------|
 | `'load'` | — | Fired once when the container reaches `ready`. |
 | `'stateChange'` | `newState: string`, `previousState: string` | Mirrors the container state machine (§5). |
-| `'placementChange'` | `mode: 'expand' \| 'resize' \| 'collapse' \| 'fullscreen'`, plus placement metrics passed through from the originating request | See §7 `placementChange`. |
+| `'placementChange'` | `placementUpdate: object` (the new placement payload), `extra: object \| null` (caller-supplied options, e.g. `transition`, `closeButtonPosition`), `intent: 'expand' \| 'resize' \| 'collapse' \| 'fullscreen'` | The field name is **`intent`**, not `mode`. See §7 `placementChange`. |
 | `'close'` | — | Fired when the creative or container initiates close. |
 | `'destroy'` | — | Fired during `_terminate()` cleanup. |
 | `'error'` | `errorCode: number`, `errorMessage: string`, `source: 'creative' \| 'container'` | Canonical fatal-error payload (see below). |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1227,6 +1227,41 @@ environmentData.supportedFeatures = [
 ];
 ```
 
+### Lifecycle event payloads
+
+Extensions opt in to container lifecycle by implementing `onContainerLifecycleEvent(event)`. Every dispatched event carries a stable base shape; per-type fields are layered on top.
+
+**Base event shape (every type):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `string` | One of `'load'`, `'stateChange'`, `'placementChange'`, `'close'`, `'destroy'`, `'error'`. |
+| `container` | `SHARCContainer` | The originating container instance. |
+| `timestamp` | `number` | `Date.now()` at dispatch. |
+
+**Per-type detail fields:**
+
+| `type` | Additional fields | Notes |
+|--------|-------------------|-------|
+| `'load'` | — | Fired once when the container reaches `ready`. |
+| `'stateChange'` | `newState: string`, `previousState: string` | Mirrors the container state machine (§5). |
+| `'placementChange'` | `mode: 'expand' \| 'resize' \| 'collapse' \| 'fullscreen'`, plus placement metrics passed through from the originating request | See §7 `placementChange`. |
+| `'close'` | — | Fired when the creative or container initiates close. |
+| `'destroy'` | — | Fired during `_terminate()` cleanup. |
+| `'error'` | `errorCode: number`, `errorMessage: string`, `source: 'creative' \| 'container'` | Canonical fatal-error payload (see below). |
+
+#### Error event payload contract
+
+Both fatal-error paths in `SHARCContainer` dispatch the same canonical shape to extensions:
+
+| Field | Type | Source path | Description |
+|-------|------|-------------|-------------|
+| `errorCode` | `number` | both | Numeric error code (see `ErrorCodes` in `sharc-protocol.js`). |
+| `errorMessage` | `string` | both | Human-readable message. **Field name is `errorMessage`** — matches the public `onError(errorCode, errorMessage)` callback signature. There is no `message` alias. |
+| `source` | `'creative' \| 'container'` | discriminator | `'creative'` when the error arrived via `SHARC:Creative:fatalError` (`_handleCreativeFatalError`); `'container'` when raised locally by the container (`_handleFatalError`). |
+
+Pinned by `test/node/test-omid-container-lifecycle.js` §H6. The `errorMessage` field name is locked — pre-1.0 may rename it, but `message` is explicitly NOT a synonym.
+
 ### OmidCompatBridge
 
 Container-side extension that wires SHARC container lifecycle to the IAB Open Measurement SDK (OM SDK) `AdSession`. The publisher page loads OM SDK; the container drives session lifecycle from its own state transitions. Added in 0.7.3. See [`docs/design/0.7.3-omid-wiring.md`](design/0.7.3-omid-wiring.md) for the architecture.

--- a/test/node/test-omid-container-lifecycle.js
+++ b/test/node/test-omid-container-lifecycle.js
@@ -1813,6 +1813,21 @@ section('H6. #123 — extension onContainerLifecycleEvent.error receives canonic
       assert(typeof e.timestamp === 'number',
         'creative-fatal: timestamp field is a number');
     }
+
+    // Stability pin: errorMessage MUST normalize to '' when the creative
+    // omits it. Implementation at src/sharc-container.js:3411 does
+    // `errorMessage: errorMessage || ''`; this assertion guards consumers
+    // that rely on `.length` / string ops without an undefined check.
+    c._handleCreativeFatalError({ args: { errorCode: 9002 } });
+    const omittedMsgEvents = captured.filter(
+      (e) => e && e.type === 'error' && e.errorCode === 9002,
+    );
+    assert(omittedMsgEvents.length >= 1,
+      'creative-fatal (no errorMessage): error event still fires');
+    if (omittedMsgEvents.length >= 1) {
+      assert(omittedMsgEvents[0].errorMessage === '',
+        'creative-fatal (no errorMessage): errorMessage normalizes to "" (not undefined)');
+    }
   }
 
   // ── Sub-test 2: container-fatal-error path ─────────────────────────────
@@ -1863,8 +1878,11 @@ section('H6. #123 — extension onContainerLifecycleEvent.error receives canonic
     const errors = captured.filter((e) => e && e.type === 'error');
     assert(errors.length >= 2,
       'two errors fire — one per path');
-    // Required field set across BOTH error events.
-    const required = ['container', 'errorCode', 'errorMessage', 'source', 'type'];
+    // Required field set across BOTH error events. Includes `state` because
+    // the base-event shape promises it on every dispatch (see api-reference.md
+    // §9 "Lifecycle event payloads"). `timestamp` is asserted separately by
+    // subtests 1 and 2; `container` covers the same base-shape promise here.
+    const required = ['container', 'errorCode', 'errorMessage', 'source', 'state', 'type'];
     for (let i = 0; i < errors.length; i++) {
       for (const field of required) {
         assert(field in errors[i],

--- a/test/node/test-omid-container-lifecycle.js
+++ b/test/node/test-omid-container-lifecycle.js
@@ -1812,6 +1812,13 @@ section('H6. #123 — extension onContainerLifecycleEvent.error receives canonic
         'creative-fatal: container reference is the originating container');
       assert(typeof e.timestamp === 'number',
         'creative-fatal: timestamp field is a number');
+      // Audit guard against the "two field names" alternative explicitly
+      // ruled out in the 0.7.4 ADR. The canonical contract is
+      // `errorMessage` only — `message` is not a synonym, not even one
+      // that aliases the same value. If a future refactor adds `message`
+      // back (even as an alias), this assertion fires.
+      assert(!('message' in e),
+        'creative-fatal: `message` field is forbidden (canonical: errorMessage only)');
     }
 
     // Stability pin: errorMessage MUST normalize to '' when the creative
@@ -1855,10 +1862,12 @@ section('H6. #123 — extension onContainerLifecycleEvent.error receives canonic
       assert(e.source === 'container',
         'container-fatal: source === "container" discriminator');
       // Audit guard against the "two field names" alternative explicitly
-      // ruled out in the 0.7.4 ADR. If a future refactor reintroduces a
-      // `message` field on the container path, this assertion fires.
-      assert(!('message' in e) || e.message === e.errorMessage,
-        'container-fatal: no stray `message` field shadows errorMessage (canonical: errorMessage only)');
+      // ruled out in the 0.7.4 ADR. The canonical contract is
+      // `errorMessage` only — `message` is not a synonym, not even one
+      // that aliases the same value. The earlier `|| e.message === e.errorMessage`
+      // tolerance was wrong: the ADR forbids the field outright.
+      assert(!('message' in e),
+        'container-fatal: `message` field is forbidden (canonical: errorMessage only)');
     }
   }
 

--- a/test/node/test-omid-container-lifecycle.js
+++ b/test/node/test-omid-container-lifecycle.js
@@ -1747,6 +1747,163 @@ section('H5. #126 — destroy then re-resolve: subsequent _createSessionWhenRead
 }
 
 // ══════════════════════════════════════════════════════════════════════════
+// H6. EXTENSION ERROR CONTRACT (0.7.4 — issue #123)
+// ══════════════════════════════════════════════════════════════════════════
+//
+// Extensions implementing onContainerLifecycleEvent({ type: 'error', ... })
+// MUST receive a canonical { errorCode, errorMessage, source } payload from
+// BOTH the creative-fatal-error path (_handleCreativeFatalError) and the
+// container-fatal-error path (_handleFatalError). The field is errorMessage
+// (not message) — same name as the public onError(errorCode, errorMessage)
+// callback signature.
+//
+// Audit (against a1a6ee1):
+//   - src/sharc-container.js:3394 already passes errorMessage from creative
+//   - src/sharc-container.js:3960 already passes errorMessage from container
+//
+// The container side is ALREADY correct on main. These tests pin the
+// contract so a future refactor can't quietly drop a field. PR D's
+// production-code component is therefore docs-only (api-reference.md §9
+// "Lifecycle hook contract" gains an event-payload column). PR D's test
+// component is THIS section — coverage that the existing implementation
+// keeps its promise.
+//
+// One sub-test (the "no stray `message` field" assertion) IS expected to
+// flip if the implementation regresses. If it passes on main, that's a
+// signal the implementation already matches the contract.
+
+section('H6. #123 — extension onContainerLifecycleEvent.error receives canonical { errorCode, errorMessage, source }');
+{
+  // Stub extension that captures every lifecycle event it receives.
+  const captured = [];
+  const captureExtension = {
+    getFeatureName() { return 'com.example.capture'; },
+    onContainerLifecycleEvent(evt) { captured.push(evt); },
+  };
+
+  // ── Sub-test 1: creative-fatal-error path ──────────────────────────────
+  {
+    captured.length = 0;
+    const c = new SHARCContainer(markupOptions({
+      extensions: [captureExtension],
+    }));
+    c._iframe = document.createElement('iframe');
+    c._protocol.sendStateChange = () => {};
+
+    // Simulate the creative sending a fatalError message.
+    c._handleCreativeFatalError({
+      args: { errorCode: 9001, errorMessage: 'simulated creative fatal' },
+    });
+
+    const errorEvents = captured.filter((e) => e && e.type === 'error');
+    assert(errorEvents.length >= 1,
+      'creative-fatal: at least one error lifecycle event delivered to extension');
+    if (errorEvents.length >= 1) {
+      const e = errorEvents[0];
+      assert(e.errorCode === 9001,
+        'creative-fatal: errorCode field present and matches');
+      assert(e.errorMessage === 'simulated creative fatal',
+        'creative-fatal: errorMessage field present and matches (NOT `message`)');
+      assert(e.source === 'creative',
+        'creative-fatal: source === "creative" discriminator');
+      assert(e.type === 'error',
+        'creative-fatal: type === "error"');
+      assert(e.container === c,
+        'creative-fatal: container reference is the originating container');
+      assert(typeof e.timestamp === 'number',
+        'creative-fatal: timestamp field is a number');
+    }
+  }
+
+  // ── Sub-test 2: container-fatal-error path ─────────────────────────────
+  {
+    captured.length = 0;
+    const c = new SHARCContainer(markupOptions({
+      extensions: [captureExtension],
+    }));
+    c._iframe = document.createElement('iframe');
+    c._protocol.sendStateChange = () => {};
+    // Stub sendFatalError to avoid protocol-side noise.
+    c._protocol.sendFatalError = () => Promise.resolve();
+
+    c._handleFatalError(2117, 'simulated container fatal');
+
+    const errorEvents = captured.filter((e) => e && e.type === 'error');
+    assert(errorEvents.length >= 1,
+      'container-fatal: at least one error lifecycle event delivered to extension');
+    if (errorEvents.length >= 1) {
+      const e = errorEvents[0];
+      assert(e.errorCode === 2117,
+        'container-fatal: errorCode field present and matches');
+      assert(e.errorMessage === 'simulated container fatal',
+        'container-fatal: errorMessage field present and matches (NOT `message`)');
+      assert(e.source === 'container',
+        'container-fatal: source === "container" discriminator');
+      // Audit guard against the "two field names" alternative explicitly
+      // ruled out in the 0.7.4 ADR. If a future refactor reintroduces a
+      // `message` field on the container path, this assertion fires.
+      assert(!('message' in e) || e.message === e.errorMessage,
+        'container-fatal: no stray `message` field shadows errorMessage (canonical: errorMessage only)');
+    }
+  }
+
+  // ── Sub-test 3: payload-shape stability across both error paths ────────
+  {
+    captured.length = 0;
+    const c = new SHARCContainer(markupOptions({
+      extensions: [captureExtension],
+    }));
+    c._iframe = document.createElement('iframe');
+    c._protocol.sendStateChange = () => {};
+    c._protocol.sendFatalError = () => Promise.resolve();
+
+    c._handleCreativeFatalError({ args: { errorCode: 1001, errorMessage: 'creative' } });
+    c._handleFatalError(2002, 'container');
+
+    const errors = captured.filter((e) => e && e.type === 'error');
+    assert(errors.length >= 2,
+      'two errors fire — one per path');
+    // Required field set across BOTH error events.
+    const required = ['container', 'errorCode', 'errorMessage', 'source', 'type'];
+    for (let i = 0; i < errors.length; i++) {
+      for (const field of required) {
+        assert(field in errors[i],
+          `payload-stability event[${i}]: required field "${field}" present`);
+      }
+    }
+  }
+
+  // ── Sub-test 4: OmidCompatBridge as the consumer — finishes session on
+  //    error event regardless of which path fired the error. This is the
+  //    in-tree extension that exercises the contract today.
+  {
+    const mock = createMockOmidSdk();
+    installMockSdk(mock);
+    try {
+      const bridge = new OmidCompatBridge({
+        omSdkServiceScriptUrl: 'https://omid.example/omweb-v1.js',
+        omSdkSessionClientUrl: 'https://omid.example/omid-session-client-v1.js',
+      });
+      const c = createContainerWithOmid(bridge);
+      c.setState('ready');
+      c._notifyExtensionsLifecycle('stateChange', { newState: 'ready', previousState: 'loading' });
+      c.setState('active');
+      c._notifyExtensionsLifecycle('stateChange', { newState: 'active', previousState: 'ready' });
+
+      // Container-fatal path → OmidCompatBridge should finish session.
+      c._protocol.sendFatalError = () => Promise.resolve();
+      c._handleFatalError(2117, 'renderer protocol error');
+      assert(mock.stats.finishCalls >= 1,
+        'container-fatal: OmidCompatBridge receives error event AND finishes AdSession');
+      assert(bridge._omid.sessionFinished === true,
+        'container-fatal: OmidCompatBridge sessionFinished flag set');
+    } finally {
+      uninstallMockSdk();
+    }
+  }
+}
+
+// ══════════════════════════════════════════════════════════════════════════
 // SUMMARY
 // ══════════════════════════════════════════════════════════════════════════
 console.log('');


### PR DESCRIPTION
## Summary

Pins the public extension-lifecycle error event contract — `{ errorCode, errorMessage, source }` — that both `_handleCreativeFatalError` and `_handleFatalError` already dispatch through `_notifyExtensionsLifecycle('error', ...)`. **No production code change** — implementation already meets the contract on `main`; this PR locks it against future regression.

Two commits:

1. **Test pin (H6)** — architect's pre-committed `test/node/test-omid-container-lifecycle.js` section H6, rebased onto current main. Four subsections, ~25 assertions covering: creative-fatal path payload, container-fatal path payload, payload-shape stability ("no stray `message` field" guard), and OmidCompatBridge as a real consumer.
2. **Docs** — `docs/api-reference.md` § 9 gains a new "Lifecycle event payloads" subsection with three tables: base event shape (`type` / `container` / `timestamp`), per-type detail fields (including the canonical error contract row), and a dedicated "Error event payload contract" subsection that explicitly notes **the field is `errorMessage`, not `message`** (no alias) and back-references the H6 test.

## Audit verified

Per locked /discover decision Q2 (2026-05-23) and design doc § 2.5 #123:

- `src/sharc-container.js:3406` (`_handleCreativeFatalError`) → dispatches `{ errorCode, errorMessage: errorMessage \|\| '', source: 'creative' }`
- `src/sharc-container.js:3974` (`_handleFatalError`) → dispatches `{ errorCode, errorMessage: message, source: 'container' }`

Both match the contract. The H6 "no stray `message` field" assertion is the guard against the two-field-names alternative the 0.7.4 ADR explicitly ruled out.

## Verify

- Lint: clean
- Types: clean
- Targeted test (`test:omid-container-lifecycle`): all H1–H6 assertions pass
- Full `test:all` (15 suites) on fresh dist: all green
- Scope (`git diff origin/main..HEAD`): 2 files, +192 lines, zero `src/` changes
- Rebased onto current `main` (post-#161) — no conflict

## Design context

- Issue: [#123](https://github.com/jeffreycarlson/SHARC/issues/123)
- Release design: [`docs/design/0.7.4-omid-hardening.md`](https://github.com/jeffreycarlson/SHARC/blob/main/docs/design/0.7.4-omid-hardening.md) § 2.5
- Sibling: [#125](https://github.com/jeffreycarlson/SHARC/issues/125) (next PR — new `feature_load_failed` SecurityEvent variant)

## Test plan

- [x] H6 subsections execute and assert against actual container instances
- [x] Both fatal paths exercised (creative + container)
- [x] Stability guard prevents future `message` alias from creeping back
- [x] Docs table matches H6 assertions exactly

## Follow-up note (not bundled)

The "Tracked follow-ups" list in `OmidCompatBridge` still cites #123. Once this merges, that bullet can be removed in the next docs touch.

Closes #123