### PR TITLE
chore(release): 0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+## [0.7.6] - 2026-05-24
+
+**Release-doc-first cycle.** Three features shipped in parallel: the headline
+bfcache round-trip Puppeteer harness wiring (#178, Claude-authored via the
+locked design doc at [`docs/design/0.7.6-bfcache-puppeteer-wiring.md`](docs/design/0.7.6-bfcache-puppeteer-wiring.md)),
+optional `creativeRendererIntegrity` preflight (#24, codex-authored), and
+bid-signaled OMID auto-installation (#185, codex-authored).
+
 ### Added
 
 - **Optional `creativeRendererIntegrity` preflight for Creative Markup**
@@ -1722,7 +1730,8 @@ messages are sent at additional transition points; no new message types.
 - `supportedFeatures` extension mechanism
 
 <!-- Version compare links (Update when new tags are pushed) -->
-[Unreleased]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.5...main
+[Unreleased]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.6...main
+[0.7.6]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.5...v0.7.6
 [0.7.5]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.4...v0.7.5
 [0.7.4]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.3...v0.7.4
 [0.7.3]: https://github.com/jeffreycarlson/SHARC/compare/v0.7.2...v0.7.3

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # SHARC (Secure HTML Ad Richmedia Container)
 
-![Package status](https://img.shields.io/badge/package-v0.7.5%20(pre--publish)-informational)
+![Package status](https://img.shields.io/badge/package-v0.7.6%20(pre--publish)-informational)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/jeffreycarlson/SHARC/actions/workflows/ci.yml/badge.svg)](https://github.com/jeffreycarlson/SHARC/actions/workflows/ci.yml)
 
 Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol reference implementation.
 
 > 📋 This repository is the current SHARC reference implementation and working specification set.
-> It is in active pre-1.0 development at package version `0.7.5` and is not yet published to npm.
+> It is in active pre-1.0 development at package version `0.7.6` and is not yet published to npm.
 > Start with the curated docs index at [docs/README.md](docs/README.md) and the current state summary at [docs/current-status.md](docs/current-status.md).
 
 ## Overview
@@ -238,9 +238,9 @@ All public entry points build into `dist/` as ESM (`.mjs`) plus browser/IIFE bun
 
 After the package is published, public CDN URL patterns should mirror the current `dist/` filenames:
 
-- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.5/dist/sharc-container.js`
-- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.5/dist/sharc-creative.js`
-- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.5/dist/sharc-protocol.js`
+- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.6/dist/sharc-container.js`
+- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.6/dist/sharc-creative.js`
+- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.6/dist/sharc-protocol.js`
 
 Versioning guidance:
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -4,7 +4,7 @@
 
 SHARC is an IAB Tech Lab reference implementation in active **pre-1.0** development.
 
-- Repository package version: `0.7.5`
+- Repository package version: `0.7.6`
 - npm publication status: **not yet published**
 - Current implementation scope: **web iframe**, **iOS WKWebView**, **Android WebView**
 - Current repo posture: suitable for technical evaluation and standards review; not yet presented here as a broadly adopted production release line
@@ -20,9 +20,27 @@ The following are the most reliable descriptions of the present implementation:
 - [proposals/creative-sources.md](./proposals/creative-sources.md) — design rationale, threat model, and decision log for the 0.7.0 Creative Sources work
 - bridge design docs under [`docs/design/`](./design)
 - the current source and generated `dist/` artifacts
-- [CHANGELOG.md](../CHANGELOG.md) — what shipped in `0.7.5` and earlier
+- [CHANGELOG.md](../CHANGELOG.md) — what shipped in `0.7.6` and earlier
 
 As of `0.6.0`, every public package subpath ships generated TypeScript declaration files (`.d.ts`) alongside its `.mjs` bundle. TypeScript consumers get full IntelliSense and compile-time argument validation when importing any subpath. 0.7.0 expands the typedef surface to cover the Creative Markup variant — `creativeUrl` is optional, `creativeHtml` / `creativeRendererUrl` / `onSecurityEvent` are added, and `SHARCSecurityEvent` is a discriminated union that now covers seven reserved variants (0.7.1 added `bridge_load_failed`; 0.7.4 added `feature_load_failed`).
+
+## What Shipped in 0.7.6
+
+0.7.6 ships three parallel features (Claude + Codex co-authored) plus a release-design doc, all targeting the next layer of operator-experience hardening on top of 0.7.4's OMID work.
+
+**bfcache round-trip Puppeteer coverage** ([#178](https://github.com/jeffreycarlson/SHARC/issues/178)). The scaffold shipped in 0.7.4 (5 `IMPLEMENTOR-TODO` chokepoints, red on `main`) is now live in real Chrome. New `test/browser/bfcache-fixture.html`, `bfcache-away.html`, and `bfcache-creative.html` drive a permissive non-SHARC container through bfcache entry/restore and exercise the HTML lifecycle adapter's `pagehide`/`pageshow` paths end-to-end. Two-tier flake policy (per [`docs/design/0.7.6-bfcache-puppeteer-wiring.md`](./design/0.7.6-bfcache-puppeteer-wiring.md) ADR-178-E): structural assertions (bf-1 eligibility, bf-5 no "invalid transition" warns) run once; behavioral assertions (bf-2 LOADING→ACTIVE→HIDDEN→FROZEN, bf-3 FROZEN→ACTIVE restore, bf-4 strict-mode yield with `pageshow.persisted === true` guard) retry up to 3× inside the runner. New `npm run test:bfcache` script, deliberately NOT added to `test:all` (CI gets a dedicated step with `BFCACHE_INSTALL_MS=750`). No production code changes — the adapter under test was already jsdom-validated; this closes the real-browser-bfcache gap jsdom cannot model.
+
+**Optional `creativeRendererIntegrity` preflight for Creative Markup** ([#24](https://github.com/jeffreycarlson/SHARC/issues/24)). Operators can pass a `sha384-<base64>` digest for `creativeRendererUrl`; the container fetches and verifies the renderer document bytes before assigning `iframe.src`. On mismatch or unverifiable bytes, the container fires `RENDERER_INTEGRITY_FAIL` (2120), emits a `renderer_protocol_error` security event with `details.subtype='integrity_failed'`, and never sends `SHARC:Renderer:render`. This is defense-in-depth rather than native iframe SRI, because browsers do not support `integrity=` on iframe navigations; cross-origin renderer hosts must allow the verification fetch with CORS.
+
+**Bid-signaled OMID auto-installation** ([#185](https://github.com/jeffreycarlson/SHARC/issues/185)). When bid metadata declares AdCOM OMID code `7` via `creativeMeta.apis` and supplies `creativeMeta.measurement.omid.verificationScripts`, operators can pass `omidAutoInstall` with trusted OM SDK URLs and partner defaults. The container appends an `OmidCompatBridge` extension without adding `'omid'` to the renderer bridge list — preserving the locked 0.7.3 decision that OMID is measurement, not a renderer bridge. Missing or invalid OMID sidecar data warns and continues without installing measurement. Closes the narrow follow-up scope from #118.
+
+**Release-design pattern.** 0.7.6 is the third release in the family to ship with a locked release-level design doc front-loading the decisions (after 0.7.3 and 0.7.4 — 0.7.5 was small enough to skip). The bfcache wiring locked 10 ADRs (A–J) via PR #187 before any implementation; the implementor (Senior Developer) executed against the contract rather than re-deciding it. The pattern continues to compress per-PR cycles and gives reviewers a stable source of truth.
+
+Further reading:
+
+- Release design + ADRs (bfcache): [`docs/design/0.7.6-bfcache-puppeteer-wiring.md`](./design/0.7.6-bfcache-puppeteer-wiring.md)
+- CHANGELOG entries: [CHANGELOG.md `[0.7.6]` section](../CHANGELOG.md#076---2026-05-24)
+- API reference updates: [`api-reference.md`](./api-reference.md) (`creativeRendererIntegrity`, `omidAutoInstall`, `creativeMeta.measurement.omid` documented)
 
 ## What Shipped in 0.7.5
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iabtechlab/sharc",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol",
   "type": "module",
   "files": [

--- a/src/lifecycle-adapters/base-adapter.js
+++ b/src/lifecycle-adapters/base-adapter.js
@@ -22,7 +22,7 @@
  * for the rationale that picked the adapter-class shape over inline-switch
  * or registry alternatives.
  *
- * @version 0.7.5
+ * @version 0.7.6
  */
 
 'use strict';

--- a/src/lifecycle-adapters/html-adapter.js
+++ b/src/lifecycle-adapters/html-adapter.js
@@ -30,7 +30,7 @@
  *   - jsdom does NOT ship an IntersectionObserver implementation. Tests
  *     stub `global.IntersectionObserver` with a manually-triggerable mock.
  *
- * @version 0.7.5
+ * @version 0.7.6
  */
 
 'use strict';

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -26,7 +26,7 @@
  * container.load();
  * ```
  *
- * @version 0.7.5
+ * @version 0.7.6
  */
 
 'use strict';

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -34,7 +34,7 @@
  * </script>
  * ```
  *
- * @version 0.7.5
+ * @version 0.7.6
  */
 
 'use strict';

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -14,7 +14,7 @@
  *   3. sharc-mraid-bridge.js → window.mraid (this file)
  *   4. <MRAID creative>
  *
- * @version 0.7.5
+ * @version 0.7.6
  * @see mraid-bridge-design.md
  */
 

--- a/src/sharc-navigation-bridge.js
+++ b/src/sharc-navigation-bridge.js
@@ -81,7 +81,7 @@
  *
  * Spec: docs/proposals/creative-sources.md § Click-through audit and policy boundary.
  *
- * @version 0.7.5
+ * @version 0.7.6
  */
 
 'use strict';

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -21,7 +21,7 @@
  *   - creativeType and impressionType MUST be set before impressionOccurred()
  *   - AdSession must be started before any events are fired
  *
- * @version 0.7.5
+ * @version 0.7.6
  * @see https://iabtechlab.com/standards/open-measurement-sdk/
  * @see https://github.com/IABTechLab/SHARC
  */

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -13,7 +13,7 @@
  *
  * Both extend SHARCProtocolBase which provides the shared message bus.
  *
- * @version 0.7.5
+ * @version 0.7.6
  * @see https://github.com/IABTechLab/SHARC
  */
 
@@ -27,7 +27,7 @@
 // ---------------------------------------------------------------------------
 
 /** Current SHARC spec version this implementation conforms to. */
-const SHARC_VERSION = '0.7.5';
+const SHARC_VERSION = '0.7.6';
 
 /**
  * Placeholder AdCOM `APIFramework` integer code for SHARC.

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -19,7 +19,7 @@
  *   - exp-push (push expand) — deferred to v2; fires 'failed' callback
  *   - $sf.ext.cookie() — permanently excluded; fires 'failed' callback
  *
- * @version 0.7.5
+ * @version 0.7.6
  * @see safeframe-bridge-design.md
  */
 


### PR DESCRIPTION
## Summary

Cuts the **0.7.6 release**. Single-commit close-out PR. The three feature PRs (#186, #188, #189) plus the design doc PR (#187) shipped in parallel during 0.7.5/0.7.6 window; this PR promotes everything to a versioned heading.

**Closures (administrative):** #178, #24, #185 — substantive work landed in #189, #186, #188 respectively.

## What's in this PR

**CHANGELOG.md:**
- Promotes `[Unreleased]` → `[0.7.6] - 2026-05-24` with a lead paragraph framing the three-PR parallel-shipping pattern
- **No backfill needed** — all three feature PRs added their `[Unreleased]` entries inline at merge time (improvement over 0.7.4's PR H which had to backfill 5 missing entries)
- Adds `[0.7.6]` compare link; updates `[Unreleased]` to `v0.7.6...main`

**Version bump via `npm version patch` + `scripts/sync-version.js`:**
- `package.json` + `package-lock.json`: 0.7.5 → 0.7.6
- `src/sharc-protocol.js`: `SHARC_VERSION` constant + `@version` JSDoc
- `@version` JSDoc on 7 other src files (container, creative, mraid-bridge, safeframe-bridge, omid-bridge, navigation-bridge, both lifecycle adapters)
- `README.md`: version badge + 3 CDN example URLs (via sync-version.js) + line 10 inline prose token (manual — sync-version.js doesn't touch the prose paragraph)

**docs/current-status.md:**
- Repository package version: `0.7.6`
- New "What Shipped in 0.7.6" section above 0.7.5, covering all three features (bfcache test infra, renderer integrity preflight, bid-signaled OMID auto-install) + an observation on the release-design-doc pattern continuing to compress per-PR cycles

## Verify

- Lint: clean
- Build: dist rebuilt at 0.7.6
- Targeted tests (omid-container-lifecycle, bfcache, smoke): all green at the bumped version
- Scope: 14 files (sync-version.js's 12 + CHANGELOG + current-status)

## Release sequencing reference

- 0.7.6 design doc: PR #187 (10 ADRs locked, merged 2026-05-24)
- Feature PRs in this release window:
  - #186: renderer integrity preflight (codex) → closes #24
  - #188: bid-signaled OMID auto-install (codex) → closes #185
  - #189: bfcache Puppeteer harness wiring (Claude) → closes #178

## Post-merge

Tag-push (`v0.7.6`) NOT included in this PR — separate explicit greenlight required:

```bash
git tag -a v0.7.6 <merge-sha> -m "v0.7.6 — bfcache + renderer integrity + bid-signaled OMID"
git push origin v0.7.6
```