### PR TITLE
chore(release): 0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,8 +116,29 @@ for the release-level design and ADRs.
   operator-visible contract is unchanged on Markup; URL variant now
   advertises the feature when (and only when) injection actually ran.
 
+### Fixed
+
+- **Freeze-from-READY lifecycle state walk** ([#164]). The HTML lifecycle
+  adapter's `_transitionToFrozen` previously handled ACTIVE / PASSIVE /
+  HIDDEN starting states but not READY. A container frozen directly from
+  READY now correctly walks READY → ACTIVE → HIDDEN → FROZEN (the state
+  machine only has a direct `HIDDEN → FROZEN` edge). Test coverage added
+  in `test/node/test-html-lifecycle-adapter.js`.
+- **Spoofed-renderer-marker warning** ([#175]). When the
+  `__sharcRenderer` marker is present on the creative window but the
+  navigation bridge is not installed, the creative SDK now emits a
+  `console.warn` instead of silently skipping the auto-install. Catches
+  the spoofed-marker case where a creative or wrapper sets the marker
+  but doesn't actually wire up the bridge, which would otherwise let
+  native `target="_blank"` clickthroughs bypass SHARC's navigation
+  audit.
+
 ### Docs
 
+- **Navigation callback semantics clarification** ([#177]). Updates
+  `docs/api-reference.md`, `docs/creative-cookbook.md`, and
+  `docs/getting-started.md` to clarify navigation-callback behavior;
+  small fix to `docs/design/0.7.2-WORK-IN-PROGRESS.md`.
 - **Legacy `requestOmid` audit closure** ([#121]). Historical-artifact
   banners on `docs/research/OM-sdk-research.md` and
   `docs/reviews/OM-sdk-architect-recommendations.md` — both pre-0.7.3 docs
@@ -141,12 +162,16 @@ for the release-level design and ADRs.
   code); this `Removed` entry records the closure under the version that
   finalized it.
 
+[#59]: https://github.com/jeffreycarlson/SHARC/issues/59
 [#102]: https://github.com/jeffreycarlson/SHARC/issues/102
 [#121]: https://github.com/jeffreycarlson/SHARC/issues/121
 [#123]: https://github.com/jeffreycarlson/SHARC/issues/123
 [#124]: https://github.com/jeffreycarlson/SHARC/issues/124
 [#125]: https://github.com/jeffreycarlson/SHARC/issues/125
 [#126]: https://github.com/jeffreycarlson/SHARC/issues/126
+[#164]: https://github.com/jeffreycarlson/SHARC/pull/164
+[#175]: https://github.com/jeffreycarlson/SHARC/pull/175
+[#177]: https://github.com/jeffreycarlson/SHARC/pull/177
 [#178]: https://github.com/jeffreycarlson/SHARC/issues/178
 
 ## [0.7.3] - 2026-05-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,56 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-05-24
+
+**OMID hardening release.** Finishes five OMID hardening items
+deferred from the 0.7.3 design (#121 legacy `requestOmid` audit closure,
+#123 extension error payload contract, #124 multi-bridge dedup warn,
+#125 `feature_load_failed` SecurityEvent variant, #126 termination-mid-load
+coverage), ships the headline URL-variant `creativeSdkUrl` injection
+feature (#106 — closes the 0.7.2 PR #105 follow-up), and ships a bfcache
+round-trip coverage scaffold (#102, wiring deferred to #178). See
+[`docs/design/0.7.4-omid-hardening.md`](docs/design/0.7.4-omid-hardening.md)
+for the release-level design and ADRs.
+
 ### Added
 
+- **`feature_load_failed` `SHARCSecurityEvent` variant** ([#125]). New
+  non-terminating discriminated-union variant fired when an extension's
+  load-time asset (e.g. the OM SDK script for `OmidCompatBridge`) fails to
+  load on the publisher page. Sibling to `bridge_load_failed`; this variant
+  covers the publisher-page extension-load path while `bridge_load_failed`
+  covers the renderer-side dynamic bridge import. Carries
+  `details: { featureName, reason, scriptUrl }` with `reason` as a
+  classified token (current in-tree bridges emit `'timeout'`, `'network'`,
+  or `'evaluation_throw'`) and `scriptUrl` bounded to 500 chars (parity
+  with `bridge_load_failed.details.url`). `OmidCompatBridge` is the first
+  in-tree consumer; the variant is generalizable to any future extension
+  that loads remote scripts. No `errorCode` (non-terminating; outside the
+  21xx renderer-error-code namespace).
+- **Extension-lifecycle error event payload contract pinned** ([#123]).
+  Both fatal-error paths (`_handleCreativeFatalError` and
+  `_handleFatalError`) already dispatched a canonical
+  `{ errorCode, errorMessage, source }` payload to extensions via
+  `onContainerLifecycleEvent({ type: 'error', ... })`. PR D adds
+  `test/node/test-omid-container-lifecycle.js` § H6 coverage to pin the
+  contract against future regression — the field is `errorMessage` (not
+  `message`), `source` discriminates `'creative'` vs. `'container'`, and
+  the assertion outright rejects any `message` alias per the 0.7.4 ADR.
+  `docs/api-reference.md` § 9 gains a new "Lifecycle event payloads"
+  subsection documenting the base event shape (including `state`),
+  per-type detail fields (including the correct `intent` field on
+  `placementChange`), and the error event payload contract. No production
+  code change — the implementation already met the contract.
+- **Termination-mid-load coverage** ([#126]). Pins the deferred-follow-up
+  edge case from PR #122: when termination or destroy fires while the OM
+  SDK script-load promise is still pending, the resolved promise must NOT
+  create a session, must NOT fire late callbacks, and must NOT emit
+  `feature_load_failed` (the failure here is normal teardown, not a
+  script-load failure). Five-section coverage (H1–H5) in
+  `test/node/test-omid-container-lifecycle.js`. No production code change —
+  the implementation already enforces the contract; these are regression
+  guards.
 - **bfcache round-trip Puppeteer coverage scaffold** ([#102]).
   `test/browser/test-html-lifecycle-adapter-bfcache.js` ships a 5-section
   contract scaffold (bf-1 through bf-5) covering the bfcache round-trip
@@ -49,6 +97,13 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ### Changed
 
+- **Multi-bridge dedup observability** ([#124]). When multiple AdCOM
+  `creativeMeta.apis` codes resolve to the same renderer bridge (e.g. two
+  MRAID-version codes that both load `sharc-mraid-bridge.js`), the
+  container now emits a single `console.warn` at `_mapAdComApisToBridges`
+  identifying which AdCOM codes collapsed and which bridge they
+  collapsed to. Scope is AdCOM-only (explicit `bridges: [...]` arrays
+  and adm-scan paths don't surface this race in practice).
 - **Creative placement type validation** ([#59]). `setPlacementType()` now
   throws `TypeError` for values other than `inline` or `interstitial`, surfacing
   creative-side misconfiguration before `createSession`.
@@ -61,7 +116,37 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   operator-visible contract is unchanged on Markup; URL variant now
   advertises the feature when (and only when) injection actually ran.
 
+### Docs
+
+- **Legacy `requestOmid` audit closure** ([#121]). Historical-artifact
+  banners on `docs/research/OM-sdk-research.md` and
+  `docs/reviews/OM-sdk-architect-recommendations.md` — both pre-0.7.3 docs
+  proposed a creative-initiated `SHARC:Creative:requestOmid` measurement
+  path that was later removed in favor of fully container-driven OMID
+  (decision log D7/D17 in `docs/design/0.7.3-omid-wiring.md`). Audit
+  confirmed zero residual symbols across `src/`, `test/`, `examples/`,
+  `dist/`, `scripts/` for the bidirectional grep
+  `requestOmid|installOmidBridge|SHARC:Creative:requestOmid|omid.*request|request.*omid`.
+  The banners preserve the historical docs while pointing future readers
+  to the as-shipped design.
+
+### Removed
+
+- **Legacy creative-side OMID APIs audit closure** ([#121]). The
+  creative-frame `installOmidBridge()` helper and the
+  `SHARC:Creative:requestOmid` message type that were added in 0.2.0 were
+  removed during the 0.7.2/0.7.3 cycle when OMID became fully
+  container-driven, but neither 0.7.2 nor 0.7.3 changelog recorded the
+  removal. PR C of 0.7.4 closed the audit (zero residuals in production
+  code); this `Removed` entry records the closure under the version that
+  finalized it.
+
 [#102]: https://github.com/jeffreycarlson/SHARC/issues/102
+[#121]: https://github.com/jeffreycarlson/SHARC/issues/121
+[#123]: https://github.com/jeffreycarlson/SHARC/issues/123
+[#124]: https://github.com/jeffreycarlson/SHARC/issues/124
+[#125]: https://github.com/jeffreycarlson/SHARC/issues/125
+[#126]: https://github.com/jeffreycarlson/SHARC/issues/126
 [#178]: https://github.com/jeffreycarlson/SHARC/issues/178
 
 ## [0.7.3] - 2026-05-21
@@ -1537,7 +1622,8 @@ messages are sent at additional transition points; no new message types.
 - `supportedFeatures` extension mechanism
 
 <!-- Version compare links (Update when new tags are pushed) -->
-[Unreleased]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.3...main
+[Unreleased]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.4...main
+[0.7.4]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.3...v0.7.4
 [0.7.3]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.0...v0.7.1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol reference implementation.
 
 > 📋 This repository is the current SHARC reference implementation and working specification set.
-> It is in active pre-1.0 development at package version `0.7.3` and is not yet published to npm.
+> It is in active pre-1.0 development at package version `0.7.4` and is not yet published to npm.
 > Start with the curated docs index at [docs/README.md](docs/README.md) and the current state summary at [docs/current-status.md](docs/current-status.md).
 
 ## Overview
@@ -122,7 +122,7 @@ Frozen instance properties are available for callbacks, dashboards, and validato
 
 ## Open Measurement (OMID)
 
-SHARC 0.7.3 ships container-owned OMID measurement through the `OmidCompatBridge` extension. The publisher page loads the OM SDK scripts, the container owns the full `AdSession` lifecycle, and OM SDK events fire automatically from SHARC container state transitions. Creatives do nothing — MRAID, SafeFrame, and SHARC-native creatives all receive OMID measurement transparently.
+SHARC ships container-owned OMID measurement through the `OmidCompatBridge` extension (introduced in 0.7.3; load-failure signaling added in 0.7.4). The publisher page loads the OM SDK scripts, the container owns the full `AdSession` lifecycle, and OM SDK events fire automatically from SHARC container state transitions. Creatives do nothing — MRAID, SafeFrame, and SHARC-native creatives all receive OMID measurement transparently.
 
 OMID is intentionally **not** a SHARC bridge. The `bridges` vocabulary stays scoped to renderer-loaded creative API compatibility (`'mraid'`, `'safeframe'`). OMID is measurement, not API translation, so it uses the `extensions` slot on `SHARCContainer` instead. The container rejects `bridges: ['omid']`, and AdCOM `APIFramework` code `7` does not auto-instantiate the bridge — installing `OmidCompatBridge` is always an explicit operator decision.
 
@@ -156,12 +156,19 @@ container.load();
 
 Both `omSdkServiceScriptUrl` and `omSdkSessionClientUrl` are required for the bridge to advertise `com.iabtechlab.sharc.omid` in `supportedFeatures`. When either URL is omitted, the bridge is inert and the feature is not declared.
 
-### What's shipped in 0.7.3
+### What's shipped
+
+**Core (0.7.3):**
 
 - **Automatic OM SDK loading.** Container loads the Service Script and Session Client on the publisher page from the two configured URLs (skipped if already present). Strict HTTPS validation on both URLs at construction; userinfo and non-HTTPS rejected.
 - **Automatic session lifecycle.** Session starts when the container reaches `READY`, fires `loaded()` and the impression once on the first viewable moment, tracks viewability across `ACTIVE ↔ PASSIVE / HIDDEN / FROZEN`, and finishes on `close`, `destroy`, `error`, or `TERMINATED`.
 - **Video/audio extras.** `MediaEvents.playerStateChange` fires on placement intent changes for video/audio sessions; display sessions get `AdEvents` only.
 - **Verification scripts and friendly obstruction.** Verification scripts are HTTPS-validated and deduplicated at construction; the container's auto-rendered close button is registered as a friendly obstruction.
+
+**Hardening (0.7.4):**
+
+- **Structured SDK load-failure signaling.** OM SDK script-load failures now fire the new `feature_load_failed` `SHARCSecurityEvent` variant with `details: { featureName, reason, scriptUrl }` (non-terminating; container keeps running, failed extension goes inert). Reason is a classified token: `'timeout'`, `'network'`, or `'evaluation_throw'`. The `_loadingUrl` tracker on the bridge reports the specific URL that failed (service vs. session client), not just whichever was configured first.
+- **Termination-mid-load contract pinned.** Test coverage (H1–H5) for the bfcache / destroy-mid-load edge case: when termination fires while the OM SDK load promise is pending, no session is created, no late callbacks fire, and no `feature_load_failed` is emitted (the failure here is normal teardown, not script-load failure).
 
 ### Verifying integration
 
@@ -174,15 +181,15 @@ Confirm the wiring without instrumenting the creative:
 
 ### Tracked follow-ups
 
-- **URL-variant SDK injection** — `creativeSdkUrl` auto-injection works for the Markup variant (`creativeHtml`) only; the URL variant (`creativeUrl`) doesn't yet inject the SHARC SDK. Tracked in [#106](https://github.com/jeffreycarlson/SHARC/issues/106).
-- **Silent SDK load failure** — if `OmidCompatBridge` advertises OMID but the OM SDK scripts fail to load, the container currently degrades silently. Clearer signaling is tracked in [#125](https://github.com/jeffreycarlson/SHARC/issues/125).
 - **Fuller docs** — full `OmidCompatBridge` API surface in [`docs/api-reference.md`](docs/api-reference.md) is tracked in [#136](https://github.com/jeffreycarlson/SHARC/issues/136); a "Wire Container-Owned OMID" recipe in [`docs/operator-cookbook.md`](docs/operator-cookbook.md) is tracked in [#135](https://github.com/jeffreycarlson/SHARC/issues/135). Until those land, the bridge constructor JSDoc in [`src/sharc-omid-bridge.js`](src/sharc-omid-bridge.js) and the design spec below are authoritative.
+
+> **Resolved in 0.7.4:** URL-variant `creativeSdkUrl` auto-injection ([#106](https://github.com/jeffreycarlson/SHARC/issues/106), explicit opt-in via `useMarkupInjection: true`) and structured OM SDK load-failure signaling via the new `feature_load_failed` `SHARCSecurityEvent` variant ([#125](https://github.com/jeffreycarlson/SHARC/issues/125)). See the [0.7.4 CHANGELOG section](CHANGELOG.md#074---2026-05-24).
 
 ### References
 
-- **Design spec:** [`docs/design/0.7.3-omid-wiring.md`](docs/design/0.7.3-omid-wiring.md) — full architecture, state-mapping table, validation rules, and decision log.
+- **Design specs:** [`docs/design/0.7.3-omid-wiring.md`](docs/design/0.7.3-omid-wiring.md) — original architecture, state-mapping table, validation rules, and decision log; [`docs/design/0.7.4-omid-hardening.md`](docs/design/0.7.4-omid-hardening.md) — 0.7.4 hardening additions (#121 audit, #123 error contract, #124 dedup warn, #125 feature_load_failed, #126 termination-mid-load).
 - **Working demo:** [`examples/demos/omid-integration/`](examples/demos/omid-integration/) — publisher page + test creative with a live event log.
-- **Implementation PR:** [#122](https://github.com/jeffreycarlson/SHARC/pull/122) (0.7.3 container-owned wiring) and [#138](https://github.com/jeffreycarlson/SHARC/pull/138) (LOW hardening sweep).
+- **Implementation PRs:** [#122](https://github.com/jeffreycarlson/SHARC/pull/122) (0.7.3 container-owned wiring), [#138](https://github.com/jeffreycarlson/SHARC/pull/138) (LOW hardening sweep), and [#171](https://github.com/jeffreycarlson/SHARC/pull/171) (0.7.4 `feature_load_failed` variant).
 
 ## Distribution and URL Guidance
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SHARC (Secure HTML Ad Richmedia Container)
 
-![Package status](https://img.shields.io/badge/package-v0.7.3%20(pre--publish)-informational)
+![Package status](https://img.shields.io/badge/package-v0.7.4%20(pre--publish)-informational)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/jeffreycarlson/SHARC/actions/workflows/ci.yml/badge.svg)](https://github.com/jeffreycarlson/SHARC/actions/workflows/ci.yml)
 
@@ -198,9 +198,9 @@ All public entry points build into `dist/` as ESM (`.mjs`) plus browser/IIFE bun
 
 After the package is published, public CDN URL patterns should mirror the current `dist/` filenames:
 
-- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.3/dist/sharc-container.js`
-- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.3/dist/sharc-creative.js`
-- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.3/dist/sharc-protocol.js`
+- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.4/dist/sharc-container.js`
+- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.4/dist/sharc-creative.js`
+- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.4/dist/sharc-protocol.js`
 
 Versioning guidance:
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -4,7 +4,7 @@
 
 SHARC is an IAB Tech Lab reference implementation in active **pre-1.0** development.
 
-- Repository package version: `0.7.3`
+- Repository package version: `0.7.4`
 - npm publication status: **not yet published**
 - Current implementation scope: **web iframe**, **iOS WKWebView**, **Android WebView**
 - Current repo posture: suitable for technical evaluation and standards review; not yet presented here as a broadly adopted production release line
@@ -20,9 +20,34 @@ The following are the most reliable descriptions of the present implementation:
 - [proposals/creative-sources.md](./proposals/creative-sources.md) — design rationale, threat model, and decision log for the 0.7.0 Creative Sources work
 - bridge design docs under [`docs/design/`](./design)
 - the current source and generated `dist/` artifacts
-- [CHANGELOG.md](../CHANGELOG.md) — what shipped in `0.7.3` and earlier
+- [CHANGELOG.md](../CHANGELOG.md) — what shipped in `0.7.4` and earlier
 
 As of `0.6.0`, every public package subpath ships generated TypeScript declaration files (`.d.ts`) alongside its `.mjs` bundle. TypeScript consumers get full IntelliSense and compile-time argument validation when importing any subpath. 0.7.0 expands the typedef surface to cover the Creative Markup variant — `creativeUrl` is optional, `creativeHtml` / `creativeRendererUrl` / `onSecurityEvent` are added, and `SHARCSecurityEvent` is a discriminated union that now covers seven reserved variants (0.7.1 added `bridge_load_failed`; 0.7.4 added `feature_load_failed`).
+
+## What Shipped in 0.7.4
+
+0.7.4 is an **OMID hardening release**. It finishes five OMID-adjacent items deferred from the 0.7.3 design so PR #122 could merge clean, ships the headline URL-variant `creativeSdkUrl` injection feature that closes the 0.7.2 PR #105 follow-up, and ships a bfcache round-trip coverage scaffold (full Puppeteer wiring deferred to issue [#178](https://github.com/jeffreycarlson/SHARC/issues/178), target 0.7.6).
+
+**Headline feature — URL-variant `creativeSdkUrl` injection** ([#106](https://github.com/jeffreycarlson/SHARC/issues/106)). The built-in SHARC creative SDK auto-injection added in 0.7.2 now reaches the Creative URL variant. With `useMarkupInjection: true`, the container fetches the creative URL, injects the `<script src="...sharc-creative.js">` tag, and loads via `iframe.srcdoc` — mirroring the Markup-variant ordering contract (built-in runs first, operator `injectIntoMarkup()` extensions run after and see the markup with the SDK already present). Activation is **explicit opt-in only**: without `useMarkupInjection: true`, the URL variant continues to load via `iframe.src` and `creativeSdkUrl` is a no-op, so operators sharing constructor config across Markup and URL bid variants don't see iframe-loading semantics flip from `src` to `srcdoc` under them. Fetch failures (CORS, 404, transport) emit a `console.warn` diagnostic and fall through to the un-injected `iframe.src` load; no `SHARCSecurityEvent` fires for this path. The runtime `_creativeSdkInjected` flag gates feature advertising — `com.iabtechlab.sharc.creative-injector` is advertised only when injection actually ran (no capability lie on fetch failure).
+
+**New SHARCSecurityEvent variant — `feature_load_failed`** ([#125](https://github.com/jeffreycarlson/SHARC/issues/125)). Sibling to `bridge_load_failed`; covers the publisher-page extension-load path while `bridge_load_failed` covers the renderer-side dynamic bridge import. Non-terminating (the container keeps running, the failed extension goes inert), no `errorCode` (extensions are outside the 21xx renderer-error-code namespace), `details: { featureName, reason, scriptUrl }` with `reason` as a classified token (current in-tree bridges emit `'timeout'`, `'network'`, or `'evaluation_throw'` — script-tag loaders cannot distinguish HTTP status). `OmidCompatBridge` is the first in-tree consumer; the variant is generalizable to any future extension that loads remote scripts. Operators monitoring `onSecurityEvent` now get a structured non-terminating signal when OM SDK script-load fails.
+
+**Extension-lifecycle error event payload contract pinned** ([#123](https://github.com/jeffreycarlson/SHARC/issues/123)). Both fatal-error paths (`_handleCreativeFatalError` and `_handleFatalError`) already dispatched a canonical `{ errorCode, errorMessage, source }` payload to extensions via `onContainerLifecycleEvent({ type: 'error', ... })`. 0.7.4 adds test coverage to pin the contract against regression — the field is `errorMessage` (not `message`), `source` discriminates `'creative'` vs. `'container'`, and the assertion outright rejects any `message` alias per the 0.7.4 ADR. `docs/api-reference.md` § 9 gains a new "Lifecycle event payloads" subsection documenting the base event shape (including `state`), per-type detail fields (including the correct `intent` field on `placementChange`), and the error event payload contract.
+
+**Multi-bridge dedup observability** ([#124](https://github.com/jeffreycarlson/SHARC/issues/124)). When multiple AdCOM `creativeMeta.apis` codes resolve to the same renderer bridge (e.g. two MRAID-version codes that both load `sharc-mraid-bridge.js`), the container emits a single `console.warn` at `_mapAdComApisToBridges` identifying which AdCOM codes collapsed and which bridge they collapsed to. Scope is AdCOM-only; explicit `bridges: [...]` arrays and adm-scan paths don't surface this race in practice.
+
+**Legacy `requestOmid` audit closure** ([#121](https://github.com/jeffreycarlson/SHARC/issues/121)). The creative-frame `installOmidBridge()` helper and the `SHARC:Creative:requestOmid` message type that were added in 0.2.0 were removed during the 0.7.2/0.7.3 cycle when OMID became fully container-driven, but neither 0.7.2 nor 0.7.3 changelog recorded the removal. 0.7.4 closes the audit (zero residual symbols across `src/`, `test/`, `examples/`, `dist/`, `scripts/`) and adds historical-artifact banners to the two pre-0.7.3 docs that proposed the rejected path.
+
+**Termination-mid-load coverage** ([#126](https://github.com/jeffreycarlson/SHARC/issues/126)). Pins the deferred-follow-up edge case from PR #122: when termination or destroy fires while the OM SDK script-load promise is still pending, the resolved promise must NOT create a session, must NOT fire late callbacks, and must NOT emit `feature_load_failed`. Five-section coverage (H1–H5) in `test/node/test-omid-container-lifecycle.js` — regression guards only; no production code change.
+
+**bfcache round-trip Puppeteer coverage scaffold** ([#102](https://github.com/jeffreycarlson/SHARC/issues/102)). Ships `test/browser/test-html-lifecycle-adapter-bfcache.js` as a 5-section assertion contract scaffold (bf-1 through bf-5) for the bfcache round-trip behavior the HTML lifecycle adapter honors. Full Puppeteer + Chrome wiring is deferred to issue [#178](https://github.com/jeffreycarlson/SHARC/issues/178) (current target 0.7.6, may slip with devops capacity for bfcache CI tuning). The file is NOT in `npm run test:all`; ships as an orphaned coverage marker until #178 wires the harness.
+
+Further reading:
+
+- Release design + ADRs: [`docs/design/0.7.4-omid-hardening.md`](./design/0.7.4-omid-hardening.md)
+- CHANGELOG entries: [CHANGELOG.md `[0.7.4]` section](../CHANGELOG.md#074---2026-05-24)
+- API reference updates: [`api-reference.md`](./api-reference.md)
+- Operator integration recipes: [`operator-cookbook.md`](./operator-cookbook.md)
 
 ## What Shipped in 0.7.3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iabtechlab/sharc",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol",
   "type": "module",
   "files": [

--- a/src/lifecycle-adapters/base-adapter.js
+++ b/src/lifecycle-adapters/base-adapter.js
@@ -22,7 +22,7 @@
  * for the rationale that picked the adapter-class shape over inline-switch
  * or registry alternatives.
  *
- * @version 0.7.3
+ * @version 0.7.4
  */
 
 'use strict';

--- a/src/lifecycle-adapters/html-adapter.js
+++ b/src/lifecycle-adapters/html-adapter.js
@@ -30,7 +30,7 @@
  *   - jsdom does NOT ship an IntersectionObserver implementation. Tests
  *     stub `global.IntersectionObserver` with a manually-triggerable mock.
  *
- * @version 0.7.3
+ * @version 0.7.4
  */
 
 'use strict';

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -26,7 +26,7 @@
  * container.load();
  * ```
  *
- * @version 0.7.3
+ * @version 0.7.4
  */
 
 'use strict';

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -34,7 +34,7 @@
  * </script>
  * ```
  *
- * @version 0.7.3
+ * @version 0.7.4
  */
 
 'use strict';

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -14,7 +14,7 @@
  *   3. sharc-mraid-bridge.js → window.mraid (this file)
  *   4. <MRAID creative>
  *
- * @version 0.7.3
+ * @version 0.7.4
  * @see mraid-bridge-design.md
  */
 

--- a/src/sharc-navigation-bridge.js
+++ b/src/sharc-navigation-bridge.js
@@ -81,7 +81,7 @@
  *
  * Spec: docs/proposals/creative-sources.md § Click-through audit and policy boundary.
  *
- * @version 0.7.3
+ * @version 0.7.4
  */
 
 'use strict';

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -21,7 +21,7 @@
  *   - creativeType and impressionType MUST be set before impressionOccurred()
  *   - AdSession must be started before any events are fired
  *
- * @version 0.7.3
+ * @version 0.7.4
  * @see https://iabtechlab.com/standards/open-measurement-sdk/
  * @see https://github.com/IABTechLab/SHARC
  */

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -13,7 +13,7 @@
  *
  * Both extend SHARCProtocolBase which provides the shared message bus.
  *
- * @version 0.7.3
+ * @version 0.7.4
  * @see https://github.com/IABTechLab/SHARC
  */
 
@@ -27,7 +27,7 @@
 // ---------------------------------------------------------------------------
 
 /** Current SHARC spec version this implementation conforms to. */
-const SHARC_VERSION = '0.7.3';
+const SHARC_VERSION = '0.7.4';
 
 /**
  * Placeholder AdCOM `APIFramework` integer code for SHARC.

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -19,7 +19,7 @@
  *   - exp-push (push expand) — deferred to v2; fires 'failed' callback
  *   - $sf.ext.cookie() — permanently excluded; fires 'failed' callback
  *
- * @version 0.7.3
+ * @version 0.7.4
  * @see safeframe-bridge-design.md
  */
 


### PR DESCRIPTION
## Summary

Cuts the **0.7.4 OMID hardening release**. Single commit close-out PR (PR H of the 8-PR release plan).

**Administrative closures:** #121, #123, #124, #125, #126, #106, #102 (substantive work landed in PRs #154, #158, #162, #163, #171, #176, #179). Follow-up tracking for bfcache wiring: #178.

## What's in this PR

**CHANGELOG.md** — promotes `[Unreleased]` → `[0.7.4] - 2026-05-24`:
- Backfills entries for PRs A (#154), B (#158), C (#162), D (#163), E (#171) — none of these added `[Unreleased]` entries at the time
- Adds `Removed` entry for legacy creative-side OMID APIs (`installOmidBridge`, `requestOmid`) — never recorded as removed in 0.7.2/0.7.3 per the PR C audit closure
- Updates `[Unreleased]` compare link to `v0.7.4...main`; adds `[0.7.4]` compare link
- Adds missing `[#NNN]` reference defs

**Version bump via `npm version patch` + `scripts/sync-version.js`:**
- `package.json` + `package-lock.json`: 0.7.3 → 0.7.4
- `src/sharc-protocol.js`: `SHARC_VERSION` constant + `@version` JSDoc
- `@version` JSDoc on 7 other src files (container, creative, mraid-bridge, safeframe-bridge, omid-bridge, navigation-bridge, lifecycle adapters)
- `README.md`: version badge + CDN example URLs

**docs/current-status.md:**
- Repository package version: `0.7.4`
- New "What Shipped in 0.7.4" section mirroring the release narrative (headline URL-variant SDK injection + 5 hardening items + bfcache scaffold deferred)

## Verify

Full pipeline run locally before PR open:
- `npm run lint`: clean
- `npm run test:types`: clean
- `npm run build`: dist rebuilt at 0.7.4
- `npm run test:all` (16 suites): all green at the bumped version
- Size budgets: within tolerance (sharc-container 17.23/25kB)

## Release context

- Release design + ADRs: [`docs/design/0.7.4-omid-hardening.md`](https://github.com/jeffreycarlson/SHARC/blob/main/docs/design/0.7.4-omid-hardening.md)
- Predecessor: [0.7.3](https://github.com/jeffreycarlson/SHARC/blob/main/CHANGELOG.md#073---2026-05-21)
- Follow-up: [#178](https://github.com/jeffreycarlson/SHARC/issues/178) (bfcache Puppeteer harness wiring, target 0.7.6)

## Post-merge

Tag-push (`v0.7.4`) NOT included in this PR — that step happens after merge via:
```bash
git tag v0.7.4 <merge-sha>
git push origin v0.7.4
```
Awaiting explicit greenlight before tag-push.