### PR TITLE
feat: add creative validator markup runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,12 @@ jobs:
       - name: Creative validator normalizer
         run: npm run test:creative-validator-normalizer
 
+      - name: Creative validator diagnosis buckets
+        run: npm run test:creative-validator-diagnose
+
+      - name: Creative validator Markup runner
+        run: npm run test:creative-validator-runner
+
       - name: Creative Sources performance harness (issue #41, AC L1170)
         # CI runners are noisy neighbors; perf tests can flake on shared
         # hardware. Pass-if-any-of-3-runs balances false-failure rate against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   JSONL test-case output, and synthetic reduction fixtures. The real private
   corpus and generated reports remain gitignored.
 
+- **Creative validator Markup runner foundation.** Adds the first execution
+  layer for normalized creative-validator cases: HTML-ish `adm` runs through
+  the local SHARC Creative Markup renderer in headless Chrome, skipped inputs
+  are reported as `unsupported-input`, and per-case JSONL reports capture
+  lifecycle state, SHARC security events, console/page errors, failed requests,
+  navigation observations, and diagnosis buckets under the private report path.
+
 ## [0.7.6] - 2026-05-24
 
 **Release-doc-first cycle.** Three features shipped in parallel: the headline

--- a/package.json
+++ b/package.json
@@ -71,10 +71,12 @@
     "test:omid-container-lifecycle": "node test/node/test-omid-container-lifecycle.js",
     "test:renderer-fallback": "node test/node/test-renderer-domparser-fallback.js",
     "test:creative-validator-normalizer": "node tools/creative-validator/test/test-normalizer.js",
+    "test:creative-validator-diagnose": "node tools/creative-validator/test/test-diagnose.js",
+    "test:creative-validator-runner": "node tools/creative-validator/test/test-runner.js",
     "test:perf": "node test/node/test-creative-sources-perf.js",
     "test:types": "tsc -p test/types/tsconfig.json",
     "test:all": "npm run build && npm run test:all:built",
-    "test:all:built": "npm run test:smoke && npm run test:treeshake && npm run test:creative-protocol-placement-type && npm run test:placement && npm run test:placement-stamping && npm run test:creative-sources && npm run test:creative-sources-load && npm run test:browser && npm run test:navigation-bridge && npm run test:creative-sdk-autoinstall && npm run test:creative-sdk-injection && npm run test:bridges-detection && npm run test:non-sharc-loading && npm run test:html-lifecycle-adapter && npm run test:omid-container-lifecycle && npm run test:renderer-fallback && npm run test:creative-validator-normalizer",
+    "test:all:built": "npm run test:smoke && npm run test:treeshake && npm run test:creative-protocol-placement-type && npm run test:placement && npm run test:placement-stamping && npm run test:creative-sources && npm run test:creative-sources-load && npm run test:browser && npm run test:navigation-bridge && npm run test:creative-sdk-autoinstall && npm run test:creative-sdk-injection && npm run test:bridges-detection && npm run test:non-sharc-loading && npm run test:html-lifecycle-adapter && npm run test:omid-container-lifecycle && npm run test:renderer-fallback && npm run test:creative-validator-normalizer && npm run test:creative-validator-diagnose && npm run test:creative-validator-runner",
     "regen:baseline": "node scripts/regen-mraid3-baseline.js",
     "lint": "eslint src/*.js --max-warnings=0",
     "check": "npm run build && npm run test:all:built && npm run size && npm run build"

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -5,8 +5,9 @@
 > `tools/creative-validator/private/`.
 
 Private-first hardening harness for real bid-derived creative compatibility
-testing. Phase 1 normalizes cleaned OpenRTB export rows into stable test-case
-records. It does not run a browser yet.
+testing. The current tool normalizes cleaned OpenRTB export rows into stable
+test-case records and can run executable HTML-ish cases through the local SHARC
+Creative Markup renderer.
 
 ## Private Corpus
 
@@ -54,8 +55,49 @@ not raw OpenRTB bid-request or bid-response documents.
 
 Output is JSONL, one normalized test case per bid.
 
+## Run
+
+Build first so the local renderer and container artifacts are current:
+
+```bash
+npm run build
+node tools/creative-validator/src/cli.js run \
+  tools/creative-validator/private/normalized/cases.jsonl \
+  --out tools/creative-validator/private/reports/report.jsonl
+```
+
+Useful run options:
+
+```text
+--render-timeout-ms 10000
+--settle-ms 2000
+--port 18865
+--renderer-port 18866
+--renderer-url http://localhost:18866/examples/renderer/
+--repo-root .
+--verbose
+```
+
+The v0 runner executes only HTML-ish cases where `expectations.execute` is
+`true`. VAST, native JSON, unknown payloads, and Creative URL mode are reported
+as skipped `unsupported-input` cases.
+
+Each report row contains the case identifiers and diagnostic signals, but does
+not duplicate raw `creative.html`.
+
+### Security
+
+The runner executes real creative JavaScript. Run private corpus passes from a
+VM, container, or dedicated low-privilege user, not from a host/session with
+deploy keys, production credentials, or private notes mounted. Chrome launches
+with its OS sandbox enabled by default. If a disposable environment requires
+disabling it, set `SHARC_VALIDATOR_CHROME_NO_SANDBOX=1`; do not use that mode
+on a normal developer laptop.
+
 ## Test
 
 ```bash
 npm run test:creative-validator-normalizer
+npm run test:creative-validator-diagnose
+npm run test:creative-validator-runner
 ```

--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; frame-src http://localhost:* http://127.0.0.1:*; connect-src *; img-src * data:;">
+<title>SHARC Creative Validator Markup Runner</title>
+<style>
+  body { margin: 0; font: 14px/1.4 system-ui, sans-serif; }
+  #placement { width: 320px; height: 250px; border: 0; }
+</style>
+</head>
+<body>
+<div id="placement"></div>
+
+<script type="module">
+import { SHARCContainer } from '/dist/sharc-container.mjs';
+
+const placement = document.getElementById('placement');
+
+function cloneForReport(value) {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (_) {
+    return String(value);
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function waitUntil(predicate, timeoutMs) {
+  const started = performance.now();
+  return new Promise((resolve) => {
+    function poll() {
+      if (predicate()) {
+        resolve({ timedOut: false });
+        return;
+      }
+      if (performance.now() - started >= timeoutMs) {
+        resolve({ timedOut: true });
+        return;
+      }
+      setTimeout(poll, 50);
+    }
+    poll();
+  });
+}
+
+function resetPlacement() {
+  placement.innerHTML = '';
+  placement.removeAttribute('class');
+  placement.removeAttribute('style');
+  placement.style.width = '320px';
+  placement.style.height = '250px';
+}
+
+window.__sharcCreativeValidatorHarness = {
+  async runCase(testCase, options) {
+    resetPlacement();
+    const started = performance.now();
+    const stateHistory = [];
+    const securityEvents = [];
+    const errors = [];
+    const navigationEvents = [];
+    const interactionEvents = [];
+    const messages = [];
+    let constructionError = null;
+    let loadError = null;
+    let container = null;
+
+    try {
+      container = new SHARCContainer({
+        creativeHtml: testCase.creative.html,
+        creativeRendererUrl: options.rendererUrl,
+        placementElement: placement,
+        creativeMeta: testCase.sharcOptions.creativeMeta || {},
+        requireSharcInit: testCase.sharcOptions.requireSharcInit === true,
+        placementType: testCase.sharcOptions.placementType || 'inline',
+        timeouts: {
+          rendererLoad: options.renderTimeoutMs,
+          rendererReply: options.renderTimeoutMs,
+          createSession: options.renderTimeoutMs,
+        },
+        onStateChange: (state, previousState) => {
+          stateHistory.push({
+            t: Math.round(performance.now() - started),
+            from: previousState || null,
+            to: state,
+          });
+        },
+        onSecurityEvent: (event) => {
+          securityEvents.push(cloneForReport(event));
+        },
+        onError: (code, message) => {
+          errors.push({
+            t: Math.round(performance.now() - started),
+            code,
+            message: message || '',
+          });
+        },
+        onNavigation: (args) => {
+          navigationEvents.push({
+            t: Math.round(performance.now() - started),
+            args: cloneForReport(args),
+          });
+        },
+        onInteraction: (uris) => {
+          interactionEvents.push({
+            t: Math.round(performance.now() - started),
+            uris: cloneForReport(uris),
+          });
+        },
+        onMessage: (direction, message) => {
+          messages.push({
+            t: Math.round(performance.now() - started),
+            direction,
+            type: message && message.type ? message.type : null,
+          });
+        },
+      });
+    } catch (err) {
+      constructionError = err && err.message ? err.message : String(err);
+    }
+
+    if (container) {
+      try {
+        container.load();
+      } catch (err) {
+        loadError = err && err.message ? err.message : String(err);
+      }
+    }
+
+    const isTerminated = () => container && container.getState() === 'terminated';
+    const terminal = container
+      ? await waitUntil(
+          () => container.creativeRendered === true || isTerminated(),
+          options.renderTimeoutMs,
+        )
+      : { timedOut: false };
+
+    if (container && container.creativeRendered && !isTerminated()) {
+      await sleep(options.settleMs);
+    }
+
+    const result = {
+      durationMs: Math.round(performance.now() - started),
+      constructionError,
+      loadError,
+      timedOut: terminal.timedOut,
+      creativeRendered: container ? container.creativeRendered === true : false,
+      creativeInjected: container ? container.creativeInjected === true : false,
+      terminated: isTerminated(),
+      finalState: container ? container.getState() : null,
+      placementSessionId: container ? container.placementSessionId : null,
+      stateHistory,
+      securityEvents,
+      errors,
+      navigationEvents,
+      interactionEvents,
+      messages,
+    };
+
+    if (container) {
+      try { container.close(); } catch (_) { /* ignore cleanup */ }
+    }
+    resetPlacement();
+    return result;
+  },
+};
+</script>
+</body>
+</html>

--- a/tools/creative-validator/src/cli.js
+++ b/tools/creative-validator/src/cli.js
@@ -7,6 +7,7 @@
 import { createWriteStream, existsSync, mkdirSync, readFileSync, readdirSync, statSync } from 'fs';
 import { basename, dirname, relative, resolve, sep } from 'path';
 import { normalizeCleanedCorpus, toJsonl } from './normalizer.js';
+import { runNormalizedCases } from './runner.js';
 
 const DEFAULT_PRIVATE_ROOT = resolve('tools/creative-validator/private');
 const FORBIDDEN_PUBLIC_DIRS = [
@@ -20,13 +21,16 @@ function usage() {
 
 Usage:
   creative-validator normalize <corpus-file-or-glob> [more-files...] --out <private/cases.jsonl>
+  creative-validator run <normalized-cases.jsonl> --out <private/reports/report.jsonl>
 
 Examples:
   node tools/creative-validator/src/cli.js normalize "tools/creative-validator/private/*.cleaned.json" --out tools/creative-validator/private/normalized/cases.jsonl
+  node tools/creative-validator/src/cli.js run tools/creative-validator/private/normalized/cases.jsonl --out tools/creative-validator/private/reports/report.jsonl
 
 Notes:
   - Globs are supported only in the final path segment, e.g. private/*.cleaned.json.
   - Output must stay under tools/creative-validator/private/ unless --allow-public-out is passed.
+  - Run options: --port, --renderer-port, --renderer-url, --repo-root, --render-timeout-ms, --settle-ms, --verbose.
 `;
 }
 
@@ -90,19 +94,40 @@ function parseArgs(argv) {
     console.log(usage());
     process.exit(0);
   }
-  if (command !== 'normalize') {
-    throw new Error('Expected command: normalize\n\n' + usage());
+  if (command !== 'normalize' && command !== 'run') {
+    throw new Error('Expected command: normalize or run\n\n' + usage());
   }
 
   const inputs = [];
   let out = null;
   let allowPublicOut = false;
+  let port = null;
+  let rendererPort = null;
+  let rendererUrl = null;
+  let repoRoot = null;
+  let renderTimeoutMs = null;
+  let settleMs = null;
+  let verbose = false;
   for (let i = 0; i < rest.length; i++) {
     const arg = rest[i];
     if (arg === '--out') {
       out = rest[++i];
     } else if (arg === '--allow-public-out') {
       allowPublicOut = true;
+    } else if (arg === '--port') {
+      port = parsePositiveInt(rest[++i], '--port');
+    } else if (arg === '--renderer-port') {
+      rendererPort = parsePositiveInt(rest[++i], '--renderer-port');
+    } else if (arg === '--renderer-url') {
+      rendererUrl = rest[++i];
+    } else if (arg === '--repo-root') {
+      repoRoot = rest[++i];
+    } else if (arg === '--render-timeout-ms') {
+      renderTimeoutMs = parsePositiveInt(rest[++i], '--render-timeout-ms');
+    } else if (arg === '--settle-ms') {
+      settleMs = parsePositiveInt(rest[++i], '--settle-ms');
+    } else if (arg === '--verbose') {
+      verbose = true;
     } else if (arg === '--help' || arg === '-h') {
       console.log(usage());
       process.exit(0);
@@ -112,7 +137,30 @@ function parseArgs(argv) {
   }
   if (inputs.length === 0) throw new Error('At least one corpus input is required.');
   if (!out) throw new Error('--out <cases.jsonl> is required.');
-  return { allowPublicOut, inputs, out };
+  if (command === 'run' && inputs.length !== 1) {
+    throw new Error('run expects exactly one normalized JSONL input file.');
+  }
+  return {
+    allowPublicOut,
+    command,
+    inputs,
+    out,
+    port,
+    rendererPort,
+    rendererUrl,
+    repoRoot,
+    renderTimeoutMs,
+    settleMs,
+    verbose,
+  };
+}
+
+function parsePositiveInt(value, flag) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`${flag} must be a positive integer.`);
+  }
+  return n;
 }
 
 function readJsonCorpus(file) {
@@ -154,17 +202,46 @@ function writeCasesJsonl(outPath, files) {
 }
 
 async function main() {
-  const { allowPublicOut, inputs, out } = parseArgs(process.argv.slice(2));
-  const files = inputs.flatMap(expandInput);
-  if (files.length === 0) {
-    throw new Error('No input files matched.');
-  }
-
+  const {
+    allowPublicOut,
+    command,
+    inputs,
+    out,
+    port,
+    rendererPort,
+    rendererUrl,
+    repoRoot,
+    renderTimeoutMs,
+    settleMs,
+    verbose,
+  } = parseArgs(process.argv.slice(2));
   const outPath = resolve(out);
   assertOutputPath(outPath, allowPublicOut);
-  mkdirSync(dirname(outPath), { recursive: true });
-  const count = await writeCasesJsonl(outPath, files);
-  console.log(`Normalized ${count} cases from ${files.length} file(s) to ${outPath}`);
+
+  if (command === 'normalize') {
+    const files = inputs.flatMap(expandInput);
+    if (files.length === 0) {
+      throw new Error('No input files matched.');
+    }
+
+    mkdirSync(dirname(outPath), { recursive: true });
+    const count = await writeCasesJsonl(outPath, files);
+    console.log(`Normalized ${count} cases from ${files.length} file(s) to ${outPath}`);
+    return;
+  }
+
+  const inputPath = resolve(inputs[0]);
+  if (!existsSync(inputPath)) throw new Error(`Input file not found: ${inputs[0]}`);
+  const result = await runNormalizedCases(inputPath, outPath, {
+    port,
+    rendererPort,
+    rendererUrl,
+    repoRoot,
+    renderTimeoutMs,
+    settleMs,
+    verbose,
+  });
+  console.log(`Ran ${result.count} normalized case(s) to ${result.outFile}`);
 }
 
 main().catch((err) => {

--- a/tools/creative-validator/src/diagnose.js
+++ b/tools/creative-validator/src/diagnose.js
@@ -1,0 +1,130 @@
+/**
+ * @file Creative validator diagnosis buckets.
+ */
+
+const EMPTY_RUN = Object.freeze({
+  durationMs: 0,
+  constructionError: null,
+  loadError: null,
+  timedOut: false,
+  creativeRendered: false,
+  creativeInjected: false,
+  terminated: false,
+  finalState: null,
+  placementSessionId: null,
+  stateHistory: [],
+  securityEvents: [],
+  errors: [],
+  navigationEvents: [],
+  interactionEvents: [],
+  messages: [],
+  consoleMessages: [],
+  pageErrors: [],
+  failedRequests: [],
+});
+
+function makeEmptyRun(overrides = {}) {
+  return {
+    ...EMPTY_RUN,
+    stateHistory: [],
+    securityEvents: [],
+    errors: [],
+    navigationEvents: [],
+    interactionEvents: [],
+    messages: [],
+    consoleMessages: [],
+    pageErrors: [],
+    failedRequests: [],
+    ...overrides,
+  };
+}
+
+function hasSecurityEvent(run, type) {
+  return run.securityEvents.some((event) => event && event.type === type);
+}
+
+function hasRendererSubtype(run, subtype) {
+  return run.securityEvents.some((event) =>
+    event
+      && event.type === 'renderer_protocol_error'
+      && event.details
+      && event.details.subtype === subtype);
+}
+
+function hasNetworkDiagnostics(run) {
+  if (run.failedRequests && run.failedRequests.length > 0) return true;
+  return (run.consoleMessages || []).some((msg) => {
+    const text = String(msg && msg.text ? msg.text : '').toLowerCase();
+    return text.includes('cors')
+      || text.includes('cross-origin')
+      || text.includes('content security policy')
+      || text.includes('csp');
+  });
+}
+
+function classifyOutcome(testCase, run) {
+  if (!testCase.expectations || testCase.expectations.execute !== true) {
+    return {
+      status: 'skipped',
+      bucket: 'unsupported-input',
+      reason: testCase.expectations ? testCase.expectations.skipReason : 'not-executable',
+    };
+  }
+
+  if (run.constructionError || run.loadError) {
+    return {
+      status: 'failed',
+      bucket: 'sharc-runner-error',
+      reason: run.constructionError || run.loadError,
+    };
+  }
+
+  if (hasRendererSubtype(run, 'timeout') || run.timedOut) {
+    return { status: 'failed', bucket: 'renderer-timeout', reason: 'renderer timed out' };
+  }
+  if (hasRendererSubtype(run, 'integrity_failed')) {
+    return { status: 'failed', bucket: 'renderer-integrity', reason: 'renderer integrity failed' };
+  }
+  if (hasSecurityEvent(run, 'renderer_origin_mismatch')) {
+    return { status: 'failed', bucket: 'renderer-origin', reason: 'renderer origin mismatch' };
+  }
+  if (hasRendererSubtype(run, 'malformed_payload') || hasRendererSubtype(run, 'post_failed')) {
+    return { status: 'failed', bucket: 'renderer-protocol', reason: 'renderer protocol error' };
+  }
+  if (hasSecurityEvent(run, 'renderer_failed')) {
+    return { status: 'failed', bucket: 'renderer-protocol', reason: 'renderer failed' };
+  }
+  if (hasSecurityEvent(run, 'unauthorized_navigation')) {
+    return { status: 'failed', bucket: 'navigation-policy', reason: 'unauthorized navigation' };
+  }
+  if (hasSecurityEvent(run, 'bridge_load_failed')) {
+    return { status: 'failed', bucket: 'bridge-missing', reason: 'bridge failed to load' };
+  }
+  if (hasSecurityEvent(run, 'feature_load_failed')) {
+    return { status: 'failed', bucket: 'measurement-omid', reason: 'feature load failed' };
+  }
+
+  if (run.creativeRendered && !run.terminated) {
+    return { status: 'passed', bucket: 'passed', reason: 'creative rendered without fatal signals' };
+  }
+
+  if (hasNetworkDiagnostics(run)) {
+    return {
+      status: 'failed',
+      bucket: 'network-cors',
+      reason: 'network/CORS/CSP diagnostics before terminal success',
+    };
+  }
+
+  if (run.pageErrors && run.pageErrors.length > 0) {
+    return { status: 'failed', bucket: 'creative-broken', reason: 'page error before terminal success' };
+  }
+
+  return { status: 'failed', bucket: 'inconclusive', reason: 'no terminal success signal' };
+}
+
+export {
+  classifyOutcome,
+  hasNetworkDiagnostics,
+  makeEmptyRun,
+};

--- a/tools/creative-validator/src/runner.js
+++ b/tools/creative-validator/src/runner.js
@@ -1,0 +1,421 @@
+/**
+ * @file Creative validator SHARC Markup runner.
+ */
+
+import { spawn } from 'node:child_process';
+import { createWriteStream, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import http from 'node:http';
+import { dirname, resolve } from 'node:path';
+import puppeteer from 'puppeteer-core';
+import { classifyOutcome, makeEmptyRun } from './diagnose.js';
+
+const DEFAULT_PORT = 18865;
+const DEFAULT_RENDERER_PORT = 18866;
+const DEFAULT_RENDER_TIMEOUT_MS = 10_000;
+const DEFAULT_SETTLE_MS = 2_000;
+
+function parsePort(raw, fallback) {
+  if (raw === undefined || raw === null || raw === '') return fallback;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw new Error(`Invalid port '${raw}' — must be an integer in 1..65535.`);
+  }
+  return n;
+}
+
+function resolveChromePath() {
+  const fromEnv = process.env.CHROME_PATH
+    || process.env.CHROME_EXECUTABLE_PATH
+    || process.env.BROWSER_PATH
+    || process.env.PUPPETEER_EXECUTABLE_PATH;
+  if (fromEnv) {
+    if (!existsSync(fromEnv)) {
+      throw new Error(`Chrome executable override does not exist: ${fromEnv}`);
+    }
+    return fromEnv;
+  }
+
+  const candidates = process.platform === 'darwin'
+    ? [
+        '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        '/Applications/Chromium.app/Contents/MacOS/Chromium',
+        '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
+      ]
+    : process.platform === 'linux'
+    ? [
+        '/usr/bin/google-chrome',
+        '/usr/bin/google-chrome-stable',
+        '/usr/bin/chromium',
+        '/usr/bin/chromium-browser',
+      ]
+    : process.platform === 'win32'
+    ? [
+        'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+        'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+      ]
+    : [];
+
+  const found = candidates.find((candidate) => existsSync(candidate));
+  if (found) return found;
+
+  throw new Error(
+    'Unable to locate Chrome/Chromium. Set CHROME_PATH, '
+    + 'CHROME_EXECUTABLE_PATH, BROWSER_PATH, or PUPPETEER_EXECUTABLE_PATH.',
+  );
+}
+
+function waitForServer(url, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolvePromise, reject) => {
+    function attempt() {
+      const req = http.get(url, (res) => {
+        res.resume();
+        resolvePromise();
+      });
+      req.on('error', (err) => {
+        if (Date.now() >= deadline) {
+          reject(new Error(`Timed out waiting for ${url}: ${err.message}`));
+          return;
+        }
+        setTimeout(attempt, 100);
+      });
+      req.setTimeout(1000, () => {
+        req.destroy(new Error('request timed out'));
+      });
+    }
+    attempt();
+  });
+}
+
+async function withServer(options, body) {
+  let serverStdout = '';
+  let serverStderr = '';
+  let stopping = false;
+  const server = spawn(process.execPath, ['server.cjs'], {
+    cwd: options.repoRoot,
+    env: {
+      ...process.env,
+      PORT: String(options.port),
+      RENDERER_PORT: String(options.rendererPort),
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const exitError = (code, signal) => new Error(
+    `Dev server exited unexpectedly (code=${code}, signal=${signal}).\n`
+    + serverStdout
+    + serverStderr,
+  );
+
+  server.stdout.on('data', (chunk) => {
+    serverStdout += String(chunk);
+    const text = String(chunk).trim();
+    if (options.verbose && text) console.log('[server]', text);
+  });
+  server.stderr.on('data', (chunk) => {
+    serverStderr += String(chunk);
+    const text = String(chunk).trim();
+    if (options.verbose && text) console.error('[server!]', text);
+  });
+
+  try {
+    let serverReady = false;
+    const earlyExit = new Promise((_, reject) => {
+      server.once('exit', (code, signal) => {
+        if (serverReady) return;
+        reject(exitError(code, signal));
+      });
+    });
+    await Promise.race([
+      waitForServer(options.baseUrl + '/', 10_000).then(() => { serverReady = true; }),
+      earlyExit,
+    ]);
+    const midRunExit = new Promise((_, reject) => {
+      server.once('exit', (code, signal) => {
+        if (!stopping) reject(exitError(code, signal));
+      });
+    });
+    return await Promise.race([body(), midRunExit]);
+  } finally {
+    stopping = true;
+    server.kill('SIGTERM');
+    await new Promise((resolvePromise) => {
+      const done = () => resolvePromise();
+      server.once('exit', done);
+      setTimeout(done, 1500);
+    });
+  }
+}
+
+function readJsonl(file) {
+  return readFileSync(file, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line, index) => {
+      try {
+        return JSON.parse(line);
+      } catch (err) {
+        throw new Error(`Failed to parse ${file} line ${index + 1}: ${err.message}`);
+      }
+    });
+}
+
+function summarizeCase(testCase) {
+  return {
+    source: testCase.source,
+    ids: testCase.ids,
+    creative: {
+      mode: testCase.creative && testCase.creative.mode,
+      admKind: testCase.creative && testCase.creative.admKind,
+      width: testCase.creative && testCase.creative.width,
+      height: testCase.creative && testCase.creative.height,
+      placementType: testCase.creative && testCase.creative.placementType,
+      transformations: testCase.creative && testCase.creative.transformations,
+    },
+    expectations: testCase.expectations,
+    bidSignals: {
+      apis: testCase.bidSignals && testCase.bidSignals.apis,
+      mtype: testCase.bidSignals && testCase.bidSignals.mtype,
+      measurement: testCase.bidSignals && testCase.bidSignals.measurement,
+    },
+  };
+}
+
+function summarizeConsoleMessage(msg) {
+  const type = msg.type();
+  if (type === 'debug' || type === 'info') return null;
+  return {
+    type,
+    text: msg.text()
+      .replace(/https?:\/\/\S+/g, '[url]')
+      .slice(0, 240),
+  };
+}
+
+function summarizePageError(err) {
+  return {
+    message: String(err && err.message ? err.message : err).slice(0, 500),
+  };
+}
+
+function summarizeRequestUrl(url) {
+  try {
+    const parsed = new URL(url);
+    return parsed.origin + parsed.pathname.slice(0, 500);
+  } catch (_) {
+    return String(url).split('?')[0].slice(0, 500);
+  }
+}
+
+function chromeLaunchArgs() {
+  if (process.env.SHARC_VALIDATOR_CHROME_NO_SANDBOX === '1') {
+    console.error(
+      '[creative-validator] WARNING: launching Chrome with OS sandbox disabled. '
+      + 'Only use SHARC_VALIDATOR_CHROME_NO_SANDBOX=1 inside a disposable VM/container.',
+    );
+    return ['--no-sandbox', '--disable-setuid-sandbox'];
+  }
+  return [];
+}
+
+async function runExecutableCase(browser, testCase, options) {
+  const context = typeof browser.createBrowserContext === 'function'
+    ? await browser.createBrowserContext()
+    : await browser.createIncognitoBrowserContext();
+  const page = await context.newPage();
+  // Allows page.goto + in-page render/settle work to report cleanly before
+  // Puppeteer aborts the evaluate call itself.
+  page.setDefaultTimeout(options.renderTimeoutMs + options.settleMs + 5_000);
+
+  const consoleMessages = [];
+  const pageErrors = [];
+  const failedRequests = [];
+
+  page.on('console', (msg) => {
+    const summarized = summarizeConsoleMessage(msg);
+    if (summarized) consoleMessages.push(summarized);
+  });
+  page.on('pageerror', (err) => {
+    pageErrors.push(summarizePageError(err));
+  });
+  page.on('requestfailed', (request) => {
+    const failure = request.failure();
+    failedRequests.push({
+      url: summarizeRequestUrl(request.url()),
+      method: request.method(),
+      resourceType: request.resourceType(),
+      errorText: failure ? failure.errorText : '',
+    });
+  });
+
+  try {
+    await page.goto(options.harnessUrl, {
+      waitUntil: 'domcontentloaded',
+      timeout: options.renderTimeoutMs,
+    });
+    const hasHarness = await page.evaluate(() =>
+      Boolean(window.__sharcCreativeValidatorHarness
+        && typeof window.__sharcCreativeValidatorHarness.runCase === 'function'));
+    if (!hasHarness) {
+      return {
+        constructionError: 'validator harness did not initialize',
+        loadError: null,
+        timedOut: false,
+        creativeRendered: false,
+        creativeInjected: false,
+        terminated: false,
+        finalState: null,
+        placementSessionId: null,
+        durationMs: 0,
+        stateHistory: [],
+        securityEvents: [],
+        errors: [],
+        navigationEvents: [],
+        interactionEvents: [],
+        messages: [],
+        consoleMessages,
+        pageErrors,
+        failedRequests,
+      };
+    }
+
+    const run = await page.evaluate(
+      (item, runOptions) => window.__sharcCreativeValidatorHarness.runCase(item, runOptions),
+      testCase,
+      {
+        rendererUrl: options.rendererUrl,
+        renderTimeoutMs: options.renderTimeoutMs,
+        settleMs: options.settleMs,
+      },
+    );
+    return {
+      ...run,
+      consoleMessages,
+      pageErrors,
+      failedRequests,
+    };
+  } catch (err) {
+    return makeEmptyRun({
+      constructionError: `runner page execution failed: ${err && err.message ? err.message : String(err)}`,
+      consoleMessages,
+      pageErrors,
+      failedRequests,
+    });
+  } finally {
+    await context.close();
+  }
+}
+
+async function runCase(browser, testCase, options) {
+  const run = testCase.expectations && testCase.expectations.execute === true
+    ? await runExecutableCase(browser, testCase, options)
+    : makeEmptyRun();
+  return buildReport(testCase, run);
+}
+
+function buildReport(testCase, run) {
+  const outcome = classifyOutcome(testCase, run);
+  return {
+    case: summarizeCase(testCase),
+    outcome: {
+      ...outcome,
+      durationMs: run.durationMs,
+      creativeRendered: run.creativeRendered,
+      creativeInjected: run.creativeInjected,
+      terminated: run.terminated,
+      finalState: run.finalState,
+      reachedActive: run.stateHistory.some((entry) => entry.to === 'active'),
+    },
+    diagnostics: {
+      placementSessionId: run.placementSessionId,
+      constructionError: run.constructionError,
+      loadError: run.loadError,
+      timedOut: run.timedOut,
+      stateHistory: run.stateHistory,
+      securityEvents: run.securityEvents,
+      errors: run.errors,
+      navigationEvents: run.navigationEvents,
+      interactionEvents: run.interactionEvents,
+      messages: run.messages,
+      console: run.consoleMessages,
+      pageErrors: run.pageErrors,
+      failedRequests: run.failedRequests,
+    },
+  };
+}
+
+async function runNormalizedCases(inputFile, outFile, options = {}) {
+  const repoRoot = resolve(options.repoRoot || '.');
+  const port = parsePort(options.port, DEFAULT_PORT);
+  const rendererPort = parsePort(options.rendererPort, DEFAULT_RENDERER_PORT);
+  const baseUrl = `http://localhost:${port}`;
+  const rendererUrl = options.rendererUrl
+    || `http://localhost:${rendererPort}/examples/renderer/`;
+  const harnessUrl = `${baseUrl}/tools/creative-validator/harness/markup-runner.html`;
+  const cases = readJsonl(inputFile);
+  const runOptions = {
+    repoRoot,
+    port,
+    rendererPort,
+    baseUrl,
+    rendererUrl,
+    harnessUrl,
+    renderTimeoutMs: options.renderTimeoutMs || DEFAULT_RENDER_TIMEOUT_MS,
+    settleMs: options.settleMs || DEFAULT_SETTLE_MS,
+    verbose: options.verbose === true,
+  };
+
+  mkdirSync(dirname(outFile), { recursive: true });
+  const stream = createWriteStream(outFile, { encoding: 'utf8' });
+  let count = 0;
+  let streamError = null;
+  stream.on('error', (err) => { streamError = err; });
+
+  try {
+    await withServer(runOptions, async () => {
+      const chromePath = resolveChromePath();
+      const browser = await puppeteer.launch({
+        executablePath: chromePath,
+        headless: true,
+        args: chromeLaunchArgs(),
+      });
+
+      try {
+        for (const testCase of cases) {
+          let report;
+          try {
+            report = await runCase(browser, testCase, runOptions);
+          } catch (err) {
+            report = buildReport(testCase, makeEmptyRun({
+              constructionError: `runner case failed: ${err && err.message ? err.message : String(err)}`,
+            }));
+          }
+          stream.write(JSON.stringify(report) + '\n');
+          if (streamError) throw streamError;
+          count++;
+        }
+      } finally {
+        await browser.close();
+      }
+    });
+  } catch (err) {
+    stream.destroy();
+    throw err;
+  }
+
+  await new Promise((resolvePromise, reject) => {
+    stream.end(() => {
+      if (streamError) reject(streamError);
+      else resolvePromise();
+    });
+  });
+
+  return { count, outFile };
+}
+
+export {
+  DEFAULT_RENDER_TIMEOUT_MS,
+  DEFAULT_SETTLE_MS,
+  classifyOutcome,
+  readJsonl,
+  runNormalizedCases,
+};

--- a/tools/creative-validator/test/test-diagnose.js
+++ b/tools/creative-validator/test/test-diagnose.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/**
+ * test-diagnose.js — creative validator bucket coverage.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { classifyOutcome, makeEmptyRun } from '../src/diagnose.js';
+
+function makeCase(execute = true) {
+  return {
+    expectations: {
+      execute,
+      skipReason: execute ? null : 'unsupported-adm-kind:native-json',
+    },
+  };
+}
+
+function bucket(run, testCase = makeCase(true)) {
+  return classifyOutcome(testCase, makeEmptyRun(run)).bucket;
+}
+
+test('classifyOutcome covers non-browser buckets', () => {
+  assert.equal(bucket({}, makeCase(false)), 'unsupported-input');
+  assert.equal(bucket({ constructionError: 'boom' }), 'sharc-runner-error');
+  assert.equal(bucket({ loadError: 'boom' }), 'sharc-runner-error');
+  assert.equal(bucket({ timedOut: true }), 'renderer-timeout');
+  assert.equal(bucket({
+    securityEvents: [{ type: 'renderer_protocol_error', details: { subtype: 'timeout' } }],
+  }), 'renderer-timeout');
+  assert.equal(bucket({
+    securityEvents: [{ type: 'renderer_protocol_error', details: { subtype: 'integrity_failed' } }],
+  }), 'renderer-integrity');
+  assert.equal(bucket({ securityEvents: [{ type: 'renderer_origin_mismatch' }] }), 'renderer-origin');
+  assert.equal(bucket({
+    securityEvents: [{ type: 'renderer_protocol_error', details: { subtype: 'malformed_payload' } }],
+  }), 'renderer-protocol');
+  assert.equal(bucket({
+    securityEvents: [{ type: 'renderer_protocol_error', details: { subtype: 'post_failed' } }],
+  }), 'renderer-protocol');
+  assert.equal(bucket({ securityEvents: [{ type: 'renderer_failed' }] }), 'renderer-protocol');
+  assert.equal(bucket({ securityEvents: [{ type: 'unauthorized_navigation' }] }), 'navigation-policy');
+  assert.equal(bucket({ securityEvents: [{ type: 'bridge_load_failed' }] }), 'bridge-missing');
+  assert.equal(bucket({ securityEvents: [{ type: 'feature_load_failed' }] }), 'measurement-omid');
+  assert.equal(bucket({ creativeRendered: true, terminated: false }), 'passed');
+  assert.equal(bucket({
+    failedRequests: [{ url: 'https://cdn.example/script.js', errorText: 'net::ERR_FAILED' }],
+  }), 'network-cors');
+  assert.equal(bucket({
+    consoleMessages: [{ type: 'error', text: 'blocked by CORS policy' }],
+  }), 'network-cors');
+  assert.equal(bucket({ pageErrors: [{ message: 'creative threw' }] }), 'creative-broken');
+  assert.equal(bucket({}), 'inconclusive');
+});

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+/**
+ * test-runner.js — creative validator Phase 2 runner coverage.
+ */
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { resolve } from 'node:path';
+import test from 'node:test';
+
+const cliPath = resolve('tools/creative-validator/src/cli.js');
+
+function makeCase(overrides) {
+  return {
+    source: {
+      sourceFile: 'synthetic-runner-test',
+      rowIndex: 0,
+      auctionId: 'auction-runner-test',
+      auctionIndex: 0,
+      bidder: 'synthetic-runner',
+      mtype: 'banner',
+    },
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-test',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-test',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html',
+      html: '<!doctype html><html><body><div id="ad">runner smoke</div></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+    bidSignals: {
+      apis: { raw: [], sanitized: [], sources: [] },
+      mtype: 'banner',
+      adomain: ['runner.example'],
+      cat: [],
+      battr: [],
+      attr: [],
+      placement: { id: 'imp-runner-test', instl: 0, secure: 1, mediaTypes: ['banner'] },
+      measurement: { omid: { declaredByApi: false, sidecarPresent: false, sources: [] } },
+    },
+    expectations: {
+      declared: [],
+      sniffed: [],
+      execute: true,
+      skipReason: null,
+    },
+    sharcOptions: {
+      creativeMeta: { apis: [] },
+      requireSharcInit: false,
+      placementType: 'inline',
+    },
+    ...overrides,
+  };
+}
+
+function readJsonl(file) {
+  return readFileSync(file, 'utf8')
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line));
+}
+
+test('runner executes HTML cases and writes one report row per case', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-runner-'));
+  const inputPath = resolve(workDir, 'cases.jsonl');
+  const outPath = resolve(workDir, 'reports.jsonl');
+
+  const executable = makeCase({});
+  const skipped = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-native',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-native',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'native-json',
+      html: '{"native":{"assets":[]}}',
+      url: null,
+      width: null,
+      height: null,
+      placementType: 'inline',
+      transformations: [],
+    },
+    expectations: {
+      declared: [],
+      sniffed: [],
+      execute: false,
+      skipReason: 'unsupported-adm-kind:native-json',
+    },
+  });
+
+  try {
+    writeFileSync(inputPath, JSON.stringify(executable) + '\n' + JSON.stringify(skipped) + '\n');
+    execFileSync('node', [
+      cliPath,
+      'run',
+      inputPath,
+      '--out',
+      outPath,
+      '--render-timeout-ms',
+      '4000',
+      '--settle-ms',
+      '100',
+    ], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const reports = readJsonl(outPath);
+    assert.equal(reports.length, 2);
+
+    const htmlReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-test');
+    assert.ok(htmlReport);
+    assert.equal(htmlReport.outcome.status, 'passed');
+    assert.equal(htmlReport.outcome.bucket, 'passed');
+    assert.equal(htmlReport.outcome.creativeRendered, true);
+    assert.equal(htmlReport.outcome.terminated, false);
+    assert.equal(htmlReport.case.creative.html, undefined);
+    assert.equal(typeof htmlReport.outcome.reachedActive, 'boolean');
+    assert.ok(Array.isArray(htmlReport.diagnostics.stateHistory));
+
+    const nativeReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-native');
+    assert.ok(nativeReport);
+    assert.equal(nativeReport.outcome.status, 'skipped');
+    assert.equal(nativeReport.outcome.bucket, 'unsupported-input');
+    assert.equal(nativeReport.outcome.reason, 'unsupported-adm-kind:native-json');
+    assert.equal(nativeReport.outcome.creativeRendered, false);
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});
+
+test('runner refuses public report output by default', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-runner-guard-'));
+  const inputPath = resolve(workDir, 'cases.jsonl');
+  const publicOut = resolve('tools/creative-validator/fixtures/reports-leak.jsonl');
+
+  try {
+    writeFileSync(inputPath, JSON.stringify(makeCase({})) + '\n');
+    assert.throws(
+      () => execFileSync('node', [cliPath, 'run', inputPath, '--out', publicOut], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }),
+      /Refusing to write private creative validator output outside/,
+    );
+    assert.equal(existsSync(publicOut), false);
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add `creative-validator run` for normalized JSONL cases, writing private JSONL reports under tools/creative-validator/private
- execute HTML-ish `adm` through the local SHARC Creative Markup renderer in headless Chrome with Chrome sandbox enabled by default and one browser context per case
- capture lifecycle state, SHARC security events, errors, navigation/interaction observations, sanitized console/page errors, failed requests, and diagnosis buckets
- keep VAST/native/unknown and other non-executable cases as skipped `unsupported-input` report rows
- add standalone diagnosis bucket tests plus browser runner tests, README guidance, CHANGELOG entry, npm scripts, and CI coverage

## Review fixes
- removed default `--no-sandbox`; opt-in only via `SHARC_VALIDATOR_CHROME_NO_SANDBOX=1` with warning
- isolated each case in a fresh browser context
- replaced private `_terminated` reads with public `getState() === "terminated"`
- converted per-case runner/page failures into report rows so one bad case does not abort the corpus run
- split bucket logic into `src/diagnose.js` with coverage for renderer_failed, bridge-missing, network-cors, and existing buckets

## Tests
- npm run test:creative-validator-normalizer
- npm run test:creative-validator-diagnose
- npm run test:creative-validator-runner
- npm run check