### PR TITLE
feat: add creative validator triage summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   and expose CORS/CSP-like console-message facets under `diagnostics.network`
   for private corpus triage.
 
+- **Creative validator triage summaries.** The private validator CLI now has a
+  `triage` command that aggregates report JSONL by status, diagnosis bucket,
+  bidder, media type, adm kind, API declaration, and expected bridge. Failure
+  groups include bounded sample IDs and reduction-candidate hints for manual
+  issue filing and synthetic fixture promotion.
+
 ## [0.7.6] - 2026-05-24
 
 **Release-doc-first cycle.** Three features shipped in parallel: the headline

--- a/docs/design/creative-validator-hardening.md
+++ b/docs/design/creative-validator-hardening.md
@@ -461,6 +461,9 @@ Suggested branch: `feat/creative-validator-normalizer`.
   diagnosis bucket.
 - Promote repeated or SHARC-owned failures into synthetic reductions.
 - File focused issues manually from triaged findings.
+- First implementation target: a private `creative-validator triage` command
+  that aggregates runner report JSONL into bucketed summaries and reduction
+  candidate hints before any fixture promotion happens.
 
 ## 9. Parked Spike Reuse
 

--- a/package.json
+++ b/package.json
@@ -73,10 +73,11 @@
     "test:creative-validator-normalizer": "node tools/creative-validator/test/test-normalizer.js",
     "test:creative-validator-diagnose": "node tools/creative-validator/test/test-diagnose.js",
     "test:creative-validator-runner": "node tools/creative-validator/test/test-runner.js",
+    "test:creative-validator-triage": "node tools/creative-validator/test/test-triage.js",
     "test:perf": "node test/node/test-creative-sources-perf.js",
     "test:types": "tsc -p test/types/tsconfig.json",
     "test:all": "npm run build && npm run test:all:built",
-    "test:all:built": "npm run test:smoke && npm run test:treeshake && npm run test:creative-protocol-placement-type && npm run test:placement && npm run test:placement-stamping && npm run test:creative-sources && npm run test:creative-sources-load && npm run test:browser && npm run test:navigation-bridge && npm run test:creative-sdk-autoinstall && npm run test:creative-sdk-injection && npm run test:bridges-detection && npm run test:non-sharc-loading && npm run test:html-lifecycle-adapter && npm run test:omid-container-lifecycle && npm run test:renderer-fallback && npm run test:creative-validator-normalizer && npm run test:creative-validator-diagnose && npm run test:creative-validator-runner",
+    "test:all:built": "npm run test:smoke && npm run test:treeshake && npm run test:creative-protocol-placement-type && npm run test:placement && npm run test:placement-stamping && npm run test:creative-sources && npm run test:creative-sources-load && npm run test:browser && npm run test:navigation-bridge && npm run test:creative-sdk-autoinstall && npm run test:creative-sdk-injection && npm run test:bridges-detection && npm run test:non-sharc-loading && npm run test:html-lifecycle-adapter && npm run test:omid-container-lifecycle && npm run test:renderer-fallback && npm run test:creative-validator-normalizer && npm run test:creative-validator-diagnose && npm run test:creative-validator-runner && npm run test:creative-validator-triage",
     "regen:baseline": "node scripts/regen-mraid3-baseline.js",
     "lint": "eslint src/*.js --max-warnings=0",
     "check": "npm run build && npm run test:all:built && npm run size && npm run build"

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -117,6 +117,23 @@ messages grouped by origin, status, and resource type. These facets are
 diagnostic by default: a creative that renders successfully can still pass while
 showing broken pixels or third-party resource failures for later triage.
 
