### PR TITLE
feat: add validator script load diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   sanitized URL shape so private triage can test whether navigation-policy
   failures correlate with legacy wrapper loading patterns.
 
+- **Creative validator script-load diagnostics.** The markup runner now records
+  sanitized script discovery/load/error events with protocol, origin, lifecycle
+  state, and load status. Private triage aggregates script-load counts,
+  protocols, origins, and statuses so navigation-policy failures can be
+  correlated with external script execution without storing raw private URLs.
+
 ## [0.7.6] - 2026-05-24
 
 **Release-doc-first cycle.** Three features shipped in parallel: the headline

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -123,7 +123,10 @@ source signals captured before creative markup runs. The harness records
 counts, and pattern flags such as `iframe`, `location`, `metaRefresh`, and
 `scriptSrc`; it also records `window.open` counts and bridge/API calls such as
 `mraid.open` or `SHARC.requestNavigation` with sanitized URL protocol and
-origin. It does not store raw written markup or full private URLs.
+origin. Script loads are recorded as sanitized discovery/load/error events with
+URL protocol/origin and lifecycle timing so repeated post-render navigation
+failures can be correlated with third-party script execution. It does not store
+raw written markup or full private URLs.
 
 ## Triage
 
@@ -149,8 +152,9 @@ CORS/CSP console counts. These are intended to replace ad hoc private scripts
 when deciding which repeated failures deserve synthetic reductions.
 Navigation source facets summarize failed rows by `document.write` count,
 document-write pattern flags, `window.open` count/protocol, and bridge call
-count/method/protocol so navigation-policy clusters can be split by likely
-trigger mechanism.
+count/method/protocol. Script-load facets summarize failed rows by script count,
+load/error count, protocol, origin, and load status so navigation-policy
+clusters can be split by likely trigger mechanism.
 
 Committed reductions live under `tools/creative-validator/fixtures/reductions/`
 and must be synthetic. Each reduction directory should include a short README

--- a/tools/creative-validator/fixtures/script-load-navigation.js
+++ b/tools/creative-validator/fixtures/script-load-navigation.js
@@ -1,0 +1,3 @@
+setTimeout(function () {
+  window.location.href = 'https://click.example/script-load-navigation';
+}, 50);

--- a/tools/creative-validator/fixtures/script-load-ok.js
+++ b/tools/creative-validator/fixtures/script-load-ok.js
@@ -1,0 +1,1 @@
+window.__sharcValidatorScriptLoadOk = true;

--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -276,6 +276,21 @@ function validatorNavigationPreludeSource(probeNonce) {
       }
     }
 
