### PR TITLE
feat: verify renderer integrity preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+### Added
+
+- **Optional `creativeRendererIntegrity` preflight for Creative Markup**
+  ([#24]). Operators can pass a `sha384-<base64>` digest for
+  `creativeRendererUrl`; the container fetches and verifies the renderer
+  document bytes before assigning `iframe.src`. On mismatch or unverifiable
+  bytes, the container fires `RENDERER_INTEGRITY_FAIL` (2120), emits a
+  `renderer_protocol_error` security event with
+  `details.subtype='integrity_failed'`, and never sends
+  `SHARC:Renderer:render`. This is defense-in-depth rather than native iframe
+  SRI, because browsers do not support `integrity=` on iframe navigations;
+  cross-origin renderer hosts must allow the verification fetch with CORS.
+
+[#24]: https://github.com/jeffreycarlson/SHARC/issues/24
+
 ## [0.7.5] - 2026-05-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Exactly one creative source is required.
 | `creativeUrl` | string | `undefined` | URL of a SHARC-aware creative HTML page. |
 | `creativeHtml` | string | `undefined` | Inline Markup-variant creative HTML, commonly OpenRTB `bid.adm`. Requires `creativeRendererUrl`. |
 | `creativeRendererUrl` | string | `undefined` | HTTPS URL of an operator-hosted renderer page. Required when `creativeHtml` is set. |
+| `creativeRendererIntegrity` | string | `undefined` | Optional SRI-style SHA-384 digest (`sha384-<base64>`) for the Markup renderer page. When set, the container verifies `creativeRendererUrl` bytes before loading the iframe and refuses to send `SHARC:Renderer:render` on mismatch. Best-effort only because iframes do not support native `integrity=`; cross-origin renderer hosts must allow the verification fetch with CORS. |
 
 ### Transition-State Options
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -39,6 +39,7 @@ new SHARCContainer(options)
 | `creativeUrl` | `string` | No (one of `creativeUrl` OR `creativeHtml + creativeRendererUrl`) | URL of the SHARC-enabled creative HTML (Creative URL variant). Mutually exclusive with `creativeHtml`. Empty string normalizes to "not provided." |
 | `creativeHtml` | `string` | No (required when using Creative Markup variant — added in 0.7.0) | Raw HTML markup for the creative. Mutually exclusive with `creativeUrl`. Requires `creativeRendererUrl`. Posted to the operator-hosted renderer page via the renderer protocol. Capped at 256 KiB at construction. See [Renderer Protocol](#10-renderer-protocol). |
 | `creativeRendererUrl` | `string \| URL` | No (required when `creativeHtml` is provided) | HTTPS URL of an operator-hosted renderer page. Forbidden alongside `creativeUrl`. Must parse via `new URL(...)`, use the `https:` scheme, contain no userinfo, and be cross-origin to both `window.location` and (when accessible) `window.top.location`. Added in 0.7.0. |
+| `creativeRendererIntegrity` | `string` | No | Creative Markup variant only. Optional SRI-style SHA-384 digest (`sha384-<base64>`) for `creativeRendererUrl`. When set, the container preflight-fetches the renderer document, verifies the bytes with Web Crypto, and refuses to assign `iframe.src` or send `SHARC:Renderer:render` on mismatch or unverifiable bytes (`RENDERER_INTEGRITY_FAIL`, 2120). Best-effort defense-in-depth: browsers do not support native `integrity=` on iframes, so operators should still use immutable renderer URLs, CDN controls, and CORS headers that allow publisher-side fetch verification. |
 | `placementElement` | `HTMLElement` | Yes | The DOM element to insert the iframe into. |
 | `environmentData` | `Object` | No | Environment data sent in `Container:init`. Default: `{}`. See [EnvironmentData](#6-environmentdata-structure). |
 | `placementId` | `string\|null` | No | Publisher-supplied placement identifier. Omitting the option or passing `''` both produce `null`. |
@@ -1530,13 +1531,13 @@ The seven reserved `type` values and their `details` schemas:
 |---|---|---|---|
 | `wrapper_top_frame_inaccessible` | `'warning'` (or `'error'` when `wrapperPolicy: 'block'`) | — | `{ wrapperOrigin, creativeRendererUrl }` |
 | `renderer_origin_mismatch` | `'error'` | `2116` | `{ expectedOrigin, actualOrigin }` |
-| `renderer_protocol_error` | `'error'` | `2114` \| `2117` \| `2119` | `{ subtype: 'timeout' \| 'malformed_payload' \| 'post_failed', reason }` |
+| `renderer_protocol_error` | `'error'` | `2114` \| `2117` \| `2119` \| `2120` | `{ subtype: 'timeout' \| 'malformed_payload' \| 'post_failed' \| 'integrity_failed', reason }` |
 | `renderer_failed` | `'error'` | `2115` | `{ reason }` |
 | `bridge_load_failed` (0.7.1+) | `'error'` | `2115` | `{ reason, bridge, url }` — `bridge` is the failed identifier (`'mraid'`, `'safeframe'`, …), bounded to 200 chars; `url` is the resolved bridge-module URL (or substituted-but-unparseable template string on the unparseable-URL path), bounded to 500 chars, `''` when unavailable; `reason` is the literal `'bridge_load_failed'` for parity with `renderer_failed`. |
 | `unauthorized_navigation` | `'error'` | `2118` | `{ variant: 'markup' \| 'url', msSinceRender: number }` |
 | `feature_load_failed` (0.7.4+) | `'error'` | — (non-terminating; no code) | `{ featureName, reason, scriptUrl }` — `featureName` is the canonical `supportedFeatures` entry whose load failed (e.g. `'com.iabtechlab.sharc.omid'`); `reason` is a classified token — current in-tree bridges emit `'timeout'`, `'network'`, or `'evaluation_throw'` (script-tag loaders cannot distinguish a 404 from other transport failures; future fetch-based loaders may emit additional tokens like `'http_404'`); `scriptUrl` is the URL that failed to load, bounded to 500 chars (parity with `bridge_load_failed.details.url`). |
 
-Note: timeout (`2114`) and post-failed (`2119`) both surface as `renderer_protocol_error` on the structured channel — the spec vocabulary does not include them as distinct event types. The `details.subtype` discriminates inside the variant.
+Note: timeout (`2114`), post-failed (`2119`), and integrity-failed (`2120`) all surface as `renderer_protocol_error` on the structured channel — the spec vocabulary does not include them as distinct event types. The `details.subtype` discriminates inside the variant.
 
 `bridge_load_failed` shares error code `2115` with `renderer_failed` but gets its own structured-event variant so operators on `onSecurityEvent` see bridge import failures (404, MIME mismatch, network failure, same-origin assertion failure, evaluation throw) distinct from creative-side render failures. Routed from the renderer's `:failed` reply when `reason === 'bridge_load_failed'`. Added 0.7.1 (issue #82) per [`docs/design/0.7.1-bridges-field.md`](design/0.7.1-bridges-field.md) § 4 Security Engineer guardrail #5.
 
@@ -1544,7 +1545,7 @@ Note: timeout (`2114`) and post-failed (`2119`) both surface as `renderer_protoc
 
 #### `renderer_protocol_error` `details.reason` vocabulary
 
-The `details.reason` field on `renderer_protocol_error` events is a fixed five-value vocabulary (plus the `post_failed` catch-all). Operators building monitoring dashboards can pre-allocate buckets against this table:
+The `details.reason` field on `renderer_protocol_error` events is a fixed vocabulary, except that `post_failed` carries the raw exception message. Operators building monitoring dashboards can pre-allocate buckets against this table:
 
 | `details.subtype` | `details.reason` | `errorCode` | When |
 |---|---|---|---|
@@ -1553,6 +1554,7 @@ The `details.reason` field on `renderer_protocol_error` events is a fixed five-v
 | `malformed_payload` | `rendered_missing_renderer_origin` | `2117` | `:rendered` envelope-valid but `data.rendererOrigin` missing, non-string, or empty |
 | `malformed_payload` | `failed_missing_reason` | `2117` | `:failed` envelope-valid but `data.reason` missing, non-string, or empty |
 | `post_failed` | (raw `postErr.message`) | `2119` | `iframe.contentWindow.postMessage` threw synchronously (e.g. `DataCloneError`, null `contentWindow`); carries the underlying error message verbatim |
+| `integrity_failed` | verification failure reason | `2120` | `creativeRendererIntegrity` preflight failed before assigning `iframe.src`; no `SHARC:Renderer:render` message was sent |
 
 The `post_failed` row's `reason` is arbitrary — it carries whatever string the underlying postMessage exception produced. Operators monitoring this bucket should match on `subtype === 'post_failed'` rather than the `reason` value.
 
@@ -1684,6 +1686,7 @@ See section 11 below — codes `2114`–`2119` cover the renderer protocol surfa
 | 2117 | Renderer protocol error | Renderer message had an envelope-valid type (`SHARC:Renderer:rendered` or `SHARC:Renderer:failed`) but malformed payload — `rendererOrigin` (rendered) or `reason` (failed) is missing, not a string, or empty. Markup variant only. See [Renderer Protocol](#10-renderer-protocol). |
 | 2118 | Renderer unauthorized navigation | The container attaches a `load` listener after the variant-specific render anchor (Markup: envelope-validated `:rendered`; URL: initial iframe `load`); a subsequent `load` event means the iframe document navigated outside the SHARC protocol path. Defense-in-depth backstop for click-throughs that bypass the navigation bridge. Both variants. `details.variant` discriminates `'markup' \| 'url'`. See [Renderer Protocol](#10-renderer-protocol). |
 | 2119 | Renderer post failed | `iframe.contentWindow.postMessage(SHARC:Renderer:render, ...)` threw synchronously (e.g. `DataCloneError`, null `contentWindow`). Distinct from 2114 (timeout) — a transport-layer send failure is not a latency failure. Markup variant only. See [Renderer Protocol](#10-renderer-protocol). |
+| 2120 | Renderer integrity failed | Optional `creativeRendererIntegrity` preflight failed before the renderer iframe was loaded. The container did not assign `iframe.src` and did not send `SHARC:Renderer:render`. Markup variant only. |
 
 ### Container Errors (22xx)
 

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -315,19 +315,21 @@ const SHARC_BUILD_MODE = /** @type {'dev'|'prod'} */ ('__SHARC_BUILD_MODE__');
 
 /**
  * @remarks Variant collapse: spec § Security Model line 715 reserves only
- * 5 structured event types, so timeout (2114) and post-failed (2119) —
- * distinct error codes with distinct internal `[type]` log tags — both
+ * 5 structured event types, so timeout (2114), post-failed (2119), and
+ * integrity-failed (2120) — distinct error codes with distinct internal
+ * `[type]` log tags — all
  * surface here as `renderer_protocol_error`. The `details.subtype` field
- * discriminates `timeout` / `malformed_payload` / `post_failed`. See
+ * discriminates `timeout` / `malformed_payload` / `post_failed` /
+ * `integrity_failed`. See
  * api-reference.md § Renderer Protocol § onSecurityEvent surface for the
  * consumer contract.
  *
  * @typedef {SHARCSecurityEventBase & {
  *   type: 'renderer_protocol_error',
  *   severity: 'error',
- *   errorCode: 2114 | 2117 | 2119,
+ *   errorCode: 2114 | 2117 | 2119 | 2120,
  *   details: {
- *     subtype: 'malformed_payload' | 'timeout' | 'post_failed',
+ *     subtype: 'malformed_payload' | 'timeout' | 'post_failed' | 'integrity_failed',
  *     reason: string,
  *   },
  * }} RendererProtocolErrorEvent
@@ -471,6 +473,16 @@ class SHARCContainer {
    *   also a recognized dev origin), contain no userinfo, and be cross-origin to
    *   both `window.location` and (when accessible) `window.top.location`. See
    *   proposal § Validation Rules. Empty string (`''`) is treated as "not provided."
+   * @param {string} [options.creativeRendererIntegrity] - Optional SRI-style
+   *   SHA-384 digest for the operator-hosted renderer page, in the form
+   *   `sha384-<base64>`. Creative Markup only. When provided, the container
+   *   fetches `creativeRendererUrl`, computes SHA-384 over the response bytes,
+   *   and refuses to assign `iframe.src` or send `SHARC:Renderer:render` when
+   *   the digest mismatches or the bytes cannot be verified. This is a
+   *   best-effort preflight because browsers do not support native
+   *   `integrity=` enforcement on iframes; operators should still serve the
+   *   renderer from immutable versioned URLs with strong CDN controls and CORS
+   *   headers that allow publisher-side fetch verification.
    * @param {SHARCSecurityEventCallback} [options.onSecurityEvent] - Callback fired
    *   with a {@link SHARCSecurityEvent} for security-relevant events (wrapper carve-out,
    *   origin mismatch, renderer protocol failure, etc.). Production observability hook.
@@ -675,6 +687,7 @@ class SHARCContainer {
       creativeUrl,
       creativeHtml,
       creativeRendererUrl,
+      creativeRendererIntegrity,
       onSecurityEvent,
       allowPopups = true,
       allowTopNavigationByUserActivation = true,
@@ -854,6 +867,25 @@ class SHARCContainer {
      * @type {string|null}
      */
     this.creativeRendererUrl = hasRendererUrl ? creativeRendererUrl : null;
+
+    /**
+     * Optional SRI-style SHA-384 digest for the Creative Markup renderer
+     * document. When set, `_createIframe()` verifies renderer bytes before
+     * assigning `iframe.src`; on mismatch the container terminates with
+     * RENDERER_INTEGRITY_FAIL and never sends `SHARC:Renderer:render`.
+     *
+     * This is a best-effort preflight, not native iframe SRI. Browsers do not
+     * support `integrity=` on iframes, so the navigation still happens via
+     * normal `iframe.src` after the fetch check passes. Operators should use
+     * immutable renderer URLs, allow publisher-side CORS fetches, and treat
+     * this as defense in depth.
+     *
+     * @type {string|null}
+     * @private
+     */
+    this._creativeRendererIntegrity = hasCreativeHtml && creativeRendererIntegrity !== undefined
+      ? creativeRendererIntegrity
+      : null;
 
     /**
      * Construction-time-derived renderer origin (`parsedRendererUrl.origin`,
@@ -1730,9 +1762,13 @@ class SHARCContainer {
     if (this.creativeSource === 'html') {
       // Markup variant uses the renderer protocol — initChannel fires after
       // the renderer's :rendered reply, NOT directly on iframe load.
-      this._wireRendererProtocol(iframe);
       const src = this._resolvedIframeSrc();
       this._assertResolvedIframeSrcAllowed(src);
+      if (this._creativeRendererIntegrity !== null) {
+        this._loadVerifiedRendererIframe(iframe, src);
+        return;
+      }
+      this._wireRendererProtocol(iframe);
       iframe.src = src;
       return;
     }
@@ -1935,6 +1971,136 @@ class SHARCContainer {
         + 'cross-origin guarantee relies on this method returning the exact renderer URL.'
       );
     }
+  }
+
+  /**
+   * Verifies the configured renderer document integrity before assigning
+   * `iframe.src`. This is necessarily best-effort because browsers do not
+   * support native Subresource Integrity on iframe navigations. The preflight
+   * still prevents the container from sending `SHARC:Renderer:render` when the
+   * bytes fetched for `creativeRendererUrl` do not match the operator-supplied
+   * digest.
+   *
+   * @param {HTMLIFrameElement} iframe
+   * @param {string} src
+   * @private
+   */
+  _loadVerifiedRendererIframe(iframe, src) {
+    const timeoutMs = this.timeouts.rendererLoad || DEFAULT_TIMEOUTS.rendererLoad;
+    const controller = typeof AbortController === 'function' ? new AbortController() : null;
+    let timeoutHandle = null;
+    const timeoutPromise = new Promise((_, reject) => {
+      timeoutHandle = setTimeout(() => {
+        if (controller) controller.abort();
+        reject(new Error(
+          'renderer integrity preflight timed out after ' + timeoutMs + 'ms'
+        ));
+      }, timeoutMs);
+    });
+
+    Promise.race([
+      this._verifyRendererIntegrity(controller ? { signal: controller.signal } : {}),
+      timeoutPromise,
+    ])
+      .then(() => {
+        if (this._terminated || this._iframe !== iframe) return;
+        this._wireRendererProtocol(iframe);
+        iframe.src = src;
+      })
+      .catch((err) => {
+        if (this._terminated || this._iframe !== iframe) return;
+        const reason = err && err.message ? err.message : String(err || 'unknown');
+        this._emitSecurityEventAndTerminate(
+          'renderer_integrity_failed',
+          ErrorCodes.RENDERER_INTEGRITY_FAIL,
+          'creativeRendererIntegrity verification failed before renderer load: '
+            + this._sanitizeForLog(reason),
+          {
+            subtype: 'integrity_failed',
+            reason: reason,
+          }
+        );
+      })
+      .finally(() => {
+        if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+      });
+  }
+
+  /**
+   * Fetches `creativeRendererUrl` and verifies it against the configured
+   * `sha384-...` digest.
+   *
+   * @param {{signal?: AbortSignal|undefined}} [options]
+   * @returns {Promise<void>}
+   * @private
+   */
+  async _verifyRendererIntegrity(options = {}) {
+    if (this._creativeRendererIntegrity === null) return;
+    if (typeof fetch !== 'function') {
+      throw new Error('fetch is unavailable');
+    }
+    const cryptoObj = (typeof globalThis !== 'undefined' && globalThis.crypto)
+      ? globalThis.crypto
+      : (typeof crypto !== 'undefined' ? crypto : null);
+    if (!cryptoObj || !cryptoObj.subtle || typeof cryptoObj.subtle.digest !== 'function') {
+      throw new Error('Web Crypto SHA-384 is unavailable');
+    }
+
+    const response = await fetch(/** @type {string} */ (this.creativeRendererUrl), {
+      method: 'GET',
+      redirect: 'follow',
+      credentials: 'omit',
+      cache: 'no-store',
+      signal: options.signal,
+    });
+    if (!response || !response.ok) {
+      const status = response ? String(response.status || '') : '';
+      const statusText = response ? String(response.statusText || '') : '';
+      throw new Error(('HTTP ' + status + ' ' + statusText).trim());
+    }
+    if (response.url) {
+      let responseOrigin = null;
+      try {
+        responseOrigin = new URL(response.url).origin;
+      } catch (_) { /* ignore unparsable response.url */ }
+      if (responseOrigin !== null && responseOrigin !== this._rendererOrigin) {
+        throw new Error(
+          'renderer fetch redirected from ' + this._rendererOrigin
+          + ' to ' + responseOrigin
+        );
+      }
+    }
+
+    const bytes = await response.arrayBuffer();
+    const digest = await cryptoObj.subtle.digest('SHA-384', bytes);
+    const actual = 'sha384-' + SHARCContainer._base64FromArrayBuffer(digest);
+    if (actual !== this._creativeRendererIntegrity) {
+      throw new Error('SHA-384 digest mismatch');
+    }
+  }
+
+  /**
+   * Encodes an ArrayBuffer as base64 without depending on Node Buffer.
+   *
+   * @param {ArrayBuffer} buffer
+   * @returns {string}
+   * @private
+   */
+  static _base64FromArrayBuffer(buffer) {
+    const bytes = new Uint8Array(buffer);
+    let binary = '';
+    const chunkSize = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      const chunk = bytes.subarray(i, i + chunkSize);
+      binary += String.fromCharCode.apply(null, Array.from(chunk));
+    }
+    if (typeof btoa === 'function') {
+      return btoa(binary);
+    }
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.from(binary, 'binary').toString('base64');
+    }
+    throw new Error('No base64 encoder available');
   }
 
   /**
@@ -4138,6 +4304,7 @@ class SHARCContainer {
    *   1. **Dev-channel `[type]` log tag** (the `internalType` argument). Seven
    *      granular values for grep-ability in production console output:
    *      `renderer_protocol_timeout`, `renderer_protocol_post_failed`,
+   *      `renderer_integrity_failed`,
    *      `renderer_protocol_error`, `renderer_origin_mismatch`,
    *      `renderer_failed`, `bridge_load_failed`, `unauthorized_navigation`.
    *
@@ -4148,9 +4315,9 @@ class SHARCContainer {
    *      `bridge_load_failed` added in 0.7.1 (issue #82). Both timeout
    *      (2114) and post-failed (2119) flow through the structured channel
    *      as `renderer_protocol_error` with a `details.subtype` discriminating
-   *      timeout vs post-failed vs malformed-payload — the spec vocabulary
-   *      has only one event type for renderer protocol failures, so we
-   *      honor it. `bridge_load_failed` carries error code 2115 (same as
+   *      timeout vs post-failed vs integrity-failed vs malformed-payload — the
+   *      spec vocabulary has only one event type for renderer protocol
+   *      failures, so we honor it. `bridge_load_failed` carries error code 2115 (same as
    *      `renderer_failed`) but gets its own `event.type` for operator
    *      observability — bridge import failures are a distinct deployment
    *      concern from creative-side render failures.
@@ -4201,7 +4368,8 @@ class SHARCContainer {
     if (typeof this._onSecurityEvent === 'function') {
       let structuredType;
       if (internalType === 'renderer_protocol_timeout'
-          || internalType === 'renderer_protocol_post_failed') {
+          || internalType === 'renderer_protocol_post_failed'
+          || internalType === 'renderer_integrity_failed') {
         structuredType = 'renderer_protocol_error';
       } else {
         structuredType = internalType;
@@ -5218,6 +5386,7 @@ class SHARCContainer {
    *   creativeUrl?: string|null|undefined,
    *   creativeHtml?: string|null|undefined,
    *   creativeRendererUrl?: any,
+   *   creativeRendererIntegrity?: any,
    *   onSecurityEvent?: SHARCSecurityEventCallback|undefined,
    *   wrapperPolicy?: string|undefined,
    *   bridges?: string[]|null|undefined,
@@ -5238,6 +5407,7 @@ class SHARCContainer {
       creativeUrl,
       creativeHtml,
       creativeRendererUrl,
+      creativeRendererIntegrity,
       onSecurityEvent,
       wrapperPolicy = 'warn',
       bridges,
@@ -5289,6 +5459,23 @@ class SHARCContainer {
         '[SHARCContainer] creativeRendererUrl is only valid alongside creativeHtml '
         + '(Creative Markup variant). Remove creativeRendererUrl when using creativeUrl.'
       );
+    }
+
+    if (creativeRendererIntegrity !== undefined && !hasCreativeHtml) {
+      throw new TypeError(
+        '[SHARCContainer] creativeRendererIntegrity is only valid alongside '
+        + 'creativeHtml + creativeRendererUrl (Creative Markup variant).'
+      );
+    }
+
+    if (creativeRendererIntegrity !== undefined) {
+      if (typeof creativeRendererIntegrity !== 'string'
+          || !/^sha384-[A-Za-z0-9+/]+={0,2}$/.test(creativeRendererIntegrity)) {
+        throw new TypeError(
+          '[SHARCContainer] creativeRendererIntegrity must be an SRI-style '
+          + 'SHA-384 digest string in the form "sha384-<base64>".'
+        );
+      }
     }
 
     // Rule 3b (0.7.1, issue #82): `bridges` and `creativeMeta` are Creative Markup

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -208,6 +208,10 @@ const ErrorCodes = Object.freeze({
   // null contentWindow, etc. Distinct from 2114 (timeout) for telemetry/alerting
   // accuracy: a transport-layer send failure is not a latency failure.
   RENDERER_POST_FAILED: 2119,
+  // 2120: optional preflight integrity verification for creativeRendererUrl
+  // failed before the renderer iframe was allowed to load. Distinct from
+  // renderer-reported failures because no SHARC:Renderer:render message was sent.
+  RENDERER_INTEGRITY_FAIL: 2120,
   UNSPECIFIED_CONTAINER: 2200,
   WRONG_SHARC_VERSION_CONTAINER: 2201,
   UNSUPPORTED_FEATURE: 2203,

--- a/test/node/test-creative-sources-load.js
+++ b/test/node/test-creative-sources-load.js
@@ -159,6 +159,11 @@ function markupOptions(overrides) {
     ...overrides,
   };
 }
+async function sha384Sri(input) {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await globalThis.crypto.subtle.digest('SHA-384', bytes);
+  return 'sha384-' + SHARCContainer._base64FromArrayBuffer(digest);
+}
 
 /**
  * Builds a Markup container, calls .load(), captures the SHARC:Renderer:render
@@ -2563,6 +2568,128 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       'URL: idempotency probe — exactly one unauthorized_navigation event fired');
   }
   flushContainers();
+}
+
+// -- 19. creativeRendererIntegrity preflight (#24) ────────────────────────
+{
+  console.log('\n19. creativeRendererIntegrity preflight');
+  const originalFetch = globalThis.fetch;
+  const originalError = console.error;
+  const rendererDoc = '<!doctype html><html><body>renderer v1</body></html>';
+  const validIntegrity = await sha384Sri(rendererDoc);
+
+  function mockFetchWith(body, responseOverrides = {}) {
+    globalThis.fetch = async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      url: RENDERER_URL,
+      arrayBuffer: async () => new TextEncoder().encode(body).buffer,
+      ...responseOverrides,
+    });
+  }
+
+  try {
+    // Positive path: no iframe navigation and no render post happen until the
+    // preflight fetch + SHA-384 comparison succeeds.
+    {
+      mockFetchWith(rendererDoc);
+      const captured = { posts: [] };
+      const c = track(new SHARCContainer(markupOptions({
+        creativeRendererIntegrity: validIntegrity,
+        timeouts: { rendererLoad: 50, rendererReply: 50 },
+      })));
+      c.load();
+      const iframe = c._iframe;
+      iframe.contentWindow.postMessage = (data, targetOrigin) => {
+        captured.posts.push({ data, targetOrigin });
+      };
+      assert(iframe.getAttribute('src') === null,
+        'integrity positive: iframe.src is not assigned synchronously');
+      await new Promise((r) => setTimeout(r, 20));
+      assert(iframe.getAttribute('src') && iframe.getAttribute('src').startsWith(RENDERER_URL + '#sharcNonce='),
+        'integrity positive: iframe.src assigned after digest match');
+      iframe.contentWindow.postMessage = (data, targetOrigin) => {
+        captured.posts.push({ data, targetOrigin });
+      };
+      iframe.dispatchEvent(new dom.window.Event('load'));
+      assert(captured.posts.length === 1,
+        'integrity positive: SHARC:Renderer:render posts after verified load');
+      assert(captured.posts[0].data.type === 'SHARC:Renderer:render',
+        'integrity positive: posted message is renderer render');
+      flushContainers();
+    }
+
+    // Negative path: mismatch terminates before iframe.src assignment, so the
+    // renderer never receives SHARC:Renderer:render.
+    {
+      mockFetchWith(rendererDoc + '<!-- tampered -->');
+      const errors = [];
+      const securityEvents = [];
+      const captured = { posts: [] };
+      console.error = () => {};
+      const c = track(new SHARCContainer(markupOptions({
+        creativeRendererIntegrity: validIntegrity,
+        timeouts: { rendererLoad: 50, rendererReply: 50 },
+        onError: (code, msg) => errors.push({ code, msg }),
+        onSecurityEvent: (event) => securityEvents.push(event),
+      })));
+      c.load();
+      const iframe = c._iframe;
+      iframe.contentWindow.postMessage = (data, targetOrigin) => {
+        captured.posts.push({ data, targetOrigin });
+      };
+      await new Promise((r) => setTimeout(r, 60));
+      assert(errors.length === 1 && errors[0].code === ErrorCodes.RENDERER_INTEGRITY_FAIL,
+        'integrity mismatch: onError receives RENDERER_INTEGRITY_FAIL (2120)');
+      assert(securityEvents[0] && securityEvents[0].type === 'renderer_protocol_error',
+        'integrity mismatch: onSecurityEvent maps to renderer_protocol_error');
+      assert(securityEvents[0] && securityEvents[0].details.subtype === 'integrity_failed',
+        'integrity mismatch: security event details.subtype === integrity_failed');
+      assert(captured.posts.length === 0,
+        'integrity mismatch: SHARC:Renderer:render is never posted');
+      assert(iframe.getAttribute('src') === null,
+        'integrity mismatch: iframe.src is never assigned');
+      flushContainers();
+    }
+
+    // Stalled verification fetch: the preflight shares the rendererLoad budget
+    // so integrity-enabled placements cannot remain loading forever before the
+    // normal iframe-load timeout has a chance to arm.
+    {
+      globalThis.fetch = () => new Promise(() => {});
+      const errors = [];
+      const securityEvents = [];
+      const captured = { posts: [] };
+      console.error = () => {};
+      const c = track(new SHARCContainer(markupOptions({
+        creativeRendererIntegrity: validIntegrity,
+        timeouts: { rendererLoad: 30, rendererReply: 50 },
+        onError: (code, msg) => errors.push({ code, msg }),
+        onSecurityEvent: (event) => securityEvents.push(event),
+      })));
+      c.load();
+      const iframe = c._iframe;
+      iframe.contentWindow.postMessage = (data, targetOrigin) => {
+        captured.posts.push({ data, targetOrigin });
+      };
+      await new Promise((r) => setTimeout(r, 70));
+      assert(errors.length === 1 && errors[0].code === ErrorCodes.RENDERER_INTEGRITY_FAIL,
+        'integrity stalled fetch: onError receives RENDERER_INTEGRITY_FAIL (2120)');
+      assert(errors[0] && /timed out after 30ms/.test(errors[0].msg),
+        'integrity stalled fetch: error message names the preflight timeout');
+      assert(securityEvents[0] && securityEvents[0].details.subtype === 'integrity_failed',
+        'integrity stalled fetch: security event details.subtype === integrity_failed');
+      assert(captured.posts.length === 0,
+        'integrity stalled fetch: SHARC:Renderer:render is never posted');
+      assert(iframe.getAttribute('src') === null,
+        'integrity stalled fetch: iframe.src is never assigned');
+      flushContainers();
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.error = originalError;
+  }
 }
 
 // ── Summary ───────────────────────────────────────────────────────────────

--- a/test/node/test-creative-sources.js
+++ b/test/node/test-creative-sources.js
@@ -127,6 +127,8 @@ console.log('test-creative-sources.js — issue #41 Phase A regression\n');
     'RENDERER_PROTOCOL_ERROR === 2117');
   assert(ErrorCodes.RENDERER_UNAUTHORIZED_NAVIGATION === 2118,
     'RENDERER_UNAUTHORIZED_NAVIGATION === 2118');
+  assert(ErrorCodes.RENDERER_INTEGRITY_FAIL === 2120,
+    'RENDERER_INTEGRITY_FAIL === 2120');
 }
 
 // -- 1b. _validateCreativeSources direct unit surface (#64) ────────────────
@@ -786,6 +788,27 @@ console.log('test-creative-sources.js — issue #41 Phase A regression\n');
     'rule 4 (parseable) thrown before rule 5 (https:)',
     Error,
   );
+
+  assertThrows(
+    () => new SHARCContainer(urlOptions({ creativeRendererIntegrity: 'sha384-abc=' })),
+    /creativeRendererIntegrity is only valid/,
+    'creativeRendererIntegrity with Creative URL throws TypeError',
+    TypeError,
+  );
+
+  assertThrows(
+    () => new SHARCContainer(markupOptions({ creativeRendererIntegrity: 'sha256-abc=' })),
+    /creativeRendererIntegrity must be an SRI-style SHA-384/,
+    'creativeRendererIntegrity rejects non-sha384 algorithm',
+    TypeError,
+  );
+
+  assertThrows(
+    () => new SHARCContainer(markupOptions({ creativeRendererIntegrity: 123 })),
+    /creativeRendererIntegrity must be an SRI-style SHA-384/,
+    'creativeRendererIntegrity rejects non-string value',
+    TypeError,
+  );
 }
 
 // -- 12. Creative URL variant — instance properties ────────────────────────
@@ -834,6 +857,11 @@ console.log('test-creative-sources.js — issue #41 Phase A regression\n');
     'container.bridges is a frozen array (0.7.1)');
   assert(c.bridges.length === 0,
     'container.bridges = [] for fixture creativeHtml without bridge signals');
+
+  const integrity = 'sha384-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+  const withIntegrity = new SHARCContainer(markupOptions({ creativeRendererIntegrity: integrity }));
+  assert(withIntegrity._creativeRendererIntegrity === integrity,
+    'creativeRendererIntegrity is preserved privately for Markup variant');
 }
 
 // -- 14. Sandbox / policy options — defaults and overrides ────────────────

--- a/test/types/consumer.ts
+++ b/test/types/consumer.ts
@@ -65,6 +65,7 @@ void sid;
 const markupContainer = new SHARCContainer({
   creativeHtml: '<html><body>inline ad markup</body></html>',
   creativeRendererUrl: 'https://renderer.operator.example/0.7.0/',
+  creativeRendererIntegrity: 'sha384-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
   placementElement: slot,
   allowPopups: true,
   allowTopNavigationByUserActivation: true,
@@ -107,7 +108,7 @@ if (_evt.type === 'wrapper_top_frame_inaccessible') {
   void actual;
   void code;
 } else if (_evt.type === 'renderer_protocol_error') {
-  const subtype: 'malformed_payload' | 'timeout' | 'post_failed' = _evt.details.subtype;
+  const subtype: 'malformed_payload' | 'timeout' | 'post_failed' | 'integrity_failed' = _evt.details.subtype;
   const reason: string = _evt.details.reason;
   void subtype;
   void reason;


### PR DESCRIPTION
## Summary
- add optional `creativeRendererIntegrity` for Creative Markup renderer SHA-384 preflight verification
- block renderer iframe load and `SHARC:Renderer:render` when verification fails, surfacing `RENDERER_INTEGRITY_FAIL` / `renderer_protocol_error`
- document iframe-SRI limitations, including the CORS requirement for cross-origin verification fetches, and add constructor/load/type coverage

## Notes
- This is defense in depth rather than native iframe SRI because browsers do not support `integrity=` on iframe navigations.
- No Form 2 fallback path is added here because there is not currently a configured fallback option to switch to.

## Tests
- `npm run build`
- `npm run test:creative-sources`
- `npm run test:creative-sources-load`
- `npm run test:types`
- `npm run lint`
- `npm run check`

Closes #24
