### PR TITLE
refactor: convert bridge plugins to classes

### DIFF
--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -1059,7 +1059,6 @@ function installMRAIDBridge(SHARC) {
  * Container-side extension that signals the SHARC container to inject the
  * MRAID bridge scripts into the creative iframe before creative code runs.
  *
- * @constructor
  * @param {Object} [options] - Configuration options.
  * @param {string} [options.baseUrl='/sharc'] - Base URL path for bridge script injection.
  *   Must resolve to trusted SHARC-hosted assets, because the wrapper injects scripts from this location into the creative iframe before creative code runs.
@@ -1070,36 +1069,36 @@ function installMRAIDBridge(SHARC) {
  *     extensions: [new MRAIDCompatBridge()]
  *   });
  */
-function MRAIDCompatBridge(options) {
-  this.name = 'com.iabtechlab.sharc.mraid';
-  this.options = options || {};
-  if (this.options.baseUrl != null) {
-    validateBridgeBaseUrl(this.options.baseUrl);
+class MRAIDCompatBridge {
+  constructor(options = {}) {
+    this.name = 'com.iabtechlab.sharc.mraid';
+    this.options = options;
+    if (this.options.baseUrl != null) {
+      validateBridgeBaseUrl(this.options.baseUrl);
+    }
   }
-}
 
-MRAIDCompatBridge.prototype = {
   /**
    * Returns the list of script URLs to inject before the creative.
    * The container should prepend these to the wrapper page or inject via srcdoc.
    * @returns {string[]}
    */
-  getScriptUrls: function () {
+  getScriptUrls() {
     var base = this.options.baseUrl || '/sharc';
     return [
       base + '/sharc-protocol.js',
       base + '/sharc-creative.js',
       base + '/sharc-mraid-bridge.js',
     ];
-  },
+  }
 
   /**
    * Returns the feature advertisement string for Container:init.
    * @returns {string}
    */
-  getFeatureName: function () {
+  getFeatureName() {
     return this.name;
-  },
+  }
 
   /**
    * Returns the wrapper URL for a given creative URL.
@@ -1107,11 +1106,11 @@ MRAIDCompatBridge.prototype = {
    * @param {string} creativeUrl
    * @returns {string}
    */
-  getWrapperUrl: function (creativeUrl) {
+  getWrapperUrl(creativeUrl) {
     var base = this.options.baseUrl || '/sharc';
     return base + '/mraid-wrapper.html?creative=' + encodeURIComponent(creativeUrl);
-  },
-};
+  }
+}
 
 // ---------------------------------------------------------------------------
 // ESM exports

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -682,7 +682,6 @@ function installSafeFrameBridge(SHARC) {
  * Container-side extension that signals the SHARC container to inject the
  * SafeFrame bridge scripts into the creative iframe before creative code runs.
  *
- * @constructor
  * @param {Object} [options] - Configuration options.
  * @param {string} [options.baseUrl='/sharc'] - Base URL path for bridge script injection.
  *   Must resolve to trusted SHARC-hosted assets, because the wrapper injects scripts from this location into the creative iframe before creative code runs.
@@ -693,36 +692,36 @@ function installSafeFrameBridge(SHARC) {
  *     extensions: [new SafeFrameCompatBridge()]
  *   });
  */
-function SafeFrameCompatBridge(options) {
-  this.name    = 'com.iabtechlab.sharc.safeframe';
-  this.options = options || {};
-  if (this.options.baseUrl != null) {
-    validateBridgeBaseUrl(this.options.baseUrl);
+class SafeFrameCompatBridge {
+  constructor(options = {}) {
+    this.name    = 'com.iabtechlab.sharc.safeframe';
+    this.options = options;
+    if (this.options.baseUrl != null) {
+      validateBridgeBaseUrl(this.options.baseUrl);
+    }
   }
-}
 
-SafeFrameCompatBridge.prototype = {
   /**
    * Returns the list of script URLs to inject before the creative.
    * The container should prepend these to the wrapper page or inject via srcdoc.
    * @returns {string[]}
    */
-  getScriptUrls: function () {
+  getScriptUrls() {
     var base = this.options.baseUrl || '/sharc';
     return [
       base + '/sharc-protocol.js',
       base + '/sharc-creative.js',
       base + '/sharc-safeframe-bridge.js',
     ];
-  },
+  }
 
   /**
    * Returns the feature advertisement string for Container:init.
    * @returns {string}
    */
-  getFeatureName: function () {
+  getFeatureName() {
     return this.name;
-  },
+  }
 
   /**
    * Returns the wrapper URL for a given creative URL.
@@ -730,10 +729,10 @@ SafeFrameCompatBridge.prototype = {
    * @param {string} creativeUrl
    * @returns {string}
    */
-  getWrapperUrl: function (creativeUrl) {
+  getWrapperUrl(creativeUrl) {
     var base = this.options.baseUrl || '/sharc';
     return base + '/safeframe-wrapper.html?creative=' + encodeURIComponent(creativeUrl);
-  },
+  }
 
   /**
    * Augments environmentData with sfMeta before Container:init is sent.
@@ -742,11 +741,11 @@ SafeFrameCompatBridge.prototype = {
    * @param {Object} environmentData - The environment data object to augment
    * @param {Object} [sfMeta] - SafeFrame metadata: { shared: {}, owned: {} }
    */
-  setMeta: function (environmentData, sfMeta) {
+  setMeta(environmentData, sfMeta) {
     if (!environmentData) return;
     environmentData.sfMeta = sfMeta || { shared: {}, owned: {} };
-  },
-};
+  }
+}
 
 // ---------------------------------------------------------------------------
 // ESM exports


### PR DESCRIPTION
## Summary
- convert MRAIDCompatBridge and SafeFrameCompatBridge from constructor/prototype objects to ES6 classes
- preserve the existing public methods, default constructor behavior, and baseUrl validation
- verify generated declarations expose a single class surface with optional constructor args

## Tests
- npm run build
- npm run lint
- npm run test:bridges-detection
- npm run test:browser
- npm run test:types
- npm run check

Closes #33