### PR TITLE
feat: add creative validator network diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   `diagnostics.measurement.omid`, and classify sidecar install/session-start
   failures under `measurement-omid`.
 
+- **Creative validator network diagnostics.** Executable report rows now
+  capture HTTP error responses separately from transport-level failed
+  requests, summarize network diagnostics by origin, status, and resource type,
+  and expose CORS/CSP-like console-message facets under `diagnostics.network`
+  for private corpus triage.
+
 ## [0.7.6] - 2026-05-24
 
 **Release-doc-first cycle.** Three features shipped in parallel: the headline

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -111,6 +111,12 @@ declared but no sidecar" from "OMID sidecar installed and the container-owned
 session started." This validates SHARC's measurement wiring; it does not contact
 real verification vendors or certify OM SDK vendor behavior.
 
+Report rows also include `diagnostics.network`, a compact summary of
+transport-level failed requests, HTTP error responses, and CORS/CSP-like console
+messages grouped by origin, status, and resource type. These facets are
+diagnostic by default: a creative that renders successfully can still pass while
+showing broken pixels or third-party resource failures for later triage.
+
 ### Security
 
 The runner executes real creative JavaScript. Run private corpus passes from a

--- a/tools/creative-validator/src/diagnose.js
+++ b/tools/creative-validator/src/diagnose.js
@@ -23,6 +23,7 @@ const EMPTY_RUN = Object.freeze({
   consoleMessages: [],
   pageErrors: [],
   failedRequests: [],
+  failedResponses: [],
 });
 
 function makeEmptyRun(overrides = {}) {
@@ -39,6 +40,7 @@ function makeEmptyRun(overrides = {}) {
     consoleMessages: [],
     pageErrors: [],
     failedRequests: [],
+    failedResponses: [],
     ...overrides,
   };
 }
