### PR TITLE
feat: add creative validator OMID diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   report rows include `diagnostics.bridgeProbes`, and missing or failing bridge
   probes are classified as `bridge-missing` or `bridge-api-error`.
 
+- **Creative validator OMID measurement signal path.** Normalized cases now
+  preserve sanitized OMID verification sidecars when bid metadata declares
+  AdCOM API `7`. Executable runs feed those sidecars through SHARC's
+  `omidAutoInstall` path using an in-page mock OM SDK Session Client, report
+  `diagnostics.measurement.omid`, and classify sidecar install/session-start
+  failures under `measurement-omid`.
+
 ## [0.7.6] - 2026-05-24
 
 **Release-doc-first cycle.** Three features shipped in parallel: the headline

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -102,6 +102,15 @@ The runner caches the fetched local SDK and bridge-probe source for the lifetime
 of one harness page. This keeps batch runs consistent; a failed local SDK fetch
 causes subsequent bridge cases in the same run to fail the same way.
 
+When an executable case declares OMID via AdCOM API `7` and carries a sanitized
+`creativeMeta.measurement.omid.verificationScripts` sidecar, the runner enables
+the container's `omidAutoInstall` path with validator-owned HTTPS placeholder
+SDK URLs and an in-page mock OM SDK Session Client. Report rows include
+`diagnostics.measurement.omid` so private corpus triage can distinguish "OMID
+declared but no sidecar" from "OMID sidecar installed and the container-owned
+session started." This validates SHARC's measurement wiring; it does not contact
+real verification vendors or certify OM SDK vendor behavior.
+
 ### Security
 
 The runner executes real creative JavaScript. Run private corpus passes from a

--- a/tools/creative-validator/fixtures/reductions/001-normalizer-cleaned-corpus/cleaned-corpus.fixture.json
+++ b/tools/creative-validator/fixtures/reductions/001-normalizer-cleaned-corpus/cleaned-corpus.fixture.json
@@ -36,6 +36,24 @@
                   "adomain": ["advertiser.example"],
                   "cat": ["IAB1"],
                   "attr": [1],
+                  "ext": {
+                    "measurement": {
+                      "omid": {
+                        "verificationScripts": [
+                          {
+                            "resourceUrl": "https://verify.example/omid.js",
+                            "vendor": "vendor.example",
+                            "verificationParameters": "fixture-params",
+                            "accessMode": "limited"
+                          }
+                        ],
+                        "creativeType": "display",
+                        "mediaType": "display",
+                        "impressionType": "beginToRender",
+                        "contentUrl": "https://advertiser.example/creative.html"
+                      }
+                    }
+                  },
                   "w": 320,
                   "h": 50,
                   "price": 1.25,

--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -74,6 +74,141 @@ function shouldInlineCreativeSdk(testCase) {
   return expected.has('mraid') || expected.has('safeframe');
 }
 
