### PR TITLE
fix: rebuild dist before test all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+### Fixed
+
+- **`npm run test:all` now rebuilds `dist/` before running dist-based
+  tests** ([#182]). The public all-tests script now runs `npm run build`
+  first, preventing stale generated artifacts from causing misleading
+  failures after source or version changes. The existing no-rebuild chain
+  moved to `test:all:built` so `npm run check` can continue building once
+  up front without paying for a duplicate build.
+
 ### Removed
 
 - **Bridge `getWrapperUrl` helpers retired** ([#149]). `MRAIDCompatBridge`,
@@ -186,6 +195,7 @@ for the release-level design and ADRs.
 [#175]: https://github.com/jeffreycarlson/SHARC/pull/175
 [#177]: https://github.com/jeffreycarlson/SHARC/pull/177
 [#178]: https://github.com/jeffreycarlson/SHARC/issues/178
+[#182]: https://github.com/jeffreycarlson/SHARC/issues/182
 
 ## [0.7.3] - 2026-05-21
 

--- a/package.json
+++ b/package.json
@@ -71,10 +71,11 @@
     "test:renderer-fallback": "node test/node/test-renderer-domparser-fallback.js",
     "test:perf": "node test/node/test-creative-sources-perf.js",
     "test:types": "tsc -p test/types/tsconfig.json",
-    "test:all": "npm run test:smoke && npm run test:treeshake && npm run test:creative-protocol-placement-type && npm run test:placement && npm run test:placement-stamping && npm run test:creative-sources && npm run test:creative-sources-load && npm run test:browser && npm run test:navigation-bridge && npm run test:creative-sdk-autoinstall && npm run test:creative-sdk-injection && npm run test:bridges-detection && npm run test:non-sharc-loading && npm run test:html-lifecycle-adapter && npm run test:omid-container-lifecycle && npm run test:renderer-fallback",
+    "test:all": "npm run build && npm run test:all:built",
+    "test:all:built": "npm run test:smoke && npm run test:treeshake && npm run test:creative-protocol-placement-type && npm run test:placement && npm run test:placement-stamping && npm run test:creative-sources && npm run test:creative-sources-load && npm run test:browser && npm run test:navigation-bridge && npm run test:creative-sdk-autoinstall && npm run test:creative-sdk-injection && npm run test:bridges-detection && npm run test:non-sharc-loading && npm run test:html-lifecycle-adapter && npm run test:omid-container-lifecycle && npm run test:renderer-fallback",
     "regen:baseline": "node scripts/regen-mraid3-baseline.js",
     "lint": "eslint src/*.js --max-warnings=0",
-    "check": "npm run build && npm run test:all && npm run size && npm run build"
+    "check": "npm run build && npm run test:all:built && npm run size && npm run build"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",


### PR DESCRIPTION
## Summary
- make npm run test:all rebuild dist/ before running dist-based test suites
- move the prior test chain to test:all:built for callers that already built artifacts
- update npm run check to keep its single upfront build and call test:all:built

## Tests
- npm run test:all
- npm run check
- npm run lint

Closes #182