### PR TITLE
feat: add creative validator bridge probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   lifecycle state, SHARC security events, console/page errors, failed requests,
   navigation observations, and diagnosis buckets under the private report path.
 
+- **Creative validator bridge probe foundation.** Adds MRAID and SafeFrame
+  compatibility probes to executable validator runs. Expected bridges from
+  declared/sniffed bid signals are checked inside the rendered creative frame,
+  report rows include `diagnostics.bridgeProbes`, and missing or failing bridge
+  probes are classified as `bridge-missing` or `bridge-api-error`.
+
 ## [0.7.6] - 2026-05-24
 
 **Release-doc-first cycle.** Three features shipped in parallel: the headline

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -80,10 +80,27 @@ Useful run options:
 
 The v0 runner executes only HTML-ish cases where `expectations.execute` is
 `true`. VAST, native JSON, unknown payloads, and Creative URL mode are reported
-as skipped `unsupported-input` cases.
+as skipped `unsupported-input` cases. Expected MRAID and SafeFrame cases use the
+local `dist/sharc-creative.js` SDK inline so bridge probes can exercise the
+SHARC-backed compatibility surface without fetching a production SDK.
 
 Each report row contains the case identifiers and diagnostic signals, but does
 not duplicate raw `creative.html`.
+
+For MRAID and SafeFrame cases, the runner injects a small validator probe into
+the creative document and records `diagnostics.bridgeProbes[].bridges`. These
+probes check bridge presence plus a few read-only/basic methods, then classify
+expected bridge absence as `bridge-missing` and method-call failures as
+`bridge-api-error`. They are compatibility smoke tests for corpus triage, not a
+complete MRAID or SafeFrame compliance suite. Probe results are accepted only
+from the current renderer iframe, the expected renderer origin, and the current
+per-case nonce; forged or duplicate probe messages are ignored. If the probe
+does not run, the case falls through to the existing rendered/inconclusive
+buckets instead of being treated as a bridge absence.
+
+The runner caches the fetched local SDK and bridge-probe source for the lifetime
+of one harness page. This keeps batch runs consistent; a failed local SDK fetch
+causes subsequent bridge cases in the same run to fail the same way.
 
 ### Security
 

--- a/tools/creative-validator/harness/bridge-probe.js
+++ b/tools/creative-validator/harness/bridge-probe.js
@@ -1,0 +1,96 @@
+(function () {
+  var ERROR_CAP = 512;
+  var PROBE_NONCE = '__SHARC_VALIDATOR_PROBE_NONCE__';
+
+  try {
+    if (document.currentScript && document.currentScript.parentNode) {
+      document.currentScript.parentNode.removeChild(document.currentScript);
+    }
+  } catch (_) {
+    // Best-effort: removing the inline probe source hides the per-case nonce
+    // from later creative scripts in this private validator harness.
+  }
+
+  function cappedError(err) {
+    var message = err && err.message ? err.message : String(err);
+    return String(message).slice(0, ERROR_CAP);
+  }
+
+  function cloneForProbe(value) {
+    if (value === undefined) return null;
+    if (value === null || typeof value === 'string'
+        || typeof value === 'number' || typeof value === 'boolean') {
+      return value;
+    }
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch (_) {
+      return Object.prototype.toString.call(value);
+    }
+  }
+
+  function probeMethod(target, name, args) {
+    var out = { exists: false, status: 'absent', value: null, error: null };
+    try {
+      // Intentionally probe a fixed method list. Do not enumerate bridge
+      // objects here; hostile Proxy traps could turn enumeration into code.
+      var fn = Reflect.get(target, name);
+      out.exists = typeof fn === 'function';
+      if (!out.exists) return out;
+      out.value = cloneForProbe(Reflect.apply(fn, target, args || []));
+      out.status = 'ok';
+    } catch (err) {
+      out.status = 'threw';
+      out.error = cappedError(err);
+    }
+    return out;
+  }
+
+  function mraidProbe() {
+    var mraid = window.mraid;
+    var out = {
+      exists: !!mraid,
+      installed: window.__sharcMraidBridgeInstalled === true,
+      methods: {},
+    };
+    if (!mraid) return out;
+    out.methods.getVersion = probeMethod(mraid, 'getVersion');
+    out.methods.getState = probeMethod(mraid, 'getState');
+    out.methods.isViewable = probeMethod(mraid, 'isViewable');
+    out.methods.supports = probeMethod(mraid, 'supports', ['sms']);
+    return out;
+  }
+
+  function safeframeProbe() {
+    var sf = window.$sf && window.$sf.ext;
+    var out = {
+      exists: !!sf,
+      installed: window.__sharcSafeFrameBridgeInstalled === true,
+      methods: {},
+    };
+    if (!sf) return out;
+    out.methods.supports = probeMethod(sf, 'supports');
+    out.methods.geom = probeMethod(sf, 'geom');
+    return out;
+  }
+
+  function runProbe() {
+    window.parent.postMessage({
+      type: 'SHARC:Validator:bridgeProbe',
+      probeNonce: PROBE_NONCE,
+      payload: {
+        bridges: {
+          mraid: mraidProbe(),
+          safeframe: safeframeProbe(),
+        },
+      },
+    }, '*');
+  }
+
+  // The reference renderer imports bridge modules before document.write().
+  // Queueing the probe here lets bridge auto-install timers run first, while
+  // this probe still fires before timers queued by later creative code. If
+  // creative code suppresses this timer, the parent records no probe and the
+  // case falls through to existing rendered/inconclusive buckets.
+  setTimeout(runProbe, 0);
+}());

