### PR TITLE
test: cover freeze from ready lifecycle state

### DIFF
--- a/test/node/test-html-lifecycle-adapter.js
+++ b/test/node/test-html-lifecycle-adapter.js
@@ -320,6 +320,31 @@ flushContainers();
 }
 flushContainers();
 
+// -- 7c. freeze event from READY → ACTIVE → HIDDEN → FROZEN ---------------
+{
+  console.log('\n7c. freeze event from READY → FROZEN');
+  const transitions = [];
+  const { c } = makeContainer({
+    onStateChange: (s, prev) => transitions.push(`${prev}->${s}`),
+  });
+
+  const ready = c.setState(ContainerStates.READY);
+  assert(ready === true, 'pre: LOADING → READY accepted');
+
+  document.dispatchEvent(new dom.window.Event('freeze'));
+  await sleep(5);
+
+  assert(c.getState() === ContainerStates.FROZEN,
+    'freeze walks READY → ACTIVE → HIDDEN → FROZEN');
+  assert(transitions.includes('ready->active'),
+    'READY → ACTIVE transition fired');
+  assert(transitions.includes('active->hidden'),
+    'ACTIVE → HIDDEN transition fired');
+  assert(transitions.includes('hidden->frozen'),
+    'HIDDEN → FROZEN transition fired');
+}
+flushContainers();
+
 // -- 8. pageshow with persisted: true → FROZEN → ACTIVE (if visible) -------
 //    bfcache restoration: dispatchable as event; the real bfcache roundtrip
 //    is NOT modeled in jsdom. This is the Chrome-only end-to-end gap per


### PR DESCRIPTION
## Summary
- add the companion READY-state regression for the document freeze event
- keep the follow-up test-only; production handling already landed in #164

## Tests
- npm run test:html-lifecycle-adapter

Refs #99
Follow-up to #164