### PR TITLE
docs(design): 0.7.6 bfcache Puppeteer wiring release design

### DIFF
--- a/docs/design/0.7.6-bfcache-puppeteer-wiring.md
+++ b/docs/design/0.7.6-bfcache-puppeteer-wiring.md
@@ -1,0 +1,527 @@
+# 0.7.6 — bfcache Puppeteer Harness Wiring
+
+**Status:** Proposed (design under review)
+**Issue:** [#178](https://github.com/jeffreycarlson/SHARC/issues/178)
+**Target version:** 0.7.6
+**Predecessors:** 0.7.4 PR G (architect-shipped scaffold at `test/browser/test-html-lifecycle-adapter-bfcache.js`, 5-section assertion matrix bf-1 through bf-5, currently red on `main` with `IMPLEMENTOR-TODO` errors). 0.7.2 design § 8.4 (Puppeteer follow-up note). PR #98 (strict-LOADING freeze yield — bf-4 is its regression guard).
+**Baseline commit:** `99612ce` (post-0.7.5 release).
+**Plan C origin:** the assertion contract was authored and red-pinned by the architect in PR #176; 0.7.6 is the **wiring-only** release that lights up the 4 `IMPLEMENTOR-TODO` chokepoints. No new failing tests are introduced — the contract is already pinned.
+
+---
+
+## Table of contents
+
+1. [Release framing](#1-release-framing)
+2. [Per-item ADRs (the 9 locked decisions)](#2-per-item-adrs)
+3. [Harness internal architecture (4 implementor chokepoints)](#3-harness-internal-architecture)
+4. [Fixture page architecture](#4-fixture-page-architecture)
+5. [`server.cjs` integration](#5-servercjs-integration)
+6. [`package.json` scripts](#6-packagejson-scripts)
+7. [CI workflow integration](#7-ci-workflow-integration)
+8. [Code-paths-touched map](#8-code-paths-touched-map)
+9. [Decision log](#9-decision-log)
+10. [References](#10-references)
+
+---
+
+## 1. Release framing
+
+0.7.6 is a **test-infrastructure-only release**. The 0.7.4 hardening cycle deferred PR G's Chrome wiring with an explicit architect sanction ("if devops capacity blocks, this scaffold ships as-is and the wiring rolls forward"). 0.7.5 closed unrelated container-SDK work. 0.7.6 picks up the orphaned scaffold and wires it to a real Chrome instance driven by `puppeteer-core` (already a dep at `^24.22.0`, exercised today by `test/browser/test-creative-sources-puppeteer.js`).
+
+**Scope is deliberately solo.** No bundling with #185, #96, #24, or other open follow-ups. The bfcache-roundtrip class of test failure has a non-trivial CI-flake footprint and benefits from landing in isolation so the retry policy can be tuned without confounding signals.
+
+**No production code touched.** The HTML lifecycle adapter at `src/lifecycle-adapters/html-adapter.js` is already validated by the jsdom suite (`test/node/test-html-lifecycle-adapter.js` § 7, § 8, § 13). The Puppeteer suite closes the real-browser-bfcache gap that jsdom cannot model (event-loop freeze, implicit iframe freezing, browser eligibility rules). If the wiring surfaces a real adapter bug, that is a 0.7.7+ regression item — out of 0.7.6 scope.
+
+### Sequencing
+
+One content PR (G2 — the wiring) + one close-out PR (H equivalent — CHANGELOG / current-status / version bump). The scaffold's "no architect-pre-committed failing-test branch" note is correct: the assertions exist in `main` already, red, with `IMPLEMENTOR-TODO` errors. The wiring PR turns those errors into real harness setup, and the same assertion bodies become executable.
+
+| PR | Issue | Type | Rough scope |
+|----|-------|------|-------------|
+| G2 | [#178](https://github.com/jeffreycarlson/SHARC/issues/178) | Test infra + 2 new fixture HTML files | Replace 4 `IMPLEMENTOR-TODO` helpers with real Puppeteer wiring. New `test/browser/bfcache-fixture.html` + `test/browser/bfcache-away.html`. New `npm run test:bfcache` script. New CI job step (separate from `test:all`). |
+| H  | —     | Mechanical | CHANGELOG `[Unreleased]` → `[0.7.6]` entry, `current-status.md` "What Shipped in 0.7.6" stanza, `npm version patch` → propagates via `scripts/sync-version.js`, `npm run build` to regenerate `dist/`. |
+
+### Breaking-change inventory
+
+**None.** No public API surface change. The test file is internal to the repo; the fixture pages are new and unused outside the test runner; `npm run test:bfcache` is purely additive; CI gets a new step. SemVer-strict consumers see only the version bump and CHANGELOG entry.
+
+---
+
+## 2. Per-item ADRs
+
+### ADR-178-A — Tool: `puppeteer-core` (NOT Playwright)
+
+**Context.** The scaffold is structured for Puppeteer (see `IMPLEMENTOR-TODO` comments referencing `page.goto`, `page.goBack()`, `page.evaluate`). The repo already has `puppeteer-core@^24.22.0` as a runtime dep, exercised by `test/browser/test-creative-sources-puppeteer.js`. Adding Playwright would introduce a second browser-automation framework with overlapping responsibilities.
+
+**Decision.** Use `puppeteer-core`. Match the import/launch pattern of `test/browser/test-creative-sources-puppeteer.js` (resolveChromePath, `--no-sandbox`, headless launch). Cross-browser future-proofing is not a 0.7.6 concern — Chrome is the bfcache implementation under test, and Chrome is where bfcache semantics actually matter (WebKit's PageCache is structurally different; Firefox's bfcache has weaker observability). When/if WebKit-side bfcache testing becomes a need, that is a separate /design conversation.
+
+**Consequences.** Reuse `resolveChromePath()`, the `CHROME_PATH` / `PUPPETEER_EXECUTABLE_PATH` env var ladder, and the `args: ['--no-sandbox', '--disable-setuid-sandbox']` baseline from the existing Puppeteer test. Add a single new flag — see ADR-178-G — for bfcache CI determinism. No package.json dep change.
+
+**Alternatives rejected.** Playwright (introduces second framework, no current parity payoff). `puppeteer` (full) instead of `puppeteer-core` (would bundle a Chromium download into the npm install; CI already pins Chrome via setup-chrome action style). Headed Chrome via system browser (defeats CI portability).
+
+---
+
+### ADR-178-B — Standalone fixture page (NOT reusing `examples/demos/`)
+
+**Context.** The fixture must instantiate `SHARCContainer` with `requireSharcInit: false` (permissive mode — bf-1, bf-2, bf-3, bf-5) and also support a strict variant (`requireSharcInit: true`) for bf-4. The `examples/demos/` tree is operator-facing reference material; embedding test-only state-capture wiring into a demo page would either pollute the public reference or create branching code paths.
+
+**Decision.** Standalone `test/browser/bfcache-fixture.html`. The page lives alongside the other test-browser HTML fixtures (`test-creative-sources.html`, `mraid-test.html`, etc.) — same directory, same convention, served by the same `server.cjs` route.
+
+**Consequences.** Test concerns stay in `test/browser/`. The fixture can carry a `window.__capturedStateChanges` global and a `window.__sharcBfcacheHarness` namespace without contaminating example code. The fixture URL is parameterizable (e.g. `?strict=1` for bf-4) without forking files.
+
+**Alternatives rejected.** Reusing `examples/demos/index.html` (mixes test instrumentation into reference docs). Inlining the fixture HTML via `page.setContent()` (loses bfcache eligibility — the page must come from a network response with appropriate headers, not from a synthetic content set). Reusing `test/browser/test-creative-sources.html` (designed around the Creative Sources harness, not a permissive non-SHARC container; would distort that file's purpose).
+
+---
+
+### ADR-178-C — State capture via `page.evaluate(() => window.__capturedStateChanges)` (NOT CDP event streaming)
+
+**Context.** The bfcache assertions need an in-order record of `onStateChange(newState, previousState)` callbacks across multiple navigation phases (before entry → during entry → after restore). Two architectural options: (1) drive a CDP `Runtime.consoleAPICalled` stream with a structured payload; (2) push each callback into a `window.__capturedStateChanges` array and harvest it with `page.evaluate`.
+
+**Decision.** `page.evaluate(() => window.__capturedStateChanges)` after each phase. The fixture's `onStateChange` handler appends `{ newState, previousState, timestamp }` to the array; the harness reads it on demand.
+
+**Consequences.** Simpler implementation, no CDP wiring. The array survives bfcache entry/exit because the document survives (that's the whole point of bfcache). After restoration, the same array is still there with the entry transitions intact, and new restore-phase transitions append in order. The harness can do `captureStateChangeSequence(page)` at any boundary and get the full ordered log.
+
+**Caveat.** The timestamp uses `performance.now()`, which freezes in bfcache (per spec). The frozen-during-bfcache transitions will all carry timestamps from before-entry; the post-restore transitions get fresh timestamps. This is correct behavior — assertions order by array index, not by timestamp.
+
+**Alternatives rejected.** CDP `Runtime.consoleAPICalled` streaming (more code, more failure modes, and bfcache itself disconnects the CDP session in some Chrome versions — the very behavior we're testing breaks the channel that would observe it). `MessageChannel` or `BroadcastChannel` (bfcache closes both). Polling via `page.exposeFunction()` (the exposed function is invalidated when the page enters bfcache, then reinstated on restore — fragile around the transitions we care most about).
+
+---
+
+### ADR-178-D — Navigate-away target: sibling `test/browser/bfcache-away.html` on `:8765` (NOT `about:blank`)
+
+**Context.** Triggering bfcache entry requires navigating away to a different document. Chrome's bfcache eligibility rules are strict: the source page (the fixture) must not have any disqualifying conditions (open `WebSocket`, `unload` handler, `Cache-Control: no-store`, etc.), AND the navigation must be a normal HTTP load — not `about:blank`, not `data:` URLs, not file-protocol navigations. Chrome treats those as special cases that often defeat bfcache.
+
+**Decision.** A sibling fixture `test/browser/bfcache-away.html` served by `server.cjs` at `http://localhost:8765/test/browser/bfcache-away.html`. Trivial content — a single heading. No JavaScript. No iframes. No `unload` handler. No `pagehide` listener. No `Cache-Control: no-store` response header (the dev server doesn't set it; ADR-178-E verifies).
+
+**Consequences.** Same-origin navigation, same server, same headers as the fixture page. This maximizes bfcache eligibility: same-origin transitions are the documented happy path for bfcache in Chrome. The away page is reachable via `page.goto('http://localhost:8765/test/browser/bfcache-away.html')` and the bounce back uses `page.goBack()`.
+
+**Alternatives rejected.** `about:blank` (Chrome's bfcache treats `about:blank` specially; navigation to it from a `http:` origin is not a reliable bfcache trigger). `data:text/html,<h1>away</h1>` (same issue). An external URL like `https://example.com` (requires network, flakes on offline CI runners, and may carry surprise headers). Reusing an existing test page like `mraid-test.html` (carries its own SHARC instrumentation that could fire `pagehide` handlers and disqualify the *source* page's bfcache eligibility via cross-frame side effects).
+
+---
+
+### ADR-178-E — CI strategy: tier + retry (structural vs behavioral assertions)
+
+**Context.** bfcache is famously CI-flaky. The exact moment Chrome installs a page into bfcache depends on internal heuristics that have varied across Chrome versions (memory pressure, navigation timing, recently-used-frame tracking). Some bf-* assertions are deterministic regardless of Chrome internals; others depend on the bfcache actually installing.
+
+**Decision.** Two tiers:
+
+| Tier | Assertions | Determinism source | CI policy |
+|------|-----------|-------------------|-----------|
+| **Structural** | bf-1 (eligibility check), bf-5 (no `invalid transition` warns) | bf-1 reads Chrome's own bfcache-eligibility signal via CDP; bf-5 is a presence-check over `console.warn` output. Both pass even if the page does not actually enter bfcache. | No retries. Fail = hard fail. |
+| **Behavioral** | bf-2 (LOADING → ACTIVE → HIDDEN → FROZEN), bf-3 (FROZEN → ACTIVE restore), bf-4 (strict-LOADING yield) | Depends on bfcache actually installing on this Chrome version under these CI conditions. | Up to **3 retries** at the test-runner level. Pass on any-of-3 = pass. |
+
+The retry happens *inside* the test runner (not at the workflow level), so a single CI job reports a single pass/fail. The runner logs each attempt so a true regression is distinguishable from flake (regression = all 3 fail with the same diagnostic; flake = mixed pass/fail).
+
+**Consequences.** The runner needs a tier annotation on each section. Implementation: a small `tier: 'structural' | 'behavioral'` field per section block, plus a `runWithRetry(fn, attempts)` wrapper used only on behavioral tiers. The structural assertions run inline as today.
+
+**Alternatives rejected.** Uniform 3 retries on all assertions (hides real bugs in bf-1 / bf-5 behind flake-retry). Zero retries on all (CI red on flake, false alarms, devs ignore the signal). `continue-on-error: true` at the workflow level (CI goes green even when behavioral assertions consistently fail — defeats the test's purpose). Marking the whole step `continue-on-error` (same problem, larger blast radius).
+
+---
+
+### ADR-178-F — `npm run test:bfcache` script added; NOT included in `npm run test:all`
+
+**Context.** `npm run test:all` is the canonical "run everything before pushing" entry point, also invoked by `npm run check` and used implicitly during release prep. It currently completes deterministically (perf test has a 3-attempt internal retry, but no test in `test:all` requires real bfcache). Adding a CI-flaky test would degrade the signal value of `test:all` — devs would learn to ignore failures rather than debug them.
+
+**Decision.** Add `test:bfcache` as a standalone npm script. Do NOT add it to `test:all` or `test:all:built`. CI gets a dedicated step that invokes `test:bfcache` directly. This preserves the orphaned-from-`test:all` framing the scaffold ships with (the scaffold file is currently not referenced from `test:all` either — it lives alongside `test:browser` which IS in `test:all`, but the bfcache file is independent).
+
+**Consequences.** Local developers running `npm test` or `npm run test:all` do NOT incur bfcache flake. They run `npm run test:bfcache` deliberately when working on adapter changes. CI runs it as a separate step with retry semantics (ADR-178-E). The release checklist updates to mention `npm run test:bfcache` separately.
+
+**Alternatives rejected.** Add to `test:all` (degrades `test:all` reliability for a single test class). Add to `test:all` but mark `continue-on-error` (no such mechanism in npm scripts; would require a wrapper shell script that silently swallows failures — actively harmful). Make `test:bfcache` an alias for `test:all` (defeats the separation). Skip the script entirely and put the command inline in CI (loses local reproducibility).
+
+---
+
+### ADR-178-G — PR shape: single wiring PR + release close-out PR
+
+**Context.** The work is naturally bounded: 4 `IMPLEMENTOR-TODO` chokepoints to fill, 2 new fixture HTML files, 1 npm script, 1 CI step. No upstream dependencies. No production code changes. Splitting this into multiple PRs would create artificial coordination overhead.
+
+**Decision.** Single PR G2 for all wiring. A second PR H for the release close-out (CHANGELOG / current-status / version bump / dist rebuild), matching the 0.7.4 / 0.7.5 release shape.
+
+**Consequences.** Two PRs, sequenced PR G2 → PR H. PR G2 lands the test infra; PR H bumps the version once G2 is green in CI. Same shape as previous releases, easy to review.
+
+**Alternatives rejected.** Single PR including the version bump (couples test-wiring to release mechanics; if the wiring needs review iteration, the version bump churns alongside). Three PRs (fixture pages → harness wiring → CI step) (overhead with no review benefit; the fixture pages are useless without the harness, the harness is useless without the CI step).
+
+---
+
+### ADR-178-H — 0.7.6 is solo-scoped to #178
+
+**Context.** Open follow-ups exist (#185, #96, #24, others). Each has its own design and review surface. Bundling unrelated work into the same release would either delay the bfcache wiring (waiting on the slowest item) or muddy the CHANGELOG and post-release diagnostics.
+
+**Decision.** 0.7.6 ships #178 alone. Other follow-ups roll forward to 0.7.7+. Re-evaluate scope at 0.7.7 design time based on what's ready then.
+
+**Consequences.** A small, fast release with one clear purpose. Easy CHANGELOG, easy current-status entry, easy verification: if bfcache CI is green, 0.7.6 is shippable.
+
+**Alternatives rejected.** Bundle #185 ("if it's small enough"). Bundle anything labeled "0.7.x" in the issue tracker (speculative version-tagging is explicitly flagged as bad practice per the user's prior feedback). Wait for a "bigger" release window (the wiring itself is small; waiting gains nothing).
+
+---
+
+### ADR-178-I — Release design doc first, locking the 8 prior decisions as ADRs
+
+**Context.** This is the third release-design doc in the family (0.7.3, 0.7.4, now 0.7.6 — 0.7.5 was small enough to skip a doc). The pattern works: locked decisions go into the doc, the dev agent gets a stable reference, scope drift is visible at review time.
+
+**Decision.** Produce this doc before `/develop`. Lock the 8 prior /discover decisions as ADRs A–H above. The doc commits to a branch but does NOT auto-PR — Jeffrey reviews and decides whether to merge straight to main (per the 0.7.5-style mini-release shape) or open a PR (per the 0.7.4 doc which went through PR #153).
+
+**Consequences.** /develop's first action is to read this doc, not to start coding. The 4 `IMPLEMENTOR-TODO` chokepoints have contract specifications below (§ 3) — function signatures, return types, error semantics. /develop fills the contracts; this doc does not.
+
+**Alternatives rejected.** Skip the design doc (the family pattern is two releases deep — breaking it now loses the per-release historical record). Inline the design into the PR description (too long, too easy to lose, not searchable from the docs/ tree).
+
+---
+
+## 3. Harness internal architecture
+
+This section specifies the **contract** of the 4 `IMPLEMENTOR-TODO` functions in `test/browser/test-html-lifecycle-adapter-bfcache.js`. Function signatures, return types, error semantics. /develop writes the implementations.
+
+### 3.1 `setupPuppeteerBfcacheHarness() → Promise<Harness>`
+
+**Signature.**
+
+```js
+/**
+ * @returns {Promise<{
+ *   browser: import('puppeteer-core').Browser,
+ *   page: import('puppeteer-core').Page,
+ *   serverProc: import('node:child_process').ChildProcess,
+ *   consoleWarns: string[],
+ *   cleanup: () => Promise<void>
+ * }>}
+ */
+async function setupPuppeteerBfcacheHarness()
+```
+
+**Behavior.**
+
+1. **Spawn `server.cjs`** on `PORT=8765` (default) using the `withServer()` pattern from `test/browser/test-creative-sources-puppeteer.js`. Wait for `http://localhost:8765/` to respond before returning. Allow env override via `PORT` (default 8765 per repo convention). Reuse the existing `RENDERER_PORT` plumbing even though bfcache doesn't need the renderer origin — keeps the spawn invocation symmetric.
+2. **Launch Chrome** via `puppeteer.launch()` with:
+   - `executablePath: resolveChromePath()` (reuse the helper pattern from the existing Puppeteer test; do NOT inline a copy — extract to a shared module under `test/browser/shared/` if the implementor judges it warranted, otherwise import from the existing file).
+   - `headless: true`
+   - `args`:
+     - `--no-sandbox`
+     - `--disable-setuid-sandbox`
+     - `--enable-features=BackForwardCache,BackForwardCacheMemoryControls`
+     - `--disable-features=BackForwardCacheTimeToLiveControl` (disables the bfcache eviction timer that can race CI's `page.goBack()` call on slow runners)
+3. **Create a `page`** via `browser.newPage()`. Attach a `console` listener that pushes warning-tier messages into a `consoleWarns: string[]` array (shared with the test via the returned harness object — bf-5 reads it).
+4. **Attach a `pageerror` listener** that logs uncaught page exceptions to stderr for diagnostic purposes (does not affect test pass/fail).
+5. **Return** the harness object. `cleanup()` closes the browser, kills the server process (mirroring the SIGTERM + 1500 ms grace pattern from the existing test), and resolves.
+
+**Error semantics.** If Chrome cannot be located, throw the existing `resolveChromePath` error verbatim (operator gets the env-var ladder hint). If the server fails to start within 10 s, throw `Error('Server failed to start within 10 s')`. If `browser.newPage()` fails, propagate. The current SCAFFOLD `throw new Error('IMPLEMENTOR-TODO: ...')` goes away.
+
+**Timeout semantics.** `RUN_TIMEOUT_MS = 60_000` (longer than the existing Puppeteer test's 30 s because bfcache install can take up to 10 s on a slow CI runner). `page.setDefaultTimeout(60_000)` on the returned page.
+
+### 3.2 `loadPermissiveContainerInPuppeteer(page, options) → Promise<void>`
+
+**Signature.**
+
+```js
+/**
+ * @param {import('puppeteer-core').Page} page
+ * @param {{ requireSharcInit?: boolean }} options
+ * @returns {Promise<void>}
+ */
+async function loadPermissiveContainerInPuppeteer(page, options)
+```
+
+**Behavior.**
+
+1. Compute fixture URL: `const strict = options && options.requireSharcInit === true; const url = strict ? 'http://localhost:8765/test/browser/bfcache-fixture.html?strict=1' : 'http://localhost:8765/test/browser/bfcache-fixture.html';`
+2. `await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60_000 });`
+3. **Wait for container ready signal.** The fixture sets `window.__sharcBfcacheReady = true` once its `SHARCContainer` instance is constructed and the first `onStateChange` callback has fired (i.e. the initial LOADING → ACTIVE transition for permissive mode, or LOADING for strict mode). Wait via `await page.waitForFunction(() => window.__sharcBfcacheReady === true, { timeout: 30_000 });`
+4. Return when ready. Throw on timeout.
+
+**Error semantics.** Timeout on `waitForFunction` throws Puppeteer's standard `TimeoutError`; the test runner's try/catch logs it. Container construction failures (e.g. SHARCContainer throws during construction) surface as `pageerror` events captured by the harness setup and logged to stderr. The test's `bf-1` assertion will fail because `__sharcBfcacheReady` never becomes true.
+
+**Options handling.** Only `requireSharcInit` is read in 0.7.6. Future options (e.g. `creativeUrl`, `creativeHtml` variants) extend the signature with default fallthrough. The fixture HTML reads `URLSearchParams` from `location.search` and branches construction accordingly — see § 4.
+
+### 3.3 `captureStateChangeSequence(page) → Promise<Array<{newState, previousState, timestamp}>>`
+
+**Signature.**
+
+```js
+/**
+ * @param {import('puppeteer-core').Page} page
+ * @returns {Promise<Array<{newState: string, previousState: string, timestamp: number}>>}
+ */
+async function captureStateChangeSequence(page)
+```
+
+**Behavior.**
+
+1. `return page.evaluate(() => Array.isArray(window.__capturedStateChanges) ? window.__capturedStateChanges.slice() : []);`
+2. **Non-destructive.** Returns a shallow copy. Does NOT clear `window.__capturedStateChanges`. The array continues to accumulate across phases. The test compares slices (`.slice(beforeCount)`) to isolate per-phase transitions.
+
+**Rationale for non-destructive read.** bf-2 needs the full sequence across pre-entry → entry → restore. A destructive read would lose context. The slight memory cost (a handful of `{ newState, previousState, timestamp }` objects per phase) is negligible. The harness can call it freely; the test code is responsible for slicing.
+
+**Error semantics.** If `window.__capturedStateChanges` is undefined (fixture not loaded yet, or fixture failed to install the capture), returns `[]`. Tests should call `loadPermissiveContainerInPuppeteer` first and verify a non-empty array on first read.
+
+### 3.4 `triggerBfcacheEntry(page) → Promise<void>` and `triggerBfcacheRestore(page) → Promise<void>`
+
+**`triggerBfcacheEntry` signature.**
+
+```js
+/**
+ * @param {import('puppeteer-core').Page} page
+ * @returns {Promise<void>}
+ */
+async function triggerBfcacheEntry(page)
+```
+
+**Behavior.**
+
+1. `await page.goto('http://localhost:8765/test/browser/bfcache-away.html', { waitUntil: 'domcontentloaded', timeout: 30_000 });`
+2. **Wait for bfcache install.** Chrome installs the previous page into bfcache asynchronously after navigation. The wait strategy: `await page.waitForFunction(() => document.readyState === 'complete', { timeout: 10_000 });` on the new page, then `await new Promise((r) => setTimeout(r, 500));` to let Chrome's bfcache installer settle. The 500 ms is empirically derived; tunable via `BFCACHE_INSTALL_MS` env var if a CI tuning pass needs to raise it.
+3. Return.
+
+**`triggerBfcacheRestore` signature.**
+
+```js
+/**
+ * @param {import('puppeteer-core').Page} page
+ * @returns {Promise<{ persisted: boolean }>}
+ */
+async function triggerBfcacheRestore(page)
+```
+
+**Behavior.**
+
+1. **Arm a `pageshow` capture on the previous page** before `goBack`. The fixture already has a `pageshow` listener (installed by the HTML adapter via `window.addEventListener('pageshow', ...)`) that writes the event's `persisted` flag to `window.__lastPageshowPersisted`. The harness reads this after restore.
+2. `await page.goBack({ waitUntil: 'domcontentloaded', timeout: 30_000 });`
+3. `await page.waitForFunction(() => window.__lastPageshowPersisted !== undefined, { timeout: 10_000 });`
+4. `const persisted = await page.evaluate(() => window.__lastPageshowPersisted);`
+5. Return `{ persisted }`.
+
+**Verification of bfcache install.** Callers (the bf-2/bf-3 assertions) check `result.persisted === true`. If `persisted` is `false`, Chrome did not install bfcache for this page — the test runner retries per ADR-178-E. After 3 attempts of `persisted: false`, the test fails with the diagnostic "bfcache did not install; check Chrome flags / disqualifying conditions in fixture".
+
+**Error semantics.** Timeout on either `waitForFunction` indicates the page is broken (no `pageshow` fired) or Chrome version mismatch — bubble Puppeteer's standard error. The test runner converts these into per-attempt failures handled by the retry wrapper.
+
+---
+
+## 4. Fixture page architecture
+
+### 4.1 `test/browser/bfcache-fixture.html`
+
+**Purpose.** Hosts a `SHARCContainer` instance in permissive (`requireSharcInit: false`) or strict (`requireSharcInit: true`) mode. Captures every `onStateChange` callback into `window.__capturedStateChanges`. Captures every `pageshow.persisted` value into `window.__lastPageshowPersisted`. Signals readiness via `window.__sharcBfcacheReady`.
+
+**Minimal HTML shape.**
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>SHARC bfcache fixture</title>
+  <!-- NO Cache-Control: no-store header — server.cjs default headers (Access-Control-Allow-Origin: *) do not include it, verified at server.cjs:106-110. -->
+  <!-- NO unload handler. NO beforeunload handler. -->
+</head>
+<body>
+  <h1>SHARC bfcache fixture</h1>
+  <div id="placement" style="width: 300px; height: 250px;"></div>
+  <script type="module">
+    import { SHARCContainer } from '../../dist/sharc-container.mjs';
+
+    const params = new URLSearchParams(location.search);
+    const strict = params.get('strict') === '1';
+
+    window.__capturedStateChanges = [];
+    window.__lastPageshowPersisted = undefined;
+
+    window.addEventListener('pageshow', (event) => {
+      window.__lastPageshowPersisted = event.persisted;
+    });
+
+    const container = new SHARCContainer({
+      placement: document.getElementById('placement'),
+      creativeHtml: '<html><body><h2>permissive non-SHARC creative</h2></body></html>',
+      requireSharcInit: strict,
+      onStateChange: (newState, previousState) => {
+        window.__capturedStateChanges.push({
+          newState,
+          previousState,
+          timestamp: performance.now(),
+        });
+      },
+    });
+
+    window.__sharcBfcacheContainer = container;
+    window.__sharcBfcacheReady = true;
+  </script>
+</body>
+</html>
+```
+
+**Key design choices.**
+
+- **No `unload` handler.** Any `unload` listener disqualifies bfcache in Chrome. The fixture deliberately uses `pageshow` for the persistence read, not `unload` or `pagehide` — the adapter installs its own `pagehide` listener, which is bfcache-safe.
+- **No `Cache-Control: no-store` response header.** Verified at `server.cjs:106-110`: the dev server sets only `Content-Type`, `Access-Control-Allow-Origin: *`, `Access-Control-Allow-Headers: *`, and (for HTML) `Content-Security-Policy: object-src 'none'; base-uri 'none'`. None of these disqualify bfcache.
+- **`creativeHtml` non-SHARC creative.** A plain HTML markup that does NOT load `sharc-creative.js`. This forces the permissive variant (no handshake; the HTML lifecycle adapter drives the state machine end-to-end). For bf-4's strict variant, the construction still passes `creativeHtml` — strict mode means the container will wait for a handshake that never arrives, leaving state at `LOADING`, which is exactly what bf-4 needs.
+- **Module import via `../../dist/sharc-container.mjs`.** Same path style as `examples/renderer/index.html`. Requires `npm run build` to have populated `dist/` before the test runs. ADR-178-J (deferred to /develop) decides whether `test:bfcache` should depend on `npm run build` like the post-#183 dist-based tests; recommendation is **yes** — match the `test:all` shape's "build first" property by chaining as `"test:bfcache": "npm run build && node test/browser/test-html-lifecycle-adapter-bfcache.js"`.
+
+**Inline vs separate state-capture script.** The state-capture is small enough (5 lines) to inline. No separate `state-change-capture.js` file. If 0.7.7+ adds more capture surfaces (e.g. `onSecurityEvent`, `onContainerLifecycleEvent`), promoting to a separate file becomes warranted; for 0.7.6, inline is cleaner.
+
+### 4.2 `test/browser/bfcache-away.html`
+
+**Purpose.** Trivial navigate-away target. Must not introduce ANY behavior that could retroactively disqualify the *source* page (the fixture) from bfcache eligibility.
+
+**Minimal HTML.**
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>SHARC bfcache navigate-away target</title>
+</head>
+<body>
+  <h1>Navigated away — the original page is now (hopefully) in bfcache.</h1>
+</body>
+</html>
+```
+
+**Key design choices.**
+
+- **Zero JavaScript.** No event listeners, no SHARC instantiation, no XHR, no `fetch`, no `import()`.
+- **No iframes.** Cross-frame side effects can ripple back to the source page in unexpected ways across the bfcache boundary.
+- **No `Cache-Control: no-store` header.** Same protection as the fixture. Not strictly required for the away page itself (the away page's own bfcache eligibility is irrelevant — the test navigates AWAY from it via `goBack`, never INTO bfcache from it), but consistency keeps debugging simpler.
+- **Same-origin with fixture.** Both pages live on `http://localhost:8765`, which maximizes Chrome's willingness to bfcache the transition.
+
+---
+
+## 5. `server.cjs` integration
+
+**Server changes needed:** **None.**
+
+`server.cjs` serves any file under the repo root via the `path.resolve(ROOT, '.' + rawPath)` route at line 81, with a path-traversal guard at line 84-88 ensuring requests stay inside `ROOT`. Verified:
+
+- Files at `test/browser/bfcache-fixture.html` and `test/browser/bfcache-away.html` will be served at `http://localhost:8765/test/browser/bfcache-fixture.html` and `http://localhost:8765/test/browser/bfcache-away.html`.
+- The MIME map at `server.cjs:34` covers `.html` → `text/html`.
+- The default response headers at `server.cjs:106-110` are bfcache-friendly (no `Cache-Control: no-store`, no `Set-Cookie`).
+- The `Content-Security-Policy: object-src 'none'; base-uri 'none'` header set on HTML responses at line 112 does NOT disqualify bfcache (CSP itself is not a disqualifier; only specific directives like `unsafe-eval` in combination with certain blocked actions can affect bfcache, neither of which applies here).
+- The renderer port (`:8766`) is irrelevant to bfcache; the fixture runs entirely on the publisher port (`:8765`).
+
+If the wiring surfaces an unexpected bfcache disqualifier coming from server headers, that becomes a 0.7.7+ follow-up (e.g. add an opt-in `?bfcache-friendly=1` query param that suppresses CSP for the fixture). 0.7.6 ships against the current server behavior.
+
+---
+
+## 6. `package.json` scripts
+
+### 6.1 New script: `test:bfcache`
+
+**Exact command.**
+
+```json
+"test:bfcache": "npm run build && node test/browser/test-html-lifecycle-adapter-bfcache.js"
+```
+
+**Rationale for `npm run build &&`.** The fixture imports `../../dist/sharc-container.mjs`. Without `dist/` populated, the fixture page fails to load with a module-not-found error and bf-1 fails on a totally uninformative `__sharcBfcacheReady` timeout. Chaining `build &&` matches the post-#183 pattern where `test:all` was updated to build first; consistent local + CI behavior.
+
+**Tradeoff.** Each local invocation rebuilds `dist/` (a few seconds). Acceptable cost for the reliability gain. Developers running `test:bfcache` repeatedly can run `node test/browser/test-html-lifecycle-adapter-bfcache.js` directly to skip the rebuild after the first successful build.
+
+### 6.2 Not adding: `test:browser-bfcache` alias
+
+The existing `test:browser` script points to `test/browser/test-creative-sources-puppeteer.js`. A parallel name like `test:browser-bfcache` would invite the false impression that they're peer tests. They're not: `test:browser` is part of `test:all`; `test:bfcache` is deliberately not (per ADR-178-F). Distinct names reinforce the distinction. `test:bfcache` it is.
+
+### 6.3 `test:all` unchanged
+
+Per ADR-178-F, `test:all:built` does NOT add `&& npm run test:bfcache`. Verify the script at `package.json:75` continues to terminate at `test:renderer-fallback`.
+
+---
+
+## 7. CI workflow integration
+
+### 7.1 New CI step
+
+Add after the existing `test:browser` step (line 59 in `.github/workflows/ci.yml`), before the perf step:
+
+```yaml
+      - name: HTML lifecycle adapter bfcache round-trip (issue #178)
+        # bfcache is famously CI-flaky — Chrome's install heuristics vary
+        # across versions and CI hardware. The test runner internally retries
+        # behavioral assertions (bf-2, bf-3, bf-4) up to 3 times; structural
+        # assertions (bf-1, bf-5) run once. A true regression fails all 3
+        # behavioral attempts with the same diagnostic; a flake mixes pass/fail.
+        run: npm run test:bfcache
+        env:
+          # Allow CI tuning of the post-navigate settle delay without code change.
+          BFCACHE_INSTALL_MS: '750'
+```
+
+**Step placement rationale.** Adjacent to the existing `test:browser` step (also Puppeteer-driven) so debugging shared infrastructure issues (Chrome path, headless flags) keeps the related steps close. NOT adjacent to the perf step — perf has its own 3-attempt outer retry pattern; bfcache's retry is inside the runner.
+
+### 7.2 No `continue-on-error`
+
+The step blocks PR merge on failure. Per ADR-178-E, retries are handled inside the test runner. If the runner exhausts its retries and exits non-zero, that signal must reach the PR review surface. `continue-on-error: true` would defeat the purpose of running the test in CI at all.
+
+If the bfcache step proves chronically flaky after 0.7.6 ships, that's a 0.7.7+ tuning conversation (raise `BFCACHE_INSTALL_MS`, add more Chrome flags, pin a specific Chrome version). It is NOT solved by making the failure invisible.
+
+### 7.3 Chrome version pinning
+
+Not in 0.7.6 scope. The existing `test:browser` step uses whatever Chrome the runner provides via `resolveChromePath`. The bfcache step inherits the same resolution. If a specific Chrome version proves necessary for bfcache determinism, that's a 0.7.7+ follow-up — add an `actions/setup-chrome` step or similar.
+
+### 7.4 Headless mode
+
+The harness uses `headless: true` (per ADR-178-A). Chrome's headless mode supports bfcache since Chrome 109+. The CI runner's Chrome is well past that floor. No `--headless=new` flag is needed; the default headless mode is sufficient.
+
+---
+
+## 8. Code-paths-touched map
+
+| File | Why | Owner |
+|------|-----|-------|
+| `test/browser/test-html-lifecycle-adapter-bfcache.js` | Replace 4 `IMPLEMENTOR-TODO` helpers with real wiring per § 3 contracts; add per-section tier annotation + retry wrapper per ADR-178-E | /develop |
+| `test/browser/bfcache-fixture.html` | NEW — minimal SHARC container + state-capture per § 4.1 | /develop |
+| `test/browser/bfcache-away.html` | NEW — trivial navigate-away target per § 4.2 | /develop |
+| `package.json` | Add `test:bfcache` script per § 6.1 | /develop |
+| `.github/workflows/ci.yml` | Add bfcache step per § 7.1 | /develop |
+| `server.cjs` | No changes (verified § 5) | n/a |
+| `src/lifecycle-adapters/html-adapter.js` | No changes (adapter is the system under test, not the harness) | n/a |
+| `docs/api-reference.md` | None expected (no public surface change) | n/a |
+| `CHANGELOG.md` | `[Unreleased]` Added entry in PR G2, becomes `[0.7.6]` in PR H | release |
+| `docs/current-status.md` | PR H close-out only — "What Shipped in 0.7.6" stanza copy-pasted from 0.7.4 / 0.7.5 shape | release |
+| `package.json`, `package-lock.json`, `src/sharc-*.js` `@version` tags | PR H — version bump via `npm version patch` → propagates via `scripts/sync-version.js` | release |
+| `dist/*.mjs` | PR H — rebuild via `npm run build` post-version-bump | release |
+| `docs/design/0.7.6-bfcache-puppeteer-wiring.md` | This document — committed before /develop on `docs/design-0.7.6-bfcache` branch | architect (this turn) |
+
+---
+
+## 9. Decision log
+
+Numbered summary of the 9 locked decisions for fast scanning. Full justification in § 2.
+
+1. **Tool: `puppeteer-core`** (NOT Playwright). Match existing test infra.
+2. **Standalone fixture page** at `test/browser/bfcache-fixture.html` (NOT reusing `examples/demos/`).
+3. **State capture via `page.evaluate(() => window.__capturedStateChanges)`** after each phase (NOT CDP event streaming).
+4. **Navigate-away target: `test/browser/bfcache-away.html` on `:8765`** (NOT `about:blank`).
+5. **CI strategy: tier + retry.** bf-1/bf-5 deterministic (no retry); bf-2/bf-3/bf-4 behavioral (up to 3 retries inside the runner).
+6. **`npm run test:bfcache` added; NOT included in `npm run test:all`.** Dedicated CI step. Preserves `test:all` reliability.
+7. **PR shape: single wiring PR G2 + release close-out PR H.** Mirrors 0.7.4 / 0.7.5 release shape.
+8. **0.7.6 is solo-scoped to #178.** No bundling with #185, #96, #24, etc.
+9. **Release design doc first** (this doc), locking decisions 1–8 as ADRs before /develop starts.
+
+---
+
+## 10. References
+
+### Closes
+
+- [#178](https://github.com/jeffreycarlson/SHARC/issues/178) — Wire Puppeteer + Chrome harness for bfcache round-trip coverage
+
+### Related (existing follow-ups; NOT in 0.7.6 scope)
+
+- [#185](https://github.com/jeffreycarlson/SHARC/issues/185) — deferred to 0.7.7+
+- [#96](https://github.com/jeffreycarlson/SHARC/issues/96) — deferred
+- [#24](https://github.com/jeffreycarlson/SHARC/issues/24) — deferred
+
+### Prior ADRs and design docs
+
+- [`docs/design/0.7.4-omid-hardening.md`](./0.7.4-omid-hardening.md) — structural template for this doc; OMID hardening release that shipped the PR G scaffold under wiring-deferred status
+- [`docs/design/0.7.3-omid-wiring.md`](./0.7.3-omid-wiring.md) — earlier example of the per-release design doc pattern
+- [`docs/design/0.7.2-non-sharc-loading.md`](./0.7.2-non-sharc-loading.md) § 8.4 — original "Puppeteer follow-up" note; this release closes that note
+
+### Code paths under test (system under test, not modified)
+
+- `src/lifecycle-adapters/html-adapter.js` § 7 (`_onPagehide`), § 8 (`_onPageshow`), § 13 (strict-LOADING freeze yield at `_transitionToFrozen`) — validated end-to-end by this harness; jsdom counterpart at `test/node/test-html-lifecycle-adapter.js` § 7, § 8, § 13
+
+### Test infra precedent (pattern reuse)
+
+- `test/browser/test-creative-sources-puppeteer.js` — Puppeteer harness pattern; `resolveChromePath`, `withServer`, `parsePort`, console listener, page-error handling all reused by the 0.7.6 wiring
+
+---
+
+*End of design.*

--- a/docs/design/0.7.6-bfcache-puppeteer-wiring.md
+++ b/docs/design/0.7.6-bfcache-puppeteer-wiring.md
@@ -250,7 +250,7 @@ async function loadPermissiveContainerInPuppeteer(page, options)
 
 1. Compute fixture URL: `const baseUrl = process.env.BASE_URL || 'http://localhost:18765'; const strict = options && options.requireSharcInit === true; const url = strict ? \`${baseUrl}/test/browser/bfcache-fixture.html?strict=1\` : \`${baseUrl}/test/browser/bfcache-fixture.html\`;`
 2. `await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60_000 });`
-3. **Wait for container ready signal.** The fixture sets `window.__sharcBfcacheReady = true` synchronously immediately after `new SHARCContainer({...})` returns (see § 4.1 fixture body). Construction-time readiness is the right signal for both modes: permissive mode's `LOADING → ACTIVE` transition is async (gated on iframe `load` + intersection), and strict mode never leaves `LOADING` at all — `onStateChange` never fires for the initial `LOADING` state because there's no transition INTO it. The harness waits for the construction signal, then races against a `pageerror` listener for fast-fail diagnostics:
+3. **Wait for container ready signal.** The fixture sets `window.__sharcBfcacheReady = true` synchronously after `new SHARCContainer({...})` construction AND `container.load()` return (see § 4.1 fixture body). Both calls are synchronous from the harness's perspective: `load()` (see `src/sharc-container.js:1391-1416`) creates the iframe, registers protocol listeners, attaches the page-lifecycle listeners, and synchronously attaches the lifecycle adapter (which installs the `pagehide` / `pageshow` window listeners required for bfcache observation) before returning `this`. Iframe creation kicks off async DOM work, but adapter binding is complete before `load()` returns — that is the invariant the readiness flag gates on. Load-time readiness (post-`load()`, pre-iframe-onload) is the right signal for both modes: permissive mode's `LOADING → ACTIVE` transition is async (gated on iframe `load` + intersection), and strict mode never leaves `LOADING` at all — `onStateChange` never fires for the initial `LOADING` state because there's no transition INTO it. The harness waits for the load-completion signal, then races against a `pageerror` listener for fast-fail diagnostics:
 
    ```js
    await Promise.race([
@@ -389,6 +389,14 @@ async function triggerBfcacheRestore(page)
       },
     });
 
+    // load() creates the iframe, attaches the page-lifecycle listeners, and
+    // (synchronously) attaches the HTML lifecycle adapter — which installs
+    // the `pagehide` / `pageshow` listeners required for bfcache testing.
+    // Without this call the adapter never attaches and the entire § 5
+    // assertion contract has nothing to observe. load() returns `this`
+    // synchronously; no await needed. See src/sharc-container.js:1391-1416.
+    container.load();
+
     window.__sharcBfcacheContainer = container;
     window.__sharcBfcacheReady = true;
   </script>
@@ -398,6 +406,7 @@ async function triggerBfcacheRestore(page)
 
 **Key design choices.**
 
+- **`container.load()` is required.** Construction alone does not create the iframe or attach the lifecycle adapter — those happen in `load()` (see `src/sharc-container.js:1391-1416`). The adapter's `attach()` is what installs the `pagehide` / `pageshow` window listeners (see `src/lifecycle-adapters/html-adapter.js:210-213`); without `load()` the fixture has no bfcache observability. `load()` is synchronous and returns `this`, so no await is required before flipping `__sharcBfcacheReady`.
 - **`placementElement:` (NOT `placement:`).** The container's constructor option is `placementElement` (see `src/sharc-container.js:687`, `:730`). A hard guard at `:712-718` also throws on the deprecated `containerEl` name. Match the existing idiom from `test/browser/test-creative-sources.html:178`.
 - **Creative URL variant, not Creative Markup.** Fixture uses `creativeUrl: './bfcache-creative.html'` per ADR-178-J — see § 2 for the locked decision (Path B + Path C rejected).
 - **No `unload` handler.** Any `unload` listener disqualifies bfcache in Chrome. The fixture deliberately uses `pageshow` for the persistence read, not `unload` or `pagehide` — the adapter installs its own `pagehide` listener, which is bfcache-safe.

--- a/docs/design/0.7.6-bfcache-puppeteer-wiring.md
+++ b/docs/design/0.7.6-bfcache-puppeteer-wiring.md
@@ -12,7 +12,7 @@
 ## Table of contents
 
 1. [Release framing](#1-release-framing)
-2. [Per-item ADRs (the 9 locked decisions)](#2-per-item-adrs)
+2. [Per-item ADRs (the 10 locked decisions)](#2-per-item-adrs)
 3. [Harness internal architecture (4 implementor chokepoints)](#3-harness-internal-architecture)
 4. [Fixture page architecture](#4-fixture-page-architecture)
 5. [`server.cjs` integration](#5-servercjs-integration)
@@ -163,6 +163,33 @@ The retry happens *inside* the test runner (not at the workflow level), so a sin
 **Consequences.** /develop's first action is to read this doc, not to start coding. The 4 `IMPLEMENTOR-TODO` chokepoints have contract specifications below (§ 3) — function signatures, return types, error semantics. /develop fills the contracts; this doc does not.
 
 **Alternatives rejected.** Skip the design doc (the family pattern is two releases deep — breaking it now loses the per-release historical record). Inline the design into the PR description (too long, too easy to lose, not searchable from the docs/ tree).
+
+---
+
+### ADR-178-J — Fixture creative-source variant: Creative URL (NOT Creative Markup)
+
+**Context.** The bfcache fixture (§ 4.1) needs to instantiate a `SHARCContainer`. The container API accepts two mutually exclusive creative-source variants:
+
+- **Creative URL variant:** `creativeUrl: 'http://.../creative.html'` — the iframe loads a URL directly from a given origin. Single-port harness; no renderer protocol involved.
+- **Creative Markup variant:** `creativeHtml: '<...>'` + `creativeRendererUrl: 'http://other-origin/renderer.html'` — the iframe loads a cross-origin renderer page, which receives the markup via the renderer protocol and rasterizes it. Two-port harness; renderer protocol on the critical path.
+
+Both variants exercise the HTML lifecycle adapter (`src/lifecycle-adapters/html-adapter.js`), which is the system under test for bfcache. The choice does not change *which adapter code* runs; it changes *what else runs alongside* the adapter inside the test's blast radius.
+
+This decision was deferred during the initial /discover pass (the original framing focused on harness wiring, fixture page count, and CI retry strategy — see ADRs A–I). It was settled inline in § 4.1 during the first design pass. Per Jeffrey's pushback, lifting it into a proper ADR is the right move: every other meaningful choice in this release got an ADR, future engineers searching "why not Markup variant?" need findable Context/Decision/Alternatives, and the 0.7.4 release precedent confirms there's no purity rule against mid-design ADR additions — the rule is against sneaking decisions in via review-pass commits, which is the opposite of what this is.
+
+**Decision.** Creative URL variant. The fixture sets `creativeUrl: new URL('./bfcache-creative.html', location.href).href` — a bare HTML page hosted on the publisher origin (`:18765`) with zero JavaScript. The renderer port (`:18766`) is spawned by `withServer` for symmetry with `test-creative-sources-puppeteer.js` but receives no traffic across the bfcache test's lifetime.
+
+**Consequences.**
+
+- **Narrower blast radius.** The fixture exercises the HTML lifecycle adapter and nothing else. A regression in the renderer protocol (post-0.7.6) cannot mask or be masked by a bfcache regression in this suite — the two test surfaces fail independently.
+- **Single-port-functional harness.** Renderer port `:18766` is spawned for invocation symmetry but is functionally idle; the fixture's iframe loads its content from the publisher origin. Operators reading harness logs see the renderer-port spawn message and may briefly wonder why — § 5 documents the symmetry rationale.
+- **Strict-mode bf-4 falls out mechanically.** Because `bfcache-creative.html` deliberately does not load `sharc-creative.js`, the creative-side handshake (`createSession`) never fires. With `requireSharcInit: true`, the adapter (`src/lifecycle-adapters/html-adapter.js:401`) does not auto-promote to ACTIVE. The container stays pinned at LOADING for the duration of the strict-mode round trip — no `?delay=N` query param, no never-resolving renderer stub, no `setTimeout` hack. The absence of the SDK in the creative page IS the mechanism. See § 4.1 and § 4.3.
+- **Tradeoff accepted.** Path A trades some production-surface coverage (renderer protocol, cross-origin postMessage handshake) for failure isolation. The trade is acceptable because that surface is already covered by `test/browser/test-creative-sources-puppeteer.js`; doubling coverage here would re-test what's already tested and couple bfcache stability to renderer-protocol stability.
+
+**Alternatives rejected.**
+
+- **Path B: Markup variant + existing renderer at `:18766`.** Would exercise more of SHARC's real production surface — `creativeHtml` validation (Rule 2 at `src/sharc-container.js:5277-5284`), `creativeRendererUrl` cross-origin enforcement (Rule 7 at `:5349-5358`), the renderer page's postMessage handshake, and the renderer-to-container markup transfer. Rejected on three grounds. (a) **Redundant coverage:** the renderer protocol is already exercised end-to-end by `test/browser/test-creative-sources-puppeteer.js`; running it again inside the bfcache suite tests the same code paths twice without adding signal. (b) **Coupled failure modes:** a future renderer-protocol regression would either mask a bfcache regression (if it fails before the bfcache assertions run) or be masked by one (if the bfcache install never lands). Both directions destroy the test's diagnostic value. (c) **Scope mismatch:** the test's stated purpose (§ 1) is HTML lifecycle adapter behavior across bfcache transitions — not renderer-protocol behavior. Path B drifts the test's purpose.
+- **Path C: Hybrid — run both fixtures, both variants.** Would maximize coverage by running the full assertion matrix twice: once against a Creative URL fixture, once against a Creative Markup fixture with a real renderer page. Rejected as over-engineering for v1. Doubles CI time on a step already flagged as flake-prone (ADR-178-E). Doubles the flake surface — if either path goes red, the whole step goes red. Redundant with existing renderer-protocol coverage (same rationale as Path B). If post-0.7.6 telemetry surfaces a real adapter ↔ bfcache ↔ renderer interaction this Path A test doesn't catch, that is a separate 0.7.7+ /design conversation — better triggered by evidence than by speculative defense-in-depth.
 
 ---
 
@@ -372,7 +399,7 @@ async function triggerBfcacheRestore(page)
 **Key design choices.**
 
 - **`placementElement:` (NOT `placement:`).** The container's constructor option is `placementElement` (see `src/sharc-container.js:687`, `:730`). A hard guard at `:712-718` also throws on the deprecated `containerEl` name. Match the existing idiom from `test/browser/test-creative-sources.html:178`.
-- **Creative URL variant, not Creative Markup.** Container validation Rule 2 (`src/sharc-container.js:5277-5284`) requires `creativeHtml` to be paired with `creativeRendererUrl`, and Rule 7 (`:5349-5358`) requires the renderer URL to be cross-origin to `window.location`. The fixture's purpose is to exercise the HTML lifecycle adapter's bfcache behavior, NOT the renderer protocol — so we sidestep the renderer entirely by using `creativeUrl: './bfcache-creative.html'`. Single-port harness wiring, narrower test blast radius.
+- **Creative URL variant, not Creative Markup.** Fixture uses `creativeUrl: './bfcache-creative.html'` per ADR-178-J — see § 2 for the locked decision (Path B + Path C rejected).
 - **No `unload` handler.** Any `unload` listener disqualifies bfcache in Chrome. The fixture deliberately uses `pageshow` for the persistence read, not `unload` or `pagehide` — the adapter installs its own `pagehide` listener, which is bfcache-safe.
 - **No `Cache-Control: no-store` response header.** Verified at `server.cjs:106-110`: the dev server sets only `Content-Type`, `Access-Control-Allow-Origin: *`, `Access-Control-Allow-Headers: *`, and (for HTML) `Content-Security-Policy: object-src 'none'; base-uri 'none'`. None of these disqualify bfcache.
 - **Strict-mode handshake defer for bf-4.** The strict-mode test requires that the SHARC handshake NOT fire before bfcache entry — LOADING must be the live state when bfcache installs. The mechanism here is mechanical, not timing-based: `bfcache-creative.html` (see § 4.3) is a plain HTML page that never loads `sharc-creative.js` and therefore never initiates the handshake. With `requireSharcInit: true` set on the container, the adapter does not auto-promote to ACTIVE (see `src/lifecycle-adapters/html-adapter.js:401`), so the container stays in LOADING indefinitely. No `?delay=N` query param, no never-resolving renderer, no `setTimeout` hack required — the absence of the SDK in the creative page is the entire mechanism.
@@ -430,7 +457,7 @@ async function triggerBfcacheRestore(page)
 
 - **No JavaScript.** Specifically: no `sharc-creative.js` script tag, no postMessage, no inline script that could probe the parent window.
 - **Same-origin with the fixture.** Lives on the publisher port (`:18765`), so the iframe load completes deterministically without a second server origin in play. (The renderer port `:18766` is reserved for the renderer protocol, which this fixture deliberately avoids — see § 5.)
-- **Used by `creativeUrl`, not `creativeHtml`.** The container's `creativeUrl` path loads the URL directly into the iframe without invoking the renderer protocol (no `creativeRendererUrl` needed). This is the simplest valid container configuration for adapter-only testing.
+- **Used by `creativeUrl`, not `creativeHtml`.** The container's `creativeUrl` path loads the URL directly into the iframe without invoking the renderer protocol (no `creativeRendererUrl` needed). This is the simplest valid container configuration for adapter-only testing. See ADR-178-J (§ 2) for the full rationale on why bare HTML over a Markup variant.
 
 ---
 
@@ -534,7 +561,7 @@ The harness uses `headless: true` (per ADR-178-A). Chrome's headless mode suppor
 
 ## 9. Decision log
 
-Numbered summary of the 9 locked decisions for fast scanning. Full justification in § 2.
+Numbered summary of the 10 locked decisions for fast scanning. Full justification in § 2.
 
 1. **Tool: `puppeteer-core`** (NOT Playwright). Match existing test infra.
 2. **Standalone fixture page** at `test/browser/bfcache-fixture.html` (NOT reusing `examples/demos/`).
@@ -545,6 +572,7 @@ Numbered summary of the 9 locked decisions for fast scanning. Full justification
 7. **PR shape: single wiring PR G2 + release close-out PR H.** Mirrors 0.7.4 / 0.7.5 release shape.
 8. **0.7.6 is solo-scoped to #178.** No bundling with #185, #96, #24, etc.
 9. **Release design doc first** (this doc), locking decisions 1–8 as ADRs before /develop starts.
+10. **Fixture creative-source variant: Creative URL.** `bfcache-creative.html` as a bare-HTML page on the publisher origin; Markup variant + renderer protocol rejected as over-coupling for the test's scope.
 
 ---
 

--- a/docs/design/0.7.6-bfcache-puppeteer-wiring.md
+++ b/docs/design/0.7.6-bfcache-puppeteer-wiring.md
@@ -38,7 +38,7 @@ One content PR (G2 — the wiring) + one close-out PR (H equivalent — CHANGELO
 
 | PR | Issue | Type | Rough scope |
 |----|-------|------|-------------|
-| G2 | [#178](https://github.com/jeffreycarlson/SHARC/issues/178) | Test infra + 2 new fixture HTML files | Replace 4 `IMPLEMENTOR-TODO` helpers with real Puppeteer wiring. New `test/browser/bfcache-fixture.html` + `test/browser/bfcache-away.html`. New `npm run test:bfcache` script. New CI job step (separate from `test:all`). |
+| G2 | [#178](https://github.com/jeffreycarlson/SHARC/issues/178) | Test infra + 3 new fixture HTML files | Replace 4 `IMPLEMENTOR-TODO` helpers with real Puppeteer wiring. New `test/browser/bfcache-fixture.html` + `test/browser/bfcache-away.html` + `test/browser/bfcache-creative.html`. New `npm run test:bfcache` script. New CI job step (separate from `test:all`). |
 | H  | —     | Mechanical | CHANGELOG `[Unreleased]` → `[0.7.6]` entry, `current-status.md` "What Shipped in 0.7.6" stanza, `npm version patch` → propagates via `scripts/sync-version.js`, `npm run build` to regenerate `dist/`. |
 
 ### Breaking-change inventory
@@ -87,13 +87,13 @@ One content PR (G2 — the wiring) + one close-out PR (H equivalent — CHANGELO
 
 ---
 
-### ADR-178-D — Navigate-away target: sibling `test/browser/bfcache-away.html` on `:8765` (NOT `about:blank`)
+### ADR-178-D — Navigate-away target: sibling `test/browser/bfcache-away.html` on publisher origin (NOT `about:blank`)
 
 **Context.** Triggering bfcache entry requires navigating away to a different document. Chrome's bfcache eligibility rules are strict: the source page (the fixture) must not have any disqualifying conditions (open `WebSocket`, `unload` handler, `Cache-Control: no-store`, etc.), AND the navigation must be a normal HTTP load — not `about:blank`, not `data:` URLs, not file-protocol navigations. Chrome treats those as special cases that often defeat bfcache.
 
-**Decision.** A sibling fixture `test/browser/bfcache-away.html` served by `server.cjs` at `http://localhost:8765/test/browser/bfcache-away.html`. Trivial content — a single heading. No JavaScript. No iframes. No `unload` handler. No `pagehide` listener. No `Cache-Control: no-store` response header (the dev server doesn't set it; ADR-178-E verifies).
+**Decision.** A sibling fixture `test/browser/bfcache-away.html` served by `server.cjs` at `http://localhost:18765/test/browser/bfcache-away.html` (the test-runner's default publisher origin — see § 3.1). Trivial content — a single heading. No JavaScript. No iframes. No `unload` handler. No `pagehide` listener. No `Cache-Control: no-store` response header (the dev server doesn't set it; ADR-178-E verifies).
 
-**Consequences.** Same-origin navigation, same server, same headers as the fixture page. This maximizes bfcache eligibility: same-origin transitions are the documented happy path for bfcache in Chrome. The away page is reachable via `page.goto('http://localhost:8765/test/browser/bfcache-away.html')` and the bounce back uses `page.goBack()`.
+**Consequences.** Same-origin navigation, same server, same headers as the fixture page. This maximizes bfcache eligibility: same-origin transitions are the documented happy path for bfcache in Chrome. The away page is reachable via `page.goto('http://localhost:18765/test/browser/bfcache-away.html')` and the bounce back uses `page.goBack()`.
 
 **Alternatives rejected.** `about:blank` (Chrome's bfcache treats `about:blank` specially; navigation to it from a `http:` origin is not a reliable bfcache trigger). `data:text/html,<h1>away</h1>` (same issue). An external URL like `https://example.com` (requires network, flakes on offline CI runners, and may carry surprise headers). Reusing an existing test page like `mraid-test.html` (carries its own SHARC instrumentation that could fire `pagehide` handlers and disqualify the *source* page's bfcache eligibility via cross-frame side effects).
 
@@ -189,7 +189,7 @@ async function setupPuppeteerBfcacheHarness()
 
 **Behavior.**
 
-1. **Spawn `server.cjs`** on `PORT=8765` (default) using the `withServer()` pattern from `test/browser/test-creative-sources-puppeteer.js`. Wait for `http://localhost:8765/` to respond before returning. Allow env override via `PORT` (default 8765 per repo convention). Reuse the existing `RENDERER_PORT` plumbing even though bfcache doesn't need the renderer origin — keeps the spawn invocation symmetric.
+1. **Spawn `server.cjs`** on `PORT=18765` (default) using the `withServer()` pattern from `test/browser/test-creative-sources-puppeteer.js`. Wait for `http://localhost:18765/` to respond before returning. Allow env override via `PORT`. The 18765 default matches the existing Puppeteer test's reuse pattern — single source of truth, avoids collision with stray `:8765` dev servers. Reuse the existing `RENDERER_PORT` plumbing (default `PORT + 1 = 18766`) even though the bfcache fixture serves its creative from the publisher origin (see § 4.3) — keeps the spawn invocation symmetric with `test-creative-sources-puppeteer.js`.
 2. **Launch Chrome** via `puppeteer.launch()` with:
    - `executablePath: resolveChromePath()` (reuse the helper pattern from the existing Puppeteer test; do NOT inline a copy — extract to a shared module under `test/browser/shared/` if the implementor judges it warranted, otherwise import from the existing file).
    - `headless: true`
@@ -221,12 +221,22 @@ async function loadPermissiveContainerInPuppeteer(page, options)
 
 **Behavior.**
 
-1. Compute fixture URL: `const strict = options && options.requireSharcInit === true; const url = strict ? 'http://localhost:8765/test/browser/bfcache-fixture.html?strict=1' : 'http://localhost:8765/test/browser/bfcache-fixture.html';`
+1. Compute fixture URL: `const baseUrl = process.env.BASE_URL || 'http://localhost:18765'; const strict = options && options.requireSharcInit === true; const url = strict ? \`${baseUrl}/test/browser/bfcache-fixture.html?strict=1\` : \`${baseUrl}/test/browser/bfcache-fixture.html\`;`
 2. `await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60_000 });`
-3. **Wait for container ready signal.** The fixture sets `window.__sharcBfcacheReady = true` once its `SHARCContainer` instance is constructed and the first `onStateChange` callback has fired (i.e. the initial LOADING → ACTIVE transition for permissive mode, or LOADING for strict mode). Wait via `await page.waitForFunction(() => window.__sharcBfcacheReady === true, { timeout: 30_000 });`
-4. Return when ready. Throw on timeout.
+3. **Wait for container ready signal.** The fixture sets `window.__sharcBfcacheReady = true` synchronously immediately after `new SHARCContainer({...})` returns (see § 4.1 fixture body). Construction-time readiness is the right signal for both modes: permissive mode's `LOADING → ACTIVE` transition is async (gated on iframe `load` + intersection), and strict mode never leaves `LOADING` at all — `onStateChange` never fires for the initial `LOADING` state because there's no transition INTO it. The harness waits for the construction signal, then races against a `pageerror` listener for fast-fail diagnostics:
 
-**Error semantics.** Timeout on `waitForFunction` throws Puppeteer's standard `TimeoutError`; the test runner's try/catch logs it. Container construction failures (e.g. SHARCContainer throws during construction) surface as `pageerror` events captured by the harness setup and logged to stderr. The test's `bf-1` assertion will fail because `__sharcBfcacheReady` never becomes true.
+   ```js
+   await Promise.race([
+     page.waitForFunction(() => window.__sharcBfcacheReady === true, { timeout: 30_000 }),
+     new Promise((_, reject) => page.once('pageerror', (err) =>
+       reject(new Error('Fixture page error: ' + err.message)))),
+   ]);
+   ```
+
+   The `pageerror` race surfaces SHARCContainer construction errors (e.g. validation `TypeError`s) immediately instead of burying them behind a 30 s `__sharcBfcacheReady` timeout. This saves debug time when (not if) the fixture has a construction bug.
+4. Return when ready. Throw on timeout or page error.
+
+**Error semantics.** Construction failures (e.g. SHARCContainer throws during construction) bubble through the `pageerror` race in step 3 with a clear `'Fixture page error: ...'` prefix. Timeout on `waitForFunction` (genuinely stuck readiness, not a thrown error) surfaces Puppeteer's standard `TimeoutError`. The test runner's try/catch logs both.
 
 **Options handling.** Only `requireSharcInit` is read in 0.7.6. Future options (e.g. `creativeUrl`, `creativeHtml` variants) extend the signature with default fallthrough. The fixture HTML reads `URLSearchParams` from `location.search` and branches construction accordingly — see § 4.
 
@@ -265,8 +275,16 @@ async function triggerBfcacheEntry(page)
 
 **Behavior.**
 
-1. `await page.goto('http://localhost:8765/test/browser/bfcache-away.html', { waitUntil: 'domcontentloaded', timeout: 30_000 });`
-2. **Wait for bfcache install.** Chrome installs the previous page into bfcache asynchronously after navigation. The wait strategy: `await page.waitForFunction(() => document.readyState === 'complete', { timeout: 10_000 });` on the new page, then `await new Promise((r) => setTimeout(r, 500));` to let Chrome's bfcache installer settle. The 500 ms is empirically derived; tunable via `BFCACHE_INSTALL_MS` env var if a CI tuning pass needs to raise it.
+1. `const baseUrl = process.env.BASE_URL || 'http://localhost:18765'; await page.goto(\`${baseUrl}/test/browser/bfcache-away.html\`, { waitUntil: 'domcontentloaded', timeout: 30_000 });`
+2. **Wait for bfcache install.** Chrome installs the previous page into bfcache asynchronously after navigation. The wait strategy:
+
+   ```js
+   await page.waitForFunction(() => document.readyState === 'complete', { timeout: 10_000 });
+   const SETTLE_MS = Number(process.env.BFCACHE_INSTALL_MS) || 500;
+   await new Promise((r) => setTimeout(r, SETTLE_MS));
+   ```
+
+   The 500 ms default is empirically derived; the harness reads `BFCACHE_INSTALL_MS` from the environment so CI tuning passes (see § 7.1) can raise it without a code change.
 3. Return.
 
 **`triggerBfcacheRestore` signature.**
@@ -326,9 +344,14 @@ async function triggerBfcacheRestore(page)
       window.__lastPageshowPersisted = event.persisted;
     });
 
+    // Creative URL variant (not creativeHtml + creativeRendererUrl).
+    // The creative is a plain HTML page on the publisher origin that does NOT
+    // load sharc-creative.js, so no handshake fires in either mode. In strict
+    // mode (?strict=1), the absence of a handshake keeps the adapter pinned at
+    // LOADING, which is exactly what bf-4 needs to test.
     const container = new SHARCContainer({
-      placement: document.getElementById('placement'),
-      creativeHtml: '<html><body><h2>permissive non-SHARC creative</h2></body></html>',
+      placementElement: document.getElementById('placement'),
+      creativeUrl: new URL('./bfcache-creative.html', location.href).href,
       requireSharcInit: strict,
       onStateChange: (newState, previousState) => {
         window.__capturedStateChanges.push({
@@ -348,10 +371,12 @@ async function triggerBfcacheRestore(page)
 
 **Key design choices.**
 
+- **`placementElement:` (NOT `placement:`).** The container's constructor option is `placementElement` (see `src/sharc-container.js:687`, `:730`). A hard guard at `:712-718` also throws on the deprecated `containerEl` name. Match the existing idiom from `test/browser/test-creative-sources.html:178`.
+- **Creative URL variant, not Creative Markup.** Container validation Rule 2 (`src/sharc-container.js:5277-5284`) requires `creativeHtml` to be paired with `creativeRendererUrl`, and Rule 7 (`:5349-5358`) requires the renderer URL to be cross-origin to `window.location`. The fixture's purpose is to exercise the HTML lifecycle adapter's bfcache behavior, NOT the renderer protocol — so we sidestep the renderer entirely by using `creativeUrl: './bfcache-creative.html'`. Single-port harness wiring, narrower test blast radius.
 - **No `unload` handler.** Any `unload` listener disqualifies bfcache in Chrome. The fixture deliberately uses `pageshow` for the persistence read, not `unload` or `pagehide` — the adapter installs its own `pagehide` listener, which is bfcache-safe.
 - **No `Cache-Control: no-store` response header.** Verified at `server.cjs:106-110`: the dev server sets only `Content-Type`, `Access-Control-Allow-Origin: *`, `Access-Control-Allow-Headers: *`, and (for HTML) `Content-Security-Policy: object-src 'none'; base-uri 'none'`. None of these disqualify bfcache.
-- **`creativeHtml` non-SHARC creative.** A plain HTML markup that does NOT load `sharc-creative.js`. This forces the permissive variant (no handshake; the HTML lifecycle adapter drives the state machine end-to-end). For bf-4's strict variant, the construction still passes `creativeHtml` — strict mode means the container will wait for a handshake that never arrives, leaving state at `LOADING`, which is exactly what bf-4 needs.
-- **Module import via `../../dist/sharc-container.mjs`.** Same path style as `examples/renderer/index.html`. Requires `npm run build` to have populated `dist/` before the test runs. ADR-178-J (deferred to /develop) decides whether `test:bfcache` should depend on `npm run build` like the post-#183 dist-based tests; recommendation is **yes** — match the `test:all` shape's "build first" property by chaining as `"test:bfcache": "npm run build && node test/browser/test-html-lifecycle-adapter-bfcache.js"`.
+- **Strict-mode handshake defer for bf-4.** The strict-mode test requires that the SHARC handshake NOT fire before bfcache entry — LOADING must be the live state when bfcache installs. The mechanism here is mechanical, not timing-based: `bfcache-creative.html` (see § 4.3) is a plain HTML page that never loads `sharc-creative.js` and therefore never initiates the handshake. With `requireSharcInit: true` set on the container, the adapter does not auto-promote to ACTIVE (see `src/lifecycle-adapters/html-adapter.js:401`), so the container stays in LOADING indefinitely. No `?delay=N` query param, no never-resolving renderer, no `setTimeout` hack required — the absence of the SDK in the creative page is the entire mechanism.
+- **Module import via `../../dist/sharc-container.mjs`.** Same path style as `examples/renderer/index.html`. Requires `npm run build` to have populated `dist/` before the test runs. § 6.1 commits to chaining `npm run build &&` into the `test:bfcache` script for exactly this reason.
 
 **Inline vs separate state-capture script.** The state-capture is small enough (5 lines) to inline. No separate `state-change-capture.js` file. If 0.7.7+ adds more capture surfaces (e.g. `onSecurityEvent`, `onContainerLifecycleEvent`), promoting to a separate file becomes warranted; for 0.7.6, inline is cleaner.
 
@@ -379,7 +404,33 @@ async function triggerBfcacheRestore(page)
 - **Zero JavaScript.** No event listeners, no SHARC instantiation, no XHR, no `fetch`, no `import()`.
 - **No iframes.** Cross-frame side effects can ripple back to the source page in unexpected ways across the bfcache boundary.
 - **No `Cache-Control: no-store` header.** Same protection as the fixture. Not strictly required for the away page itself (the away page's own bfcache eligibility is irrelevant — the test navigates AWAY from it via `goBack`, never INTO bfcache from it), but consistency keeps debugging simpler.
-- **Same-origin with fixture.** Both pages live on `http://localhost:8765`, which maximizes Chrome's willingness to bfcache the transition.
+- **Same-origin with fixture.** Both pages live on `http://localhost:18765`, which maximizes Chrome's willingness to bfcache the transition.
+
+### 4.3 `test/browser/bfcache-creative.html`
+
+**Purpose.** The creative loaded into the container's iframe in both permissive and strict modes. Trivial visible content; deliberately does NOT load `sharc-creative.js` so no handshake is initiated. This is the mechanism that keeps strict-mode bf-4 pinned at LOADING (see § 4.1 design choices).
+
+**Minimal HTML.**
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>SHARC bfcache creative</title>
+</head>
+<body style="margin:0;padding:8px;font:14px/1.4 system-ui;">
+  <h2>bfcache creative</h2>
+  <p>Non-SHARC creative — no handshake, no SDK load.</p>
+</body>
+</html>
+```
+
+**Key design choices.**
+
+- **No JavaScript.** Specifically: no `sharc-creative.js` script tag, no postMessage, no inline script that could probe the parent window.
+- **Same-origin with the fixture.** Lives on the publisher port (`:18765`), so the iframe load completes deterministically without a second server origin in play. (The renderer port `:18766` is reserved for the renderer protocol, which this fixture deliberately avoids — see § 5.)
+- **Used by `creativeUrl`, not `creativeHtml`.** The container's `creativeUrl` path loads the URL directly into the iframe without invoking the renderer protocol (no `creativeRendererUrl` needed). This is the simplest valid container configuration for adapter-only testing.
 
 ---
 
@@ -389,11 +440,11 @@ async function triggerBfcacheRestore(page)
 
 `server.cjs` serves any file under the repo root via the `path.resolve(ROOT, '.' + rawPath)` route at line 81, with a path-traversal guard at line 84-88 ensuring requests stay inside `ROOT`. Verified:
 
-- Files at `test/browser/bfcache-fixture.html` and `test/browser/bfcache-away.html` will be served at `http://localhost:8765/test/browser/bfcache-fixture.html` and `http://localhost:8765/test/browser/bfcache-away.html`.
+- Files at `test/browser/bfcache-fixture.html`, `test/browser/bfcache-away.html`, and `test/browser/bfcache-creative.html` will be served at `http://localhost:18765/test/browser/<file>.html` (using the test-runner's default port — see § 3.1).
 - The MIME map at `server.cjs:34` covers `.html` → `text/html`.
 - The default response headers at `server.cjs:106-110` are bfcache-friendly (no `Cache-Control: no-store`, no `Set-Cookie`).
 - The `Content-Security-Policy: object-src 'none'; base-uri 'none'` header set on HTML responses at line 112 does NOT disqualify bfcache (CSP itself is not a disqualifier; only specific directives like `unsafe-eval` in combination with certain blocked actions can affect bfcache, neither of which applies here).
-- The renderer port (`:8766`) is irrelevant to bfcache; the fixture runs entirely on the publisher port (`:8765`).
+- The renderer port (`:18766` by default, or `PORT + 1` when overridden) is spawned for symmetry with `test-creative-sources-puppeteer.js`'s server-spawn pattern but is functionally irrelevant to the bfcache fixture, which deliberately uses `creativeUrl` (not `creativeHtml` + `creativeRendererUrl`) to load `bfcache-creative.html` from the publisher origin. See § 4.3 for the rationale.
 
 If the wiring surfaces an unexpected bfcache disqualifier coming from server headers, that becomes a 0.7.7+ follow-up (e.g. add an opt-in `?bfcache-friendly=1` query param that suppresses CSP for the fixture). 0.7.6 ships against the current server behavior.
 
@@ -427,7 +478,7 @@ Per ADR-178-F, `test:all:built` does NOT add `&& npm run test:bfcache`. Verify t
 
 ### 7.1 New CI step
 
-Add after the existing `test:browser` step (line 59 in `.github/workflows/ci.yml`), before the perf step:
+Add immediately after the `test:browser` step at lines 58-59 of `.github/workflows/ci.yml` (the perf step is at line 82, with other intermediate steps; adjacency to `test:browser` matters more than placement relative to perf — shared Puppeteer infra keeps debugging context close):
 
 ```yaml
       - name: HTML lifecycle adapter bfcache round-trip (issue #178)
@@ -467,6 +518,7 @@ The harness uses `headless: true` (per ADR-178-A). Chrome's headless mode suppor
 | `test/browser/test-html-lifecycle-adapter-bfcache.js` | Replace 4 `IMPLEMENTOR-TODO` helpers with real wiring per § 3 contracts; add per-section tier annotation + retry wrapper per ADR-178-E | /develop |
 | `test/browser/bfcache-fixture.html` | NEW — minimal SHARC container + state-capture per § 4.1 | /develop |
 | `test/browser/bfcache-away.html` | NEW — trivial navigate-away target per § 4.2 | /develop |
+| `test/browser/bfcache-creative.html` | NEW — non-SHARC creative loaded via `creativeUrl` per § 4.3 | /develop |
 | `package.json` | Add `test:bfcache` script per § 6.1 | /develop |
 | `.github/workflows/ci.yml` | Add bfcache step per § 7.1 | /develop |
 | `server.cjs` | No changes (verified § 5) | n/a |
@@ -487,7 +539,7 @@ Numbered summary of the 9 locked decisions for fast scanning. Full justification
 1. **Tool: `puppeteer-core`** (NOT Playwright). Match existing test infra.
 2. **Standalone fixture page** at `test/browser/bfcache-fixture.html` (NOT reusing `examples/demos/`).
 3. **State capture via `page.evaluate(() => window.__capturedStateChanges)`** after each phase (NOT CDP event streaming).
-4. **Navigate-away target: `test/browser/bfcache-away.html` on `:8765`** (NOT `about:blank`).
+4. **Navigate-away target: `test/browser/bfcache-away.html` on the publisher origin** (NOT `about:blank`).
 5. **CI strategy: tier + retry.** bf-1/bf-5 deterministic (no retry); bf-2/bf-3/bf-4 behavioral (up to 3 retries inside the runner).
 6. **`npm run test:bfcache` added; NOT included in `npm run test:all`.** Dedicated CI step. Preserves `test:all` reliability.
 7. **PR shape: single wiring PR G2 + release close-out PR H.** Mirrors 0.7.4 / 0.7.5 release shape.


### PR DESCRIPTION
## Summary

Release-level design doc for 0.7.6 — wiring the bfcache Puppeteer harness scaffold shipped by PR G of 0.7.4. Locks 9 ADRs that the implementation PR (G2) and release close-out (H) will execute against.

This is the third release-design doc in the family (0.7.3, 0.7.4, now 0.7.6). 0.7.5 was small enough to skip a doc; 0.7.6 has a non-trivial CI-flake risk surface that benefits from front-loading the locked decisions.

## Locked decisions

| ADR | Decision |
|-----|----------|
| 178-A | `puppeteer-core` (not Playwright) — match existing test infra |
| 178-B | Standalone `test/browser/bfcache-fixture.html` (not reusing demos) |
| 178-C | `page.evaluate(() => window.__capturedStateChanges)` capture (not CDP — bfcache disconnects CDP sessions) |
| 178-D | Sibling `test/browser/bfcache-away.html` on `:8765` (not `about:blank`) |
| 178-E | CI strategy: tier + retry — bf-1/bf-5 deterministic, bf-2/bf-3/bf-4 up to 3 retries inside the runner |
| 178-F | `npm run test:bfcache` script; NOT in `test:all`; dedicated CI step |
| 178-G | Single wiring PR (G2) + release close-out PR (H) |
| 178-H | 0.7.6 is solo-scoped to #178 |
| 178-I | Release design doc first |

## What the doc contains

10 sections, ~5100 words, mirrors `docs/design/0.7.4-omid-hardening.md` structure:

1. Release framing (test-infrastructure-only; no production code)
2. Per-item ADRs (the 9 above with Context / Decision / Consequences / Alternatives-rejected)
3. Harness internal architecture (concrete function signatures + return types + error semantics + timeouts for the 4 `IMPLEMENTOR-TODO` functions)
4. Fixture page architecture (~30-line HTML for `bfcache-fixture.html`, trivial `bfcache-away.html`)
5. `server.cjs` integration — verified zero changes needed
6. `package.json` scripts — `test:bfcache` script spec (chains `npm run build &&` per post-#183 pattern)
7. CI workflow integration — exact YAML snippet, retry strategy rationale, no `continue-on-error`
8. Code-paths-touched map (5 files modified; 2 of those are new)
9. Decision log (numbered summary)
10. References

## What's NOT in 0.7.6 scope

- #185 (bid-signaled OMID auto-install) — deferred to 0.7.7+
- #96 (URL-variant ergonomics) — deferred
- #24 (SRI) — deferred
- Production code changes — the adapter is already jsdom-validated; if the wiring surfaces a real bug, that's a 0.7.7+ regression item

## Verify

- Doc file at `docs/design/0.7.6-bfcache-puppeteer-wiring.md`
- No code changes — design-only PR
- Architect verified the contract details against existing source (`server.cjs` routing, `package.json` script chain, `.github/workflows/ci.yml` shape, existing Puppeteer test infra patterns from `test/browser/test-creative-sources-puppeteer.js`)

## Sequencing

1. **This PR** — design doc lands on main, locks the contract
2. **PR G2** — implementation: 4 IMPLEMENTOR-TODO functions wired + 2 new HTML fixtures + npm script + CI step
3. **PR H** — release close-out: CHANGELOG promote, version bump 0.7.5 → 0.7.6, current-status section, dist rebuild

Refs #178