+function expectedOmid(testCase) {
+  return expectedBridgeSet(testCase).has('omid');
+}
+
+function omidSidecarPresent(testCase) {
+  return !!(testCase
+    && testCase.bidSignals
+    && testCase.bidSignals.measurement
+    && testCase.bidSignals.measurement.omid
+    && testCase.bidSignals.measurement.omid.sidecarPresent === true);
+}
+
+function collectOmidDiagnostics(container, testCase) {
+  const expected = expectedOmid(testCase);
+  const sidecarPresent = omidSidecarPresent(testCase);
+  const out = {
+    expected,
+    sidecarPresent,
+    extensionPresent: false,
+    featureAdvertised: false,
+    sessionStarted: false,
+    sessionFinished: false,
+    loadedFired: false,
+    impressionFired: false,
+    verificationScriptCount: 0,
+  };
+  if (!container || !Array.isArray(container._extensions)) return out;
+
+  const extension = container._extensions.find((ext) => {
+    if (!ext) return false;
+    if (ext.name === 'com.iabtechlab.sharc.omid') return true;
+    if (typeof ext.getFeatureName === 'function') {
+      try { return ext.getFeatureName() === 'com.iabtechlab.sharc.omid'; } catch (_) { return false; }
+    }
+    return false;
+  });
+  if (!extension) return out;
+
+  out.extensionPresent = true;
+  try {
+    out.featureAdvertised = typeof extension.getFeatureName === 'function'
+      && extension.getFeatureName() === 'com.iabtechlab.sharc.omid';
+  } catch (_) {
+    out.featureAdvertised = false;
+  }
+  if (extension.options && Array.isArray(extension.options.verificationScripts)) {
+    out.verificationScriptCount = extension.options.verificationScripts.length;
+  }
+  if (extension._omid) {
+    out.sessionStarted = extension._omid.sessionStarted === true;
+    out.sessionFinished = extension._omid.sessionFinished === true;
+    out.loadedFired = extension._omid.loadedFired === true;
+    out.impressionFired = extension._omid.impressionFired === true;
+  }
+  return out;
+}
+
+function installMockOmidSessionClient() {
+  if (window.OmidSessionClient
+      && window.OmidSessionClient.AdSession
+      && window.OmidSessionClient.Partner
+      && window.OmidSessionClient.Context) {
+    return;
+  }
+
+  function Partner(name, version) {
+    this.name = name;
+    this.version = version;
+  }
+
+  function VerificationScriptResource(url, vendor, verificationParameters, accessMode) {
+    this.url = url;
+    this.vendor = vendor;
+    this.verificationParameters = verificationParameters;
+    this.accessMode = accessMode;
+  }
+
+  function Context(partner, verificationScripts) {
+    this.partner = partner;
+    this.verificationScripts = verificationScripts || [];
+  }
+  Context.prototype.setContentUrl = function (url) {
+    this.contentUrl = url;
+  };
+  Context.prototype.setServiceScriptUrl = function (url) {
+    this.serviceScriptUrl = url;
+  };
+
+  function AdSession(context) {
+    this.context = context;
+  }
+  AdSession.prototype.setCreativeType = function (creativeType) {
+    this.creativeType = creativeType;
+  };
+  AdSession.prototype.setImpressionType = function (impressionType) {
+    this.impressionType = impressionType;
+  };
+  AdSession.prototype.registerAdView = function (adView) {
+    this.adView = adView;
+  };
+  AdSession.prototype.registerSessionObserver = function (observer) {
+    this.observer = observer;
+  };
+  AdSession.prototype.start = function () {
+    this.started = true;
+  };
+  AdSession.prototype.finish = function () {
+    this.finished = true;
+    if (typeof this.observer === 'function') {
+      this.observer({ type: 'sessionFinish' });
+    }
+  };
+
+  function AdEvents(session) {
+    this.session = session;
+  }
+  AdEvents.prototype.loaded = function () {
+    this.loadedCalled = true;
+  };
+  AdEvents.prototype.impressionOccurred = function () {
+    this.impressionCalled = true;
+  };
+  AdEvents.prototype.stateChange = function (state) {
+    this.lastState = state;
+  };
+
+  window.OmidSessionClient = {
+    Partner,
+    VerificationScriptResource,
+    Context,
+    AdSession,
+    AdEvents,
+  };
+}
+
 let creativeSdkSourcePromise = null;
 function loadCreativeSdkSource(url) {
   // Batch-runner cache: every case in one harness page uses the same local
@@ -169,6 +304,9 @@ window.__sharcCreativeValidatorHarness = {
     window.addEventListener('message', onMessageEvent);
 
     try {
+      if (omidSidecarPresent(testCase)) {
+        installMockOmidSessionClient();
+      }
       const creativeSdkSource = shouldInlineCreativeSdk(testCase)
         ? await loadCreativeSdkSource(options.creativeSdkUrl)
         : '';
@@ -183,6 +321,7 @@ window.__sharcCreativeValidatorHarness = {
         creativeRendererUrl: options.rendererUrl,
         placementElement: placement,
         creativeMeta: testCase.sharcOptions.creativeMeta || {},
+        omidAutoInstall: options.omidAutoInstall || null,
         requireSharcInit: testCase.sharcOptions.requireSharcInit === true,
         placementType: testCase.sharcOptions.placementType || 'inline',
         timeouts: {
@@ -248,6 +387,15 @@ window.__sharcCreativeValidatorHarness = {
       : { timedOut: false };
 
     if (container && container.creativeRendered && !isTerminated()) {
+      if (omidSidecarPresent(testCase)
+          && typeof container.setState === 'function'
+          && container.getState() === 'loading') {
+        // Headless corpus runs do not reliably trigger viewport-driven state
+        // transitions. For OMID sidecar cases, advance only the private
+        // harness lifecycle far enough to validate container-owned measurement.
+        container.setState('ready');
+        container.setState('active');
+      }
       await sleep(options.settleMs);
     }
 
@@ -268,6 +416,9 @@ window.__sharcCreativeValidatorHarness = {
       interactionEvents,
       messages,
       bridgeProbes,
+      measurement: {
+        omid: collectOmidDiagnostics(container, testCase),
+      },
     };
 
     if (container) {

--- a/tools/creative-validator/src/diagnose.js
+++ b/tools/creative-validator/src/diagnose.js
@@ -19,6 +19,7 @@ const EMPTY_RUN = Object.freeze({
   interactionEvents: [],
   messages: [],
   bridgeProbes: [],
+  measurement: { omid: null },
   consoleMessages: [],
   pageErrors: [],
   failedRequests: [],
@@ -34,6 +35,7 @@ function makeEmptyRun(overrides = {}) {
     interactionEvents: [],
     messages: [],
     bridgeProbes: [],
+    measurement: { omid: null },
     consoleMessages: [],
     pageErrors: [],
     failedRequests: [],
@@ -91,6 +93,25 @@ function hasBridgeApiError(probe) {
     method && method.status === 'threw');
 }
 
+function expectedOmid(testCase) {
+  const declared = (testCase.expectations && testCase.expectations.declared) || [];
+  return declared.includes('omid');
+}
+
+function omidSidecarExpected(testCase) {
+  const omid = testCase
+    && testCase.bidSignals
+    && testCase.bidSignals.measurement
+    && testCase.bidSignals.measurement.omid;
+  return !!(omid && omid.sidecarPresent === true);
+}
+
+function omidRun(run) {
+  return run && run.measurement && run.measurement.omid
+    ? run.measurement.omid
+    : null;
+}
+
 function classifyOutcome(testCase, run) {
   if (!testCase.expectations || testCase.expectations.execute !== true) {
     return {
@@ -131,6 +152,16 @@ function classifyOutcome(testCase, run) {
   }
   if (hasSecurityEvent(run, 'feature_load_failed')) {
     return { status: 'failed', bucket: 'measurement-omid', reason: 'feature load failed' };
+  }
+
+  if (expectedOmid(testCase) && omidSidecarExpected(testCase)) {
+    const omid = omidRun(run);
+    if (!omid || omid.extensionPresent !== true) {
+      return { status: 'failed', bucket: 'measurement-omid', reason: 'OMID sidecar did not install measurement extension' };
+    }
+    if (omid.featureAdvertised !== true || omid.sessionStarted !== true) {
+      return { status: 'failed', bucket: 'measurement-omid', reason: 'OMID measurement session did not start' };
+    }
   }
 
   const expected = expectedBridges(testCase);

--- a/tools/creative-validator/src/normalizer.js
+++ b/tools/creative-validator/src/normalizer.js
@@ -42,6 +42,12 @@ const MRAID_METHODS = [
 ].join('|');
 const MRAID_METHOD_RE = new RegExp(`\\bmraid\\s*\\.\\s*(${MRAID_METHODS})\\b`);
 
+function isPlainObject(value) {
+  return value !== null
+    && typeof value === 'object'
+    && !Array.isArray(value);
+}
+
 /**
  * @typedef {object} NormalizedCase
  * @property {object} source
@@ -92,6 +98,74 @@ function normalizeApiValue(value) {
  */
 function hasAny(codes, set) {
   return codes.some((code) => set.has(code));
+}
+
+function safeHttpsUrl(value) {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  try {
+    const parsed = new URL(value.trim());
+    if (parsed.protocol !== 'https:') return null;
+    if (parsed.username || parsed.password) return null;
+    return parsed.href;
+  } catch (_) {
+    return null;
+  }
+}
+
+function sanitizeOptionalString(value) {
+  return typeof value === 'string' && value.length > 0 ? value.slice(0, 500) : undefined;
+}
+
+function sanitizeVerificationScript(script) {
+  if (!isPlainObject(script)) return null;
+  const resourceUrl = safeHttpsUrl(script.resourceUrl || script.url);
+  if (!resourceUrl) return null;
+
+  const out = { resourceUrl };
+  const vendor = sanitizeOptionalString(script.vendor);
+  const verificationParameters = sanitizeOptionalString(script.verificationParameters);
+  const accessMode = sanitizeOptionalString(script.accessMode);
+  if (vendor !== undefined) out.vendor = vendor;
+  if (verificationParameters !== undefined) out.verificationParameters = verificationParameters;
+  if (accessMode !== undefined) out.accessMode = accessMode;
+  return out;
+}
+
+function sanitizeOmidSidecar(value) {
+  if (!isPlainObject(value) || !Array.isArray(value.verificationScripts)) return null;
+  const scripts = value.verificationScripts
+    .map((script) => sanitizeVerificationScript(script))
+    .filter(Boolean);
+  if (scripts.length === 0) return null;
+
+  const out = { verificationScripts: scripts };
+  for (const key of ['creativeType', 'impressionType', 'mediaType', 'contentUrl']) {
+    const sanitized = key === 'contentUrl'
+      ? safeHttpsUrl(value[key])
+      : sanitizeOptionalString(value[key]);
+    if (sanitized !== undefined && sanitized !== null) out[key] = sanitized;
+  }
+  if (isPlainObject(value.vastProperties)) {
+    out.vastProperties = { ...value.vastProperties };
+  }
+  return out;
+}
+
+function extractOmidSidecar(bid) {
+  const sources = [];
+  const candidates = [
+    ['bid.ext.measurement.omid', bid && bid.ext && bid.ext.measurement && bid.ext.measurement.omid],
+    ['bid.ext.omid', bid && bid.ext && bid.ext.omid],
+  ];
+
+  for (const [path, value] of candidates) {
+    const sidecar = sanitizeOmidSidecar(value);
+    if (sidecar) {
+      sources.push({ path, verificationScriptCount: sidecar.verificationScripts.length });
+      return { sidecar, sources };
+    }
+  }
+  return { sidecar: null, sources };
 }
 
 /**
@@ -431,6 +505,10 @@ function normalizeBid(row, rowIndex, auction, auctionIndex, bid, options) {
   const execution = resolveExecution(mode, admKind);
   const creativeMeta = { apis: apis.sanitized.slice() };
   const omidDeclared = hasAny(apis.sanitized, OMID_API_CODES);
+  const omidSidecar = extractOmidSidecar(bid);
+  if (omidSidecar.sidecar) {
+    creativeMeta.measurement = { omid: omidSidecar.sidecar };
+  }
 
   return {
     source: {
@@ -469,9 +547,11 @@ function normalizeBid(row, rowIndex, auction, auctionIndex, bid, options) {
       measurement: {
         omid: {
           declaredByApi: omidDeclared,
-          sidecarPresent: false,
-          // Populated when Phase 4 teaches the validator about OMID sidecars.
-          sources: [],
+          sidecarPresent: !!omidSidecar.sidecar,
+          verificationScriptCount: omidSidecar.sidecar
+            ? omidSidecar.sidecar.verificationScripts.length
+            : 0,
+          sources: omidSidecar.sources,
         },
       },
     },

--- a/tools/creative-validator/src/runner.js
+++ b/tools/creative-validator/src/runner.js
@@ -273,6 +273,7 @@ async function runExecutableCase(browser, testCase, options) {
         interactionEvents: [],
         messages: [],
         bridgeProbes: [],
+        measurement: { omid: null },
         consoleMessages,
         pageErrors,
         failedRequests,
@@ -284,6 +285,7 @@ async function runExecutableCase(browser, testCase, options) {
       testCase,
       {
         creativeSdkUrl: options.creativeSdkUrl,
+        omidAutoInstall: options.omidAutoInstall,
         rendererUrl: options.rendererUrl,
         renderTimeoutMs: options.renderTimeoutMs,
         settleMs: options.settleMs,
@@ -339,6 +341,7 @@ function buildReport(testCase, run) {
       interactionEvents: run.interactionEvents,
       messages: run.messages,
       bridgeProbes: run.bridgeProbes,
+      measurement: run.measurement,
       console: run.consoleMessages,
       pageErrors: run.pageErrors,
       failedRequests: run.failedRequests,
@@ -355,6 +358,15 @@ async function runNormalizedCases(inputFile, outFile, options = {}) {
     || `http://localhost:${rendererPort}/examples/renderer/`;
   const creativeSdkUrl = new URL('/dist/sharc-creative.js', rendererUrl).href;
   const harnessUrl = `${baseUrl}/tools/creative-validator/harness/markup-runner.html`;
+  const omidAutoInstall = {
+    partnerName: 'SHARC Creative Validator',
+    partnerVersion: '0.0.0',
+    creativeType: 'display',
+    mediaType: 'display',
+    impressionType: 'beginToRender',
+    omSdkServiceScriptUrl: 'https://omid.validator.example/omweb-v1.js',
+    omSdkSessionClientUrl: 'https://omid.validator.example/omid-session-client-v1.js',
+  };
   const cases = readJsonl(inputFile);
   const runOptions = {
     repoRoot,
@@ -362,6 +374,7 @@ async function runNormalizedCases(inputFile, outFile, options = {}) {
     rendererPort,
     baseUrl,
     creativeSdkUrl,
+    omidAutoInstall,
     rendererUrl,
     harnessUrl,
     renderTimeoutMs: options.renderTimeoutMs || DEFAULT_RENDER_TIMEOUT_MS,

--- a/tools/creative-validator/test/test-diagnose.js
+++ b/tools/creative-validator/test/test-diagnose.js
@@ -17,7 +17,28 @@ function makeCase(execute = true, expectations = {}) {
       skipReason: execute ? null : 'unsupported-adm-kind:native-json',
       ...expectations,
     },
+    bidSignals: {
+      measurement: {
+        omid: {
+          declaredByApi: false,
+          sidecarPresent: false,
+          verificationScriptCount: 0,
+          sources: [],
+        },
+      },
+    },
   };
+}
+
+function makeOmidSidecarCase() {
+  const testCase = makeCase(true, { declared: ['omid'] });
+  testCase.bidSignals.measurement.omid = {
+    declaredByApi: true,
+    sidecarPresent: true,
+    verificationScriptCount: 1,
+    sources: [{ path: 'bid.ext.measurement.omid', verificationScriptCount: 1 }],
+  };
+  return testCase;
 }
 
 function bucket(run, testCase = makeCase(true)) {
@@ -46,6 +67,34 @@ test('classifyOutcome covers non-browser buckets', () => {
   assert.equal(bucket({ securityEvents: [{ type: 'unauthorized_navigation' }] }), 'navigation-policy');
   assert.equal(bucket({ securityEvents: [{ type: 'bridge_load_failed' }] }), 'bridge-missing');
   assert.equal(bucket({ securityEvents: [{ type: 'feature_load_failed' }] }), 'measurement-omid');
+  assert.equal(bucket({
+    creativeRendered: true,
+    measurement: { omid: { expected: true, sidecarPresent: true, extensionPresent: false } },
+  }, makeOmidSidecarCase()), 'measurement-omid');
+  assert.equal(bucket({
+    creativeRendered: true,
+    measurement: {
+      omid: {
+        expected: true,
+        sidecarPresent: true,
+        extensionPresent: true,
+        featureAdvertised: true,
+        sessionStarted: false,
+      },
+    },
+  }, makeOmidSidecarCase()), 'measurement-omid');
+  assert.equal(bucket({
+    creativeRendered: true,
+    measurement: {
+      omid: {
+        expected: true,
+        sidecarPresent: true,
+        extensionPresent: true,
+        featureAdvertised: true,
+        sessionStarted: true,
+      },
+    },
+  }, makeOmidSidecarCase()), 'passed');
   assert.equal(bucket({ creativeRendered: true, terminated: false }), 'passed');
   assert.equal(bucket({
     failedRequests: [{ url: 'https://cdn.example/script.js', errorText: 'net::ERR_FAILED' }],

--- a/tools/creative-validator/test/test-normalizer.js
+++ b/tools/creative-validator/test/test-normalizer.js
@@ -82,6 +82,23 @@ test('cleaned corpus normalization emits one stable case per bid', () => {
     (s) => s.path === 'imp.video.api' && s.role === 'context',
   ));
   assert.deepEqual(mraid.sharcOptions.creativeMeta.apis, [3, 5, 7]);
+  assert.equal(mraid.bidSignals.measurement.omid.declaredByApi, true);
+  assert.equal(mraid.bidSignals.measurement.omid.sidecarPresent, true);
+  assert.equal(mraid.bidSignals.measurement.omid.verificationScriptCount, 1);
+  assert.deepEqual(mraid.bidSignals.measurement.omid.sources, [{
+    path: 'bid.ext.measurement.omid',
+    verificationScriptCount: 1,
+  }]);
+  assert.deepEqual(mraid.sharcOptions.creativeMeta.measurement.omid.verificationScripts, [{
+    resourceUrl: 'https://verify.example/omid.js',
+    vendor: 'vendor.example',
+    verificationParameters: 'fixture-params',
+    accessMode: 'limited',
+  }]);
+  assert.equal(mraid.sharcOptions.creativeMeta.measurement.omid.creativeType, 'display');
+  assert.equal(mraid.sharcOptions.creativeMeta.measurement.omid.mediaType, 'display');
+  assert.equal(mraid.sharcOptions.creativeMeta.measurement.omid.impressionType, 'beginToRender');
+  assert.equal(mraid.sharcOptions.creativeMeta.measurement.omid.contentUrl, 'https://advertiser.example/creative.html');
   assert.equal(mraid.sharcOptions.requireSharcInit, false);
   assert.deepEqual(mraid.expectations.declared, ['mraid', 'omid']);
   assert.deepEqual(mraid.expectations.sniffed, ['mraid']);

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -254,6 +254,69 @@ test('runner executes HTML cases and writes one report row per case', () => {
       placementType: 'inline',
     },
   });
+  const omid = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-omid',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-omid',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html',
+      html: '<!doctype html><html><body><div>omid display creative</div></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+    bidSignals: {
+      apis: { raw: [7], sanitized: [7], sources: [{ path: 'bid.api', values: [7], role: 'bid' }] },
+      mtype: 'banner',
+      adomain: ['runner.example'],
+      cat: [],
+      battr: [],
+      attr: [],
+      placement: { id: 'imp-runner-test', instl: 0, secure: 1, mediaTypes: ['banner'] },
+      measurement: {
+        omid: {
+          declaredByApi: true,
+          sidecarPresent: true,
+          verificationScriptCount: 1,
+          sources: [{ path: 'bid.ext.measurement.omid', verificationScriptCount: 1 }],
+        },
+      },
+    },
+    expectations: {
+      declared: ['omid'],
+      sniffed: [],
+      execute: true,
+      skipReason: null,
+    },
+    sharcOptions: {
+      creativeMeta: {
+        apis: [7],
+        measurement: {
+          omid: {
+            verificationScripts: [{
+              resourceUrl: 'https://verify.example/omid.js',
+              vendor: 'vendor.example',
+              verificationParameters: 'runner-params',
+              accessMode: 'limited',
+            }],
+            creativeType: 'display',
+            mediaType: 'display',
+            impressionType: 'beginToRender',
+            contentUrl: 'https://advertiser.example/creative.html',
+          },
+        },
+      },
+      requireSharcInit: false,
+      placementType: 'inline',
+    },
+  });
   const skipped = makeCase({
     ids: {
       requestId: 'request-runner-test',
@@ -287,6 +350,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
       safeframe,
       missingMraid,
       mraidApiError,
+      omid,
       skipped,
     ].map((item) => JSON.stringify(item)).join('\n') + '\n');
     execFileSync('node', [
@@ -305,7 +369,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
     });
 
     const reports = readJsonl(outPath);
-    assert.equal(reports.length, 6);
+    assert.equal(reports.length, 7);
 
     const htmlReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-test');
     assert.ok(htmlReport);
@@ -320,6 +384,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(htmlReport.diagnostics.bridgeProbes.length, 1);
     assert.equal(htmlReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.installed, false);
     assert.equal(htmlReport.diagnostics.bridgeProbes.at(-1).bridges.safeframe.installed, false);
+    assert.equal(htmlReport.diagnostics.measurement.omid.expected, false);
 
     const mraidReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-mraid');
     assert.ok(mraidReport);
@@ -351,6 +416,23 @@ test('runner executes HTML cases and writes one report row per case', () => {
       mraidApiErrorReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.methods.getState.status,
       'threw',
     );
+
+    const omidReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-omid');
+    assert.ok(omidReport);
+    assert.equal(omidReport.outcome.status, 'passed');
+    assert.equal(omidReport.outcome.bucket, 'passed');
+    assert.equal(omidReport.case.bidSignals.measurement.omid.declaredByApi, true);
+    assert.equal(omidReport.case.bidSignals.measurement.omid.sidecarPresent, true);
+    assert.equal(omidReport.diagnostics.measurement.omid.expected, true);
+    assert.equal(omidReport.diagnostics.measurement.omid.sidecarPresent, true);
+    assert.equal(omidReport.diagnostics.measurement.omid.extensionPresent, true);
+    assert.equal(omidReport.diagnostics.measurement.omid.featureAdvertised, true);
+    assert.equal(omidReport.diagnostics.measurement.omid.sessionStarted, true);
+    assert.equal(omidReport.diagnostics.measurement.omid.loadedFired, true);
+    assert.equal(omidReport.diagnostics.measurement.omid.impressionFired, true);
+    assert.equal(omidReport.diagnostics.measurement.omid.verificationScriptCount, 1);
+    assert.deepEqual(omidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.installed, false);
+    assert.deepEqual(omidReport.diagnostics.bridgeProbes.at(-1).bridges.safeframe.installed, false);
 
     const nativeReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-native');
     assert.ok(nativeReport);


### PR DESCRIPTION
## Summary
- preserve sanitized OMID verification sidecars from normalized bid metadata and thread them into creativeMeta.measurement.omid
- run OMID sidecar cases through SHARC's omidAutoInstall path with validator-owned HTTPS placeholder SDK URLs and an in-page mock OM SDK Session Client
- report diagnostics.measurement.omid and classify sidecar install/session-start failures under measurement-omid

## Validation
- npm run test:creative-validator-normalizer
- npm run test:creative-validator-diagnose
- npm run test:creative-validator-runner
- git diff --check
- npm run lint
- npm run check