--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -55,6 +55,88 @@ function resetPlacement() {
   placement.style.height = '250px';
 }
 
+function escapeInlineScriptSource(source) {
+  return String(source)
+    .replace(/<\/script/gi, '<\\/script')
+    .replace(/<!--/g, '<\\!--');
+}
+
+function expectedBridgeSet(testCase) {
+  const values = new Set([
+    ...((testCase.expectations && testCase.expectations.declared) || []),
+    ...((testCase.expectations && testCase.expectations.sniffed) || []),
+  ]);
+  return values;
+}
+
+function shouldInlineCreativeSdk(testCase) {
+  const expected = expectedBridgeSet(testCase);
+  return expected.has('mraid') || expected.has('safeframe');
+}
+
+let creativeSdkSourcePromise = null;
+function loadCreativeSdkSource(url) {
+  // Batch-runner cache: every case in one harness page uses the same local
+  // dist SDK. If the fetch fails, later bridge cases fail the same way.
+  if (!creativeSdkSourcePromise) {
+    creativeSdkSourcePromise = fetch(url).then((response) => {
+      if (!response.ok) throw new Error('Failed to load validator SDK: HTTP ' + response.status);
+      return response.text();
+    });
+  }
+  return creativeSdkSourcePromise;
+}
+
+let bridgeProbeSourcePromise = null;
+function loadBridgeProbeSource() {
+  if (!bridgeProbeSourcePromise) {
+    bridgeProbeSourcePromise = fetch('/tools/creative-validator/harness/bridge-probe.js')
+      .then((response) => {
+        if (!response.ok) throw new Error('Failed to load validator bridge probe: HTTP ' + response.status);
+        return response.text();
+      });
+  }
+  return bridgeProbeSourcePromise;
+}
+
+function randomProbeNonce() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return String(Date.now()) + '-' + Math.random();
+}
+
+function insertAtDocumentStart(html, script) {
+  if (!script) return html;
+  const headMatch = /<head(?:\s[^>]*)?>/i.exec(html);
+  if (headMatch) {
+    const index = headMatch.index + headMatch[0].length;
+    return html.slice(0, index) + script + html.slice(index);
+  }
+  const htmlMatch = /<html(?:\s[^>]*)?>/i.exec(html);
+  if (htmlMatch) {
+    const index = htmlMatch.index + htmlMatch[0].length;
+    return html.slice(0, index) + script + html.slice(index);
+  }
+  const doctypeMatch = /<!doctype[^>]*>/i.exec(html);
+  if (doctypeMatch) {
+    const index = doctypeMatch.index + doctypeMatch[0].length;
+    return html.slice(0, index) + script + html.slice(index);
+  }
+  return script + html;
+}
+
+function addValidatorInstrumentation(html, creativeSdkSource, bridgeProbeSource, probeNonce) {
+  const probeSource = bridgeProbeSource.replace('__SHARC_VALIDATOR_PROBE_NONCE__', probeNonce);
+  const probeScript = '<scr' + 'ipt>' + escapeInlineScriptSource(probeSource) + '\n</scr' + 'ipt>';
+  const sdkScript = creativeSdkSource
+    ? '<scr' + 'ipt>' + escapeInlineScriptSource(creativeSdkSource) + '\n</scr' + 'ipt>'
+    : '';
+  const instrumentation = sdkScript + probeScript;
+  if (typeof html !== 'string') return instrumentation;
+  return insertAtDocumentStart(html, instrumentation);
+}
+
 window.__sharcCreativeValidatorHarness = {
   async runCase(testCase, options) {
     resetPlacement();
@@ -65,13 +147,39 @@ window.__sharcCreativeValidatorHarness = {
     const navigationEvents = [];
     const interactionEvents = [];
     const messages = [];
+    const bridgeProbes = [];
     let constructionError = null;
     let loadError = null;
     let container = null;
+    const rendererOrigin = new URL(options.rendererUrl).origin;
+    const probeNonce = randomProbeNonce();
+    const onMessageEvent = (event) => {
+      if (bridgeProbes.length > 0) return;
+      // SECURITY: the probe uses postMessage(..., '*') from inside a sandboxed
+      // renderer frame. This private harness listener is the trust boundary:
+      // accept only the current renderer iframe, expected renderer origin,
+      // current per-case nonce, and first valid probe.
+      if (event && event.origin === rendererOrigin && container && container._iframe
+          && event.source === container._iframe.contentWindow
+          && event.data && event.data.type === 'SHARC:Validator:bridgeProbe'
+          && event.data.probeNonce === probeNonce) {
+        bridgeProbes.push(cloneForReport(event.data.payload || {}));
+      }
+    };
+    window.addEventListener('message', onMessageEvent);
 
     try {
+      const creativeSdkSource = shouldInlineCreativeSdk(testCase)
+        ? await loadCreativeSdkSource(options.creativeSdkUrl)
+        : '';
+      const bridgeProbeSource = await loadBridgeProbeSource();
       container = new SHARCContainer({
-        creativeHtml: testCase.creative.html,
+        creativeHtml: addValidatorInstrumentation(
+          testCase.creative.html,
+          creativeSdkSource,
+          bridgeProbeSource,
+          probeNonce,
+        ),
         creativeRendererUrl: options.rendererUrl,
         placementElement: placement,
         creativeMeta: testCase.sharcOptions.creativeMeta || {},
@@ -159,11 +267,13 @@ window.__sharcCreativeValidatorHarness = {
       navigationEvents,
       interactionEvents,
       messages,
+      bridgeProbes,
     };
 
     if (container) {
       try { container.close(); } catch (_) { /* ignore cleanup */ }
     }
+    window.removeEventListener('message', onMessageEvent);
     resetPlacement();
     return result;
   },

--- a/tools/creative-validator/src/diagnose.js
+++ b/tools/creative-validator/src/diagnose.js
@@ -18,6 +18,7 @@ const EMPTY_RUN = Object.freeze({
   navigationEvents: [],
   interactionEvents: [],
   messages: [],
+  bridgeProbes: [],
   consoleMessages: [],
   pageErrors: [],
   failedRequests: [],
@@ -32,6 +33,7 @@ function makeEmptyRun(overrides = {}) {
     navigationEvents: [],
     interactionEvents: [],
     messages: [],
+    bridgeProbes: [],
     consoleMessages: [],
     pageErrors: [],
     failedRequests: [],
@@ -60,6 +62,33 @@ function hasNetworkDiagnostics(run) {
       || text.includes('content security policy')
       || text.includes('csp');
   });
+}
+
+function expectedBridges(testCase) {
+  const values = new Set([
+    ...((testCase.expectations && testCase.expectations.declared) || []),
+    ...((testCase.expectations && testCase.expectations.sniffed) || []),
+  ]);
+  // Phase 3 validates renderer bridges only. OMID remains a measurement signal
+  // and is handled by measurement-omid buckets.
+  return ['mraid', 'safeframe'].filter((bridge) => values.has(bridge));
+}
+
+function firstBridgeProbe(run) {
+  return run.bridgeProbes && run.bridgeProbes.length > 0
+    ? run.bridgeProbes[0]
+    : null;
+}
+
+function bridgeProbeFor(probe, bridge) {
+  if (!probe || !probe.bridges) return null;
+  return probe.bridges[bridge] || null;
+}
+
+function hasBridgeApiError(probe) {
+  if (!probe || !probe.methods) return false;
+  return Object.values(probe.methods).some((method) =>
+    method && method.status === 'threw');
 }
 
 function classifyOutcome(testCase, run) {
@@ -104,6 +133,20 @@ function classifyOutcome(testCase, run) {
     return { status: 'failed', bucket: 'measurement-omid', reason: 'feature load failed' };
   }
 
+  const expected = expectedBridges(testCase);
+  const probe = firstBridgeProbe(run);
+  if (expected.length > 0 && probe) {
+    for (const bridge of expected) {
+      const bridgeProbe = bridgeProbeFor(probe, bridge);
+      if (!bridgeProbe || bridgeProbe.exists !== true) {
+        return { status: 'failed', bucket: 'bridge-missing', reason: `${bridge} bridge missing` };
+      }
+      if (hasBridgeApiError(bridgeProbe)) {
+        return { status: 'failed', bucket: 'bridge-api-error', reason: `${bridge} bridge probe failed` };
+      }
+    }
+  }
+
   if (run.creativeRendered && !run.terminated) {
     return { status: 'passed', bucket: 'passed', reason: 'creative rendered without fatal signals' };
   }
@@ -125,6 +168,7 @@ function classifyOutcome(testCase, run) {
 
 export {
   classifyOutcome,
+  expectedBridges,
   hasNetworkDiagnostics,
   makeEmptyRun,
 };

--- a/tools/creative-validator/src/runner.js
+++ b/tools/creative-validator/src/runner.js
@@ -272,6 +272,7 @@ async function runExecutableCase(browser, testCase, options) {
         navigationEvents: [],
         interactionEvents: [],
         messages: [],
+        bridgeProbes: [],
         consoleMessages,
         pageErrors,
         failedRequests,
@@ -282,6 +283,7 @@ async function runExecutableCase(browser, testCase, options) {
       (item, runOptions) => window.__sharcCreativeValidatorHarness.runCase(item, runOptions),
       testCase,
       {
+        creativeSdkUrl: options.creativeSdkUrl,
         rendererUrl: options.rendererUrl,
         renderTimeoutMs: options.renderTimeoutMs,
         settleMs: options.settleMs,
@@ -336,6 +338,7 @@ function buildReport(testCase, run) {
       navigationEvents: run.navigationEvents,
       interactionEvents: run.interactionEvents,
       messages: run.messages,
+      bridgeProbes: run.bridgeProbes,
       console: run.consoleMessages,
       pageErrors: run.pageErrors,
       failedRequests: run.failedRequests,
@@ -350,6 +353,7 @@ async function runNormalizedCases(inputFile, outFile, options = {}) {
   const baseUrl = `http://localhost:${port}`;
   const rendererUrl = options.rendererUrl
     || `http://localhost:${rendererPort}/examples/renderer/`;
+  const creativeSdkUrl = new URL('/dist/sharc-creative.js', rendererUrl).href;
   const harnessUrl = `${baseUrl}/tools/creative-validator/harness/markup-runner.html`;
   const cases = readJsonl(inputFile);
   const runOptions = {
@@ -357,6 +361,7 @@ async function runNormalizedCases(inputFile, outFile, options = {}) {
     port,
     rendererPort,
     baseUrl,
+    creativeSdkUrl,
     rendererUrl,
     harnessUrl,
     renderTimeoutMs: options.renderTimeoutMs || DEFAULT_RENDER_TIMEOUT_MS,

--- a/tools/creative-validator/test/test-diagnose.js
+++ b/tools/creative-validator/test/test-diagnose.js
@@ -8,11 +8,14 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { classifyOutcome, makeEmptyRun } from '../src/diagnose.js';
 
-function makeCase(execute = true) {
+function makeCase(execute = true, expectations = {}) {
   return {
     expectations: {
       execute,
+      declared: [],
+      sniffed: [],
       skipReason: execute ? null : 'unsupported-adm-kind:native-json',
+      ...expectations,
     },
   };
 }
@@ -52,4 +55,49 @@ test('classifyOutcome covers non-browser buckets', () => {
   }), 'network-cors');
   assert.equal(bucket({ pageErrors: [{ message: 'creative threw' }] }), 'creative-broken');
   assert.equal(bucket({}), 'inconclusive');
+});
+
+test('classifyOutcome buckets expected bridge probe failures', () => {
+  const mraidCase = makeCase(true, { declared: ['mraid'] });
+  assert.equal(bucket({
+    creativeRendered: false,
+    bridgeProbes: [],
+  }, mraidCase), 'inconclusive');
+  assert.equal(bucket({
+    creativeRendered: true,
+    bridgeProbes: [{ bridges: { mraid: { exists: false, methods: {} } } }],
+  }, mraidCase), 'bridge-missing');
+  assert.equal(bucket({
+    creativeRendered: true,
+    bridgeProbes: [{
+      bridges: { mraid: {
+        exists: true,
+        methods: { getState: { exists: true, status: 'threw', error: 'boom' } },
+      } },
+    }],
+  }, mraidCase), 'bridge-api-error');
+  assert.equal(bucket({
+    creativeRendered: true,
+    bridgeProbes: [{
+      bridges: { mraid: {
+        exists: true,
+        methods: { getState: { exists: true, status: 'ok', value: 'loading' } },
+      } },
+    }],
+  }, mraidCase), 'passed');
+
+  const safeframeCase = makeCase(true, { sniffed: ['safeframe'] });
+  assert.equal(bucket({
+    creativeRendered: true,
+    bridgeProbes: [{ bridges: { safeframe: { exists: false, methods: {} } } }],
+  }, safeframeCase), 'bridge-missing');
+  assert.equal(bucket({
+    creativeRendered: true,
+    bridgeProbes: [{
+      bridges: { safeframe: {
+        exists: true,
+        methods: { geom: { exists: true, status: 'threw', error: 'boom' } },
+      } },
+    }],
+  }, safeframeCase), 'bridge-api-error');
 });

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -86,6 +86,174 @@ test('runner executes HTML cases and writes one report row per case', () => {
   const outPath = resolve(workDir, 'reports.jsonl');
 
   const executable = makeCase({});
+  const mraid = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-mraid',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-mraid',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html-mraid',
+      html: '<!doctype html><html><body><script>'
+        + 'window.__sawMraid = typeof window.mraid !== "undefined";'
+        + 'window.parent.postMessage({type:"SHARC:Validator:bridgeProbe",probeNonce:"forged",payload:{bridges:{mraid:{exists:false,methods:{}}}}},"*");'
+        + '</script></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+    bidSignals: {
+      apis: { raw: [5], sanitized: [5], sources: [{ path: 'bid.api', values: [5], role: 'bid' }] },
+      mtype: 'banner',
+      adomain: ['runner.example'],
+      cat: [],
+      battr: [],
+      attr: [],
+      placement: { id: 'imp-runner-test', instl: 0, secure: 1, mediaTypes: ['banner'] },
+      measurement: { omid: { declaredByApi: false, sidecarPresent: false, sources: [] } },
+    },
+    expectations: {
+      declared: ['mraid'],
+      sniffed: ['mraid'],
+      execute: true,
+      skipReason: null,
+    },
+    sharcOptions: {
+      creativeMeta: { apis: [5] },
+      requireSharcInit: false,
+      placementType: 'inline',
+    },
+  });
+  const safeframe = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-safeframe',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-safeframe',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html-safeframe',
+      html: '<!doctype html><html><body><script>window.__sawSf = !!(window.$sf && window.$sf.ext);</script></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+    bidSignals: {
+      apis: { raw: [9002], sanitized: [9002], sources: [{ path: 'bid.api', values: [9002], role: 'bid' }] },
+      mtype: 'banner',
+      adomain: ['runner.example'],
+      cat: [],
+      battr: [],
+      attr: [],
+      placement: { id: 'imp-runner-test', instl: 0, secure: 1, mediaTypes: ['banner'] },
+      measurement: { omid: { declaredByApi: false, sidecarPresent: false, sources: [] } },
+    },
+    expectations: {
+      declared: ['safeframe'],
+      sniffed: ['safeframe'],
+      execute: true,
+      skipReason: null,
+    },
+    sharcOptions: {
+      creativeMeta: { apis: [9002] },
+      requireSharcInit: false,
+      placementType: 'inline',
+    },
+  });
+  const missingMraid = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-mraid-missing',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-mraid-missing',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html-mraid',
+      html: '<!doctype html><html><body><div>declared mraid without bridge signal</div></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+    bidSignals: {
+      apis: { raw: [5], sanitized: [5], sources: [{ path: 'bid.api', values: [5], role: 'bid' }] },
+      mtype: 'banner',
+      adomain: ['runner.example'],
+      cat: [],
+      battr: [],
+      attr: [],
+      placement: { id: 'imp-runner-test', instl: 0, secure: 1, mediaTypes: ['banner'] },
+      measurement: { omid: { declaredByApi: false, sidecarPresent: false, sources: [] } },
+    },
+    expectations: {
+      declared: ['mraid'],
+      sniffed: [],
+      execute: true,
+      skipReason: null,
+    },
+    sharcOptions: {
+      creativeMeta: { apis: [] },
+      requireSharcInit: false,
+      placementType: 'inline',
+    },
+  });
+  const mraidApiError = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-mraid-api-error',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-mraid-api-error',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html-mraid',
+      html: '<!doctype html><html><body><script>'
+        + 'Object.defineProperty(window,"mraid",{configurable:true,set:function(value){'
+        + 'value.getState=function(){throw new Error("probe boom")};'
+        + 'Object.defineProperty(window,"mraid",{configurable:true,value:value});'
+        + '}});'
+        + '</script></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+    bidSignals: {
+      apis: { raw: [5], sanitized: [5], sources: [{ path: 'bid.api', values: [5], role: 'bid' }] },
+      mtype: 'banner',
+      adomain: ['runner.example'],
+      cat: [],
+      battr: [],
+      attr: [],
+      placement: { id: 'imp-runner-test', instl: 0, secure: 1, mediaTypes: ['banner'] },
+      measurement: { omid: { declaredByApi: false, sidecarPresent: false, sources: [] } },
+    },
+    expectations: {
+      declared: ['mraid'],
+      sniffed: ['mraid'],
+      execute: true,
+      skipReason: null,
+    },
+    sharcOptions: {
+      creativeMeta: { apis: [5] },
+      requireSharcInit: false,
+      placementType: 'inline',
+    },
+  });
   const skipped = makeCase({
     ids: {
       requestId: 'request-runner-test',
@@ -113,7 +281,14 @@ test('runner executes HTML cases and writes one report row per case', () => {
   });
 
   try {
-    writeFileSync(inputPath, JSON.stringify(executable) + '\n' + JSON.stringify(skipped) + '\n');
+    writeFileSync(inputPath, [
+      executable,
+      mraid,
+      safeframe,
+      missingMraid,
+      mraidApiError,
+      skipped,
+    ].map((item) => JSON.stringify(item)).join('\n') + '\n');
     execFileSync('node', [
       cliPath,
       'run',
@@ -130,7 +305,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
     });
 
     const reports = readJsonl(outPath);
-    assert.equal(reports.length, 2);
+    assert.equal(reports.length, 6);
 
     const htmlReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-test');
     assert.ok(htmlReport);
@@ -141,6 +316,41 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(htmlReport.case.creative.html, undefined);
     assert.equal(typeof htmlReport.outcome.reachedActive, 'boolean');
     assert.ok(Array.isArray(htmlReport.diagnostics.stateHistory));
+    assert.equal(htmlReport.outcome.creativeInjected, false);
+    assert.equal(htmlReport.diagnostics.bridgeProbes.length, 1);
+    assert.equal(htmlReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.installed, false);
+    assert.equal(htmlReport.diagnostics.bridgeProbes.at(-1).bridges.safeframe.installed, false);
+
+    const mraidReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-mraid');
+    assert.ok(mraidReport);
+    assert.equal(mraidReport.outcome.status, 'passed');
+    assert.equal(mraidReport.diagnostics.bridgeProbes.length, 1);
+    assert.equal(mraidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.exists, true);
+    assert.equal(mraidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.installed, true);
+    assert.equal(mraidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.methods.getState.status, 'ok');
+    assert.equal(mraidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.methods.getVersion.status, 'ok');
+
+    const safeframeReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-safeframe');
+    assert.ok(safeframeReport);
+    assert.equal(safeframeReport.outcome.status, 'passed');
+    assert.equal(safeframeReport.diagnostics.bridgeProbes.at(-1).bridges.safeframe.exists, true);
+    assert.equal(safeframeReport.diagnostics.bridgeProbes.at(-1).bridges.safeframe.installed, true);
+    assert.equal(safeframeReport.diagnostics.bridgeProbes.at(-1).bridges.safeframe.methods.geom.status, 'ok');
+    assert.equal(safeframeReport.diagnostics.bridgeProbes.at(-1).bridges.safeframe.methods.supports.status, 'ok');
+
+    const missingMraidReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-mraid-missing');
+    assert.ok(missingMraidReport);
+    assert.equal(missingMraidReport.outcome.status, 'failed');
+    assert.equal(missingMraidReport.outcome.bucket, 'bridge-missing');
+
+    const mraidApiErrorReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-mraid-api-error');
+    assert.ok(mraidApiErrorReport);
+    assert.equal(mraidApiErrorReport.outcome.status, 'failed');
+    assert.equal(mraidApiErrorReport.outcome.bucket, 'bridge-api-error');
+    assert.equal(
+      mraidApiErrorReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.methods.getState.status,
+      'threw',
+    );
 
     const nativeReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-native');
     assert.ok(nativeReport);


### PR DESCRIPTION
## Summary
- add validator-injected MRAID/SafeFrame bridge probes inside rendered creative markup
- classify expected bridge absence and method-call failures as bridge-missing / bridge-api-error
- extend runner diagnostics, README, changelog, and coverage for MRAID/SafeFrame executable cases

## Validation
- npm run test:creative-validator-diagnose
- npm run test:creative-validator-runner
- npm run lint
- git diff --check
- npm run check