### PR TITLE
refactor: extract creative sources validation

### DIFF
--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -652,280 +652,17 @@ class SHARCContainer {
       );
     }
 
-    // Generate the placementSessionId up-front so any structured event fired
-    // during construction (e.g. the wrapper-cross-origin carve-out below)
-    // carries the SAME UUID that the constructed instance will expose. The
-    // assignment to `this.placementSessionId` happens later, but the value is
-    // captured here so observability pipelines can correlate construction-time
-    // security events to the running container.
-    const placementSessionId = SHARCContainer._generateUUID();
-
-    // ── Creative Sources — 8 sequenced validation rules. ──
-    // Evaluated in order; first violation throws. Shape errors (rules 1–3,
-    // TypeError) precede value errors (rules 4–8, Error). See proposal:
-    // docs/proposals/creative-sources.md § Validation Rules.
-    //
-    // Note on `''` (empty string) handling: empty strings for `creativeUrl`,
-    // `creativeHtml`, and `creativeRendererUrl` are intentionally treated as
-    // "not provided" — same as `null`/`undefined`. Operators passing an empty
-    // string have nothing to load; conflating that with absent makes rule 1
-    // fire with the more useful "got neither" message instead of "got empty
-    // string."
-    const hasCreativeUrl = creativeUrl != null && creativeUrl !== '';
-    const hasCreativeHtml = creativeHtml != null && creativeHtml !== '';
-    const hasRendererUrl = creativeRendererUrl != null && creativeRendererUrl !== '';
-
-    // Rule 1: exactly one of `creativeUrl` or `creativeHtml`. Neither or both → TypeError.
-    if (!hasCreativeUrl && !hasCreativeHtml) {
-      throw new TypeError(
-        '[SHARCContainer] creativeUrl is required (or pass creativeHtml + creativeRendererUrl '
-        + 'for inline-markup Creative Markup variant). Got neither.'
-      );
-    }
-    if (hasCreativeUrl && hasCreativeHtml) {
-      throw new TypeError(
-        '[SHARCContainer] creativeUrl and creativeHtml are mutually exclusive — '
-        + 'exactly one must be provided. Got both.'
-      );
-    }
-
-    // Rule 2: `creativeHtml` requires `creativeRendererUrl`.
-    if (hasCreativeHtml && !hasRendererUrl) {
-      throw new TypeError(
-        '[SHARCContainer] creativeHtml requires creativeRendererUrl '
-        + '(operator-hosted renderer page). Bare srcdoc is not supported — '
-        + 'see proposal § Bare srcdoc breaks silently.'
-      );
-    }
-
-    // Rule 3: `creativeRendererUrl` is only valid alongside `creativeHtml`.
-    if (hasCreativeUrl && hasRendererUrl) {
-      throw new TypeError(
-        '[SHARCContainer] creativeRendererUrl is only valid alongside creativeHtml '
-        + '(Creative Markup variant). Remove creativeRendererUrl when using creativeUrl.'
-      );
-    }
-
-    // Rule 3b (0.7.1, issue #82): `bridges` and `creativeMeta` are Creative Markup
-    // variant only. The Creative URL variant doesn't load bridges (no renderer
-    // protocol), so silently dropping these options would mislead operators
-    // who pass `bridges: ['mraid']` alongside `creativeUrl` and wonder why
-    // MRAID doesn't auto-install. Mirrors Rule 3's variant-coupling check.
-    if (hasCreativeUrl && (bridges !== undefined || creativeMeta !== undefined)) {
-      throw new TypeError(
-        '[SHARCContainer] bridges and creativeMeta options are only valid alongside '
-        + 'creativeHtml (Creative Markup variant); the Creative URL variant does not load bridges. '
-        + 'Remove the bridges/creativeMeta options when using creativeUrl.'
-      );
-    }
+    const {
+      placementSessionId,
+      parsedRendererUrl,
+      hasCreativeUrl,
+      hasCreativeHtml,
+      hasRendererUrl,
+    } = SHARCContainer._validateCreativeSources(options, {
+      window: (typeof window !== 'undefined') ? window : undefined,
+    });
 
     if (!placementElement) throw new Error('[SHARCContainer] placementElement is required');