+## Triage
+
+After a corpus run, aggregate one or more private report JSONL files:
+
+```bash
+node tools/creative-validator/src/cli.js triage \
+  "tools/creative-validator/private/reports/*.jsonl" \
+  --out tools/creative-validator/private/triage/summary.json
+```
+
+The summary groups rows by outcome status, diagnosis bucket, bidder, media type,
+`admKind`, sanitized API declaration, and expected bridge. Failed rows are also
+grouped by bucket + bidder + mtype + adm kind + API declaration, with bounded
+sample IDs and a `reductionCandidates` list to guide manual issue filing and
+synthetic fixture promotion. Like normalize/run output, triage summaries stay
+under `tools/creative-validator/private/` by default.
+
 ### Security
 
 The runner executes real creative JavaScript. Run private corpus passes from a
@@ -132,4 +149,5 @@ on a normal developer laptop.
 npm run test:creative-validator-normalizer
 npm run test:creative-validator-diagnose
 npm run test:creative-validator-runner
+npm run test:creative-validator-triage
 ```

--- a/tools/creative-validator/src/cli.js
+++ b/tools/creative-validator/src/cli.js
@@ -4,10 +4,11 @@
  * @file Creative validator CLI.
  */
 
-import { createWriteStream, existsSync, mkdirSync, readFileSync, readdirSync, statSync } from 'fs';
+import { createWriteStream, existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'fs';
 import { basename, dirname, relative, resolve, sep } from 'path';
 import { normalizeCleanedCorpus, toJsonl } from './normalizer.js';
 import { runNormalizedCases } from './runner.js';
+import { triageReports } from './triage.js';
 
 const DEFAULT_PRIVATE_ROOT = resolve('tools/creative-validator/private');
 const FORBIDDEN_PUBLIC_DIRS = [
@@ -22,10 +23,12 @@ function usage() {
 Usage:
   creative-validator normalize <corpus-file-or-glob> [more-files...] --out <private/cases.jsonl>
   creative-validator run <normalized-cases.jsonl> --out <private/reports/report.jsonl>
+  creative-validator triage <report-jsonl-or-glob> [more-files...] --out <private/triage/summary.json>
 
 Examples:
   node tools/creative-validator/src/cli.js normalize "tools/creative-validator/private/*.cleaned.json" --out tools/creative-validator/private/normalized/cases.jsonl
   node tools/creative-validator/src/cli.js run tools/creative-validator/private/normalized/cases.jsonl --out tools/creative-validator/private/reports/report.jsonl
+  node tools/creative-validator/src/cli.js triage "tools/creative-validator/private/reports/*.jsonl" --out tools/creative-validator/private/triage/summary.json
 
 Notes:
   - Globs are supported only in the final path segment, e.g. private/*.cleaned.json.
@@ -94,8 +97,8 @@ function parseArgs(argv) {
     console.log(usage());
     process.exit(0);
   }
-  if (command !== 'normalize' && command !== 'run') {
-    throw new Error('Expected command: normalize or run\n\n' + usage());
+  if (command !== 'normalize' && command !== 'run' && command !== 'triage') {
+    throw new Error('Expected command: normalize, run, or triage\n\n' + usage());
   }
 
   const inputs = [];
@@ -227,6 +230,19 @@ async function main() {
     mkdirSync(dirname(outPath), { recursive: true });
     const count = await writeCasesJsonl(outPath, files);
     console.log(`Normalized ${count} cases from ${files.length} file(s) to ${outPath}`);
+    return;
+  }
+
+  if (command === 'triage') {
+    const files = inputs.flatMap(expandInput);
+    if (files.length === 0) {
+      throw new Error('No report files matched.');
+    }
+
+    mkdirSync(dirname(outPath), { recursive: true });
+    const summary = triageReports(files);
+    writeFileSync(outPath, JSON.stringify(summary, null, 2) + '\n');
+    console.log(`Triaged ${summary.totals.reports} report row(s) from ${files.length} file(s) to ${outPath}`);
     return;
   }
 

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -1,0 +1,196 @@
+/**
+ * @file Creative validator report triage.
+ *
+ * Converts private runner report JSONL into aggregate summaries for manual
+ * issue filing and synthetic-reduction planning. The summary intentionally
+ * avoids raw creative markup and keeps sample identifiers bounded.
+ */
+
+import { readFileSync } from 'fs';
+import { basename } from 'path';
+
+const SAMPLE_LIMIT = 5;
+
+function emptySummary(files) {
+  return {
+    generatedAt: new Date().toISOString(),
+    sourceFiles: files.map((file) => basename(file)),
+    totals: {
+      reports: 0,
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      other: 0,
+    },
+    byStatus: {},
+    byBucket: {},
+    byBidder: {},
+    byMtype: {},
+    byAdmKind: {},
+    byApi: {},
+    byExpectedBridge: {},
+    failureGroups: [],
+    reductionCandidates: [],
+  };
+}
+
+function increment(map, key, amount = 1) {
+  const normalized = normalizeKey(key);
+  map[normalized] = (map[normalized] || 0) + amount;
+}
+
+function normalizeKey(value) {
+  if (value === null || value === undefined || value === '') return 'unknown';
+  return String(value);
+}
+
+function apiKey(row) {
+  const values = row
+    && row.case
+    && row.case.bidSignals
+    && row.case.bidSignals.apis
+    && row.case.bidSignals.apis.sanitized;
+  return Array.isArray(values) && values.length > 0 ? values.join(',') : 'none';
+}
+
+function expectedBridgeKeys(row) {
+  const declared = (row.case && row.case.expectations && row.case.expectations.declared) || [];
+  const sniffed = (row.case && row.case.expectations && row.case.expectations.sniffed) || [];
+  const set = new Set([...declared, ...sniffed]);
+  return set.size > 0 ? [...set].sort() : ['none'];
+}
+
+function reportFields(row) {
+  const source = (row.case && row.case.source) || {};
+  const creative = (row.case && row.case.creative) || {};
+  const bidSignals = (row.case && row.case.bidSignals) || {};
+  const outcome = row.outcome || {};
+  return {
+    status: normalizeKey(outcome.status),
+    bucket: normalizeKey(outcome.bucket),
+    bidder: normalizeKey(source.bidder),
+    mtype: normalizeKey(bidSignals.mtype || source.mtype),
+    admKind: normalizeKey(creative.admKind),
+    api: apiKey(row),
+  };
+}
+
+function sampleId(row) {
+  const ids = (row.case && row.case.ids) || {};
+  const source = (row.case && row.case.source) || {};
+  const sourceFile = normalizeKey(source.sourceFile);
+  return {
+    bidId: normalizeKey(ids.bidId),
+    crid: normalizeKey(ids.crid),
+    sourceFile: sourceFile === 'unknown' ? 'unknown' : basename(sourceFile),
+    rowIndex: source.rowIndex === undefined ? null : source.rowIndex,
+  };
+}
+
+function addFailureGroup(groups, row) {
+  const fields = reportFields(row);
+  const key = [
+    fields.bucket,
+    fields.bidder,
+    fields.mtype,
+    fields.admKind,
+    fields.api,
+  ].join('\u001f');
+  let group = groups.get(key);
+  if (!group) {
+    group = {
+      bucket: fields.bucket,
+      bidder: fields.bidder,
+      mtype: fields.mtype,
+      admKind: fields.admKind,
+      api: fields.api,
+      count: 0,
+      samples: [],
+    };
+    groups.set(key, group);
+  }
+  group.count += 1;
+  if (group.samples.length < SAMPLE_LIMIT) {
+    group.samples.push(sampleId(row));
+  }
+}
+
+function sortEntries(map) {
+  return Object.fromEntries(Object.entries(map)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])));
+}
+
+function sortedGroups(groups) {
+  return [...groups.values()].sort((a, b) =>
+    b.count - a.count
+    || a.bucket.localeCompare(b.bucket)
+    || a.bidder.localeCompare(b.bidder)
+    || a.mtype.localeCompare(b.mtype)
+    || a.admKind.localeCompare(b.admKind)
+    || a.api.localeCompare(b.api));
+}
+
+function isReductionCandidate(group) {
+  return group.bucket !== 'passed'
+    && group.bucket !== 'unsupported-input'
+    && group.count > 0;
+}
+
+function readReportJsonl(file) {
+  const text = readFileSync(file, 'utf8').trim();
+  if (!text) return [];
+  return text.split('\n').map((line, index) => {
+    try {
+      return JSON.parse(line);
+    } catch (err) {
+      throw new Error(`Failed to parse ${basename(file)} line ${index + 1}: ${err.message}`);
+    }
+  });
+}
+
+function triageReports(files) {
+  const summary = emptySummary(files);
+  const failureGroups = new Map();
+
+  for (const file of files) {
+    for (const row of readReportJsonl(file)) {
+      const fields = reportFields(row);
+      summary.totals.reports += 1;
+      increment(summary.byStatus, fields.status);
+      increment(summary.byBucket, fields.bucket);
+      increment(summary.byBidder, fields.bidder);
+      increment(summary.byMtype, fields.mtype);
+      increment(summary.byAdmKind, fields.admKind);
+      increment(summary.byApi, fields.api);
+      for (const bridge of expectedBridgeKeys(row)) {
+        increment(summary.byExpectedBridge, bridge);
+      }
+
+      if (fields.status === 'passed') summary.totals.passed += 1;
+      else if (fields.status === 'skipped') summary.totals.skipped += 1;
+      else if (fields.status === 'failed') {
+        summary.totals.failed += 1;
+        addFailureGroup(failureGroups, row);
+      } else {
+        summary.totals.other += 1;
+      }
+    }
+  }
+
+  summary.byStatus = sortEntries(summary.byStatus);
+  summary.byBucket = sortEntries(summary.byBucket);
+  summary.byBidder = sortEntries(summary.byBidder);
+  summary.byMtype = sortEntries(summary.byMtype);
+  summary.byAdmKind = sortEntries(summary.byAdmKind);
+  summary.byApi = sortEntries(summary.byApi);
+  summary.byExpectedBridge = sortEntries(summary.byExpectedBridge);
+  summary.failureGroups = sortedGroups(failureGroups);
+  summary.reductionCandidates = summary.failureGroups
+    .filter(isReductionCandidate)
+    .slice(0, 20);
+  return summary;
+}
+
+export {
+  triageReports,
+};

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+/**
+ * test-triage.js — creative validator Phase 6 triage coverage.
+ */
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { resolve } from 'node:path';
+import test from 'node:test';
+import { triageReports } from '../src/triage.js';
+
+const cliPath = resolve('tools/creative-validator/src/cli.js');
+
+function report(overrides = {}) {
+  return {
+    case: {
+      source: {
+        sourceFile: 'synthetic-report.jsonl',
+        rowIndex: 0,
+        bidder: 'bidder-a',
+        mtype: 'banner',
+      },
+      ids: {
+        bidId: 'bid-1',
+        crid: 'creative-1',
+      },
+      creative: {
+        admKind: 'html-mraid',
+      },
+      expectations: {
+        declared: ['mraid'],
+        sniffed: [],
+      },
+      bidSignals: {
+        apis: { sanitized: [5] },
+        mtype: 'banner',
+        measurement: { omid: { declaredByApi: false, sidecarPresent: false } },
+      },
+    },
+    outcome: {
+      status: 'failed',
+      bucket: 'bridge-missing',
+    },
+    diagnostics: {},
+    ...overrides,
+  };
+}
+
+function writeJsonl(file, rows) {
+  writeFileSync(file, rows.map((row) => JSON.stringify(row)).join('\n') + '\n');
+}
+
+test('triageReports groups private report rows by failure dimensions', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-triage-'));
+  const reportPath = resolve(workDir, 'report.jsonl');
+
+  try {
+    writeJsonl(reportPath, [
+      report({ outcome: { status: 'passed', bucket: 'passed' } }),
+      report(),
+      report({
+        case: {
+          ...report().case,
+          source: { ...report().case.source, rowIndex: 1 },
+          ids: { bidId: 'bid-2', crid: 'creative-2' },
+        },
+      }),
+      report({
+        case: {
+          ...report().case,
+          source: { ...report().case.source, bidder: 'bidder-b', rowIndex: 2 },
+          ids: { bidId: 'bid-3', crid: 'creative-3' },
+          creative: { admKind: 'html' },
+          expectations: { declared: [], sniffed: [] },
+          bidSignals: { ...report().case.bidSignals, apis: { sanitized: [] } },
+        },
+        outcome: { status: 'skipped', bucket: 'unsupported-input' },
+      }),
+      report({
+        case: {
+          ...report().case,
+          source: { ...report().case.source, rowIndex: 3 },
+          ids: { bidId: 'bid-4', crid: 'creative-4' },
+        },
+        outcome: { status: 'error', bucket: 'unknown' },
+      }),
+    ]);
+
+    const summary = triageReports([reportPath]);
+    assert.equal(summary.totals.reports, 5);
+    assert.equal(summary.totals.passed, 1);
+    assert.equal(summary.totals.failed, 2);
+    assert.equal(summary.totals.skipped, 1);
+    assert.equal(summary.totals.other, 1);
+    assert.equal(
+      summary.totals.passed + summary.totals.failed + summary.totals.skipped + summary.totals.other,
+      summary.totals.reports,
+    );
+    assert.deepEqual(summary.byStatus, { failed: 2, error: 1, passed: 1, skipped: 1 });
+    assert.equal(summary.byBucket['bridge-missing'], 2);
+    assert.equal(summary.byBidder['bidder-a'], 4);
+    assert.equal(summary.byMtype.banner, 5);
+    assert.equal(summary.byAdmKind['html-mraid'], 4);
+    assert.equal(summary.byApi['5'], 4);
+    assert.equal(summary.byExpectedBridge.mraid, 4);
+    assert.equal(summary.failureGroups.length, 1);
+    assert.equal(summary.failureGroups[0].bucket, 'bridge-missing');
+    assert.equal(summary.failureGroups[0].count, 2);
+    assert.equal(summary.failureGroups[0].samples.length, 2);
+    assert.equal(summary.reductionCandidates.length, 1);
+    assert.equal(summary.reductionCandidates[0].bucket, 'bridge-missing');
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});
+
+test('triage CLI writes private summary and rejects public output by default', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-triage-cli-'));
+  const reportPath = resolve(workDir, 'report.jsonl');
+  const outPath = resolve(workDir, 'summary.json');
+  const publicOut = resolve('tools/creative-validator/fixtures/triage-summary.json');
+
+  try {
+    writeJsonl(reportPath, [report()]);
+    execFileSync('node', [cliPath, 'triage', reportPath, '--out', outPath], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const summary = JSON.parse(readFileSync(outPath, 'utf8'));
+    assert.equal(summary.totals.reports, 1);
+    assert.equal(summary.failureGroups[0].bucket, 'bridge-missing');
+
+    assert.throws(
+      () => execFileSync('node', [cliPath, 'triage', reportPath, '--out', publicOut], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }),
+      /Refusing to write private creative validator output outside/,
+    );
+    assert.equal(existsSync(publicOut), false);
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a private creative-validator triage command for report JSONL aggregation
- group corpus results by status, diagnosis bucket, bidder, mtype, adm kind, API declaration, and expected bridge
- emit bounded failure samples and reduction-candidate hints for manual issue filing and synthetic fixture promotion
- document Phase 6 workflow and wire focused triage coverage into test:all

## Validation
- npm run test:creative-validator-normalizer
- npm run test:creative-validator-diagnose
- npm run test:creative-validator-runner
- npm run test:creative-validator-triage
- npx eslint tools/creative-validator/src/*.js tools/creative-validator/test/*.js --max-warnings=0
- git diff --check
- npm run check