### PR TITLE
test: make creative sources build-mode aware

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import terser from '@rollup/plugin-terser';
 
 const isProduction = process.env.NODE_ENV === 'production';
+const buildMode = isProduction ? 'prod' : 'dev';
 
 // Build outputs for SHARC modules:
 //   - .js  = IIFE browser-global bundles (for <script src="...">)
@@ -17,6 +18,21 @@ const inputFiles = {
   'sharc-omid-bridge': 'src/sharc-omid-bridge.js',
   'sharc-navigation-bridge': 'src/sharc-navigation-bridge.js',
 };
+
+function replaceBuildMode() {
+  const replacement = JSON.stringify(buildMode);
+  return {
+    name: 'sharc-build-mode-replace',
+    renderChunk(code) {
+      return {
+        code: code
+          .replaceAll('"__SHARC_BUILD_MODE__"', replacement)
+          .replaceAll("'__SHARC_BUILD_MODE__'", replacement),
+        map: null,
+      };
+    },
+  };
+}
 
 export default Object.keys(inputFiles).map(moduleName => {
   return {
@@ -49,6 +65,7 @@ export default Object.keys(inputFiles).map(moduleName => {
         extensions: ['.js'],
       }),
       commonjs(),
+      replaceBuildMode(),
       ...(isProduction ? [
         terser({
           compress: {

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -212,6 +212,7 @@ const DEV_ORIGIN_PATTERNS = Object.freeze([
 ]);
 
 // SHARC_VERSION imported from sharc-protocol.js
+const SHARC_BUILD_MODE = /** @type {'dev'|'prod'} */ ('__SHARC_BUILD_MODE__');
 
 // ---------------------------------------------------------------------------
 // SHARCContainer
@@ -5690,13 +5691,14 @@ class SHARCContainer {
 // ---------------------------------------------------------------------------
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { SHARCContainer, DEFAULT_TIMEOUTS, SHARC_VERSION };
+  module.exports = { SHARCContainer, DEFAULT_TIMEOUTS, SHARC_VERSION, SHARC_BUILD_MODE };
 } else if (typeof window !== 'undefined') {
   window.SHARC = window.SHARC || {};
   window.SHARC.Container = SHARCContainer;
+  window.SHARC.ContainerBuildMode = SHARC_BUILD_MODE;
 }
 
 // ESM exports
 const SHARC = (typeof window !== 'undefined') ? window.SHARC : {};
 
-export { SHARCContainer, DEFAULT_TIMEOUTS, SHARC_VERSION, SHARC };
+export { SHARCContainer, DEFAULT_TIMEOUTS, SHARC_VERSION, SHARC_BUILD_MODE, SHARC };

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -158,6 +158,7 @@ declare global {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ErrorCodes: any;
       };
+      ContainerBuildMode?: 'dev' | 'prod';
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       Container?: any;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/node/test-creative-sources-load.js
+++ b/test/node/test-creative-sources-load.js
@@ -79,7 +79,7 @@ const protoMod = await import('../../dist/sharc-protocol.mjs');
 window.SHARC = window.SHARC || {};
 window.SHARC.Protocol = protoMod;
 
-const { SHARCContainer } = await import('../../dist/sharc-container.mjs');
+const { SHARCContainer, SHARC_BUILD_MODE } = await import('../../dist/sharc-container.mjs');
 const { ErrorCodes, SHARC_VERSION, RENDERER_PROTOCOL_VERSION } = protoMod;
 
 // ── Build-mode guard ──────────────────────────────────────────────────────
@@ -87,16 +87,12 @@ const { ErrorCodes, SHARC_VERSION, RENDERER_PROTOCOL_VERSION } = protoMod;
 // `console.error`. Several Phase C log-assertion tests would vacuously pass
 // against the prod bundle because `errorOutput.some(...)` returns false on an
 // empty array, and a few negative-shape assertions (`!/X/.test('')`) would
-// silently pass. Fail fast with a clear message instead. Issue #63 will
-// replace this with a build-time-injected constant once the broader
-// test-infra work lands.
+// silently pass. Fail fast with a clear message instead.
 {
-  const fs = await import('node:fs');
-  const distSrc = fs.readFileSync('./dist/sharc-container.mjs', 'utf8');
-  if (!/console\.error/.test(distSrc)) {
+  if (SHARC_BUILD_MODE !== 'dev') {
     console.error(
-      'FATAL: dist/sharc-container.mjs has zero console.error calls — '
-      + 'this is a production build (terser drop_console=true). Phase C log '
+      'FATAL: dist/sharc-container.mjs build mode is '
+      + JSON.stringify(SHARC_BUILD_MODE) + '. Phase C log '
       + 'assertions would vacuously pass. Re-run `npm run build` (dev mode) '
       + 'and try again.'
     );

--- a/test/node/test-creative-sources.js
+++ b/test/node/test-creative-sources.js
@@ -44,8 +44,10 @@ const protoMod = await import('../../dist/sharc-protocol.mjs');
 window.SHARC = window.SHARC || {};
 window.SHARC.Protocol = protoMod;
 
-const { SHARCContainer } = await import('../../dist/sharc-container.mjs');
+const { SHARCContainer, SHARC_BUILD_MODE } = await import('../../dist/sharc-container.mjs');
 const { ErrorCodes } = protoMod;
+const IS_DEV_BUILD = SHARC_BUILD_MODE === 'dev';
+const IS_PROD_BUILD = SHARC_BUILD_MODE === 'prod';
 
 // ── Tiny assertion harness ────────────────────────────────────────────────
 let failures = 0;
@@ -113,6 +115,8 @@ console.log('test-creative-sources.js — issue #41 Phase A regression\n');
 // -- 1. Error codes 2114-2118 are exposed on the protocol module ───────────
 {
   console.log('1. Error codes 2114-2118 exposed on ErrorCodes');
+  assert(IS_DEV_BUILD || IS_PROD_BUILD,
+    `SHARC_BUILD_MODE is injected as "dev" or "prod" (got ${JSON.stringify(SHARC_BUILD_MODE)})`);
   assert(ErrorCodes.RENDERER_TIMEOUT === 2114,
     'RENDERER_TIMEOUT === 2114');
   assert(ErrorCodes.RENDERER_FAILED === 2115,
@@ -185,8 +189,13 @@ console.log('test-creative-sources.js — issue #41 Phase A regression\n');
     );
     assert(wrapperResult.placementSessionId === events[0].placementSessionId,
       '_validateCreativeSources wrapper carve-out event uses returned placementSessionId');
-    assert(warns[0] && warns[0].includes('Validation rule 7 carve-out applied'),
-      '_validateCreativeSources wrapper carve-out logs warning without constructing container');
+    if (IS_DEV_BUILD) {
+      assert(warns[0] && warns[0].includes('Validation rule 7 carve-out applied'),
+        '_validateCreativeSources wrapper carve-out logs warning without constructing container (dev bundle)');
+    } else {
+      assert(warns.length === 0,
+        '_validateCreativeSources wrapper carve-out console warning is stripped in prod bundle');
+    }
     assert(events[0] && events[0].type === 'wrapper_top_frame_inaccessible',
       '_validateCreativeSources wrapper carve-out emits security event');
   } finally {
@@ -419,13 +428,15 @@ console.log('test-creative-sources.js — issue #41 Phase A regression\n');
     }
     assert(constructed instanceof SHARCContainer,
       "default wrapperPolicy='warn' proceeds with construction");
-    // Console output is dev-channel signalling only; prod bundles
-    // (`NODE_ENV=production`) strip it via terser `drop_console: true`. The
-    // structured-event channel below is the durable contract. Skip the console
-    // probe when no output was captured (signature of a prod bundle).
-    if (warned.length > 0) {
+    // Console output is dev-channel signalling only; prod bundles strip it via
+    // terser `drop_console: true`. The build-mode constant makes that explicit
+    // so a dev bundle that fails to warn cannot masquerade as a prod bundle.
+    if (IS_DEV_BUILD) {
       assert(warned.some((w) => /Validation rule 7 carve-out/.test(w)),
         'console.warn fires once with carve-out message (dev bundle)');
+    } else {
+      assert(warned.length === 0,
+        'console.warn is stripped from wrapper carve-out path in prod bundle');
     }
     assert(events.length === 1 && events[0].type === 'wrapper_top_frame_inaccessible',
       'onSecurityEvent fires with type=wrapper_top_frame_inaccessible');
@@ -472,10 +483,13 @@ console.log('test-creative-sources.js — issue #41 Phase A regression\n');
       console.error = originalError;
     }
     assert(threw, "wrapperPolicy='block' throws synchronously at construction");
-    // Same dev-vs-prod console caveat as 9a above.
-    if (errored.length > 0) {
+    // Same explicit dev-vs-prod console assertion as 9a above.
+    if (IS_DEV_BUILD) {
       assert(errored.some((e) => /Validation rule 7 carve-out/.test(e)),
         'console.error fires with carve-out message (dev bundle)');
+    } else {
+      assert(errored.length === 0,
+        'console.error is stripped from wrapperPolicy="block" carve-out path in prod bundle');
     }
     assert(events.length === 1 && events[0].severity === 'error',
       "onSecurityEvent fires with severity='error' before throw");


### PR DESCRIPTION
## Summary
- inject SHARC_BUILD_MODE into the container bundle at Rollup build time
- replace Creative Sources console-output inference with explicit dev/prod assertions
- replace the Creative Sources load source-scan guard with the build-mode constant

## Tests
- npm run build
- npm run test:creative-sources
- npm run test:creative-sources-load
- npm run lint
- npx tsc --noEmit
- npm run build:prod
- npm run test:creative-sources
- npm run check

Closes #63