### PR TITLE
docs: clarify creative validator reductions

### DIFF
--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -141,9 +141,16 @@ CORS/CSP console counts. These are intended to replace ad hoc private scripts
 when deciding which repeated failures deserve synthetic reductions.
 
 Committed reductions live under `tools/creative-validator/fixtures/reductions/`
-and must be synthetic. `002-navigation-policy-post-render` captures the current
-Creative Markup behavior for a creative that renders and then navigates its own
-iframe: the validator buckets it as `navigation-policy`.
+and must be synthetic. Each reduction directory should include a short README
+describing the private failure pattern it represents and the behavior it pins.
+The checked-in cleaned-corpus JSON is the canonical fixture input. Avoid keeping
+duplicate creative markup in companion files unless tooling derives one copy
+from the other or the companion is explicitly marked non-canonical.
+
+`001-normalizer-cleaned-corpus` pins the cleaned export shape and normalizer
+classification/extraction behavior. `002-navigation-policy-post-render`
+captures the current Creative Markup behavior for a creative that renders and
+then navigates its own iframe: the validator buckets it as `navigation-policy`.
 
 ### Security
 

--- a/tools/creative-validator/fixtures/reductions/001-normalizer-cleaned-corpus/README.md
+++ b/tools/creative-validator/fixtures/reductions/001-normalizer-cleaned-corpus/README.md
@@ -1,0 +1,11 @@
+# 001 Normalizer Cleaned Corpus
+
+Synthetic cleaned-corpus fixture for the creative validator normalizer.
+
+This fixture covers the private corpus export shape without carrying real bid
+responses or creative markup. It includes representative banner, native, video,
+MRAID, SafeFrame, SHARC, and OMID sidecar signals so normalizer tests can pin
+classification, API extraction, bid metadata, and unsupported-input handling.
+
+The fixture is not intended to execute every creative. It is the source-of-truth
+input for normalizer tests and should stay small enough for manual review.


### PR DESCRIPTION
## Summary
- add a README for the 001 normalizer cleaned-corpus reduction
- document that committed reductions must be synthetic and include README context
- clarify that cleaned-corpus JSON is the canonical fixture input, avoiding duplicate creative markup unless explicitly non-canonical or generated

## Validation
- npm run test:creative-validator-runner
- npm run test:creative-validator-normalizer
- git diff --check