### PR TITLE
fix: scan creative SDK injection anchors

### DIFF
--- a/docs/operator-cookbook.md
+++ b/docs/operator-cookbook.md
@@ -70,12 +70,12 @@ Setting it on a Creative URL container does not inject the SDK and does not
 advertise the feature flag. URL-variant parity is tracked in
 [issue #106](https://github.com/jeffreycarlson/SHARC/issues/106).
 
-Known limit: the built-in SDK injector uses lightweight regex anchors rather
-than a full HTML tokenizer. It can behave imperfectly when malformed or exotic
-markup places `<head>` inside comments, uses legacy SGML doctype internal
-subsets, includes literal `>` characters inside quoted `<head>` attributes, or
-uses entity-encoded/pathological script markup for the idempotency guard. The
-catalog is in [issue #104](https://github.com/jeffreycarlson/SHARC/issues/104).
+Known limit: the built-in SDK injector uses lightweight scanning rather than a
+full HTML tokenizer. It handles comment-contained `<head>` tokens, legacy SGML
+doctype internal subsets, and literal `>` characters inside quoted `<head>`
+attributes, but the `creativeSdkSkipIfPresent` idempotency guard still uses a
+targeted regex and can behave imperfectly with entity-encoded or pathological
+script markup.
 
 ## 2. Render Non-SHARC Creatives in a SHARC Container
 

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -2662,6 +2662,110 @@ class SHARCContainer {
   }
 
   /**
+   * Finds the insertion index for built-in creative SDK injection.
+   *
+   * This intentionally stays small and dependency-free while avoiding the
+   * known regex anchor pitfalls: comment-contained tags, `>` inside quoted tag
+   * attributes, and `>` inside legacy doctype internal subsets.
+   *
+   * @param {string} html - Pre-injection markup.
+   * @returns {number|null} Insertion index, or null when no anchor is present.
+   * @private
+   */
+  static _findCreativeSdkInjectionIndex(html) {
+    let htmlIndex = null;
+    let doctypeIndex = null;
+
+    for (let i = 0; i < html.length; i++) {
+      if (html.charCodeAt(i) !== 60 /* < */) continue;
+
+      if (html.startsWith('<!--', i)) {
+        const commentEnd = html.indexOf('-->', i + 4);
+        if (commentEnd === -1) return htmlIndex !== null ? htmlIndex : doctypeIndex;
+        i = commentEnd + 2;
+        continue;
+      }
+
+      const lower = html.slice(i, i + 9).toLowerCase();
+      if (lower.startsWith('<!doctype')) {
+        const end = SHARCContainer._findMarkupDeclarationEnd(html, i + 9);
+        if (end !== -1 && doctypeIndex === null) doctypeIndex = end + 1;
+        if (end !== -1) i = end;
+        continue;
+      }
+
+      if (html.charCodeAt(i + 1) === 47 /* / */) continue;
+
+      const nameStart = i + 1;
+      let nameEnd = nameStart;
+      while (/[A-Za-z0-9]/.test(html.charAt(nameEnd))) nameEnd++;
+      const tagName = html.slice(nameStart, nameEnd).toLowerCase();
+      if (tagName !== 'head' && tagName !== 'html') continue;
+
+      const boundary = html.charAt(nameEnd);
+      if (boundary !== '>' && !/\s/.test(boundary)) continue;
+
+      const tagEnd = SHARCContainer._findMarkupTagEnd(html, nameEnd);
+      if (tagEnd === -1) continue;
+      if (tagName === 'head') return tagEnd + 1;
+      if (htmlIndex === null) htmlIndex = tagEnd + 1;
+      i = tagEnd;
+    }
+
+    return htmlIndex !== null ? htmlIndex : doctypeIndex;
+  }
+
+  /**
+   * Finds the closing `>` for a markup tag, ignoring `>` inside quoted attrs.
+   * @param {string} html
+   * @param {number} start
+   * @returns {number}
+   * @private
+   */
+  static _findMarkupTagEnd(html, start) {
+    let quote = '';
+    for (let i = start; i < html.length; i++) {
+      const ch = html.charAt(i);
+      if (quote) {
+        if (ch === quote) quote = '';
+      } else if (ch === '"' || ch === "'") {
+        quote = ch;
+      } else if (ch === '>') {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Finds the closing `>` for declarations such as `<!DOCTYPE ...>`, ignoring
+   * quoted text and `>` inside legacy internal subsets.
+   * @param {string} html
+   * @param {number} start
+   * @returns {number}
+   * @private
+   */
+  static _findMarkupDeclarationEnd(html, start) {
+    let quote = '';
+    let bracketDepth = 0;
+    for (let i = start; i < html.length; i++) {
+      const ch = html.charAt(i);
+      if (quote) {
+        if (ch === quote) quote = '';
+      } else if (ch === '"' || ch === "'") {
+        quote = ch;
+      } else if (ch === '[') {
+        bracketDepth++;
+      } else if (ch === ']' && bracketDepth > 0) {
+        bracketDepth--;
+      } else if (ch === '>' && bracketDepth === 0) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
    * Built-in injection: inserts a `<script src="creativeSdkUrl"></script>` tag
    * into Markup-variant creative HTML at the most-specific position present.
    * Runs FIRST in `_runMarkupInjection` (before any operator extensions), so
@@ -2670,32 +2774,16 @@ class SHARCContainer {
    *
    * Position contract (4-step, locked 2026-05-17):
    *
-   *   1. After `<head>` open tag — most specific. Lookahead `(?=[\s>])` rejects
-   *      `<header>`, `<headers>`, etc. — the bare `<head[^>]*>` pattern would
-   *      otherwise greedily consume `<header class="top">` and splice the SDK
-   *      inside the header element on Bootstrap/Tailwind landing-page creatives.
-   *   2. After `<html>` open tag — same `(?=[\s>])` lookahead defense against
+   *   1. After `<head>` open tag — most specific. Token scanning rejects
+   *      `<header>`, `<headers>`, comment-contained `<head>`, and `>` inside
+   *      quoted attributes.
+   *   2. After `<html>` open tag — same token-boundary defense against
    *      `<htmlfoo>` and similar non-`<html>` start sequences.
    *   3. After `<!DOCTYPE>` — fragment with doctype only. Inserting BEFORE the
    *      doctype pushes the browser into quirks-mode rendering, subtly breaking
    *      legacy creatives that rely on standards-mode layout. Explicit AFTER
    *      branch is the refinement (2026-05-17).
    *   4. Prepend — true fragment (no doctype, no `<html>`, no `<head>`).
-   *
-   * Known parser limitations (#104): this helper intentionally uses small,
-   * dependency-free regex anchors rather than a full HTML tokenizer. That keeps
-   * SDK injection synchronous and lightweight, but means malformed/exotic markup
-   * can produce stable-but-imperfect output:
-   *
-   *   - A `<head>` token inside an HTML comment can be selected as the injection
-   *     point, leaving the SDK script inside the comment where it will not run.
-   *   - A legacy SGML doctype internal subset can be split at the first `>`.
-   *   - A literal `>` inside a quoted `<head>` attribute can terminate the
-   *     regex match early and splice the SDK tag into the attribute text.
-   *
-   * These are operator-footgun cases, not a security boundary. If they become
-   * common in real inventory, replace the anchor search with an HTML tokenizer
-   * and update the #104 tests that pin the current limitations.
    *
    * Idempotency: when `_creativeSdkSkipIfPresent` is true (default), markup
    * already containing a `<script src="...sharc-creative.js">` tag passes
@@ -2755,12 +2843,10 @@ class SHARCContainer {
       this._creativeSdkUrl,
       this._creativeSdkScriptAttrs,
     );
-    const headMatch = html.match(/<head(?=[\s>])[^>]*>/i);
-    if (headMatch) return html.replace(headMatch[0], headMatch[0] + scriptTag);
-    const htmlMatch = html.match(/<html(?=[\s>])[^>]*>/i);
-    if (htmlMatch) return html.replace(htmlMatch[0], htmlMatch[0] + scriptTag);
-    const doctypeMatch = html.match(/<!DOCTYPE[^>]*>/i);
-    if (doctypeMatch) return html.replace(doctypeMatch[0], doctypeMatch[0] + scriptTag);
+    const insertionIndex = SHARCContainer._findCreativeSdkInjectionIndex(html);
+    if (insertionIndex !== null) {
+      return html.slice(0, insertionIndex) + scriptTag + html.slice(insertionIndex);
+    }
     return scriptTag + html;
   }
 

--- a/test/node/test-creative-sdk-injection.js
+++ b/test/node/test-creative-sdk-injection.js
@@ -1111,17 +1111,14 @@ const SDK_URL = 'https://op.example/sharc-creative.js';
   flushContainers();
 }
 
-// 7c — issue #104 documents known regex-parser limitations. These are
-//      intentionally pinned as current behavior so a later tokenizer-based
-//      fix can update the assertions deliberately.
+// 7c — issue #168 runtime hardening for the #104 parser limitations.
 {
-  console.log('\n7c. Known regex-parser limitations are documented');
+  console.log('\n7c. Tokenizer-style anchor scanning fixes known parser limitations');
 
   const expectedTag = '<script src="' + SDK_URL + '"></script>';
 
-  // 7c-1 — `<head>` inside an HTML comment is still selected by the head
-  //        anchor regex, so the SDK tag lands inside the comment and will
-  //        not execute in a browser.
+  // 7c-1 — `<head>` inside an HTML comment must be ignored; injection falls
+  //        back to the real <html> anchor.
   {
     const html = '<!DOCTYPE html><html><!-- <head> --><body>x</body></html>';
     const c = track(new SHARCContainer(baseMarkupOpts({
@@ -1129,12 +1126,11 @@ const SDK_URL = 'https://op.example/sharc-creative.js';
       creativeSdkUrl: SDK_URL,
     })));
     const out = c._runMarkupInjection();
-    assert(out === '<!DOCTYPE html><html><!-- <head>' + expectedTag + ' --><body>x</body></html>',
-      '7c-1. comment-contained <head> remains a known silent-no-op injection position');
+    assert(out === '<!DOCTYPE html><html>' + expectedTag + '<!-- <head> --><body>x</body></html>',
+      '7c-1. comment-contained <head> ignored; SDK injected after real <html>');
   }
 
-  // 7c-2 — legacy SGML doctype internal subsets are split at the first `>`
-  //        because the doctype anchor is intentionally regex-based.
+  // 7c-2 — legacy SGML doctype internal subsets must remain intact.
   {
     const html = '<!DOCTYPE html [<!ENTITY foo "bar">]><body>x</body>';
     const c = track(new SHARCContainer(baseMarkupOpts({
@@ -1142,12 +1138,12 @@ const SDK_URL = 'https://op.example/sharc-creative.js';
       creativeSdkUrl: SDK_URL,
     })));
     const out = c._runMarkupInjection();
-    assert(out === '<!DOCTYPE html [<!ENTITY foo "bar">' + expectedTag + ']><body>x</body>',
-      '7c-2. SGML doctype internal subset split at first > is documented');
+    assert(out === '<!DOCTYPE html [<!ENTITY foo "bar">]>' + expectedTag + '<body>x</body>',
+      '7c-2. SGML doctype internal subset stays intact; SDK injected after complete doctype');
   }
 
-  // 7c-3 — literal `>` inside a quoted <head> attribute terminates the regex
-  //        match early, so the SDK tag is spliced into the attribute text.
+  // 7c-3 — literal `>` inside a quoted <head> attribute must not terminate
+  //        the open tag early.
   {
     const html = '<html><head data-x=">"><title>x</title></head><body>x</body></html>';
     const c = track(new SHARCContainer(baseMarkupOpts({
@@ -1155,8 +1151,8 @@ const SDK_URL = 'https://op.example/sharc-creative.js';
       creativeSdkUrl: SDK_URL,
     })));
     const out = c._runMarkupInjection();
-    assert(out === '<html><head data-x=">' + expectedTag + '"><title>x</title></head><body>x</body></html>',
-      '7c-3. quoted > inside <head> attribute remains a documented parser limitation');
+    assert(out === '<html><head data-x=">">' + expectedTag + '<title>x</title></head><body>x</body></html>',
+      '7c-3. quoted > inside <head> attribute preserved; SDK injected after full tag');
   }
 
   flushContainers();


### PR DESCRIPTION
## Summary
- replace creative SDK injection anchor regexes with a lightweight tokenizer-style scanner
- ignore comment-contained tags, preserve quoted > in tag attributes, and keep legacy doctype internal subsets intact
- update the #104 pinned limitation tests to assert the fixed behavior
- narrow the operator cookbook warning to the remaining skipIfPresent regex caveat

## Tests
- npm run build
- npm run test:creative-sdk-injection
- npm run lint
- npx tsc --noEmit
- npm run check

Closes #168
Refs #104