### PR TITLE
docs: document creative SDK injection parser limits

### DIFF
--- a/docs/operator-cookbook.md
+++ b/docs/operator-cookbook.md
@@ -70,10 +70,12 @@ Setting it on a Creative URL container does not inject the SDK and does not
 advertise the feature flag. URL-variant parity is tracked in
 [issue #106](https://github.com/jeffreycarlson/SHARC/issues/106).
 
-Known limit: if your inventory contains malformed HTML with embedded quotes,
-entity-encoded URLs, or pathologically long repeated `<script` tokens, the
-built-in `skipIfPresent` detector can behave imperfectly. The catalog is in
-[issue #104](https://github.com/jeffreycarlson/SHARC/issues/104).
+Known limit: the built-in SDK injector uses lightweight regex anchors rather
+than a full HTML tokenizer. It can behave imperfectly when malformed or exotic
+markup places `<head>` inside comments, uses legacy SGML doctype internal
+subsets, includes literal `>` characters inside quoted `<head>` attributes, or
+uses entity-encoded/pathological script markup for the idempotency guard. The
+catalog is in [issue #104](https://github.com/jeffreycarlson/SHARC/issues/104).
 
 ## 2. Render Non-SHARC Creatives in a SHARC Container
 

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -2682,6 +2682,21 @@ class SHARCContainer {
    *      branch is the refinement (2026-05-17).
    *   4. Prepend — true fragment (no doctype, no `<html>`, no `<head>`).
    *
+   * Known parser limitations (#104): this helper intentionally uses small,
+   * dependency-free regex anchors rather than a full HTML tokenizer. That keeps
+   * SDK injection synchronous and lightweight, but means malformed/exotic markup
+   * can produce stable-but-imperfect output:
+   *
+   *   - A `<head>` token inside an HTML comment can be selected as the injection
+   *     point, leaving the SDK script inside the comment where it will not run.
+   *   - A legacy SGML doctype internal subset can be split at the first `>`.
+   *   - A literal `>` inside a quoted `<head>` attribute can terminate the
+   *     regex match early and splice the SDK tag into the attribute text.
+   *
+   * These are operator-footgun cases, not a security boundary. If they become
+   * common in real inventory, replace the anchor search with an HTML tokenizer
+   * and update the #104 tests that pin the current limitations.
+   *
    * Idempotency: when `_creativeSdkSkipIfPresent` is true (default), markup
    * already containing a `<script src="...sharc-creative.js">` tag passes
    * through unchanged. The script-src context is required — bare substring

--- a/test/node/test-creative-sdk-injection.js
+++ b/test/node/test-creative-sdk-injection.js
@@ -1111,6 +1111,57 @@ const SDK_URL = 'https://op.example/sharc-creative.js';
   flushContainers();
 }
 
+// 7c — issue #104 documents known regex-parser limitations. These are
+//      intentionally pinned as current behavior so a later tokenizer-based
+//      fix can update the assertions deliberately.
+{
+  console.log('\n7c. Known regex-parser limitations are documented');
+
+  const expectedTag = '<script src="' + SDK_URL + '"></script>';
+
+  // 7c-1 — `<head>` inside an HTML comment is still selected by the head
+  //        anchor regex, so the SDK tag lands inside the comment and will
+  //        not execute in a browser.
+  {
+    const html = '<!DOCTYPE html><html><!-- <head> --><body>x</body></html>';
+    const c = track(new SHARCContainer(baseMarkupOpts({
+      creativeHtml: html,
+      creativeSdkUrl: SDK_URL,
+    })));
+    const out = c._runMarkupInjection();
+    assert(out === '<!DOCTYPE html><html><!-- <head>' + expectedTag + ' --><body>x</body></html>',
+      '7c-1. comment-contained <head> remains a known silent-no-op injection position');
+  }
+
+  // 7c-2 — legacy SGML doctype internal subsets are split at the first `>`
+  //        because the doctype anchor is intentionally regex-based.
+  {
+    const html = '<!DOCTYPE html [<!ENTITY foo "bar">]><body>x</body>';
+    const c = track(new SHARCContainer(baseMarkupOpts({
+      creativeHtml: html,
+      creativeSdkUrl: SDK_URL,
+    })));
+    const out = c._runMarkupInjection();
+    assert(out === '<!DOCTYPE html [<!ENTITY foo "bar">' + expectedTag + ']><body>x</body>',
+      '7c-2. SGML doctype internal subset split at first > is documented');
+  }
+
+  // 7c-3 — literal `>` inside a quoted <head> attribute terminates the regex
+  //        match early, so the SDK tag is spliced into the attribute text.
+  {
+    const html = '<html><head data-x=">"><title>x</title></head><body>x</body></html>';
+    const c = track(new SHARCContainer(baseMarkupOpts({
+      creativeHtml: html,
+      creativeSdkUrl: SDK_URL,
+    })));
+    const out = c._runMarkupInjection();
+    assert(out === '<html><head data-x=">' + expectedTag + '"><title>x</title></head><body>x</body></html>',
+      '7c-3. quoted > inside <head> attribute remains a documented parser limitation');
+  }
+
+  flushContainers();
+}
+
 // =========================================================================
 // 8. URL-variant capability honesty (PR #105 review Fix 1)
 // =========================================================================


### PR DESCRIPTION
## Summary
- document the built-in creative SDK injector's known regex-parser limitations in the helper JSDoc
- expand the operator cookbook warning for comment, legacy doctype, and quoted-head-attribute edge cases
- add focused tests that pin the current #104 limitations for future tokenizer work

## Tests
- npm run test:creative-sdk-injection
- npm run check
- npm run lint

Closes #104