+    function hashUrl(value) {
+      var text;
+      try {
+        text = new URL(String(value), document.baseURI).href;
+      } catch (_) {
+        text = String(value || '');
+      }
+      var hash = 2166136261;
+      for (var i = 0; i < text.length; i += 1) {
+        hash ^= text.charCodeAt(i);
+        hash = Math.imul(hash, 16777619);
+      }
+      return (hash >>> 0).toString(16);
+    }
+
     function post(payload) {
       try {
         window.parent.postMessage({
@@ -293,6 +308,154 @@ function validatorNavigationPreludeSource(probeNonce) {
         readyState: document.readyState,
         t: Math.round(performance.now()),
       };
+    }
+
+    function scriptSummary(script) {
+      var raw = null;
+      try {
+        raw = script.getAttribute('src') || script.src;
+      } catch (_) {
+        raw = null;
+      }
+      if (!raw) return null;
+      return {
+        lifecycle: lifecycle(),
+        urlHash: hashUrl(raw),
+        url: summarizeUrl(raw),
+        async: script.async === true,
+        defer: script.defer === true,
+        type: script.type ? String(script.type).slice(0, 80) : '',
+      };
+    }
+
+    var observedScripts = [];
+
+    function postScriptLoad(script, status) {
+      var summary = scriptSummary(script);
+      if (!summary) return;
+      summary.kind = 'script-load';
+      summary.status = status;
+      post(summary);
+    }
+
+    function scriptAbsoluteUrl(script) {
+      try {
+        var raw = script.getAttribute('src') || script.src;
+        return raw ? new URL(String(raw), document.baseURI).href : null;
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function markScriptTerminal(record, status) {
+      if (!record || record.terminal) return;
+      record.terminal = true;
+      postScriptLoad(record.script, status);
+    }
+
+    function recordForScript(script) {
+      for (var i = 0; i < observedScripts.length; i += 1) {
+        if (observedScripts[i].script === script) return observedScripts[i];
+      }
+      return null;
+    }
+
+    function observeScript(script) {
+      if (!script || script.nodeType !== 1 || String(script.tagName).toLowerCase() !== 'script') return;
+      if (script.__sharcValidatorScriptObserved) return recordForScript(script);
+      var absoluteUrl = scriptAbsoluteUrl(script);
+      if (!absoluteUrl || !scriptSummary(script)) return null;
+      var record = { script: script, url: absoluteUrl, terminal: false };
+      observedScripts.push(record);
+      try {
+        Object.defineProperty(script, '__sharcValidatorScriptObserved', { value: true });
+      } catch (_) {
+        script.__sharcValidatorScriptObserved = true;
+      }
+      postScriptLoad(script, 'discovered');
+      script.addEventListener('load', function () {
+        markScriptTerminal(record, 'loaded');
+      }, { once: true });
+      script.addEventListener('error', function () {
+        markScriptTerminal(record, 'error');
+      }, { once: true });
+      return record;
+    }
+
+    function performanceEntriesByUrl() {
+      var entries = {};
+      try {
+        var resources = performance.getEntriesByType('resource') || [];
+        for (var i = 0; i < resources.length; i += 1) {
+          var entry = resources[i];
+          if (entry && entry.initiatorType === 'script' && entry.name) {
+            entries[entry.name] = entry;
+          }
+        }
+      } catch (_) {
+        // Resource timing may be unavailable; script event listeners still cover dynamic loads.
+      }
+      return entries;
+    }
+
+    function reconcileMissedScriptOutcomes() {
+      var entries = performanceEntriesByUrl();
+      for (var i = 0; i < observedScripts.length; i += 1) {
+        var record = observedScripts[i];
+        if (record.terminal) continue;
+        var entry = entries[record.url];
+        if (!entry) continue;
+        if (Number(entry.responseStatus) >= 400) {
+          markScriptTerminal(record, 'error');
+        } else {
+          markScriptTerminal(record, 'loaded');
+        }
+      }
+    }
+
+    if (typeof PerformanceObserver === 'function') {
+      try {
+        var resourceObserver = new PerformanceObserver(function () {
+          reconcileMissedScriptOutcomes();
+        });
+        resourceObserver.observe({ type: 'resource', buffered: true });
+      } catch (_) {
+        // Resource timing reconciliation is a fallback for missed static load events.
+      }
+    }
+
+    try {
+      Object.defineProperty(window, '__sharcValidatorReconcileScriptLoads', {
+        configurable: true,
+        value: function () {
+          scanScripts(document);
+          reconcileMissedScriptOutcomes();
+        },
+      });
+    } catch (_) {
+      // Window hook is best-effort; load-time reconciliation still runs below.
+    }
+
+    function scanScripts(root) {
+      observeScript(root);
+      if (root && typeof root.querySelectorAll === 'function') {
+        var scripts = root.querySelectorAll('script[src]');
+        for (var i = 0; i < scripts.length; i += 1) observeScript(scripts[i]);
+      }
+    }
+
+    if (typeof MutationObserver === 'function') {
+      try {
+        var observer = new MutationObserver(function (records) {
+          for (var i = 0; i < records.length; i += 1) {
+            var nodes = records[i].addedNodes || [];
+            for (var j = 0; j < nodes.length; j += 1) scanScripts(nodes[j]);
+          }
+        });
+        observer.observe(document.documentElement || document, { childList: true, subtree: true });
+      } catch (_) {
+        // Script-load diagnostics are best-effort and must not affect creative execution.
+      }
     }
 
     function bridgeCall(bridge, method, url) {
@@ -403,6 +566,12 @@ function validatorNavigationPreludeSource(probeNonce) {
 
     wrapDocumentMethod('write');
     wrapDocumentMethod('writeln');
+    scanScripts(document);
+    window.addEventListener('load', function () {
+      scanScripts(document);
+      setTimeout(reconcileMissedScriptOutcomes, 0);
+      setTimeout(reconcileMissedScriptOutcomes, 100);
+    });
     observeGlobal('mraid', wrapMraid);
     observeGlobal('$sf', wrapSafeFrame);
     observeGlobal('SHARC', wrapSharc);
@@ -469,8 +638,11 @@ function addValidatorInstrumentation(html, creativeSdkSource, bridgeProbeSource,
     ? '<scr' + 'ipt>window.__sharcValidatorWrapBridgeCalls && window.__sharcValidatorWrapBridgeCalls();\n</scr' + 'ipt>'
     : '';
   const instrumentation = navigationScript + sdkScript + bridgeWrapScript + probeScript;
+  const scriptLoadTail = '<scr' + 'ipt>'
+    + 'window.__sharcValidatorReconcileScriptLoads && window.__sharcValidatorReconcileScriptLoads();\n'
+    + '</scr' + 'ipt>';
   if (typeof html !== 'string') return instrumentation;
-  return insertAtDocumentStart(html, instrumentation);
+  return insertAtDocumentStart(html, instrumentation) + scriptLoadTail;
 }
 
 function emptyNavigationDiagnostics() {
@@ -499,6 +671,15 @@ function emptyNavigationDiagnostics() {
       count: 0,
       byMethod: {},
       byProtocol: {},
+      calls: [],
+    },
+    scriptLoads: {
+      count: 0,
+      loadedCount: 0,
+      errorCount: 0,
+      byProtocol: {},
+      byOrigin: {},
+      byStatus: {},
       calls: [],
     },
   };
@@ -537,6 +718,34 @@ function addNavigationDiagnostic(summary, payload) {
         url: cloneForReport(payload.url || {}),
         target: payload.target || null,
         hasFeatures: payload.hasFeatures === true,
+      });
+    }
+    return;
+  }
+  if (payload.kind === 'script-load') {
+    const scriptLoads = summary.scriptLoads;
+    const status = payload.status || 'unknown';
+    scriptLoads.byStatus[status] = (scriptLoads.byStatus[status] || 0) + 1;
+    if (status === 'discovered') {
+      scriptLoads.count += 1;
+      const protocol = payload.url && payload.url.protocol ? payload.url.protocol : 'unknown';
+      const origin = payload.url && payload.url.origin ? payload.url.origin : 'unknown';
+      scriptLoads.byProtocol[protocol] = (scriptLoads.byProtocol[protocol] || 0) + 1;
+      scriptLoads.byOrigin[origin] = (scriptLoads.byOrigin[origin] || 0) + 1;
+    } else if (status === 'loaded') {
+      scriptLoads.loadedCount += 1;
+    } else if (status === 'error') {
+      scriptLoads.errorCount += 1;
+    }
+    if (scriptLoads.calls.length < 20) {
+      scriptLoads.calls.push({
+        status,
+        lifecycle: cloneForReport(payload.lifecycle || {}),
+        urlHash: payload.urlHash || null,
+        url: cloneForReport(payload.url || {}),
+        async: payload.async === true,
+        defer: payload.defer === true,
+        type: payload.type || '',
       });
     }
     return;

--- a/tools/creative-validator/src/runner.js
+++ b/tools/creative-validator/src/runner.js
@@ -214,6 +214,29 @@ function summarizeRequestOrigin(url) {
   }
 }
 
+function summarizeScriptUrl(url) {
+  try {
+    const parsed = new URL(url);
+    return {
+      present: true,
+      protocol: parsed.protocol,
+      origin: parsed.origin === 'null' ? null : parsed.origin,
+    };
+  } catch (_) {
+    return { present: true, protocol: 'invalid', origin: null };
+  }
+}
+
+function hashUrl(url) {
+  const text = String(url || '');
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16);
+}
+
 function isFaviconRequest(url) {
   try {
     return new URL(url).pathname === '/favicon.ico';
@@ -274,6 +297,68 @@ function summarizeNetwork(run) {
   };
 }
 
+function scriptKey(url) {
+  if (!url || url.present !== true) return 'unknown|unknown';
+  return `${url.protocol || 'unknown'}|${url.origin || 'unknown'}`;
+}
+
+function scriptCallKey(call) {
+  return call && call.urlHash ? `hash:${call.urlHash}` : scriptKey(call && call.url);
+}
+
+function scriptOutcomeKey(outcome) {
+  return outcome && outcome.urlHash ? `hash:${outcome.urlHash}` : scriptKey(outcome && outcome.url);
+}
+
+function backfillScriptLoadDiagnostics(navigationDiagnostics, scriptOutcomes) {
+  const scriptLoads = navigationDiagnostics && navigationDiagnostics.scriptLoads;
+  if (!scriptLoads || !Array.isArray(scriptLoads.calls)) return;
+
+  const terminalByKey = {};
+  for (const call of scriptLoads.calls) {
+    if (!call || (call.status !== 'loaded' && call.status !== 'error')) continue;
+    incrementBucket(terminalByKey, scriptCallKey(call));
+  }
+
+  const outcomesByKey = {};
+  for (const outcome of scriptOutcomes) {
+    const key = scriptOutcomeKey(outcome);
+    if (!outcomesByKey[key]) outcomesByKey[key] = [];
+    outcomesByKey[key].push(outcome);
+  }
+
+  for (const call of scriptLoads.calls) {
+    if (!call || call.status !== 'discovered') continue;
+    const key = scriptCallKey(call);
+    if (terminalByKey[key] > 0) {
+      terminalByKey[key] -= 1;
+      continue;
+    }
+    const outcomes = outcomesByKey[key] || [];
+    const outcome = outcomes.shift();
+    if (!outcome) continue;
+    const status = outcome.status >= 400 || outcome.failed === true ? 'error' : 'loaded';
+    if (status === 'loaded') scriptLoads.loadedCount += 1;
+    else scriptLoads.errorCount += 1;
+    scriptLoads.byStatus[status] = (scriptLoads.byStatus[status] || 0) + 1;
+    if (scriptLoads.calls.length < 20) {
+      scriptLoads.calls.push({
+        status,
+        lifecycle: call.lifecycle || {},
+        url: call.url || {},
+        async: call.async === true,
+        defer: call.defer === true,
+        type: call.type || '',
+      });
+    }
+  }
+  for (const call of scriptLoads.calls) {
+    if (call && Object.prototype.hasOwnProperty.call(call, 'urlHash')) {
+      delete call.urlHash;
+    }
+  }
+}
+
 function chromeLaunchArgs() {
   if (process.env.SHARC_VALIDATOR_CHROME_NO_SANDBOX === '1') {
     console.error(
@@ -298,6 +383,7 @@ async function runExecutableCase(browser, testCase, options) {
   const pageErrors = [];
   const failedRequests = [];
   const failedResponses = [];
+  const scriptOutcomes = [];
 
   page.on('console', (msg) => {
     const summarized = summarizeConsoleMessage(msg);
@@ -315,12 +401,28 @@ async function runExecutableCase(browser, testCase, options) {
       resourceType: request.resourceType(),
       errorText: failure ? failure.errorText : '',
     });
+    if (request.resourceType() === 'script') {
+      scriptOutcomes.push({
+        urlHash: hashUrl(request.url()),
+        url: summarizeScriptUrl(request.url()),
+        failed: true,
+        status: 0,
+      });
+    }
   });
   page.on('response', (response) => {
     const status = response.status();
+    const request = response.request();
+    if (!isFaviconRequest(response.url()) && request.resourceType() === 'script') {
+      scriptOutcomes.push({
+        urlHash: hashUrl(response.url()),
+        url: summarizeScriptUrl(response.url()),
+        failed: false,
+        status,
+      });
+    }
     if (status < 400) return;
     if (isFaviconRequest(response.url())) return;
-    const request = response.request();
     failedResponses.push({
       url: summarizeRequestUrl(response.url()),
       status,
@@ -376,6 +478,7 @@ async function runExecutableCase(browser, testCase, options) {
         settleMs: options.settleMs,
       },
     );
+    backfillScriptLoadDiagnostics(run.navigationDiagnostics, scriptOutcomes);
     return {
       ...run,
       consoleMessages,

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -44,6 +44,12 @@ function emptySummary(files) {
         bridgeCallByCount: {},
         bridgeCallByMethod: {},
         bridgeCallByProtocol: {},
+        scriptLoadByCount: {},
+        scriptLoadByLoadedCount: {},
+        scriptLoadByErrorCount: {},
+        scriptLoadByProtocol: {},
+        scriptLoadByOrigin: {},
+        scriptLoadByStatus: {},
       },
       network: {
         byShape: {},
@@ -155,6 +161,7 @@ function addDiagnosticFacets(summary, row) {
   const documentWrite = navigation.documentWrite || {};
   const windowOpen = navigation.windowOpen || {};
   const bridgeCalls = navigation.bridgeCalls || {};
+  const scriptLoads = navigation.scriptLoads || {};
   increment(
     summary.diagnostics.navigationSources.documentWriteByCount,
     networkCount(documentWrite.count),
@@ -190,6 +197,36 @@ function addDiagnosticFacets(summary, row) {
   for (const [protocol, count] of Object.entries(bridgeByProtocol)) {
     if (networkCount(count) > 0) {
       increment(summary.diagnostics.navigationSources.bridgeCallByProtocol, protocol, networkCount(count));
+    }
+  }
+  increment(
+    summary.diagnostics.navigationSources.scriptLoadByCount,
+    networkCount(scriptLoads.count),
+  );
+  increment(
+    summary.diagnostics.navigationSources.scriptLoadByLoadedCount,
+    networkCount(scriptLoads.loadedCount),
+  );
+  increment(
+    summary.diagnostics.navigationSources.scriptLoadByErrorCount,
+    networkCount(scriptLoads.errorCount),
+  );
+  const scriptByProtocol = scriptLoads.byProtocol || {};
+  for (const [protocol, count] of Object.entries(scriptByProtocol)) {
+    if (networkCount(count) > 0) {
+      increment(summary.diagnostics.navigationSources.scriptLoadByProtocol, protocol, networkCount(count));
+    }
+  }
+  const scriptByOrigin = scriptLoads.byOrigin || {};
+  for (const [origin, count] of Object.entries(scriptByOrigin)) {
+    if (networkCount(count) > 0) {
+      increment(summary.diagnostics.navigationSources.scriptLoadByOrigin, origin, networkCount(count));
+    }
+  }
+  const scriptByStatus = scriptLoads.byStatus || {};
+  for (const [status, count] of Object.entries(scriptByStatus)) {
+    if (networkCount(count) > 0) {
+      increment(summary.diagnostics.navigationSources.scriptLoadByStatus, status, networkCount(count));
     }
   }
 }
@@ -344,6 +381,18 @@ function triageReports(files) {
     sortEntries(summary.diagnostics.navigationSources.bridgeCallByMethod);
   summary.diagnostics.navigationSources.bridgeCallByProtocol =
     sortEntries(summary.diagnostics.navigationSources.bridgeCallByProtocol);
+  summary.diagnostics.navigationSources.scriptLoadByCount =
+    sortEntries(summary.diagnostics.navigationSources.scriptLoadByCount, { numericKeys: true });
+  summary.diagnostics.navigationSources.scriptLoadByLoadedCount =
+    sortEntries(summary.diagnostics.navigationSources.scriptLoadByLoadedCount, { numericKeys: true });
+  summary.diagnostics.navigationSources.scriptLoadByErrorCount =
+    sortEntries(summary.diagnostics.navigationSources.scriptLoadByErrorCount, { numericKeys: true });
+  summary.diagnostics.navigationSources.scriptLoadByProtocol =
+    sortEntries(summary.diagnostics.navigationSources.scriptLoadByProtocol);
+  summary.diagnostics.navigationSources.scriptLoadByOrigin =
+    sortEntries(summary.diagnostics.navigationSources.scriptLoadByOrigin);
+  summary.diagnostics.navigationSources.scriptLoadByStatus =
+    sortEntries(summary.diagnostics.navigationSources.scriptLoadByStatus);
   summary.diagnostics.network.byShape = sortEntries(summary.diagnostics.network.byShape);
   summary.diagnostics.network.byFailedRequestCount =
     sortEntries(summary.diagnostics.network.byFailedRequestCount, { numericKeys: true });

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -468,6 +468,119 @@ test('runner executes HTML cases and writes one report row per case', () => {
       transformations: [],
     },
   });
+  const scriptLoadOk = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-script-load-ok',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-script-load-ok',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html',
+      html: '<!doctype html><html><body><script>'
+        + 'window.addEventListener("load",function(){'
+        + 'var script=document.createElement("script");'
+        + 'script.src="/tools/creative-validator/fixtures/script-load-ok.js";'
+        + 'document.body.appendChild(script);'
+        + '});'
+        + '</script></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+  });
+  const scriptLoadMissing = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-script-load-missing',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-script-load-missing',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html',
+      html: '<!doctype html><html><body><script>'
+        + 'window.addEventListener("load",function(){'
+        + 'var script=document.createElement("script");'
+        + 'script.src="/tools/creative-validator/fixtures/missing-script-load.js";'
+        + 'document.body.appendChild(script);'
+        + '});'
+        + '</script></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+  });
+  const scriptLoadNavigation = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-script-load-navigation',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-script-load-navigation',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html',
+      html: '<!doctype html><html><body><script>'
+        + 'window.addEventListener("load",function(){'
+        + 'var script=document.createElement("script");'
+        + 'script.src="/tools/creative-validator/fixtures/script-load-navigation.js";'
+        + 'document.body.appendChild(script);'
+        + '});'
+        + '</script></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+  });
+  const staticScriptLoadOk = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-static-script-load-ok',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-static-script-load-ok',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html',
+      html: '<!doctype html><html><body><script src="/tools/creative-validator/fixtures/script-load-ok.js"></script></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+  });
+  const staticScriptLoadMissing = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-static-script-load-missing',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-static-script-load-missing',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html',
+      html: '<!doctype html><html><body><script src="/tools/creative-validator/fixtures/missing-static-script-load.js"></script></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+  });
   const skipped = makeCase({
     ids: {
       requestId: 'request-runner-test',
@@ -507,6 +620,11 @@ test('runner executes HTML cases and writes one report row per case', () => {
       network404,
       docWrite,
       windowOpen,
+      scriptLoadOk,
+      scriptLoadMissing,
+      scriptLoadNavigation,
+      staticScriptLoadOk,
+      staticScriptLoadMissing,
       skipped,
     ].map((item) => JSON.stringify(item)).join('\n') + '\n');
     execFileSync('node', [
@@ -529,7 +647,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
     });
 
     const reports = readJsonl(outPath);
-    assert.equal(reports.length, 12);
+    assert.equal(reports.length, 17);
 
     const htmlReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-test');
     assert.ok(htmlReport);
@@ -644,6 +762,58 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(windowOpenReport.diagnostics.navigationDiagnostics.windowOpen.calls[0].url.origin, 'https://click.example');
     assert.equal(windowOpenReport.diagnostics.navigationDiagnostics.windowOpen.calls[0].url.protocol, 'https:');
     assert.equal(windowOpenReport.diagnostics.navigationDiagnostics.windowOpen.calls[0].target, '_blank');
+
+    const scriptLoadOkReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-script-load-ok');
+    assert.ok(scriptLoadOkReport);
+    assert.equal(scriptLoadOkReport.outcome.status, 'passed');
+    assert.equal(scriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.count, 1);
+    assert.equal(scriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.loadedCount, 1);
+    assert.equal(scriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.errorCount, 0);
+    assert.equal(scriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.byProtocol['http:'], 1);
+    assert.equal(scriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.calls[0].url.present, true);
+    assert.match(
+      scriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.calls[0].url.origin,
+      /^http:\/\/(?:127\.0\.0\.1|localhost):18868$/,
+    );
+
+    const scriptLoadMissingReport = reports.find((row) =>
+      row.case.ids.bidId === 'bid-runner-script-load-missing');
+    assert.ok(scriptLoadMissingReport);
+    assert.equal(scriptLoadMissingReport.outcome.status, 'passed');
+    assert.equal(scriptLoadMissingReport.diagnostics.navigationDiagnostics.scriptLoads.count, 1);
+    assert.equal(scriptLoadMissingReport.diagnostics.navigationDiagnostics.scriptLoads.loadedCount, 0);
+    assert.equal(scriptLoadMissingReport.diagnostics.navigationDiagnostics.scriptLoads.errorCount, 1);
+    assert.equal(scriptLoadMissingReport.diagnostics.navigationDiagnostics.scriptLoads.byStatus.error, 1);
+
+    const scriptLoadNavigationReport = reports.find((row) =>
+      row.case.ids.bidId === 'bid-runner-script-load-navigation');
+    assert.ok(scriptLoadNavigationReport);
+    assert.equal(scriptLoadNavigationReport.outcome.status, 'failed');
+    assert.equal(scriptLoadNavigationReport.outcome.bucket, 'navigation-policy');
+    assert.equal(scriptLoadNavigationReport.diagnostics.navigationDiagnostics.scriptLoads.count, 1);
+    assert.equal(scriptLoadNavigationReport.diagnostics.navigationDiagnostics.scriptLoads.loadedCount, 1);
+    assert.equal(scriptLoadNavigationReport.diagnostics.navigationDiagnostics.windowOpen.count, 0);
+    assert.equal(scriptLoadNavigationReport.diagnostics.navigationDiagnostics.bridgeCalls.count, 0);
+
+    const staticScriptLoadOkReport = reports.find((row) =>
+      row.case.ids.bidId === 'bid-runner-static-script-load-ok');
+    assert.ok(staticScriptLoadOkReport);
+    assert.equal(staticScriptLoadOkReport.outcome.status, 'failed');
+    assert.equal(staticScriptLoadOkReport.outcome.bucket, 'navigation-policy');
+    assert.equal(staticScriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.count, 1);
+    assert.equal(staticScriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.loadedCount, 1);
+    assert.equal(staticScriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.errorCount, 0);
+    assert.equal(staticScriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.byStatus.loaded, 1);
+
+    const staticScriptLoadMissingReport = reports.find((row) =>
+      row.case.ids.bidId === 'bid-runner-static-script-load-missing');
+    assert.ok(staticScriptLoadMissingReport);
+    assert.equal(staticScriptLoadMissingReport.outcome.status, 'failed');
+    assert.equal(staticScriptLoadMissingReport.outcome.bucket, 'navigation-policy');
+    assert.equal(staticScriptLoadMissingReport.diagnostics.navigationDiagnostics.scriptLoads.count, 1);
+    assert.equal(staticScriptLoadMissingReport.diagnostics.navigationDiagnostics.scriptLoads.loadedCount, 0);
+    assert.equal(staticScriptLoadMissingReport.diagnostics.navigationDiagnostics.scriptLoads.errorCount, 1);
+    assert.equal(staticScriptLoadMissingReport.diagnostics.navigationDiagnostics.scriptLoads.byStatus.error, 1);
 
     const nativeReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-native');
     assert.ok(nativeReport);

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -105,6 +105,24 @@ test('triageReports groups private report rows by failure dimensions', () => {
                 'https:': 2,
               },
             },
+            scriptLoads: {
+              count: 2,
+              loadedCount: 1,
+              errorCount: 1,
+              byProtocol: {
+                'https:': 1,
+                'http:': 1,
+              },
+              byOrigin: {
+                'https://cdn.example': 1,
+                'http://127.0.0.1:18868': 1,
+              },
+              byStatus: {
+                discovered: 2,
+                loaded: 1,
+                error: 1,
+              },
+            },
           },
         },
       }),
@@ -148,6 +166,14 @@ test('triageReports groups private report rows by failure dimensions', () => {
               count: 0,
               byMethod: {},
               byProtocol: {},
+            },
+            scriptLoads: {
+              count: 0,
+              loadedCount: 0,
+              errorCount: 0,
+              byProtocol: {},
+              byOrigin: {},
+              byStatus: {},
             },
           },
         },
@@ -258,6 +284,25 @@ test('triageReports groups private report rows by failure dimensions', () => {
       'sharc.requestNavigation': 1,
     });
     assert.deepEqual(summary.diagnostics.navigationSources.bridgeCallByProtocol, { 'https:': 2 });
+    assert.equal(summary.diagnostics.navigationSources.scriptLoadByCount['0'], 3);
+    assert.equal(summary.diagnostics.navigationSources.scriptLoadByCount['2'], 1);
+    assert.equal(summary.diagnostics.navigationSources.scriptLoadByLoadedCount['0'], 3);
+    assert.equal(summary.diagnostics.navigationSources.scriptLoadByLoadedCount['1'], 1);
+    assert.equal(summary.diagnostics.navigationSources.scriptLoadByErrorCount['0'], 3);
+    assert.equal(summary.diagnostics.navigationSources.scriptLoadByErrorCount['1'], 1);
+    assert.deepEqual(summary.diagnostics.navigationSources.scriptLoadByProtocol, {
+      'http:': 1,
+      'https:': 1,
+    });
+    assert.deepEqual(summary.diagnostics.navigationSources.scriptLoadByOrigin, {
+      'http://127.0.0.1:18868': 1,
+      'https://cdn.example': 1,
+    });
+    assert.deepEqual(summary.diagnostics.navigationSources.scriptLoadByStatus, {
+      discovered: 2,
+      error: 1,
+      loaded: 1,
+    });
     assert.equal(summary.diagnostics.network.byShape['request:1 response:0 cors:0 csp:1'], 1);
     assert.equal(summary.diagnostics.network.byShape['request:0 response:1 cors:1 csp:0'], 1);
     assert.equal(summary.diagnostics.network.byShape['request:0 response:0 cors:0 csp:0'], undefined);


### PR DESCRIPTION
## Summary
- add bounded script discovery/load/error diagnostics to the private creative validator markup runner
- aggregate script-load counts, protocols, origins, and statuses in triage summaries
- add synthetic runner and triage coverage for loaded, missing, and navigation-triggering script loads

## Validation
- npm run test:creative-validator-runner
- npm run test:creative-validator-triage
- npx eslint tools/creative-validator/src/triage.js tools/creative-validator/test/test-runner.js tools/creative-validator/test/test-triage.js tools/creative-validator/fixtures/script-load-navigation.js tools/creative-validator/fixtures/script-load-ok.js --max-warnings=0
- git diff --check
- npm run check