### PR TITLE
feat: add creative validator diagnostic triage facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,9 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   `triage` command that aggregates report JSONL by status, diagnosis bucket,
   bidder, media type, adm kind, API declaration, and expected bridge. Failure
   groups include bounded sample IDs and reduction-candidate hints for manual
-  issue filing and synthetic fixture promotion.
+  issue filing and synthetic fixture promotion. Triage output also includes
+  aggregate security-event, unauthorized-navigation timing, and network-shape
+  facets for repeated-failure analysis.
 
 ## [0.7.6] - 2026-05-24
 

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -134,6 +134,12 @@ sample IDs and a `reductionCandidates` list to guide manual issue filing and
 synthetic fixture promotion. Like normalize/run output, triage summaries stay
 under `tools/creative-validator/private/` by default.
 
+The `diagnostics` section adds aggregate-only facets for repeated failure
+patterns: security-event counts, security-event sets, unauthorized-navigation
+variant/timing bins, and network shapes based on failed request/response and
+CORS/CSP console counts. These are intended to replace ad hoc private scripts
+when deciding which repeated failures deserve synthetic reductions.
+
 ### Security
 
 The runner executes real creative JavaScript. Run private corpus passes from a

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -29,6 +29,21 @@ function emptySummary(files) {
     byAdmKind: {},
     byApi: {},
     byExpectedBridge: {},
+    diagnostics: {
+      bySecurityEvent: {},
+      bySecurityEventSet: {},
+      unauthorizedNavigation: {
+        byVariant: {},
+        byMsSinceRender: {},
+      },
+      network: {
+        byShape: {},
+        byFailedRequestCount: {},
+        byFailedResponseCount: {},
+        byCorsConsoleCount: {},
+        byCspConsoleCount: {},
+      },
+    },
     failureGroups: [],
     reductionCandidates: [],
   };
@@ -58,6 +73,68 @@ function expectedBridgeKeys(row) {
   const sniffed = (row.case && row.case.expectations && row.case.expectations.sniffed) || [];
   const set = new Set([...declared, ...sniffed]);
   return set.size > 0 ? [...set].sort() : ['none'];
+}
+
+function securityEvents(row) {
+  return row && row.diagnostics && Array.isArray(row.diagnostics.securityEvents)
+    ? row.diagnostics.securityEvents
+    : [];
+}
+
+function networkDiagnostics(row) {
+  return row && row.diagnostics && row.diagnostics.network
+    ? row.diagnostics.network
+    : {};
+}
+
+function msSinceRenderBin(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return 'unknown';
+  if (value < 100) return '0-99ms';
+  if (value < 500) return '100-499ms';
+  if (value < 1000) return '500-999ms';
+  if (value < 2000) return '1000-1999ms';
+  return '2000ms+';
+}
+
+function networkCount(value) {
+  // Treat malformed runner counters as zero so private summaries remain stable.
+  return Number.isInteger(value) && value >= 0 ? value : 0;
+}
+
+function networkShape(network) {
+  return [
+    `request:${networkCount(network.failedRequestCount)}`,
+    `response:${networkCount(network.failedResponseCount)}`,
+    `cors:${networkCount(network.corsConsoleCount)}`,
+    `csp:${networkCount(network.cspConsoleCount)}`,
+  ].join(' ');
+}
+
+function addDiagnosticFacets(summary, row) {
+  const events = securityEvents(row);
+  const eventTypes = events.map((event) => normalizeKey(event && event.type)).sort();
+  const eventSet = eventTypes.length > 0 ? [...new Set(eventTypes)].join(',') : 'none';
+  increment(summary.diagnostics.bySecurityEventSet, eventSet);
+
+  for (const event of events) {
+    const type = normalizeKey(event && event.type);
+    increment(summary.diagnostics.bySecurityEvent, type);
+    if (type === 'unauthorized_navigation') {
+      const details = (event && event.details) || {};
+      increment(summary.diagnostics.unauthorizedNavigation.byVariant, details.variant);
+      increment(
+        summary.diagnostics.unauthorizedNavigation.byMsSinceRender,
+        msSinceRenderBin(details.msSinceRender),
+      );
+    }
+  }
+
+  const network = networkDiagnostics(row);
+  increment(summary.diagnostics.network.byShape, networkShape(network));
+  increment(summary.diagnostics.network.byFailedRequestCount, networkCount(network.failedRequestCount));
+  increment(summary.diagnostics.network.byFailedResponseCount, networkCount(network.failedResponseCount));
+  increment(summary.diagnostics.network.byCorsConsoleCount, networkCount(network.corsConsoleCount));
+  increment(summary.diagnostics.network.byCspConsoleCount, networkCount(network.cspConsoleCount));
 }
 
 function reportFields(row) {
@@ -115,9 +192,14 @@ function addFailureGroup(groups, row) {
   }
 }
 
