### PR TITLE
test: cover creative validator navigation-policy reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   aggregate security-event, unauthorized-navigation timing, and network-shape
   facets for repeated-failure analysis.
 
+- **Creative validator navigation-policy reduction.** Added a synthetic
+  OpenRTB-style reduction for post-render Creative Markup iframe navigation.
+  The fixture pins the current validator behavior: rendered creatives that
+  navigate the iframe after render terminate via `unauthorized_navigation` and
+  bucket as `navigation-policy`.
+
 ## [0.7.6] - 2026-05-24
 
 **Release-doc-first cycle.** Three features shipped in parallel: the headline

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -140,6 +140,11 @@ variant/timing bins, and network shapes based on failed request/response and
 CORS/CSP console counts. These are intended to replace ad hoc private scripts
 when deciding which repeated failures deserve synthetic reductions.
 
+Committed reductions live under `tools/creative-validator/fixtures/reductions/`
+and must be synthetic. `002-navigation-policy-post-render` captures the current
+Creative Markup behavior for a creative that renders and then navigates its own
+iframe: the validator buckets it as `navigation-policy`.
+
 ### Security
 
 The runner executes real creative JavaScript. Run private corpus passes from a

--- a/tools/creative-validator/fixtures/reductions/002-navigation-policy-post-render/README.md
+++ b/tools/creative-validator/fixtures/reductions/002-navigation-policy-post-render/README.md
@@ -1,0 +1,16 @@
+# 002 Navigation Policy Post-Render
+
+Synthetic reduction for private corpus rows that rendered successfully and then
+triggered `unauthorized_navigation` shortly after render in the Creative Markup
+path.
+
+This fixture intentionally does not decide whether the pattern is a valid
+wrapper-loading flow or an unobserved navigation escape. It pins the current
+validator classification so that follow-up design work can discuss a public,
+minimal reproduction instead of private `adm`.
+
+The creative writes a small banner, logs DOM lifecycle markers, waits for
+`window.load`, and then assigns `window.location.href` after 150 ms. In current
+SHARC behavior, the container's load-event backstop terminates the placement with
+`RENDERER_UNAUTHORIZED_NAVIGATION` and the validator buckets the row as
+`navigation-policy`.

--- a/tools/creative-validator/fixtures/reductions/002-navigation-policy-post-render/cleaned-corpus.fixture.json
+++ b/tools/creative-validator/fixtures/reductions/002-navigation-policy-post-render/cleaned-corpus.fixture.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "auction-row-navigation-policy",
+    "auction": [
+      {
+        "bidder": "synthetic-navigation",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-navigation-policy",
+          "imp": [
+            {
+              "id": "imp-navigation-policy",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50,
+                "api": [3, 5]
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-navigation-policy",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-navigation-policy-post-render",
+                  "impid": "imp-navigation-policy",
+                  "crid": "creative-navigation-policy-post-render",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><div id=\"ad\">synthetic post-load navigation</div><script>(function(){ function mark(name){ console.warn('[sharc-reduction-lifecycle] ' + JSON.stringify({ name: name, readyState: document.readyState, t: Math.round(performance.now()) })); } mark('script-start'); document.addEventListener('DOMContentLoaded', function(){ mark('domcontentloaded'); }); window.addEventListener('load', function(){ mark('load'); setTimeout(function(){ mark('before-navigation'); window.location.href = 'https://click.example/post-render-navigation'; }, 150); }); })();</script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -18,6 +18,9 @@ import { resolve } from 'node:path';
 import test from 'node:test';
 
 const cliPath = resolve('tools/creative-validator/src/cli.js');
+const navigationReductionPath = resolve(
+  'tools/creative-validator/fixtures/reductions/002-navigation-policy-post-render/cleaned-corpus.fixture.json',
+);
 
 function makeCase(overrides) {
   return {
@@ -381,6 +384,10 @@ test('runner executes HTML cases and writes one report row per case', () => {
       inputPath,
       '--out',
       outPath,
+      '--port',
+      '18867',
+      '--renderer-port',
+      '18868',
       '--render-timeout-ms',
       '4000',
       '--settle-ms',
@@ -495,6 +502,69 @@ test('runner refuses public report output by default', () => {
       /Refusing to write private creative validator output outside/,
     );
     assert.equal(existsSync(publicOut), false);
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});
+
+test('runner buckets post-render iframe navigation reduction as navigation-policy', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-runner-navigation-'));
+  const inputPath = resolve(workDir, 'cases.jsonl');
+  const outPath = resolve(workDir, 'reports.jsonl');
+
+  try {
+    execFileSync('node', [cliPath, 'normalize', navigationReductionPath, '--out', inputPath], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    execFileSync('node', [
+      cliPath,
+      'run',
+      inputPath,
+      '--out',
+      outPath,
+      '--port',
+      '18869',
+      '--renderer-port',
+      '18870',
+      '--render-timeout-ms',
+      '4000',
+      '--settle-ms',
+      '500',
+    ], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const reports = readJsonl(outPath);
+    assert.equal(reports.length, 1);
+    const [reportRow] = reports;
+    assert.equal(reportRow.case.ids.bidId, 'bid-navigation-policy-post-render');
+    assert.equal(reportRow.case.creative.html, undefined);
+    assert.equal(reportRow.outcome.status, 'failed');
+    assert.equal(reportRow.outcome.bucket, 'navigation-policy');
+    assert.equal(reportRow.outcome.reason, 'unauthorized navigation');
+    assert.equal(reportRow.outcome.creativeRendered, true);
+    assert.equal(reportRow.outcome.terminated, true);
+    const navEvent = reportRow.diagnostics.securityEvents.find((event) =>
+      event.type === 'unauthorized_navigation');
+    assert.ok(navEvent);
+    assert.equal(navEvent.details.variant, 'markup');
+    assert.equal(typeof navEvent.details.msSinceRender, 'number');
+    const lifecycleMarkers = reportRow.diagnostics.console
+      .map((message) => message.text.match(/^\[sharc-reduction-lifecycle\] (.+)$/))
+      .filter(Boolean)
+      .map((match) => JSON.parse(match[1]));
+    assert.deepEqual(
+      lifecycleMarkers.map((marker) => marker.name),
+      ['script-start', 'domcontentloaded', 'load', 'before-navigation'],
+    );
+    assert.equal(
+      lifecycleMarkers.find((marker) => marker.name === 'before-navigation').readyState,
+      'complete',
+    );
   } finally {
     rmSync(workDir, { force: true, recursive: true });
   }


### PR DESCRIPTION
## Summary
- add a synthetic OpenRTB-style reduction for post-render Creative Markup iframe navigation
- pin current validator behavior: rendered creative terminates with unauthorized_navigation and buckets as navigation-policy
- document that this is a reduction for follow-up policy/design discussion, not a runtime behavior change

## Validation
- npm run test:creative-validator-normalizer
- npm run test:creative-validator-runner
- git diff --check
- npm run check