-
-    // Rules 4–7 only apply when the Markup variant is in use (renderer URL present).
-    /** @type {URL|null} */
-    let parsedRendererUrl = null;
-    if (hasRendererUrl) {
-      // Rule 4: `creativeRendererUrl` must parse via `new URL(...)`.
-      try {
-        parsedRendererUrl = new URL(creativeRendererUrl);
-      } catch (_) {
-        throw new Error(
-          '[SHARCContainer] creativeRendererUrl is not a parseable URL: '
-          + JSON.stringify(creativeRendererUrl)
-        );
-      }
-
-      const rendererOrigin = parsedRendererUrl.origin;
-      const windowOrigin = (typeof window !== 'undefined' && window.location)
-        ? window.location.origin
-        : null;
-      const isDevWindowOrigin = windowOrigin !== null
-        && DEV_ORIGIN_PATTERNS.some((pattern) => pattern.test(windowOrigin));
-      const isDevRendererOrigin =
-        DEV_ORIGIN_PATTERNS.some((pattern) => pattern.test(rendererOrigin));
-      const isLocalHttpDevRenderer = parsedRendererUrl.protocol === 'http:'
-        && isDevWindowOrigin
-        && isDevRendererOrigin;
-
-      // Rule 5: must use exactly the `https:` scheme, with a narrow localhost
-      // carve-out so the bundled HTTP dev server can continue to exercise the
-      // Creative Markup renderer protocol in browser tests. The carve-out only
-      // applies when BOTH publisher and renderer origins are recognized dev
-      // origins; production pages cannot point at a user's localhost renderer.
-      if (parsedRendererUrl.protocol !== 'https:' && !isLocalHttpDevRenderer) {
-        throw new Error(
-          '[SHARCContainer] creativeRendererUrl must use the https: scheme '
-          + '(got "' + parsedRendererUrl.protocol + '"). http: is allowed only '
-          + 'for localhost-style renderer URLs when the publisher page is also '
-          + 'running on a recognized dev origin. javascript:, data:, blob:, file:, '
-          + 'about:, and other schemes are rejected — they collapse the '
-          + 'cross-origin sandbox guarantee.'
-        );
-      }
-
-      // Rule 6: must not contain userinfo.
-      if (parsedRendererUrl.username !== '' || parsedRendererUrl.password !== '') {
-        throw new Error(
-          '[SHARCContainer] creativeRendererUrl must not contain userinfo '
-          + '(username or password). Strip credentials from the URL before passing it.'
-        );
-      }
-
-      // Rule 7: must be cross-origin to `window.location` and `window.top.location`.
-      // When `window.top.location` access throws (cross-origin top frame), the
-      // wrapper carve-out applies — `wrapperPolicy` governs warn-vs-block behavior.
-      if (windowOrigin !== null && rendererOrigin === windowOrigin) {
-        throw new Error(
-          '[SHARCContainer] creativeRendererUrl must be cross-origin to window.location '
-          + '(got same-origin: "' + rendererOrigin + '"). Same-origin renderer collapses '
-          + 'the sandbox isolation that makes Creative Markup safe.'
-        );
-      }
-      let topOrigin = null;
-      let topAccessThrew = false;
-      try {
-        // Reading window.top.location.origin throws on cross-origin top frame.
-        topOrigin = (typeof window !== 'undefined' && window.top && window.top.location)
-          ? window.top.location.origin
-          : null;
-      } catch (err) {
-        // Only treat true cross-origin SecurityError as the wrapper carve-out
-        // signal. A bare `catch (_)` would silently swallow unrelated TypeErrors
-        // (e.g. window.top poisoned by userland Object.defineProperty, detached
-        // frame edge cases) and fail-open under default wrapperPolicy='warn'.
-        // SecurityError DOMException is what every major browser throws for
-        // cross-origin top.location reads.
-        if (err && err.name === 'SecurityError') {
-          topAccessThrew = true;
-        } else {
-          // Unknown failure mode — re-throw so the operator sees the real
-          // problem instead of silently routing into the carve-out path.
-          throw err;
-        }
-      }
-      if (!topAccessThrew && topOrigin !== null && rendererOrigin === topOrigin) {
-        throw new Error(
-          '[SHARCContainer] creativeRendererUrl must be cross-origin to window.top.location '
-          + '(got same-origin: "' + rendererOrigin + '"). Same-origin to publisher top '
-          + 'collapses the sandbox isolation that makes Creative Markup safe.'
-        );
-      }
-      if (topAccessThrew) {
-        // Wrapper carve-out: cross-origin top frame inaccessible. Behavior governed
-        // by wrapperPolicy (default 'warn'). See proposal § Security Model
-        // § wrapper-cross-origin and DD-19.
-        const severity = wrapperPolicy === 'block' ? 'error' : 'warning';
-        const message = 'Validation rule 7 carve-out applied — cross-origin top frame '
-          + 'detected; cannot verify creativeRendererUrl is cross-origin to the '
-          + "publisher's top-level page. This is an unsupported deployment unless "
-          + 'the operator has independently guaranteed creativeRendererUrl is not '
-          + 'same-origin with any publisher top this wrapper is embedded into.';
-        const consoleMethod = wrapperPolicy === 'block' ? 'error' : 'warn';
-        // Phase D Compliance Auditor F1: prefix `[<placementSessionId>]` so
-        // multi-container pages can correlate the carve-out warning back to a
-        // specific instance. This matches `_emitSecurityEventAndTerminate`'s
-        // dev-channel format. The wrapper carve-out stays inline (rather than
-        // routing through that helper) because it is the only NON-terminating
-        // security event — the helper unconditionally terminates.
-        console[consoleMethod]('[SHARCContainer] [' + placementSessionId + '] ' + message);
-        // Route through the static-equivalent of `_invokeSecurityCallback`
-        // for try/catch + spec-compliant log parity with the chokepoint.
-        // The instance method isn't usable here because `this._onSecurityEvent`
-        // and `this.placementSessionId` are not yet assigned (lines 716/765
-        // below). We invoke the same shared helper with the local `onSecurityEvent`
-        // / `placementSessionId` parameters captured at construction.
-        SHARCContainer._safeInvokeSecurityCallback(onSecurityEvent, placementSessionId, {
-          type: 'wrapper_top_frame_inaccessible',
-          severity: severity,
-          timestamp: Date.now(),
-          // The same UUID the constructed instance will expose as
-          // `this.placementSessionId` — captured up-front for correlation.
-          placementSessionId: placementSessionId,
-          message: message,
-          details: {
-            wrapperOrigin: windowOrigin,
-            creativeRendererUrl: creativeRendererUrl,
-            // publisher top origin intentionally omitted — we cannot read it.
-          },
-        });
-        if (wrapperPolicy === 'block') {
-          throw new Error('[SHARCContainer] ' + message);
-        }
-      }
-
-      // Production-block guard (issue #55 / Phase F):
-      // `KNOWN_TEST_RENDERERS` are SDK-reference deployments hosted by SHARC
-      // maintainers for evaluation and integration testing only. Loading one
-      // from a non-dev origin almost always indicates a misconfiguration that
-      // would land the canonical test URL in production traffic. The guard
-      // throws synchronously at construction so the operator sees the failure
-      // before any iframe / MessageChannel / page-lifecycle listener attaches.
-      // See docs/proposals/creative-sources.md § Renderer Ownership Model
-      // and the KNOWN_TEST_RENDERERS / DEV_ORIGIN_PATTERNS module constants.
-      //
-      // Normalize on origin+pathname so the match ignores query/fragment and
-      // catches the canonical URL whether or not the operator includes the
-      // trailing slash. GitHub Pages 301-redirects the slashless variant to
-      // the canonical URL, so both forms must trip the guard — comparing the
-      // raw `parsedRendererUrl.href` would let `…/SHARC/renderer` (no slash)
-      // slip past while `…/SHARC/renderer/` is rejected.
-      const stripTrailingSlash = (s) => s.replace(/\/+$/, '');
-      const candidatePathKey = stripTrailingSlash(
-        parsedRendererUrl.origin + parsedRendererUrl.pathname
-      );
-      const isKnownTestRenderer = KNOWN_TEST_RENDERERS.some((testUrl) => {
-        const t = new URL(testUrl);
-        const tKey = stripTrailingSlash(t.origin + t.pathname);
-        // Exact match, OR candidate is under the test renderer's path prefix
-        // (e.g. '.../renderer/foo' is still the test renderer). The `+ '/'`
-        // suffix on the prefix variant prevents accidental matching of
-        // siblings like `/SHARC/renderer-other/`.
-        return candidatePathKey === tKey
-          || candidatePathKey.startsWith(tKey + '/');
-      });
-      if (isKnownTestRenderer) {
-        const isDevOrigin = windowOrigin !== null
-          && DEV_ORIGIN_PATTERNS.some((pattern) => pattern.test(windowOrigin));
-        if (!isDevOrigin) {
-          throw new Error(
-            '[SHARCContainer] creativeRendererUrl "' + parsedRendererUrl.href
-            + '" is a known SHARC reference test renderer. Production deployments '
-            + 'must use an operator-controlled renderer URL. Recognized dev origins '
-            + 'are localhost / 127.0.0.1 / *.localhost / *.test / *.local / [::1] / '
-            + '0.0.0.0. See docs/proposals/creative-sources.md § Renderer Ownership Model.'
-          );
-        }
-      }
-    }
-
-    // Rule 8: `creativeHtml` size must not exceed 256 KiB at construction (pre-injection).
-    if (hasCreativeHtml) {
-      // String.length is UTF-16 code units; the cap is UTF-8 bytes. TextEncoder
-      // is universally available in SHARC's target environments (modern browsers
-      // + Node 18+) and gives an exact UTF-8 byte count. Buffer.byteLength is
-      // a Node-only secondary path. If neither is reachable, throw — better to
-      // surface the environment problem than silently inflate by a worst-case
-      // 4× factor and false-reject near-cap markup.
-      let byteLength;
-      if (typeof TextEncoder !== 'undefined') {
-        byteLength = new TextEncoder().encode(creativeHtml).length;
-      } else if (typeof Buffer !== 'undefined') {
-        byteLength = Buffer.byteLength(creativeHtml, 'utf8');
-      } else {
-        throw new Error(
-          '[SHARCContainer] Cannot measure creativeHtml byte size: neither '
-          + 'TextEncoder nor Buffer is available in this environment.'
-        );
-      }
-      const MAX_BYTES = 256 * 1024;
-      if (byteLength > MAX_BYTES) {
-        throw new Error(
-          '[SHARCContainer] creativeHtml exceeds 256 KiB at construction '
-          + '(' + byteLength + ' bytes; cap is ' + MAX_BYTES + '). RTB markup norms '
-          + 'are well below this — payloads this large almost always indicate a bug.'
-        );
-      }
-    }
 
     // Rule 9: `bridges` is null/undefined OR an array of recognized identifier
     // strings. Stricter than the renderer-side handling because constructor