@@ -57,10 +59,11 @@ function hasRendererSubtype(run, subtype) {
 
 function hasNetworkDiagnostics(run) {
   if (run.failedRequests && run.failedRequests.length > 0) return true;
+  if (run.failedResponses && run.failedResponses.length > 0) return true;
   return (run.consoleMessages || []).some((msg) => {
     const text = String(msg && msg.text ? msg.text : '').toLowerCase();
     return text.includes('cors')
-      || text.includes('cross-origin')
+      || text.includes('access-control-allow-origin')
       || text.includes('content security policy')
       || text.includes('csp');
   });

--- a/tools/creative-validator/src/runner.js
+++ b/tools/creative-validator/src/runner.js
@@ -206,6 +206,74 @@ function summarizeRequestUrl(url) {
   }
 }
 
+function summarizeRequestOrigin(url) {
+  try {
+    return new URL(url).origin;
+  } catch (_) {
+    return 'unknown';
+  }
+}
+
+function isFaviconRequest(url) {
+  try {
+    return new URL(url).pathname === '/favicon.ico';
+  } catch (_) {
+    return false;
+  }
+}
+
+function incrementBucket(map, key) {
+  const normalized = key || 'unknown';
+  map[normalized] = (map[normalized] || 0) + 1;
+}
+
+function consoleFacet(messages, kind) {
+  return (messages || []).filter((msg) => {
+    const text = String(msg && msg.text ? msg.text : '').toLowerCase();
+    if (kind === 'cors') {
+      return text.includes('cors') || text.includes('access-control-allow-origin');
+    }
+    if (kind === 'csp') {
+      return text.includes('content security policy') || text.includes('csp');
+    }
+    return false;
+  });
+}
+
+function summarizeNetwork(run) {
+  const failedRequests = run.failedRequests || [];
+  const failedResponses = run.failedResponses || [];
+  const byResourceType = {};
+  const byOrigin = {};
+  const byStatus = {};
+
+  for (const request of failedRequests) {
+    incrementBucket(byResourceType, request.resourceType);
+    incrementBucket(byOrigin, summarizeRequestOrigin(request.url));
+  }
+  // Transport-level failures do not have HTTP status codes; byStatus is
+  // intentionally limited to completed responses with status >= 400.
+  for (const response of failedResponses) {
+    incrementBucket(byResourceType, response.resourceType);
+    incrementBucket(byOrigin, summarizeRequestOrigin(response.url));
+    incrementBucket(byStatus, String(response.status));
+  }
+
+  const corsConsole = consoleFacet(run.consoleMessages, 'cors');
+  const cspConsole = consoleFacet(run.consoleMessages, 'csp');
+  return {
+    failedRequestCount: failedRequests.length,
+    failedResponseCount: failedResponses.length,
+    corsConsoleCount: corsConsole.length,
+    cspConsoleCount: cspConsole.length,
+    byResourceType,
+    byOrigin,
+    byStatus,
+    corsConsole,
+    cspConsole,
+  };
+}
+
 function chromeLaunchArgs() {
   if (process.env.SHARC_VALIDATOR_CHROME_NO_SANDBOX === '1') {
     console.error(
@@ -229,6 +297,7 @@ async function runExecutableCase(browser, testCase, options) {
   const consoleMessages = [];
   const pageErrors = [];
   const failedRequests = [];
+  const failedResponses = [];
 
   page.on('console', (msg) => {
     const summarized = summarizeConsoleMessage(msg);
@@ -238,12 +307,26 @@ async function runExecutableCase(browser, testCase, options) {
     pageErrors.push(summarizePageError(err));
   });
   page.on('requestfailed', (request) => {
+    if (isFaviconRequest(request.url())) return;
     const failure = request.failure();
     failedRequests.push({
       url: summarizeRequestUrl(request.url()),
       method: request.method(),
       resourceType: request.resourceType(),
       errorText: failure ? failure.errorText : '',
+    });
+  });
+  page.on('response', (response) => {
+    const status = response.status();
+    if (status < 400) return;
+    if (isFaviconRequest(response.url())) return;
+    const request = response.request();
+    failedResponses.push({
+      url: summarizeRequestUrl(response.url()),
+      status,
+      statusText: response.statusText(),
+      method: request.method(),
+      resourceType: request.resourceType(),
     });
   });
 
@@ -277,6 +360,7 @@ async function runExecutableCase(browser, testCase, options) {
         consoleMessages,
         pageErrors,
         failedRequests,
+        failedResponses,
       };
     }
 
@@ -296,6 +380,7 @@ async function runExecutableCase(browser, testCase, options) {
       consoleMessages,
       pageErrors,
       failedRequests,
+      failedResponses,
     };
   } catch (err) {
     return makeEmptyRun({
@@ -303,6 +388,7 @@ async function runExecutableCase(browser, testCase, options) {
       consoleMessages,
       pageErrors,
       failedRequests,
+      failedResponses,
     });
   } finally {
     await context.close();
@@ -345,6 +431,8 @@ function buildReport(testCase, run) {
       console: run.consoleMessages,
       pageErrors: run.pageErrors,
       failedRequests: run.failedRequests,
+      failedResponses: run.failedResponses,
+      network: summarizeNetwork(run),
     },
   };
 }

--- a/tools/creative-validator/test/test-diagnose.js
+++ b/tools/creative-validator/test/test-diagnose.js
@@ -100,6 +100,9 @@ test('classifyOutcome covers non-browser buckets', () => {
     failedRequests: [{ url: 'https://cdn.example/script.js', errorText: 'net::ERR_FAILED' }],
   }), 'network-cors');
   assert.equal(bucket({
+    failedResponses: [{ url: 'https://cdn.example/script.js', status: 404 }],
+  }), 'network-cors');
+  assert.equal(bucket({
     consoleMessages: [{ type: 'error', text: 'blocked by CORS policy' }],
   }), 'network-cors');
   assert.equal(bucket({ pageErrors: [{ message: 'creative threw' }] }), 'creative-broken');

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -317,6 +317,27 @@ test('runner executes HTML cases and writes one report row per case', () => {
       placementType: 'inline',
     },
   });
+  const network404 = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-network-404',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-network-404',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html',
+      html: '<!doctype html><html><body><div>network probe</div><script>'
+        + 'setTimeout(function(){fetch("/missing-validator-fetch.json").catch(function(){});},0);'
+        + '</script></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+  });
   const skipped = makeCase({
     ids: {
       requestId: 'request-runner-test',
@@ -351,6 +372,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
       missingMraid,
       mraidApiError,
       omid,
+      network404,
       skipped,
     ].map((item) => JSON.stringify(item)).join('\n') + '\n');
     execFileSync('node', [
@@ -369,7 +391,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
     });
 
     const reports = readJsonl(outPath);
-    assert.equal(reports.length, 7);
+    assert.equal(reports.length, 8);
 
     const htmlReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-test');
     assert.ok(htmlReport);
@@ -433,6 +455,17 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(omidReport.diagnostics.measurement.omid.verificationScriptCount, 1);
     assert.deepEqual(omidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.installed, false);
     assert.deepEqual(omidReport.diagnostics.bridgeProbes.at(-1).bridges.safeframe.installed, false);
+
+    const networkReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-network-404');
+    assert.ok(networkReport);
+    assert.equal(networkReport.outcome.status, 'passed');
+    assert.equal(networkReport.outcome.bucket, 'passed');
+    assert.ok(networkReport.diagnostics.failedResponses.some((response) =>
+      response.status === 404 && response.resourceType === 'fetch'));
+    assert.equal(networkReport.diagnostics.network.failedRequestCount, 0);
+    assert.ok(networkReport.diagnostics.network.failedResponseCount >= 1);
+    assert.ok(networkReport.diagnostics.network.byStatus['404'] >= 1);
+    assert.ok(networkReport.diagnostics.network.byResourceType.fetch >= 1);
 
     const nativeReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-native');
     assert.ok(nativeReport);


### PR DESCRIPTION
## Summary
- capture HTTP error responses separately from transport-level failed requests in creative validator reports
- add diagnostics.network summaries by origin, status, and resource type, plus CORS/CSP console facets
- document the diagnostic-only behavior and add runner/diagnose regression coverage

## Validation
- npm run test:creative-validator-diagnose
- npm run test:creative-validator-runner
- git diff --check
- npm run check