### PR TITLE
feat: add creative validator normalizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Renderer DOMParser + replaceChildren fallback (issue #41)
         run: npm run test:renderer-fallback
 
+      - name: Creative validator normalizer
+        run: npm run test:creative-validator-normalizer
+
       - name: Creative Sources performance harness (issue #41, AC L1170)
         # CI runners are noisy neighbors; perf tests can flake on shared
         # hardware. Pass-if-any-of-3-runs balances false-failure rate against

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ dist-meta/
 # npm pack artifacts
 *.tgz
 
+# Creative validator private corpus and generated output
+tools/creative-validator/private/
+
 # Environment files
 .env*
 !.env.example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+### Added
+
+- **Creative validator normalizer foundation.** Adds the first private-first
+  hardening harness layer under `tools/creative-validator/`: cleaned OpenRTB
+  corpus normalization, API provenance extraction, `admKind` classification,
+  JSONL test-case output, and synthetic reduction fixtures. The real private
+  corpus and generated reports remain gitignored.
+
 ## [0.7.6] - 2026-05-24
 
 **Release-doc-first cycle.** Three features shipped in parallel: the headline

--- a/package.json
+++ b/package.json
@@ -70,10 +70,11 @@
     "test:html-lifecycle-adapter": "node test/node/test-html-lifecycle-adapter.js",
     "test:omid-container-lifecycle": "node test/node/test-omid-container-lifecycle.js",
     "test:renderer-fallback": "node test/node/test-renderer-domparser-fallback.js",
+    "test:creative-validator-normalizer": "node tools/creative-validator/test/test-normalizer.js",
     "test:perf": "node test/node/test-creative-sources-perf.js",
     "test:types": "tsc -p test/types/tsconfig.json",
     "test:all": "npm run build && npm run test:all:built",
-    "test:all:built": "npm run test:smoke && npm run test:treeshake && npm run test:creative-protocol-placement-type && npm run test:placement && npm run test:placement-stamping && npm run test:creative-sources && npm run test:creative-sources-load && npm run test:browser && npm run test:navigation-bridge && npm run test:creative-sdk-autoinstall && npm run test:creative-sdk-injection && npm run test:bridges-detection && npm run test:non-sharc-loading && npm run test:html-lifecycle-adapter && npm run test:omid-container-lifecycle && npm run test:renderer-fallback",
+    "test:all:built": "npm run test:smoke && npm run test:treeshake && npm run test:creative-protocol-placement-type && npm run test:placement && npm run test:placement-stamping && npm run test:creative-sources && npm run test:creative-sources-load && npm run test:browser && npm run test:navigation-bridge && npm run test:creative-sdk-autoinstall && npm run test:creative-sdk-injection && npm run test:bridges-detection && npm run test:non-sharc-loading && npm run test:html-lifecycle-adapter && npm run test:omid-container-lifecycle && npm run test:renderer-fallback && npm run test:creative-validator-normalizer",
     "regen:baseline": "node scripts/regen-mraid3-baseline.js",
     "lint": "eslint src/*.js --max-warnings=0",
     "check": "npm run build && npm run test:all:built && npm run size && npm run build"

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -1,0 +1,61 @@
+# SHARC Creative Validator
+
+> **DO NOT COMMIT REAL CORPUS DATA.** Keep real bid responses, raw `adm`,
+> reports, traces, screenshots, and normalized output under
+> `tools/creative-validator/private/`.
+
+Private-first hardening harness for real bid-derived creative compatibility
+testing. Phase 1 normalizes cleaned OpenRTB export rows into stable test-case
+records. It does not run a browser yet.
+
+## Private Corpus
+
+Keep real corpus files and generated output under:
+
+```text
+tools/creative-validator/private/
+```
+
+That path is ignored by git. Do not commit real bid responses, raw `adm`,
+tracking URLs, advertiser domains, device/user identifiers, reports, traces, or
+screenshots.
+
+Never pass `--out` outside `tools/creative-validator/private/` when running
+against private data. The CLI enforces that boundary by default.
+
+## Normalize
+
+```bash
+node tools/creative-validator/src/cli.js normalize \
+  "tools/creative-validator/private/*.cleaned.json" \
+  --out tools/creative-validator/private/normalized/cases.jsonl
+```
+
+Input shape:
+
+```json
+[
+  {
+    "id": "auction-row-id",
+    "auction": [
+      {
+        "bidder": "bidder-name",
+        "mtype": "banner",
+        "bid_request": {},
+        "bid_response": {}
+      }
+    ]
+  }
+]
+```
+
+The CLI expects the cleaned export shape used by the private corpus workflow,
+not raw OpenRTB bid-request or bid-response documents.
+
+Output is JSONL, one normalized test case per bid.
+
+## Test
+
+```bash
+npm run test:creative-validator-normalizer
+```

--- a/tools/creative-validator/fixtures/reductions/001-normalizer-cleaned-corpus/cleaned-corpus.fixture.json
+++ b/tools/creative-validator/fixtures/reductions/001-normalizer-cleaned-corpus/cleaned-corpus.fixture.json
@@ -1,0 +1,187 @@
+[
+  {
+    "id": "auction-row-1",
+    "auction": [
+      {
+        "bidder": "synthetic-mraid",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-1",
+          "imp": [
+            {
+              "id": "imp-banner-1",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50,
+                "api": [3, 5, 7]
+              },
+              "video": {
+                "api": [7]
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-1",
+          "cur": "USD",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-mraid-1",
+                  "impid": "imp-banner-1",
+                  "crid": "creative-mraid-1",
+                  "adomain": ["advertiser.example"],
+                  "cat": ["IAB1"],
+                  "attr": [1],
+                  "w": 320,
+                  "h": 50,
+                  "price": 1.25,
+                  "adm": "<!doctype html><html><body><script src=\"mraid.js\"></script><script>window.mraid.open('https://click.example/');</script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "bidder": "synthetic-native",
+        "mtype": "native",
+        "bid_request": {
+          "id": "request-1",
+          "imp": [
+            {
+              "id": "imp-native-1",
+              "native": {
+                "api": [3, 5, 7]
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-native-1",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-native-1",
+                  "impid": "imp-native-1",
+                  "crid": "creative-native-1",
+                  "adomain": ["native.example"],
+                  "adm": "{\"native\":{\"assets\":[{\"id\":1,\"title\":{\"text\":\"Synthetic\"}}]}}"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "bidder": "synthetic-video",
+        "mtype": "video",
+        "bid_request": {
+          "id": "request-1",
+          "imp": [
+            {
+              "id": "imp-video-1",
+              "video": {
+                "w": 640,
+                "h": 360,
+                "api": [7]
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-video-1",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-video-1",
+                  "impid": "imp-video-1",
+                  "crid": "creative-video-1",
+                  "adomain": ["video.example"],
+                  "adm": "<?xml version=\"1.0\"?><VAST version=\"4.2\"><Ad></Ad></VAST>"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "auction-row-2",
+    "auction": [
+      {
+        "bidder": "synthetic-sharc",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-2",
+          "imp": [
+            {
+              "id": "imp-banner-2",
+              "banner": {
+                "format": [
+                  { "w": 300, "h": 250 }
+                ],
+                "api": [3, 5]
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-2",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-sharc-1",
+                  "impid": "imp-banner-2",
+                  "crid": "creative-sharc-1",
+                  "api": 10,
+                  "adomain": ["sharc.example"],
+                  "adm": "<html><body><script>window.SHARC && window.SHARC.onReady && window.SHARC.onReady(function () {});</script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "bidder": "synthetic-safeframe",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-2",
+          "imp": [
+            {
+              "id": "imp-banner-3",
+              "banner": {
+                "w": 728,
+                "h": 90
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-3",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-safeframe-1",
+                  "impid": "imp-banner-3",
+                  "crid": "creative-safeframe-1",
+                  "adomain": ["safeframe.example"],
+                  "adm": "<div id=\"ad\"></div><script>$sf.ext.register(728, 90, function () {});</script>"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/tools/creative-validator/src/cli.js
+++ b/tools/creative-validator/src/cli.js
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+/**
+ * @file Creative validator CLI.
+ */
+
+import { createWriteStream, existsSync, mkdirSync, readFileSync, readdirSync, statSync } from 'fs';
+import { basename, dirname, relative, resolve, sep } from 'path';
+import { normalizeCleanedCorpus, toJsonl } from './normalizer.js';
+
+const DEFAULT_PRIVATE_ROOT = resolve('tools/creative-validator/private');
+const FORBIDDEN_PUBLIC_DIRS = [
+  resolve('tools/creative-validator/fixtures'),
+  resolve('tools/creative-validator/src'),
+  resolve('tools/creative-validator/test'),
+];
+
+function usage() {
+  return `SHARC Creative Validator
+
+Usage:
+  creative-validator normalize <corpus-file-or-glob> [more-files...] --out <private/cases.jsonl>
+
+Examples:
+  node tools/creative-validator/src/cli.js normalize "tools/creative-validator/private/*.cleaned.json" --out tools/creative-validator/private/normalized/cases.jsonl
+
+Notes:
+  - Globs are supported only in the final path segment, e.g. private/*.cleaned.json.
+  - Output must stay under tools/creative-validator/private/ unless --allow-public-out is passed.
+`;
+}
+
+function isInside(child, parent) {
+  const rel = relative(parent, child);
+  return rel === '' || (rel && !rel.startsWith('..') && !rel.startsWith(sep));
+}
+
+function assertOutputPath(outPath, allowPublicOut) {
+  if (allowPublicOut) {
+    for (const forbidden of FORBIDDEN_PUBLIC_DIRS) {
+      if (isInside(outPath, forbidden)) {
+        throw new Error(`Refusing to write validator output under ${relative(process.cwd(), forbidden)}.`);
+      }
+    }
+    return;
+  }
+
+  if (!isInside(outPath, DEFAULT_PRIVATE_ROOT)) {
+    throw new Error(
+      'Refusing to write private creative validator output outside tools/creative-validator/private/. '
+      + 'Pass --allow-public-out only for sanitized throwaway output.',
+    );
+  }
+}
+
+/**
+ * Supports simple filesystem globs in the final path segment, e.g.
+ * `private/*.cleaned.json`. This avoids adding a dependency for Phase 1.
+ *
+ * @param {string} pattern
+ * @returns {string[]}
+ */
+function expandInput(pattern) {
+  if (!pattern.includes('*')) {
+    const file = resolve(pattern);
+    if (!existsSync(file)) throw new Error(`Input file not found: ${pattern}`);
+    return [file];
+  }
+  const absolute = resolve(pattern);
+  const dir = dirname(absolute);
+  const filePattern = absolute.slice(dir.length + 1);
+  const regex = new RegExp('^' + filePattern
+    .split('*')
+    .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('.*') + '$');
+  if (!existsSync(dir) || !statSync(dir).isDirectory()) {
+    throw new Error(`Input glob directory not found: ${dirname(pattern)}`);
+  }
+  const matches = readdirSync(dir)
+    .filter((entry) => regex.test(entry))
+    .map((entry) => resolve(dir, entry))
+    .sort();
+  if (matches.length === 0) throw new Error(`Input glob matched no files: ${pattern}`);
+  return matches;
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  if (!command || command === '--help' || command === '-h') {
+    console.log(usage());
+    process.exit(0);
+  }
+  if (command !== 'normalize') {
+    throw new Error('Expected command: normalize\n\n' + usage());
+  }
+
+  const inputs = [];
+  let out = null;
+  let allowPublicOut = false;
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg === '--out') {
+      out = rest[++i];
+    } else if (arg === '--allow-public-out') {
+      allowPublicOut = true;
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(usage());
+      process.exit(0);
+    } else {
+      inputs.push(arg);
+    }
+  }
+  if (inputs.length === 0) throw new Error('At least one corpus input is required.');
+  if (!out) throw new Error('--out <cases.jsonl> is required.');
+  return { allowPublicOut, inputs, out };
+}
+
+function readJsonCorpus(file) {
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'));
+  } catch (err) {
+    if (err && err.name === 'SyntaxError') {
+      const match = /position\s+(\d+)/i.exec(err.message || '');
+      const position = match ? ` at position ${match[1]}` : '';
+      throw new Error(`Failed to parse ${basename(file)}: invalid JSON${position}.`);
+    }
+    throw err;
+  }
+}
+
+function writeCasesJsonl(outPath, files) {
+  return new Promise((resolvePromise, reject) => {
+    const stream = createWriteStream(outPath, { encoding: 'utf8' });
+    let count = 0;
+
+    stream.on('error', reject);
+    stream.on('finish', () => resolvePromise(count));
+
+    try {
+      for (const file of files) {
+        const json = readJsonCorpus(file);
+        const cases = normalizeCleanedCorpus(json, { sourceFile: file });
+        count += cases.length;
+        for (const item of cases) {
+          stream.write(toJsonl([item]));
+        }
+      }
+      stream.end();
+    } catch (err) {
+      stream.destroy();
+      reject(err);
+    }
+  });
+}
+
+async function main() {
+  const { allowPublicOut, inputs, out } = parseArgs(process.argv.slice(2));
+  const files = inputs.flatMap(expandInput);
+  if (files.length === 0) {
+    throw new Error('No input files matched.');
+  }
+
+  const outPath = resolve(out);
+  assertOutputPath(outPath, allowPublicOut);
+  mkdirSync(dirname(outPath), { recursive: true });
+  const count = await writeCasesJsonl(outPath, files);
+  console.log(`Normalized ${count} cases from ${files.length} file(s) to ${outPath}`);
+}
+
+main().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/tools/creative-validator/src/normalizer.js
+++ b/tools/creative-validator/src/normalizer.js
@@ -1,0 +1,543 @@
+/**
+ * @file Creative validator normalizer.
+ *
+ * Converts cleaned OpenRTB export rows into stable SHARC creative validator
+ * test cases. This module is intentionally dependency-free so the private
+ * hardening harness can iterate without changing the package surface.
+ */
+
+const SHARC_API_CODES = new Set([10, 11, 12]);
+const MRAID_API_CODES = new Set([3, 5, 6]);
+const OMID_API_CODES = new Set([7, 8, 9]);
+const KNOWN_API_CODES = new Set([
+  1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12,
+]);
+const EXECUTABLE_ADM_KINDS = new Set(['html', 'html-mraid', 'html-safeframe']);
+const MEDIA_FIELDS = ['banner', 'video', 'native', 'audio'];
+const MRAID_METHODS = [
+  'addEventListener',
+  'close',
+  'createCalendarEvent',
+  'expand',
+  'getCurrentPosition',
+  'getDefaultPosition',
+  'getExpandProperties',
+  'getMaxSize',
+  'getPlacementType',
+  'getResizeProperties',
+  'getScreenSize',
+  'getState',
+  'getVersion',
+  'isViewable',
+  'open',
+  'playVideo',
+  'removeEventListener',
+  'resize',
+  'setExpandProperties',
+  'setOrientationProperties',
+  'setResizeProperties',
+  'storePicture',
+  'supports',
+  'useCustomClose',
+].join('|');
+const MRAID_METHOD_RE = new RegExp(`\\bmraid\\s*\\.\\s*(${MRAID_METHODS})\\b`);
+
+/**
+ * @typedef {object} NormalizedCase
+ * @property {object} source
+ * @property {object} ids
+ * @property {object} creative
+ * @property {object} bidSignals
+ * @property {object} expectations
+ * @property {object} sharcOptions
+ */
+
+/**
+ * Sanitizes raw API framework declarations.
+ *
+ * @param {unknown[]} rawApis
+ * @returns {number[]}
+ */
+function sanitizeApiDeclarations(rawApis) {
+  if (!Array.isArray(rawApis)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const code of rawApis) {
+    if (typeof code !== 'number' || !Number.isInteger(code)) continue;
+    if (!KNOWN_API_CODES.has(code)) continue;
+    if (seen.has(code)) continue;
+    seen.add(code);
+    out.push(code);
+  }
+  out.sort((a, b) => a - b);
+  return out;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number[]|null}
+ */
+function normalizeApiValue(value) {
+  if (Array.isArray(value)) {
+    const filtered = value.filter((v) => typeof v === 'number' && Number.isInteger(v));
+    return filtered.length > 0 ? filtered : null;
+  }
+  if (typeof value === 'number' && Number.isInteger(value)) return [value];
+  return null;
+}
+
+/**
+ * @param {number[]} codes
+ * @returns {boolean}
+ */
+function hasAny(codes, set) {
+  return codes.some((code) => set.has(code));
+}
+
+/**
+ * @param {string} s
+ * @returns {object|null}
+ */
+function tryParseJson(s) {
+  try {
+    const parsed = JSON.parse(s);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+const BASE64_RE = /^[A-Za-z0-9+/\s=]+$/;
+
+/**
+ * Attempts conservative base64 decode. HTML and JSON text should not match
+ * this path because they contain non-base64 punctuation.
+ *
+ * @param {string} s
+ * @returns {string|null}
+ */
+function tryBase64Decode(s) {
+  const trimmed = s.trim();
+  if (trimmed.length < 50) return null;
+  if (!BASE64_RE.test(trimmed)) return null;
+  const compact = trimmed.replace(/\s+/g, '');
+  if (compact.length % 4 === 1) return null;
+
+  try {
+    const buf = Buffer.from(compact, 'base64');
+    if (buf.length === 0) return null;
+    const decoded = buf.toString('utf8');
+    const reencoded = Buffer.from(decoded, 'utf8').toString('base64');
+    const withoutPadding = (value) => value.replace(/=+$/, '');
+    if (withoutPadding(reencoded) !== withoutPadding(compact)) return null;
+
+    const decodedPrefix = decoded.trimStart().slice(0, 20);
+    if (!decodedPrefix.startsWith('<') && !decodedPrefix.startsWith('{')) return null;
+
+    const sample = decoded.slice(0, 500);
+    let printable = 0;
+    for (let i = 0; i < sample.length; i++) {
+      const code = sample.charCodeAt(i);
+      if ((code >= 32 && code < 127) || code === 9 || code === 10 || code === 13) {
+        printable++;
+      }
+    }
+    if (sample.length > 0 && printable / sample.length < 0.8) return null;
+    return decoded;
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Unwraps known exchange wrapper shapes around bid.adm.
+ *
+ * @param {string} rawAdm
+ * @returns {{adm: string, transformations: string[], nativeMeta: object|null}}
+ */
+function unwrapAdm(rawAdm) {
+  let adm = typeof rawAdm === 'string' ? rawAdm.trim() : '';
+  const transformations = [];
+  let nativeMeta = null;
+
+  const decoded = tryBase64Decode(adm);
+  if (decoded !== null) {
+    adm = decoded.trim();
+    transformations.push('base64');
+  }
+
+  const parsed = tryParseJson(adm);
+  if (!parsed) return { adm, transformations, nativeMeta };
+
+  if (Array.isArray(parsed.renderables) && parsed.renderables.length > 0) {
+    const renderable = parsed.renderables[0];
+    if (renderable && typeof renderable.adm === 'string' && renderable.adm.trim()) {
+      adm = renderable.adm.trim();
+      transformations.push('renderables[0].adm');
+      const inner = tryParseJson(adm);
+      if (inner && typeof inner.adm === 'string') {
+        nativeMeta = inner;
+        adm = inner.adm.trim();
+        transformations.push('inner.adm');
+      }
+      return { adm, transformations, nativeMeta };
+    }
+  }
+
+  if (parsed.native || parsed.assets) {
+    nativeMeta = parsed;
+  } else if (typeof parsed.adm === 'string') {
+    nativeMeta = parsed;
+    adm = parsed.adm.trim();
+    transformations.push('adm');
+  }
+
+  return { adm, transformations, nativeMeta };
+}
+
+/**
+ * Classifies an adm payload for v0 execution.
+ *
+ * @param {string} adm
+ * @returns {'html'|'html-mraid'|'html-safeframe'|'vast-xml'|'native-json'|'unknown'}
+ */
+function classifyAdmKind(adm) {
+  if (!adm || typeof adm !== 'string') return 'unknown';
+  const trimmed = adm.trim();
+  const lower = trimmed.slice(0, 2000).toLowerCase();
+
+  if (lower.startsWith('<?xml') || lower.includes('<vast')) return 'vast-xml';
+
+  if (trimmed.startsWith('{')) {
+    const parsed = tryParseJson(trimmed);
+    if (parsed && (parsed.native || parsed.assets)) return 'native-json';
+  }
+
+  const looksHtml = lower.includes('<!doctype')
+    || lower.includes('<html')
+    || lower.includes('<body')
+    || lower.includes('<script')
+    || lower.includes('<div')
+    || lower.includes('<iframe')
+    || lower.includes('<style');
+  if (!looksHtml) return 'unknown';
+
+  if (lower.includes('$sf.ext') || lower.includes('safeframe')) {
+    return 'html-safeframe';
+  }
+  if (lower.includes('mraid.js')
+      || lower.includes('mraid.min.js')
+      || lower.includes('window.mraid')
+      || MRAID_METHOD_RE.test(lower)) {
+    return 'html-mraid';
+  }
+  return 'html';
+}
+
+/**
+ * @param {object|null} request
+ * @param {object} bid
+ * @returns {object|null}
+ */
+function resolvePlacement(request, bid) {
+  if (!request || !Array.isArray(request.imp)) return null;
+  return request.imp.find((imp) => imp && imp.id === bid.impid) || null;
+}
+
+/**
+ * @param {object|null} placement
+ * @returns {string[]}
+ */
+function mediaTypes(placement) {
+  if (!placement || typeof placement !== 'object') return [];
+  return MEDIA_FIELDS.filter((field) => placement[field]);
+}
+
+/**
+ * @param {object|null} placement
+ * @param {string|undefined} mtype
+ * @returns {string|null}
+ */
+function primaryMediaField(placement, mtype) {
+  if (!placement || typeof placement !== 'object') return null;
+  if (mtype && placement[mtype]) return mtype;
+  const present = mediaTypes(placement);
+  return present.length === 1 ? present[0] : null;
+}
+
+/**
+ * @param {object} bid
+ * @param {object|null} placement
+ * @param {string|undefined} mtype
+ * @returns {{raw: number[], sanitized: number[], sources: object[]}}
+ */
+function extractApis(bid, placement, mtype) {
+  const sources = [];
+  const selectedRaw = [];
+
+  function addSource(path, value, role) {
+    const values = normalizeApiValue(value);
+    if (!values) return;
+    sources.push({ path, values: values.slice(), role });
+    if (role !== 'context') selectedRaw.push(...values);
+  }
+
+  addSource('bid.apis', bid.apis, 'bid');
+  addSource('bid.api', bid.api, 'bid');
+
+  const primary = primaryMediaField(placement, mtype);
+  for (const field of MEDIA_FIELDS) {
+    const value = placement && placement[field] && placement[field].api;
+    if (value === undefined) continue;
+    const role = !primary || field === primary ? 'primary' : 'context';
+    addSource(`imp.${field}.api`, value, role);
+  }
+
+  return {
+    raw: selectedRaw.slice(),
+    sanitized: sanitizeApiDeclarations(selectedRaw),
+    sources,
+  };
+}
+
+/**
+ * @param {object} bid
+ * @param {object|null} placement
+ * @returns {{width: number|null, height: number|null}}
+ */
+function resolveDimensions(bid, placement) {
+  let width = typeof bid.w === 'number' ? bid.w : null;
+  let height = typeof bid.h === 'number' ? bid.h : null;
+  const primary = primaryMediaField(placement, undefined);
+
+  function applyMedia(media) {
+    if (!media || typeof media !== 'object') return;
+    if (width === null && typeof media.w === 'number') width = media.w;
+    if (height === null && typeof media.h === 'number') height = media.h;
+    if ((width === null || height === null)
+        && Array.isArray(media.format)
+        && media.format.length > 0) {
+      const first = media.format[0];
+      if (width === null && typeof first.w === 'number') width = first.w;
+      if (height === null && typeof first.h === 'number') height = first.h;
+    }
+  }
+
+  if (placement) {
+    if (primary) applyMedia(placement[primary]);
+    for (const field of MEDIA_FIELDS) applyMedia(placement[field]);
+  }
+
+  return { width, height };
+}
+
+/**
+ * @param {object|null} placement
+ * @returns {'inline'|'interstitial'}
+ */
+function resolvePlacementType(placement) {
+  return placement && placement.instl === 1 ? 'interstitial' : 'inline';
+}
+
+/**
+ * @param {number[]} apis
+ * @param {string} admKind
+ * @returns {{declared: string[], sniffed: string[]}}
+ */
+function resolveExpectations(apis, admKind) {
+  const declared = [];
+  const sniffed = [];
+
+  if (hasAny(apis, MRAID_API_CODES)) declared.push('mraid');
+  if (hasAny(apis, OMID_API_CODES)) declared.push('omid');
+  if (hasAny(apis, SHARC_API_CODES)) declared.push('sharc');
+
+  if (admKind === 'html-mraid') sniffed.push('mraid');
+  if (admKind === 'html-safeframe') sniffed.push('safeframe');
+
+  return { declared, sniffed };
+}
+
+/**
+ * @param {string} mode
+ * @param {string} admKind
+ * @returns {{execute: boolean, skipReason: string|null}}
+ */
+function resolveExecution(mode, admKind) {
+  if (mode === 'curl') {
+    return { execute: false, skipReason: 'creative-url-mode-not-supported-v0' };
+  }
+  if (mode === 'ambiguous') {
+    return { execute: false, skipReason: 'ambiguous-adm-and-curl' };
+  }
+  if (mode === 'missing') {
+    return { execute: false, skipReason: 'missing-creative-payload' };
+  }
+  if (!EXECUTABLE_ADM_KINDS.has(admKind)) {
+    return { execute: false, skipReason: `unsupported-adm-kind:${admKind}` };
+  }
+  return { execute: true, skipReason: null };
+}
+
+/**
+ * @param {object} bid
+ * @returns {string}
+ */
+function resolveMode(bid) {
+  const hasAdm = typeof bid.adm === 'string' && bid.adm.trim().length > 0;
+  const hasCurl = typeof bid.curl === 'string' && bid.curl.trim().length > 0;
+  if (hasAdm && hasCurl) return 'ambiguous';
+  if (hasAdm) return 'adm-html';
+  if (hasCurl) return 'curl';
+  return 'missing';
+}
+
+/**
+ * @param {object} placement
+ * @returns {object|null}
+ */
+function sanitizePlacement(placement) {
+  if (!placement || typeof placement !== 'object') return null;
+  return {
+    id: placement.id || null,
+    instl: placement.instl === 1 ? 1 : 0,
+    secure: placement.secure === 1 ? 1 : 0,
+    mediaTypes: mediaTypes(placement),
+  };
+}
+
+/**
+ * @param {object} row
+ * @param {number} rowIndex
+ * @param {object} auction
+ * @param {number} auctionIndex
+ * @param {object} bid
+ * @param {object} options
+ * @returns {NormalizedCase}
+ */
+function normalizeBid(row, rowIndex, auction, auctionIndex, bid, options) {
+  const request = auction.bid_request || null;
+  const response = auction.bid_response || {};
+  const placement = resolvePlacement(request, bid);
+  const mode = resolveMode(bid);
+  const unwrapped = mode === 'adm-html'
+    ? unwrapAdm(bid.adm)
+    : { adm: '', transformations: [], nativeMeta: null };
+  const admKind = mode === 'adm-html' ? classifyAdmKind(unwrapped.adm) : 'unknown';
+  const apis = extractApis(bid, placement, auction.mtype);
+  const dimensions = resolveDimensions(bid, placement);
+  const placementType = resolvePlacementType(placement);
+  const expectations = resolveExpectations(apis.sanitized, admKind);
+  const execution = resolveExecution(mode, admKind);
+  const creativeMeta = { apis: apis.sanitized.slice() };
+  const omidDeclared = hasAny(apis.sanitized, OMID_API_CODES);
+
+  return {
+    source: {
+      sourceFile: options.sourceFile || null,
+      rowIndex,
+      auctionId: row.id || null,
+      auctionIndex,
+      bidder: auction.bidder || null,
+      mtype: auction.mtype || null,
+    },
+    ids: {
+      requestId: request && request.id ? request.id : null,
+      responseId: response.id || null,
+      bidId: bid.id || null,
+      impId: bid.impid || null,
+      crid: bid.crid || null,
+    },
+    creative: {
+      mode,
+      admKind,
+      html: mode === 'adm-html' ? unwrapped.adm : null,
+      url: mode === 'curl' ? bid.curl.trim() : null,
+      width: dimensions.width,
+      height: dimensions.height,
+      placementType,
+      transformations: unwrapped.transformations,
+    },
+    bidSignals: {
+      apis,
+      mtype: auction.mtype || null,
+      adomain: Array.isArray(bid.adomain) ? bid.adomain.slice() : [],
+      cat: Array.isArray(bid.cat) ? bid.cat.slice() : [],
+      battr: Array.isArray(bid.battr) ? bid.battr.slice() : [],
+      attr: Array.isArray(bid.attr) ? bid.attr.slice() : [],
+      placement: sanitizePlacement(placement),
+      measurement: {
+        omid: {
+          declaredByApi: omidDeclared,
+          sidecarPresent: false,
+          // Populated when Phase 4 teaches the validator about OMID sidecars.
+          sources: [],
+        },
+      },
+    },
+    expectations: {
+      declared: expectations.declared,
+      sniffed: expectations.sniffed,
+      execute: execution.execute,
+      skipReason: execution.skipReason,
+    },
+    sharcOptions: {
+      creativeMeta,
+      requireSharcInit: hasAny(apis.sanitized, SHARC_API_CODES),
+      placementType,
+    },
+  };
+}
+
+/**
+ * Normalizes cleaned corpus rows.
+ *
+ * @param {object[]} rows
+ * @param {{sourceFile?: string}} [options]
+ * @returns {NormalizedCase[]}
+ */
+function normalizeCleanedCorpus(rows, options = {}) {
+  if (!Array.isArray(rows)) {
+    throw new TypeError('Cleaned corpus must be a JSON array.');
+  }
+
+  const cases = [];
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const row = rows[rowIndex];
+    if (!row || !Array.isArray(row.auction)) continue;
+
+    for (let auctionIndex = 0; auctionIndex < row.auction.length; auctionIndex++) {
+      const auction = row.auction[auctionIndex];
+      const bids = auction
+        && auction.bid_response
+        && Array.isArray(auction.bid_response.seatbid)
+        ? auction.bid_response.seatbid.flatMap((seat) => (
+          seat && Array.isArray(seat.bid) ? seat.bid : []
+        ))
+        : [];
+
+      for (const bid of bids) {
+        if (bid && typeof bid === 'object') {
+          cases.push(normalizeBid(row, rowIndex, auction, auctionIndex, bid, options));
+        }
+      }
+    }
+  }
+  return cases;
+}
+
+/**
+ * @param {NormalizedCase[]} cases
+ * @returns {string}
+ */
+function toJsonl(cases) {
+  return cases.map((item) => JSON.stringify(item)).join('\n') + (cases.length ? '\n' : '');
+}
+
+export {
+  classifyAdmKind,
+  normalizeCleanedCorpus,
+  sanitizeApiDeclarations,
+  toJsonl,
+  unwrapAdm,
+};

--- a/tools/creative-validator/test/test-normalizer.js
+++ b/tools/creative-validator/test/test-normalizer.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+/**
+ * test-normalizer.js — creative validator Phase 1 coverage.
+ */
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+import {
+  classifyAdmKind,
+  normalizeCleanedCorpus,
+  sanitizeApiDeclarations,
+  toJsonl,
+  unwrapAdm,
+} from '../src/normalizer.js';
+
+const fixturePath = resolve(
+  'tools/creative-validator/fixtures/reductions/001-normalizer-cleaned-corpus/cleaned-corpus.fixture.json',
+);
+const cliPath = resolve('tools/creative-validator/src/cli.js');
+const fixture = JSON.parse(readFileSync(fixturePath, 'utf8'));
+const cases = normalizeCleanedCorpus(fixture, { sourceFile: fixturePath });
+
+test('API sanitization filters, deduplicates, and sorts known integer codes', () => {
+  assert.deepEqual(sanitizeApiDeclarations([7, 3, 999, 3, 'x', 10, 5]), [3, 5, 7, 10]);
+});
+
+test('adm classification detects supported and skipped creative kinds', () => {
+  assert.equal(classifyAdmKind('<script src="mraid.js"></script>'), 'html-mraid');
+  assert.equal(classifyAdmKind('<script>mraid.open("https://click.example/")</script>'), 'html-mraid');
+  assert.equal(classifyAdmKind('<div><a href="https://mraid.example.com/ad"></a></div>'), 'html');
+  assert.equal(
+    classifyAdmKind('<script>$sf.ext.register(1,1,function(){})</script>'),
+    'html-safeframe',
+  );
+  assert.equal(classifyAdmKind('<?xml version="1.0"?><VAST></VAST>'), 'vast-xml');
+  assert.equal(classifyAdmKind('{"native":{"assets":[]}}'), 'native-json');
+});
+
+test('adm unwrap handles conservative wrapper formats', () => {
+  const encoded = Buffer.from(
+    '<html><body><div>decoded</div><script>window.__creativeLoaded = true;</script></body></html>',
+    'utf8',
+  ).toString('base64');
+  const unwrapped = unwrapAdm(encoded);
+  assert.match(unwrapped.adm, /decoded/);
+  assert.deepEqual(unwrapped.transformations, ['base64']);
+
+  const encodedJson = Buffer.from(
+    JSON.stringify({ renderables: [{ adm: '<div>json inner</div>' }] }),
+    'utf8',
+  ).toString('base64');
+  const jsonWrapped = unwrapAdm(encodedJson);
+  assert.equal(jsonWrapped.adm, '<div>json inner</div>');
+  assert.deepEqual(jsonWrapped.transformations, ['base64', 'renderables[0].adm']);
+
+  const wrapped = unwrapAdm(JSON.stringify({ renderables: [{ adm: '<div>inner</div>' }] }));
+  assert.equal(wrapped.adm, '<div>inner</div>');
+  assert.deepEqual(wrapped.transformations, ['renderables[0].adm']);
+});
+
+test('adm unwrap does not tag long printable non-base64 payloads as base64', () => {
+  const tokenLike = 'a'.repeat(72) + 'bbbbccccdddd';
+  const unwrapped = unwrapAdm(tokenLike);
+  assert.equal(unwrapped.adm, tokenLike);
+  assert.deepEqual(unwrapped.transformations, []);
+});
+
+test('cleaned corpus normalization emits one stable case per bid', () => {
+  assert.equal(cases.length, 5);
+
+  const mraid = cases.find((item) => item.ids.bidId === 'bid-mraid-1');
+  assert.ok(mraid);
+  assert.equal(mraid.creative.admKind, 'html-mraid');
+  assert.equal(mraid.expectations.execute, true);
+  assert.deepEqual(mraid.bidSignals.apis.sanitized, [3, 5, 7]);
+  assert.ok(mraid.bidSignals.apis.sources.some(
+    (s) => s.path === 'imp.video.api' && s.role === 'context',
+  ));
+  assert.deepEqual(mraid.sharcOptions.creativeMeta.apis, [3, 5, 7]);
+  assert.equal(mraid.sharcOptions.requireSharcInit, false);
+  assert.deepEqual(mraid.expectations.declared, ['mraid', 'omid']);
+  assert.deepEqual(mraid.expectations.sniffed, ['mraid']);
+  assert.equal(mraid.creative.width, 320);
+  assert.equal(mraid.creative.height, 50);
+
+  const nativeCase = cases.find((item) => item.ids.bidId === 'bid-native-1');
+  assert.equal(nativeCase.creative.admKind, 'native-json');
+  assert.equal(nativeCase.expectations.execute, false);
+  assert.equal(nativeCase.expectations.skipReason, 'unsupported-adm-kind:native-json');
+
+  const vast = cases.find((item) => item.ids.bidId === 'bid-video-1');
+  assert.equal(vast.creative.admKind, 'vast-xml');
+  assert.deepEqual(vast.bidSignals.apis.sanitized, [7]);
+  assert.ok(vast.expectations.declared.includes('omid'));
+  assert.equal(vast.expectations.execute, false);
+
+  const sharc = cases.find((item) => item.ids.bidId === 'bid-sharc-1');
+  assert.equal(sharc.sharcOptions.requireSharcInit, true);
+  assert.deepEqual(sharc.bidSignals.apis.sanitized, [3, 5, 10]);
+  assert.equal(sharc.creative.width, 300);
+  assert.equal(sharc.creative.height, 250);
+  assert.deepEqual(sharc.bidSignals.battr, []);
+  assert.deepEqual(mraid.bidSignals.attr, [1]);
+
+  const safeframe = cases.find((item) => item.ids.bidId === 'bid-safeframe-1');
+  assert.equal(safeframe.creative.admKind, 'html-safeframe');
+  assert.deepEqual(safeframe.expectations.sniffed, ['safeframe']);
+});
+
+test('JSONL output emits one newline-terminated line per case', () => {
+  const jsonl = toJsonl(cases);
+  assert.equal(jsonl.endsWith('\n'), true);
+  const lines = jsonl.trim().split('\n');
+  assert.equal(lines.length, cases.length);
+  assert.equal(JSON.parse(lines[0]).ids.bidId, 'bid-mraid-1');
+});
+
+test('CLI normalizes to private output and protects public paths', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const outDir = mkdtempSync(resolve(privateRoot, 'test-normalizer-'));
+  const outPath = resolve(outDir, 'cases.jsonl');
+
+  try {
+    execFileSync('node', [cliPath, 'normalize', fixturePath, '--out', outPath], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const lines = readFileSync(outPath, 'utf8').trim().split('\n');
+    assert.equal(lines.length, cases.length);
+  } finally {
+    rmSync(outDir, { force: true, recursive: true });
+  }
+
+  const publicOut = resolve('tools/creative-validator/fixtures/leak.jsonl');
+  assert.throws(
+    () => execFileSync('node', [cliPath, 'normalize', fixturePath, '--out', publicOut], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }),
+    /Refusing to write private creative validator output outside/,
+  );
+  assert.equal(existsSync(publicOut), false);
+});
+
+test('CLI reports zero-match globs even when another input is valid', () => {
+  assert.throws(
+    () => execFileSync('node', [
+      cliPath,
+      'normalize',
+      fixturePath,
+      'tools/creative-validator/fixtures/reductions/001-normalizer-cleaned-corpus/nope-*.json',
+      '--out',
+      resolve(tmpdir(), 'sharc-validator-should-not-write.jsonl'),
+      '--allow-public-out',
+    ], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }),
+    /Input glob matched no files/,
+  );
+});


### PR DESCRIPTION
## Summary
- add the private-first creative validator normalizer scaffold under tools/creative-validator
- normalize cleaned OpenRTB export rows into JSONL test cases with admKind, API provenance, bridge/OMID expectations, and SHARC options
- add synthetic reduction fixture, README, gitignore coverage for private corpus output, and CI coverage for the normalizer test
- address review feedback: stricter base64/MRAID classification, private-only CLI output by default, zero-match glob errors, sanitized parse errors, streaming JSONL writes, and node:test coverage

## Tests
- npm run build
- npm run lint
- npm run test:creative-validator-normalizer
- node tools/creative-validator/src/cli.js normalize "tools/creative-validator/fixtures/reductions/001-normalizer-cleaned-corpus/*.json" --out tools/creative-validator/private/normalized/cases.jsonl
- npm run test:all:built