### PR TITLE
fix: validate creative placement type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+### Changed
+
+- **Creative placement type validation** ([#59]). `setPlacementType()` now
+  throws `TypeError` for values other than `inline` or `interstitial`, surfacing
+  creative-side misconfiguration before `createSession`.
+
 ## [0.7.3] - 2026-05-21
 
 Closes PR [#122]. This release keeps OMID container-owned and removes the last

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test": "npm run build && npm run size",
     "test:smoke": "node test/node/test-smoke.js",
     "test:treeshake": "node test/node/test-treeshake.js",
+    "test:creative-protocol-placement-type": "node test/node/test-creative-protocol-placement-type.js",
     "test:placement": "node test/node/test-placement-dedup.js",
     "test:placement-stamping": "node test/node/test-placement-stamping.js",
     "test:creative-sources": "node test/node/test-creative-sources.js",
@@ -70,7 +71,7 @@
     "test:renderer-fallback": "node test/node/test-renderer-domparser-fallback.js",
     "test:perf": "node test/node/test-creative-sources-perf.js",
     "test:types": "tsc -p test/types/tsconfig.json",
-    "test:all": "npm run test:smoke && npm run test:treeshake && npm run test:placement && npm run test:placement-stamping && npm run test:creative-sources && npm run test:creative-sources-load && npm run test:browser && npm run test:navigation-bridge && npm run test:creative-sdk-autoinstall && npm run test:creative-sdk-injection && npm run test:bridges-detection && npm run test:non-sharc-loading && npm run test:html-lifecycle-adapter && npm run test:omid-container-lifecycle && npm run test:renderer-fallback",
+    "test:all": "npm run test:smoke && npm run test:treeshake && npm run test:creative-protocol-placement-type && npm run test:placement && npm run test:placement-stamping && npm run test:creative-sources && npm run test:creative-sources-load && npm run test:browser && npm run test:navigation-bridge && npm run test:creative-sdk-autoinstall && npm run test:creative-sdk-injection && npm run test:bridges-detection && npm run test:non-sharc-loading && npm run test:html-lifecycle-adapter && npm run test:omid-container-lifecycle && npm run test:renderer-fallback",
     "regen:baseline": "node scripts/regen-mraid3-baseline.js",
     "lint": "eslint src/*.js --max-warnings=0",
     "check": "npm run build && npm run test:all && npm run size && npm run build"

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -152,7 +152,7 @@ class SHARCCreative {
     /** Whether the creative has reached its internal terminated bookend. @type {boolean} @private */
     this._terminated = false;
 
-    /** Placement type: 'inline' or 'interstitial'. Defaults to 'inline'. @type {string} */
+    /** Placement type. Defaults to 'inline'. @type {'inline'|'interstitial'} */
     this.placementType = 'inline';
   }
 

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -1172,9 +1172,15 @@ class SHARCCreativeProtocol extends SHARCProtocolBase {
    * Sets the placement type to be sent in the next createSession message.
    * Provides a typed accessor for the public Creative SDK so it can configure
    * placement type without reaching into the protocol's private field.
-   * @param {string} type - 'inline' or 'interstitial'.
+   * @param {'inline'|'interstitial'} type - Placement type.
+   * @throws {TypeError} If type is not 'inline' or 'interstitial'.
    */
   setPlacementType(type) {
+    if (type !== 'inline' && type !== 'interstitial') {
+      throw new TypeError(
+        `[SHARC Creative] placementType must be 'inline' or 'interstitial'; got '${type}'`,
+      );
+    }
     this._placementType = type;
   }
 

--- a/test/node/test-creative-protocol-placement-type.js
+++ b/test/node/test-creative-protocol-placement-type.js
@@ -1,0 +1,97 @@
+/**
+ * test-creative-protocol-placement-type.js — issue #59 regression
+ *
+ * Covers SHARCCreativeProtocol#setPlacementType validation. The creative
+ * protocol should only accept placement types supported by createSession.
+ *
+ * Runs in Node after `npm run build`.
+ */
+
+const { SHARCCreativeProtocol, ProtocolMessages } = await import('../../dist/sharc-protocol.mjs');
+
+let failures = 0;
+function assert(condition, message) {
+  if (condition) {
+    console.log('  ✓', message);
+  } else {
+    console.error('  ✗', message);
+    failures++;
+  }
+}
+
+function assertThrowsTypeError(fn, pattern, message) {
+  try {
+    fn();
+    console.error('  ✗', message);
+    failures++;
+  } catch (err) {
+    assert(err instanceof TypeError, `${message} throws TypeError`);
+    assert(pattern.test(err.message), `${message} error message is actionable`);
+  }
+}
+
+async function captureCreateSessionPlacementType(proto) {
+  let sent = null;
+  proto._portReadyPromise = Promise.resolve();
+  proto._sendMessage = (type, args) => {
+    sent = { type, args };
+    return Promise.resolve();
+  };
+  await proto.createSession();
+  assert(sent && sent.type === ProtocolMessages.CREATE_SESSION,
+    'createSession sends SHARC:Creative:createSession');
+  return sent.args.placementType;
+}
+
+console.log('test-creative-protocol-placement-type.js — issue #59 regression\n');
+
+// -- 1. Defaults to inline --------------------------------------------------
+{
+  console.log('1. createSession defaults placementType to inline');
+  const proto = new SHARCCreativeProtocol();
+  const placementType = await captureCreateSessionPlacementType(proto);
+  assert(placementType === 'inline',
+    'default createSession placementType is inline');
+}
+
+// -- 2. Accepts supported placement types ----------------------------------
+{
+  console.log('\n2. setPlacementType accepts inline and interstitial');
+  const inlineProto = new SHARCCreativeProtocol();
+  inlineProto.setPlacementType('inline');
+  const inlinePlacementType = await captureCreateSessionPlacementType(inlineProto);
+  assert(inlinePlacementType === 'inline',
+    'setPlacementType("inline") flows into createSession');
+
+  const interstitialProto = new SHARCCreativeProtocol();
+  interstitialProto.setPlacementType('interstitial');
+  const interstitialPlacementType = await captureCreateSessionPlacementType(interstitialProto);
+  assert(interstitialPlacementType === 'interstitial',
+    'setPlacementType("interstitial") flows into createSession');
+}
+
+// -- 3. Rejects unsupported placement types --------------------------------
+{
+  console.log('\n3. setPlacementType rejects unsupported values');
+  const proto = new SHARCCreativeProtocol();
+  proto.setPlacementType('interstitial');
+
+  for (const value of ['banner', '', null, undefined]) {
+    assertThrowsTypeError(
+      () => proto.setPlacementType(value),
+      /placementType must be 'inline' or 'interstitial'/,
+      `setPlacementType(${String(value)})`,
+    );
+  }
+
+  const placementType = await captureCreateSessionPlacementType(proto);
+  assert(placementType === 'interstitial',
+    'rejected placementType does not mutate the previous valid value');
+}
+
+if (failures > 0) {
+  console.error(`\n✗ ${failures} creative protocol placement type assertion(s) failed.`);
+  process.exit(1);
+}
+
+console.log('\n✓ All creative protocol placement type assertions passed.');


### PR DESCRIPTION
## Summary
- make SHARCCreativeProtocol#setPlacementType throw TypeError for values other than inline or interstitial
- type the Creative SDK placementType field to the same allowed values
- add focused protocol coverage and include it in test:all
- document the behavior change in CHANGELOG.md

## Tests
- npm run build
- npm run test:creative-protocol-placement-type
- npm run check
- npm run lint

Closes #59