@@ -5265,6 +5002,258 @@ class SHARCContainer {
     if (this._closeButton) {
       this._closeButton.setAttribute('data-sharc-placement-session-id', this.placementSessionId);
     }
+  }
+
+  /**
+   * Validates Creative URL vs Creative Markup constructor inputs and returns
+   * the construction-time values needed by the instance setup path.
+   *
+   * Evaluated in order; first violation throws. Shape errors (rules 1-3,
+   * TypeError) precede value errors (rules 4-8, Error). See proposal:
+   * docs/proposals/creative-sources.md § Validation Rules.
+   *
+   * @param {{
+   *   creativeUrl?: string|null|undefined,
+   *   creativeHtml?: string|null|undefined,
+   *   creativeRendererUrl?: any,
+   *   onSecurityEvent?: SHARCSecurityEventCallback|undefined,
+   *   wrapperPolicy?: string|undefined,
+   *   bridges?: string[]|null|undefined,
+   *   creativeMeta?: Object|null|undefined,
+   * }} options
+   * @param {{window?: Window|undefined}} env
+   * @returns {{
+   *   placementSessionId: string,
+   *   parsedRendererUrl: URL|null,
+   *   hasCreativeUrl: boolean,
+   *   hasCreativeHtml: boolean,
+   *   hasRendererUrl: boolean,
+   * }}
+   * @private
+   */
+  static _validateCreativeSources(options, env = {}) {
+    const {
+      creativeUrl,
+      creativeHtml,
+      creativeRendererUrl,
+      onSecurityEvent,
+      wrapperPolicy = 'warn',
+      bridges,
+      creativeMeta,
+    } = options || {};
+    const win = env.window;
+
+    // Generate the placementSessionId up-front so any structured event fired
+    // during construction (e.g. the wrapper-cross-origin carve-out below)
+    // carries the SAME UUID that the constructed instance will expose.
+    const placementSessionId = SHARCContainer._generateUUID();
+
+    // Note on `''` (empty string) handling: empty strings for `creativeUrl`,
+    // `creativeHtml`, and `creativeRendererUrl` are intentionally treated as
+    // "not provided" — same as `null`/`undefined`. Operators passing an empty
+    // string have nothing to load; conflating that with absent makes rule 1
+    // fire with the more useful "got neither" message instead of "got empty
+    // string."
+    const hasCreativeUrl = creativeUrl != null && creativeUrl !== '';
+    const hasCreativeHtml = creativeHtml != null && creativeHtml !== '';
+    const hasRendererUrl = creativeRendererUrl != null && creativeRendererUrl !== '';
+
+    // Rule 1: exactly one of `creativeUrl` or `creativeHtml`. Neither or both -> TypeError.
+    if (!hasCreativeUrl && !hasCreativeHtml) {
+      throw new TypeError(
+        '[SHARCContainer] creativeUrl is required (or pass creativeHtml + creativeRendererUrl '
+        + 'for inline-markup Creative Markup variant). Got neither.'
+      );
+    }
+    if (hasCreativeUrl && hasCreativeHtml) {
+      throw new TypeError(
+        '[SHARCContainer] creativeUrl and creativeHtml are mutually exclusive — '
+        + 'exactly one must be provided. Got both.'
+      );
+    }
+
+    // Rule 2: `creativeHtml` requires `creativeRendererUrl`.
+    if (hasCreativeHtml && !hasRendererUrl) {
+      throw new TypeError(
+        '[SHARCContainer] creativeHtml requires creativeRendererUrl '
+        + '(operator-hosted renderer page). Bare srcdoc is not supported — '
+        + 'see proposal § Bare srcdoc breaks silently.'
+      );
+    }
+
+    // Rule 3: `creativeRendererUrl` is only valid alongside `creativeHtml`.
+    if (hasCreativeUrl && hasRendererUrl) {
+      throw new TypeError(
+        '[SHARCContainer] creativeRendererUrl is only valid alongside creativeHtml '
+        + '(Creative Markup variant). Remove creativeRendererUrl when using creativeUrl.'
+      );
+    }
+
+    // Rule 3b (0.7.1, issue #82): `bridges` and `creativeMeta` are Creative Markup
+    // variant only. The Creative URL variant doesn't load bridges (no renderer
+    // protocol), so silently dropping these options would mislead operators.
+    if (hasCreativeUrl && (bridges !== undefined || creativeMeta !== undefined)) {
+      throw new TypeError(
+        '[SHARCContainer] bridges and creativeMeta options are only valid alongside '
+        + 'creativeHtml (Creative Markup variant); the Creative URL variant does not load bridges. '
+        + 'Remove the bridges/creativeMeta options when using creativeUrl.'
+      );
+    }
+
+    /** @type {URL|null} */
+    let parsedRendererUrl = null;
+    if (hasRendererUrl) {
+      // Rule 4: `creativeRendererUrl` must parse via `new URL(...)`.
+      try {
+        parsedRendererUrl = new URL(creativeRendererUrl);
+      } catch (_) {
+        throw new Error(
+          '[SHARCContainer] creativeRendererUrl is not a parseable URL: '
+          + JSON.stringify(creativeRendererUrl)
+        );
+      }
+
+      const rendererOrigin = parsedRendererUrl.origin;
+      const windowOrigin = (win && win.location) ? win.location.origin : null;
+      const isDevWindowOrigin = windowOrigin !== null
+        && DEV_ORIGIN_PATTERNS.some((pattern) => pattern.test(windowOrigin));
+      const isDevRendererOrigin =
+        DEV_ORIGIN_PATTERNS.some((pattern) => pattern.test(rendererOrigin));
+      const isLocalHttpDevRenderer = parsedRendererUrl.protocol === 'http:'
+        && isDevWindowOrigin
+        && isDevRendererOrigin;
+
+      // Rule 5: must use exactly the `https:` scheme, with a narrow localhost
+      // carve-out for bundled HTTP dev-server tests.
+      if (parsedRendererUrl.protocol !== 'https:' && !isLocalHttpDevRenderer) {
+        throw new Error(
+          '[SHARCContainer] creativeRendererUrl must use the https: scheme '
+          + '(got "' + parsedRendererUrl.protocol + '"). http: is allowed only '
+          + 'for localhost-style renderer URLs when the publisher page is also '
+          + 'running on a recognized dev origin. javascript:, data:, blob:, file:, '
+          + 'about:, and other schemes are rejected — they collapse the '
+          + 'cross-origin sandbox guarantee.'
+        );
+      }
+
+      // Rule 6: must not contain userinfo.
+      if (parsedRendererUrl.username !== '' || parsedRendererUrl.password !== '') {
+        throw new Error(
+          '[SHARCContainer] creativeRendererUrl must not contain userinfo '
+          + '(username or password). Strip credentials from the URL before passing it.'
+        );
+      }
+
+      // Rule 7: must be cross-origin to `window.location` and `window.top.location`.
+      // When `window.top.location` access throws (cross-origin top frame), the
+      // wrapper carve-out applies — `wrapperPolicy` governs warn-vs-block behavior.
+      if (windowOrigin !== null && rendererOrigin === windowOrigin) {
+        throw new Error(
+          '[SHARCContainer] creativeRendererUrl must be cross-origin to window.location '
+          + '(got same-origin: "' + rendererOrigin + '"). Same-origin renderer collapses '
+          + 'the sandbox isolation that makes Creative Markup safe.'
+        );
+      }
+      let topOrigin = null;
+      let topAccessThrew = false;
+      try {
+        topOrigin = (win && win.top && win.top.location) ? win.top.location.origin : null;
+      } catch (err) {
+        if (err && err.name === 'SecurityError') {
+          topAccessThrew = true;
+        } else {
+          throw err;
+        }
+      }
+      if (!topAccessThrew && topOrigin !== null && rendererOrigin === topOrigin) {
+        throw new Error(
+          '[SHARCContainer] creativeRendererUrl must be cross-origin to window.top.location '
+          + '(got same-origin: "' + rendererOrigin + '"). Same-origin to publisher top '
+          + 'collapses the sandbox isolation that makes Creative Markup safe.'
+        );
+      }
+      if (topAccessThrew) {
+        const severity = wrapperPolicy === 'block' ? 'error' : 'warning';
+        const message = 'Validation rule 7 carve-out applied — cross-origin top frame '
+          + 'detected; cannot verify creativeRendererUrl is cross-origin to the '
+          + "publisher's top-level page. This is an unsupported deployment unless "
+          + 'the operator has independently guaranteed creativeRendererUrl is not '
+          + 'same-origin with any publisher top this wrapper is embedded into.';
+        const consoleMethod = wrapperPolicy === 'block' ? 'error' : 'warn';
+        console[consoleMethod]('[SHARCContainer] [' + placementSessionId + '] ' + message);
+        SHARCContainer._safeInvokeSecurityCallback(onSecurityEvent, placementSessionId, {
+          type: 'wrapper_top_frame_inaccessible',
+          severity: severity,
+          timestamp: Date.now(),
+          placementSessionId: placementSessionId,
+          message: message,
+          details: {
+            wrapperOrigin: windowOrigin,
+            creativeRendererUrl: creativeRendererUrl,
+          },
+        });
+        if (wrapperPolicy === 'block') {
+          throw new Error('[SHARCContainer] ' + message);
+        }
+      }
+
+      // Production-block guard (issue #55 / Phase F): block known SHARC
+      // reference renderers from non-dev publisher origins.
+      const stripTrailingSlash = (s) => s.replace(/\/+$/, '');
+      const candidatePathKey = stripTrailingSlash(
+        parsedRendererUrl.origin + parsedRendererUrl.pathname
+      );
+      const isKnownTestRenderer = KNOWN_TEST_RENDERERS.some((testUrl) => {
+        const t = new URL(testUrl);
+        const tKey = stripTrailingSlash(t.origin + t.pathname);
+        return candidatePathKey === tKey
+          || candidatePathKey.startsWith(tKey + '/');
+      });
+      if (isKnownTestRenderer) {
+        const isDevOrigin = windowOrigin !== null
+          && DEV_ORIGIN_PATTERNS.some((pattern) => pattern.test(windowOrigin));
+        if (!isDevOrigin) {
+          throw new Error(
+            '[SHARCContainer] creativeRendererUrl "' + parsedRendererUrl.href
+            + '" is a known SHARC reference test renderer. Production deployments '
+            + 'must use an operator-controlled renderer URL. Recognized dev origins '
+            + 'are localhost / 127.0.0.1 / *.localhost / *.test / *.local / [::1] / '
+            + '0.0.0.0. See docs/proposals/creative-sources.md § Renderer Ownership Model.'
+          );
+        }
+      }
+    }
+
+    // Rule 8: `creativeHtml` size must not exceed 256 KiB at construction (pre-injection).
+    if (hasCreativeHtml) {
+      let byteLength;
+      if (typeof TextEncoder !== 'undefined') {
+        byteLength = new TextEncoder().encode(creativeHtml).length;
+      } else if (typeof Buffer !== 'undefined') {
+        byteLength = Buffer.byteLength(creativeHtml, 'utf8');
+      } else {
+        throw new Error(
+          '[SHARCContainer] Cannot measure creativeHtml byte size: neither '
+          + 'TextEncoder nor Buffer is available in this environment.'
+        );
+      }
+      const MAX_BYTES = 256 * 1024;
+      if (byteLength > MAX_BYTES) {
+        throw new Error(
+          '[SHARCContainer] creativeHtml exceeds 256 KiB at construction '
+          + '(' + byteLength + ' bytes; cap is ' + MAX_BYTES + '). RTB markup norms '
+          + 'are well below this — payloads this large almost always indicate a bug.'
+        );
+      }
+    }
+
+    return {
+      placementSessionId,
+      parsedRendererUrl,
+      hasCreativeUrl,
+      hasCreativeHtml,
+      hasRendererUrl,
+    };
   }
 
   /**

--- a/test/node/test-creative-sources.js
+++ b/test/node/test-creative-sources.js
@@ -101,6 +101,12 @@ function markupOptions(overrides) {
     ...overrides,
   };
 }
+function validationWindow(origin = PUBLISHER_ORIGIN) {
+  return {
+    location: { origin },
+    top: { location: { origin } },
+  };
+}
 
 console.log('test-creative-sources.js — issue #41 Phase A regression\n');
 
@@ -117,6 +123,75 @@ console.log('test-creative-sources.js — issue #41 Phase A regression\n');
     'RENDERER_PROTOCOL_ERROR === 2117');
   assert(ErrorCodes.RENDERER_UNAUTHORIZED_NAVIGATION === 2118,
     'RENDERER_UNAUTHORIZED_NAVIGATION === 2118');
+}
+
+// -- 1b. _validateCreativeSources direct unit surface (#64) ────────────────
+{
+  console.log('\n1b. _validateCreativeSources direct unit surface');
+
+  const urlResult = SHARCContainer._validateCreativeSources(
+    { creativeUrl: 'https://ads.example/creative.html' },
+    { window: validationWindow() },
+  );
+  assert(typeof urlResult.placementSessionId === 'string' && urlResult.placementSessionId.length > 0,
+    '_validateCreativeSources returns placementSessionId');
+  assert(urlResult.parsedRendererUrl === null,
+    '_validateCreativeSources returns null parsedRendererUrl for URL variant');
+  assert(urlResult.hasCreativeUrl === true && urlResult.hasCreativeHtml === false && urlResult.hasRendererUrl === false,
+    '_validateCreativeSources returns source presence flags for URL variant');
+
+  const markupResult = SHARCContainer._validateCreativeSources(
+    { creativeHtml: '<html></html>', creativeRendererUrl: RENDERER_URL },
+    { window: validationWindow() },
+  );
+  assert(markupResult.parsedRendererUrl instanceof URL
+    && markupResult.parsedRendererUrl.origin === 'https://renderer.operator.example',
+    '_validateCreativeSources parses renderer URL for Markup variant');
+  assert(markupResult.hasCreativeUrl === false && markupResult.hasCreativeHtml === true && markupResult.hasRendererUrl === true,
+    '_validateCreativeSources returns source presence flags for Markup variant');
+
+  assertThrows(
+    () => SHARCContainer._validateCreativeSources(
+      { creativeUrl: 'https://ads.example/creative.html', bridges: ['mraid'] },
+      { window: validationWindow() },
+    ),
+    /bridges and creativeMeta options are only valid/,
+    '_validateCreativeSources rejects Creative URL + bridges without jsdom container setup',
+    TypeError,
+  );
+
+  const events = [];
+  const warns = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warns.push(args.join(' '));
+  try {
+    const crossOriginTopWindow = {
+      location: { origin: PUBLISHER_ORIGIN },
+      top: {
+        get location() {
+          const err = new Error('Blocked a frame with origin from accessing a cross-origin frame.');
+          err.name = 'SecurityError';
+          throw err;
+        },
+      },
+    };
+    const wrapperResult = SHARCContainer._validateCreativeSources(
+      {
+        creativeHtml: '<html></html>',
+        creativeRendererUrl: RENDERER_URL,
+        onSecurityEvent: (event) => events.push(event),
+      },
+      { window: crossOriginTopWindow },
+    );
+    assert(wrapperResult.placementSessionId === events[0].placementSessionId,
+      '_validateCreativeSources wrapper carve-out event uses returned placementSessionId');
+    assert(warns[0] && warns[0].includes('Validation rule 7 carve-out applied'),
+      '_validateCreativeSources wrapper carve-out logs warning without constructing container');
+    assert(events[0] && events[0].type === 'wrapper_top_frame_inaccessible',
+      '_validateCreativeSources wrapper carve-out emits security event');
+  } finally {
+    console.warn = originalWarn;
+  }
 }
 
 // -- 2. Rule 1 — exactly one of creativeUrl or creativeHtml ────────────────


### PR DESCRIPTION
## Summary
- extract Creative Sources constructor rules into SHARCContainer._validateCreativeSources(options, { window })
- keep constructor behavior unchanged while returning placementSessionId, parsedRendererUrl, and source presence flags
- add direct unit coverage for the static helper, including URL/Markup variants and wrapper carve-out correlation

## Tests
- npm run build
- npm run test:creative-sources
- npm run lint
- npx tsc --noEmit
- npm run check

Closes #64