-function sortEntries(map) {
+function sortEntries(map, options = {}) {
+  const { numericKeys = false } = options;
   return Object.fromEntries(Object.entries(map)
-    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])));
+    .sort((a, b) =>
+      b[1] - a[1]
+      || (numericKeys
+        ? Number(a[0]) - Number(b[0])
+        : a[0].localeCompare(b[0]))));
 }
 
 function sortedGroups(groups) {
@@ -170,6 +252,7 @@ function triageReports(files) {
       else if (fields.status === 'skipped') summary.totals.skipped += 1;
       else if (fields.status === 'failed') {
         summary.totals.failed += 1;
+        addDiagnosticFacets(summary, row);
         addFailureGroup(failureGroups, row);
       } else {
         summary.totals.other += 1;
@@ -184,6 +267,21 @@ function triageReports(files) {
   summary.byAdmKind = sortEntries(summary.byAdmKind);
   summary.byApi = sortEntries(summary.byApi);
   summary.byExpectedBridge = sortEntries(summary.byExpectedBridge);
+  summary.diagnostics.bySecurityEvent = sortEntries(summary.diagnostics.bySecurityEvent);
+  summary.diagnostics.bySecurityEventSet = sortEntries(summary.diagnostics.bySecurityEventSet);
+  summary.diagnostics.unauthorizedNavigation.byVariant =
+    sortEntries(summary.diagnostics.unauthorizedNavigation.byVariant);
+  summary.diagnostics.unauthorizedNavigation.byMsSinceRender =
+    sortEntries(summary.diagnostics.unauthorizedNavigation.byMsSinceRender);
+  summary.diagnostics.network.byShape = sortEntries(summary.diagnostics.network.byShape);
+  summary.diagnostics.network.byFailedRequestCount =
+    sortEntries(summary.diagnostics.network.byFailedRequestCount, { numericKeys: true });
+  summary.diagnostics.network.byFailedResponseCount =
+    sortEntries(summary.diagnostics.network.byFailedResponseCount, { numericKeys: true });
+  summary.diagnostics.network.byCorsConsoleCount =
+    sortEntries(summary.diagnostics.network.byCorsConsoleCount, { numericKeys: true });
+  summary.diagnostics.network.byCspConsoleCount =
+    sortEntries(summary.diagnostics.network.byCspConsoleCount, { numericKeys: true });
   summary.failureGroups = sortedGroups(failureGroups);
   summary.reductionCandidates = summary.failureGroups
     .filter(isReductionCandidate)

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -68,12 +68,47 @@ test('triageReports groups private report rows by failure dimensions', () => {
   try {
     writeJsonl(reportPath, [
       report({ outcome: { status: 'passed', bucket: 'passed' } }),
-      report(),
+      report({
+        diagnostics: {
+          securityEvents: [{
+            type: 'unauthorized_navigation',
+            details: { variant: 'markup', msSinceRender: 125 },
+          }],
+          network: {
+            failedRequestCount: 1,
+            failedResponseCount: 0,
+            corsConsoleCount: 0,
+            cspConsoleCount: 1,
+          },
+        },
+      }),
       report({
         case: {
           ...report().case,
           source: { ...report().case.source, rowIndex: 1 },
           ids: { bidId: 'bid-2', crid: 'creative-2' },
+        },
+        diagnostics: {
+          securityEvents: [
+            {
+              type: 'bridge_load_failed',
+              details: { bridge: 'mraid' },
+            },
+            {
+              type: 'renderer_failed',
+              details: {},
+            },
+            {
+              type: 'renderer_failed',
+              details: {},
+            },
+          ],
+          network: {
+            failedRequestCount: 0,
+            failedResponseCount: 1,
+            corsConsoleCount: 1,
+            cspConsoleCount: 0,
+          },
         },
       }),
       report({
@@ -86,6 +121,18 @@ test('triageReports groups private report rows by failure dimensions', () => {
           bidSignals: { ...report().case.bidSignals, apis: { sanitized: [] } },
         },
         outcome: { status: 'skipped', bucket: 'unsupported-input' },
+        diagnostics: {
+          securityEvents: [{
+            type: 'unauthorized_navigation',
+            details: { variant: 'markup', msSinceRender: 250 },
+          }],
+          network: {
+            failedRequestCount: 10,
+            failedResponseCount: 10,
+            corsConsoleCount: 10,
+            cspConsoleCount: 10,
+          },
+        },
       }),
       report({
         case: {
@@ -95,29 +142,78 @@ test('triageReports groups private report rows by failure dimensions', () => {
         },
         outcome: { status: 'error', bucket: 'unknown' },
       }),
+      report({
+        case: {
+          ...report().case,
+          source: { ...report().case.source, rowIndex: 4 },
+          ids: { bidId: 'bid-5', crid: 'creative-5' },
+        },
+        diagnostics: {
+          securityEvents: [],
+          network: {
+            failedRequestCount: 2,
+            failedResponseCount: 2,
+            corsConsoleCount: 2,
+            cspConsoleCount: 2,
+          },
+        },
+      }),
+      report({
+        case: {
+          ...report().case,
+          source: { ...report().case.source, rowIndex: 5 },
+          ids: { bidId: 'bid-6', crid: 'creative-6' },
+        },
+        diagnostics: {
+          securityEvents: [],
+          network: {
+            failedRequestCount: 10,
+            failedResponseCount: 10,
+            corsConsoleCount: 10,
+            cspConsoleCount: 10,
+          },
+        },
+      }),
     ]);
 
     const summary = triageReports([reportPath]);
-    assert.equal(summary.totals.reports, 5);
+    assert.equal(summary.totals.reports, 7);
     assert.equal(summary.totals.passed, 1);
-    assert.equal(summary.totals.failed, 2);
+    assert.equal(summary.totals.failed, 4);
     assert.equal(summary.totals.skipped, 1);
     assert.equal(summary.totals.other, 1);
     assert.equal(
       summary.totals.passed + summary.totals.failed + summary.totals.skipped + summary.totals.other,
       summary.totals.reports,
     );
-    assert.deepEqual(summary.byStatus, { failed: 2, error: 1, passed: 1, skipped: 1 });
-    assert.equal(summary.byBucket['bridge-missing'], 2);
-    assert.equal(summary.byBidder['bidder-a'], 4);
-    assert.equal(summary.byMtype.banner, 5);
-    assert.equal(summary.byAdmKind['html-mraid'], 4);
-    assert.equal(summary.byApi['5'], 4);
-    assert.equal(summary.byExpectedBridge.mraid, 4);
+    assert.deepEqual(summary.byStatus, { failed: 4, error: 1, passed: 1, skipped: 1 });
+    assert.equal(summary.byBucket['bridge-missing'], 4);
+    assert.equal(summary.byBidder['bidder-a'], 6);
+    assert.equal(summary.byMtype.banner, 7);
+    assert.equal(summary.byAdmKind['html-mraid'], 6);
+    assert.equal(summary.byApi['5'], 6);
+    assert.equal(summary.byExpectedBridge.mraid, 6);
+    assert.equal(summary.diagnostics.bySecurityEvent.unauthorized_navigation, 1);
+    assert.equal(summary.diagnostics.bySecurityEvent.bridge_load_failed, 1);
+    assert.equal(summary.diagnostics.bySecurityEvent.renderer_failed, 2);
+    assert.equal(summary.diagnostics.bySecurityEventSet.unauthorized_navigation, 1);
+    assert.equal(summary.diagnostics.bySecurityEventSet['bridge_load_failed,renderer_failed'], 1);
+    assert.equal(summary.diagnostics.bySecurityEventSet.none, 2);
+    assert.equal(summary.diagnostics.unauthorizedNavigation.byVariant.markup, 1);
+    assert.equal(summary.diagnostics.unauthorizedNavigation.byMsSinceRender['100-499ms'], 1);
+    assert.equal(summary.diagnostics.network.byShape['request:1 response:0 cors:0 csp:1'], 1);
+    assert.equal(summary.diagnostics.network.byShape['request:0 response:1 cors:1 csp:0'], 1);
+    assert.equal(summary.diagnostics.network.byShape['request:0 response:0 cors:0 csp:0'], undefined);
+    assert.equal(summary.diagnostics.network.byFailedRequestCount['1'], 1);
+    assert.deepEqual(Object.keys(summary.diagnostics.network.byFailedRequestCount), ['0', '1', '2', '10']);
+    assert.equal(summary.diagnostics.network.byFailedResponseCount['1'], 1);
+    assert.deepEqual(Object.keys(summary.diagnostics.network.byFailedResponseCount), ['0', '1', '2', '10']);
+    assert.equal(summary.diagnostics.network.byCorsConsoleCount['1'], 1);
+    assert.equal(summary.diagnostics.network.byCspConsoleCount['1'], 1);
     assert.equal(summary.failureGroups.length, 1);
     assert.equal(summary.failureGroups[0].bucket, 'bridge-missing');
-    assert.equal(summary.failureGroups[0].count, 2);
-    assert.equal(summary.failureGroups[0].samples.length, 2);
+    assert.equal(summary.failureGroups[0].count, 4);
+    assert.equal(summary.failureGroups[0].samples.length, 4);
     assert.equal(summary.reductionCandidates.length, 1);
     assert.equal(summary.reductionCandidates[0].bucket, 'bridge-missing');
   } finally {


### PR DESCRIPTION
## Summary
- add aggregate diagnostic facets to creative-validator triage output
- summarize security-event counts and event-set combinations
- add unauthorized-navigation variant and ms-since-render timing bins
- summarize network failure shapes from failed request/response and CORS/CSP console counts

## Private corpus check
- normalized 437 cases from the local cleaned OpenRTB examples
- ran the validator across all 437 cases into ignored private reports
- regenerated a private triage summary and confirmed it now surfaces the repeated navigation-policy pattern without ad hoc scripts

## Validation
- npm run test:creative-validator-triage
- npx eslint tools/creative-validator/src/triage.js tools/creative-validator/test/test-triage.js --max-warnings=0
- git diff --check
- npm run check