### PR TITLE
fix: freeze ready lifecycle state

### DIFF
--- a/src/lifecycle-adapters/html-adapter.js
+++ b/src/lifecycle-adapters/html-adapter.js
@@ -509,8 +509,8 @@ class HtmlAdapter extends BaseLifecycleAdapter {
   /**
    * Drives the container to FROZEN from any pre-TERMINATED state.
    * Walks through HIDDEN if necessary because `STATE_TRANSITIONS` only
-   * has a direct `HIDDEN → FROZEN` edge; ACTIVE / PASSIVE step through
-   * HIDDEN first.
+   * has a direct `HIDDEN → FROZEN` edge; READY steps through ACTIVE,
+   * then ACTIVE / PASSIVE step through HIDDEN first.
    * @private
    */
   _transitionToFrozen() {
@@ -546,6 +546,10 @@ class HtmlAdapter extends BaseLifecycleAdapter {
       // ACTIVE first (new 0.7.2 edge from § 4.5), then walk through
       // HIDDEN to FROZEN.
       this._initialTransitionFired = true;
+      this._container.setState(ContainerStates.ACTIVE);
+    }
+
+    if (this._container.getState() === ContainerStates.READY) {
       this._container.setState(ContainerStates.ACTIVE);
     }
 

--- a/test/node/test-html-lifecycle-adapter.js
+++ b/test/node/test-html-lifecycle-adapter.js
@@ -293,6 +293,33 @@ flushContainers();
 }
 flushContainers();
 
+// -- 7b. pagehide with persisted: true from READY → ACTIVE → HIDDEN → FROZEN
+{
+  console.log('\n7b. pagehide with persisted: true from READY → FROZEN');
+  const transitions = [];
+  const { c } = makeContainer({
+    onStateChange: (s, prev) => transitions.push(`${prev}->${s}`),
+  });
+
+  const ready = c.setState(ContainerStates.READY);
+  assert(ready === true, 'pre: LOADING → READY accepted');
+
+  const evt = new dom.window.Event('pagehide');
+  Object.defineProperty(evt, 'persisted', { value: true });
+  window.dispatchEvent(evt);
+  await sleep(5);
+
+  assert(c.getState() === ContainerStates.FROZEN,
+    'pagehide(persisted=true) walks READY → ACTIVE → HIDDEN → FROZEN');
+  assert(transitions.includes('ready->active'),
+    'READY → ACTIVE transition fired');
+  assert(transitions.includes('active->hidden'),
+    'ACTIVE → HIDDEN transition fired');
+  assert(transitions.includes('hidden->frozen'),
+    'HIDDEN → FROZEN transition fired');
+}
+flushContainers();
+
 // -- 8. pageshow with persisted: true → FROZEN → ACTIVE (if visible) -------
 //    bfcache restoration: dispatchable as event; the real bfcache roundtrip
 //    is NOT modeled in jsdom. This is the Chrome-only end-to-end gap per


### PR DESCRIPTION
## Summary
- handle READY in the HTML adapter freeze/pagehide path by walking READY → ACTIVE → HIDDEN → FROZEN
- add lifecycle adapter coverage for pagehide(persisted=true) while the container is READY

## Tests
- npm run test:html-lifecycle-adapter
- npm run check

Closes #99