### PR TITLE
chore(release): 0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-05-24
+
 ### Fixed
 
 - **`npm run test:all` now rebuilds `dist/` before running dist-based
@@ -21,6 +23,15 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   failures after source or version changes. The existing no-rebuild chain
   moved to `test:all:built` so `npm run check` can continue building once
   up front without paying for a duplicate build.
+
+### Docs
+
+- **0.7.2 process artifacts archived** ([#180]). Historical 0.7.2 handoff,
+  WIP, and stage-3 comparison docs moved from `docs/design/` to
+  `docs/archive/0.7.2/`. Archive README files added to mark the material
+  as non-normative; `docs/README.md` updated to distinguish historical
+  process artifacts from current design docs. Operators bookmarking the
+  pre-archive paths under `docs/design/` should update links.
 
 ### Removed
 
@@ -195,6 +206,7 @@ for the release-level design and ADRs.
 [#175]: https://github.com/jeffreycarlson/SHARC/pull/175
 [#177]: https://github.com/jeffreycarlson/SHARC/pull/177
 [#178]: https://github.com/jeffreycarlson/SHARC/issues/178
+[#180]: https://github.com/jeffreycarlson/SHARC/pull/180
 [#182]: https://github.com/jeffreycarlson/SHARC/issues/182
 
 ## [0.7.3] - 2026-05-21
@@ -1670,7 +1682,8 @@ messages are sent at additional transition points; no new message types.
 - `supportedFeatures` extension mechanism
 
 <!-- Version compare links (Update when new tags are pushed) -->
-[Unreleased]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.4...main
+[Unreleased]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.5...main
+[0.7.5]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.4...v0.7.5
 [0.7.4]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.3...v0.7.4
 [0.7.3]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.1...v0.7.2

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # SHARC (Secure HTML Ad Richmedia Container)
 
-![Package status](https://img.shields.io/badge/package-v0.7.4%20(pre--publish)-informational)
+![Package status](https://img.shields.io/badge/package-v0.7.5%20(pre--publish)-informational)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/jeffreycarlson/SHARC/actions/workflows/ci.yml/badge.svg)](https://github.com/jeffreycarlson/SHARC/actions/workflows/ci.yml)
 
 Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol reference implementation.
 
 > 📋 This repository is the current SHARC reference implementation and working specification set.
-> It is in active pre-1.0 development at package version `0.7.4` and is not yet published to npm.
+> It is in active pre-1.0 development at package version `0.7.5` and is not yet published to npm.
 > Start with the curated docs index at [docs/README.md](docs/README.md) and the current state summary at [docs/current-status.md](docs/current-status.md).
 
 ## Overview
@@ -205,9 +205,9 @@ All public entry points build into `dist/` as ESM (`.mjs`) plus browser/IIFE bun
 
 After the package is published, public CDN URL patterns should mirror the current `dist/` filenames:
 
-- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.4/dist/sharc-container.js`
-- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.4/dist/sharc-creative.js`
-- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.4/dist/sharc-protocol.js`
+- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.5/dist/sharc-container.js`
+- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.5/dist/sharc-creative.js`
+- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.5/dist/sharc-protocol.js`
 
 Versioning guidance:
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -4,7 +4,7 @@
 
 SHARC is an IAB Tech Lab reference implementation in active **pre-1.0** development.
 
-- Repository package version: `0.7.4`
+- Repository package version: `0.7.5`
 - npm publication status: **not yet published**
 - Current implementation scope: **web iframe**, **iOS WKWebView**, **Android WebView**
 - Current repo posture: suitable for technical evaluation and standards review; not yet presented here as a broadly adopted production release line
@@ -20,9 +20,23 @@ The following are the most reliable descriptions of the present implementation:
 - [proposals/creative-sources.md](./proposals/creative-sources.md) — design rationale, threat model, and decision log for the 0.7.0 Creative Sources work
 - bridge design docs under [`docs/design/`](./design)
 - the current source and generated `dist/` artifacts
-- [CHANGELOG.md](../CHANGELOG.md) — what shipped in `0.7.4` and earlier
+- [CHANGELOG.md](../CHANGELOG.md) — what shipped in `0.7.5` and earlier
 
 As of `0.6.0`, every public package subpath ships generated TypeScript declaration files (`.d.ts`) alongside its `.mjs` bundle. TypeScript consumers get full IntelliSense and compile-time argument validation when importing any subpath. 0.7.0 expands the typedef surface to cover the Creative Markup variant — `creativeUrl` is optional, `creativeHtml` / `creativeRendererUrl` / `onSecurityEvent` are added, and `SHARCSecurityEvent` is a discriminated union that now covers seven reserved variants (0.7.1 added `bridge_load_failed`; 0.7.4 added `feature_load_failed`).
+
+## What Shipped in 0.7.5
+
+0.7.5 is a small cleanup and release-infrastructure patch.
+
+**Bridge `getWrapperUrl` helpers retired** ([#149](https://github.com/jeffreycarlson/SHARC/issues/149)). `MRAIDCompatBridge`, `SafeFrameCompatBridge`, and `OmidCompatBridge` no longer expose `getWrapperUrl(creativeUrl)`. The helper constructed wrapper-page URLs that the container never consumed; operators that still need wrapper-page flows can construct those URLs inline. The browser-harness wrapper HTML files remain unchanged.
+
+**`npm run test:all` now rebuilds `dist/` first** ([#182](https://github.com/jeffreycarlson/SHARC/issues/182)). The public all-tests script now runs `npm run build` before dist-based tests, preventing stale generated artifacts from causing misleading failures after source or version changes. The previous no-build chain is available as `test:all:built` for callers that already built artifacts; `npm run check` uses that path after its upfront build.
+
+**0.7.2 process artifacts archived** ([#180](https://github.com/jeffreycarlson/SHARC/pull/180)). Historical 0.7.2 handoff/WIP/comparison docs moved from `docs/design/` to `docs/archive/0.7.2/` with archive README markers; `docs/README.md` updated to separate historical process artifacts from current design docs.
+
+Further reading:
+
+- CHANGELOG entries: [CHANGELOG.md `[0.7.5]` section](../CHANGELOG.md#075---2026-05-24)
 
 ## What Shipped in 0.7.4
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iabtechlab/sharc",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol",
   "type": "module",
   "files": [

--- a/src/lifecycle-adapters/base-adapter.js
+++ b/src/lifecycle-adapters/base-adapter.js
@@ -22,7 +22,7 @@
  * for the rationale that picked the adapter-class shape over inline-switch
  * or registry alternatives.
  *
- * @version 0.7.4
+ * @version 0.7.5
  */
 
 'use strict';

--- a/src/lifecycle-adapters/html-adapter.js
+++ b/src/lifecycle-adapters/html-adapter.js
@@ -30,7 +30,7 @@
  *   - jsdom does NOT ship an IntersectionObserver implementation. Tests
  *     stub `global.IntersectionObserver` with a manually-triggerable mock.
  *
- * @version 0.7.4
+ * @version 0.7.5
  */
 
 'use strict';

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -26,7 +26,7 @@
  * container.load();
  * ```
  *
- * @version 0.7.4
+ * @version 0.7.5
  */
 
 'use strict';

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -34,7 +34,7 @@
  * </script>
  * ```
  *
- * @version 0.7.4
+ * @version 0.7.5
  */
 
 'use strict';

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -14,7 +14,7 @@
  *   3. sharc-mraid-bridge.js → window.mraid (this file)
  *   4. <MRAID creative>
  *
- * @version 0.7.4
+ * @version 0.7.5
  * @see mraid-bridge-design.md
  */
 

--- a/src/sharc-navigation-bridge.js
+++ b/src/sharc-navigation-bridge.js
@@ -81,7 +81,7 @@
  *
  * Spec: docs/proposals/creative-sources.md § Click-through audit and policy boundary.
  *
- * @version 0.7.4
+ * @version 0.7.5
  */
 
 'use strict';

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -21,7 +21,7 @@
  *   - creativeType and impressionType MUST be set before impressionOccurred()
  *   - AdSession must be started before any events are fired
  *
- * @version 0.7.4
+ * @version 0.7.5
  * @see https://iabtechlab.com/standards/open-measurement-sdk/
  * @see https://github.com/IABTechLab/SHARC
  */

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -13,7 +13,7 @@
  *
  * Both extend SHARCProtocolBase which provides the shared message bus.
  *
- * @version 0.7.4
+ * @version 0.7.5
  * @see https://github.com/IABTechLab/SHARC
  */
 
@@ -27,7 +27,7 @@
 // ---------------------------------------------------------------------------
 
 /** Current SHARC spec version this implementation conforms to. */
-const SHARC_VERSION = '0.7.4';
+const SHARC_VERSION = '0.7.5';
 
 /**
  * Placeholder AdCOM `APIFramework` integer code for SHARC.

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -19,7 +19,7 @@
  *   - exp-push (push expand) — deferred to v2; fires 'failed' callback
  *   - $sf.ext.cookie() — permanently excluded; fires 'failed' callback
  *
- * @version 0.7.4
+ * @version 0.7.5
  * @see safeframe-bridge-design.md
  */
 


### PR DESCRIPTION
## Summary
- promote CHANGELOG [Unreleased] entries for #149 and #182 into 0.7.5
- bump package metadata and synced source/README version references from 0.7.4 to 0.7.5
- update docs/current-status.md with the 0.7.5 release summary

## Tests
- git diff --check
- npm run check
- npm run lint
- npm --cache /private/tmp/sharc-npm-cache pack --dry-run
- npm run test:all

## Release notes
Tag push is intentionally deferred until after this PR is reviewed and merged.