### PR TITLE
refactor: retire bridge wrapper url helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+### Removed
+
+- **Bridge `getWrapperUrl` helpers retired** ([#149]). `MRAIDCompatBridge`,
+  `SafeFrameCompatBridge`, and `OmidCompatBridge` no longer expose
+  `getWrapperUrl(creativeUrl)`. The helper constructed a
+  `<baseUrl>/<feature>-wrapper.html?creative=<encoded>` string, but the
+  container never consumed it; the OMID variant was explicitly documented
+  as a dead compatibility stub since 0.7.3. Operators wiring wrapper-page
+  flows can construct the URL inline. The wrapper HTML pages themselves
+  (`test/browser/mraid-wrapper.html` and
+  `test/browser/safeframe-wrapper.html`) are unchanged.
+
 ## [0.7.4] - 2026-05-24
 
 **OMID hardening release.** Finishes five OMID hardening items
@@ -169,6 +181,7 @@ for the release-level design and ADRs.
 [#124]: https://github.com/jeffreycarlson/SHARC/issues/124
 [#125]: https://github.com/jeffreycarlson/SHARC/issues/125
 [#126]: https://github.com/jeffreycarlson/SHARC/issues/126
+[#149]: https://github.com/jeffreycarlson/SHARC/issues/149
 [#164]: https://github.com/jeffreycarlson/SHARC/pull/164
 [#175]: https://github.com/jeffreycarlson/SHARC/pull/175
 [#177]: https://github.com/jeffreycarlson/SHARC/pull/177

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -1099,17 +1099,6 @@ class MRAIDCompatBridge {
   getFeatureName() {
     return this.name;
   }
-
-  /**
-   * Returns the wrapper URL for a given creative URL.
-   * The container should load this URL in the ad iframe instead of the creative directly.
-   * @param {string} creativeUrl
-   * @returns {string}
-   */
-  getWrapperUrl(creativeUrl) {
-    var base = this.options.baseUrl || '/sharc';
-    return base + '/mraid-wrapper.html?creative=' + encodeURIComponent(creativeUrl);
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -323,7 +323,7 @@ function validateVerificationScripts(verificationScripts) {
  * @param {string} [options.omSdkServiceScriptUrl]  - URL of the OM SDK service script (omweb-v1.js).
  * @param {string} [options.omSdkSessionClientUrl]  - URL of the OM SDK session client script.
  * @param {string} [options.baseUrl='/sharc']       - Base URL for SHARC scripts.
- *   Must resolve to trusted SHARC-hosted assets when wrapperUrl is used.
+ *   Must resolve to trusted SHARC-hosted assets.
  * @param {string} [options.partnerName]            - OM SDK partner name.
  * @param {string} [options.partnerVersion]         - OM SDK partner version.
  * @param {Array}  [options.verificationScripts]    - OM SDK VerificationScriptResource objects.
@@ -517,28 +517,6 @@ OmidCompatBridge.prototype = /** @type {any} */ ({
    */
   injectIntoMarkup: function (html) {
     return html;
-  },
-
-  /**
-   * Returns a wrapper URL for a given creative URL.
-   *
-   * **Status (#127 sub-3c):** legacy compatibility stub. The container-owned
-   * OMID model (0.7.3, PR #122) does NOT use a wrapper-page approach — OM
-   * SDK runs on the publisher page and the creative iframe loads the
-   * creative directly. This method exists for bridge-interface parity with
-   * `MRAIDCompatBridge.getWrapperUrl` and `SafeFrameCompatBridge.getWrapperUrl`
-   * (where the wrapper page is still part of the legacy flow). Operators
-   * should NOT call this method for OMID setup; OMID lifecycle is driven by
-   * the container directly via `OmidCompatBridge` as an extension. Retirement
-   * of `getWrapperUrl` across all three bridges is a separate decision not
-   * scoped to 0.7.3.
-   *
-   * @param {string} creativeUrl - Original creative URL.
-   * @returns {string} The wrapper URL.
-   */
-  getWrapperUrl: function (creativeUrl) {
-    var base = this.options.baseUrl || '/sharc';
-    return base + '/omid-wrapper.html?creative=' + encodeURIComponent(creativeUrl);
   },
 
   /**

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -724,17 +724,6 @@ class SafeFrameCompatBridge {
   }
 
   /**
-   * Returns the wrapper URL for a given creative URL.
-   * The container should load this URL in the ad iframe instead of the creative directly.
-   * @param {string} creativeUrl
-   * @returns {string}
-   */
-  getWrapperUrl(creativeUrl) {
-    var base = this.options.baseUrl || '/sharc';
-    return base + '/safeframe-wrapper.html?creative=' + encodeURIComponent(creativeUrl);
-  }
-
-  /**
    * Augments environmentData with sfMeta before Container:init is sent.
    * Call this from the container before creating the SHARC session.
    *

--- a/test/node/test-omid-container-lifecycle.js
+++ b/test/node/test-omid-container-lifecycle.js
@@ -5,7 +5,7 @@
  * container-owned lifecycle. Covers:
  *
  *   A. Public API surface (getFeatureName, getFeatureDescriptor, getScriptUrls,
- *      injectScripts, injectIntoMarkup, getWrapperUrl, augmentEnvironmentData,
+ *      injectScripts, injectIntoMarkup, augmentEnvironmentData,
  *      getFeatureVersion, getFeatureFunctions)
  *   B. Container lifecycle flow: load → ready → active → error/destroy/terminated
  *      Session creation, start, loaded/impression firing, idempotent finish
@@ -319,13 +319,6 @@ section('A. Public API surface — method existence and return types');
 
   // injectIntoMarkup
   assert(typeof bridge.injectIntoMarkup === 'function', 'injectIntoMarkup is a function');
-
-  // getWrapperUrl
-  assert(typeof bridge.getWrapperUrl === 'function', 'getWrapperUrl is a function');
-  const wrapperUrl = bridge.getWrapperUrl('https://creative.example/ad.html');
-  assert(typeof wrapperUrl === 'string', 'getWrapperUrl() returns a string');
-  assert(wrapperUrl.includes('creative.example'), 'getWrapperUrl() encodes creative URL in query param');
-  assert(wrapperUrl.includes('omid-wrapper'), 'getWrapperUrl() points to omid-wrapper resource');
 
   // augmentEnvironmentData
   assert(typeof bridge.augmentEnvironmentData === 'function', 'augmentEnvironmentData is a function');
@@ -1089,15 +1082,6 @@ section('G7. Edge cases — video session creates MediaEvents; display does not'
   } finally {
     uninstallMockSdk();
   }
-}
-
-section('G8. Edge cases — getWrapperUrl properly encodes creative URL');
-{
-  const bridge = new OmidCompatBridge({ baseUrl: 'https://cdn.example/sharc' });
-  const creative = 'https://creative.example/ad.html?id=1&type=video';
-  const wrapper = bridge.getWrapperUrl(creative);
-  assert(wrapper.includes(encodeURIComponent(creative)), 'getWrapperUrl: creative URL is properly encoded');
-  assert(!wrapper.includes('?id=1&type=video'), 'getWrapperUrl: raw query chars are encoded (& is not literal)');
 }
 
 section('G9. Edge cases — onContainerStateChange without prior load is safe');


### PR DESCRIPTION
## Release sequencing

Target this for 0.7.5 release notes. The branch was parked until after the 0.7.4 release because it removes a public bridge helper.

## Summary
- remove getWrapperUrl from MRAID, SafeFrame, and OMID bridge surfaces
- drop OMID tests that covered the retired wrapper helper
- remove the remaining wrapperUrl wording from OMID baseUrl docs

## Tests
- npm run build
- npm run test:omid-container-lifecycle
- npm run test:bridges-detection
- npm run lint
- npx tsc --noEmit
- npm run check

Closes #149