### PR TITLE
test: document validator navigation boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,11 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   protocols, origins, and statuses so navigation-policy failures can be
   correlated with external script execution without storing raw private URLs.
 
+- **Creative validator navigation-boundary coverage.** Synthetic runner cases
+  now document the policy line for external scripts: no-op scripts and nested
+  iframe creation pass, while same-frame `window.location`, meta refresh, and
+  form-submit navigation bucket as `navigation-policy`.
+
 ## [0.7.6] - 2026-05-24
 
 **Release-doc-first cycle.** Three features shipped in parallel: the headline

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -156,6 +156,12 @@ count/method/protocol. Script-load facets summarize failed rows by script count,
 load/error count, protocol, origin, and load status so navigation-policy
 clusters can be split by likely trigger mechanism.
 
+The runner tests also document the current navigation-policy boundary for
+external scripts: a script that loads and does nothing passes; a script that
+creates a nested iframe passes; a script that navigates the renderer document
+with `window.location`, meta refresh, or same-frame form submit is classified
+as `navigation-policy`.
+
 Committed reductions live under `tools/creative-validator/fixtures/reductions/`
 and must be synthetic. Each reduction directory should include a short README
 describing the private failure pattern it represents and the behavior it pins.

--- a/tools/creative-validator/fixtures/navigation-boundary-form-submit.js
+++ b/tools/creative-validator/fixtures/navigation-boundary-form-submit.js
@@ -1,0 +1,7 @@
+setTimeout(function () {
+  var form = document.createElement('form');
+  form.action = 'https://click.example/form-submit';
+  form.method = 'GET';
+  document.body.appendChild(form);
+  form.submit();
+}, 50);

--- a/tools/creative-validator/fixtures/navigation-boundary-location.js
+++ b/tools/creative-validator/fixtures/navigation-boundary-location.js
@@ -1,0 +1,3 @@
+setTimeout(function () {
+  window.location.href = 'https://click.example/location';
+}, 50);

--- a/tools/creative-validator/fixtures/navigation-boundary-meta-refresh.js
+++ b/tools/creative-validator/fixtures/navigation-boundary-meta-refresh.js
@@ -1,0 +1,6 @@
+setTimeout(function () {
+  var meta = document.createElement('meta');
+  meta.httpEquiv = 'refresh';
+  meta.content = '0;url=https://click.example/meta-refresh';
+  document.head.appendChild(meta);
+}, 50);

--- a/tools/creative-validator/fixtures/navigation-boundary-nested-iframe.js
+++ b/tools/creative-validator/fixtures/navigation-boundary-nested-iframe.js
@@ -1,0 +1,9 @@
+window.__sharcValidatorNestedIframeLoaded = false;
+setTimeout(function () {
+  var frame = document.createElement('iframe');
+  frame.onload = function () {
+    window.__sharcValidatorNestedIframeLoaded = true;
+  };
+  frame.srcdoc = '<!doctype html><html><body>nested frame</body></html>';
+  document.body.appendChild(frame);
+}, 50);

--- a/tools/creative-validator/fixtures/navigation-boundary-noop.js
+++ b/tools/creative-validator/fixtures/navigation-boundary-noop.js
@@ -1,0 +1,1 @@
+window.__sharcValidatorNavigationBoundaryNoop = true;

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -848,6 +848,114 @@ test('runner refuses public report output by default', () => {
   }
 });
 
+test('runner documents external-script navigation policy boundary', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-runner-nav-boundary-'));
+  const inputPath = resolve(workDir, 'cases.jsonl');
+  const outPath = resolve(workDir, 'reports.jsonl');
+
+  const scriptCase = (slug, scriptName) => makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: `bid-runner-boundary-${slug}`,
+      impId: 'imp-runner-test',
+      crid: `creative-runner-boundary-${slug}`,
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html',
+      html: '<!doctype html><html><body><div>navigation boundary</div><script>'
+        + 'window.addEventListener("load",function(){'
+        + 'var script=document.createElement("script");'
+        + `script.src="/tools/creative-validator/fixtures/${scriptName}";`
+        + 'document.body.appendChild(script);'
+        + '});'
+        + '</script></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+  });
+
+  try {
+    writeFileSync(inputPath, [
+      scriptCase('noop', 'navigation-boundary-noop.js'),
+      scriptCase('nested-iframe', 'navigation-boundary-nested-iframe.js'),
+      scriptCase('location', 'navigation-boundary-location.js'),
+      scriptCase('meta-refresh', 'navigation-boundary-meta-refresh.js'),
+      scriptCase('form-submit', 'navigation-boundary-form-submit.js'),
+    ].map((item) => JSON.stringify(item)).join('\n') + '\n');
+    execFileSync('node', [
+      cliPath,
+      'run',
+      inputPath,
+      '--out',
+      outPath,
+      '--port',
+      '18871',
+      '--renderer-port',
+      '18872',
+      '--render-timeout-ms',
+      '4000',
+      '--settle-ms',
+      '1500',
+    ], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const reports = readJsonl(outPath);
+    assert.equal(reports.length, 5);
+
+    const bySlug = (slug) => reports.find((row) =>
+      row.case.ids.bidId === `bid-runner-boundary-${slug}`);
+    const assertScriptLoaded = (row) => {
+      assert.equal(row.diagnostics.navigationDiagnostics.scriptLoads.count, 1);
+      assert.equal(row.diagnostics.navigationDiagnostics.scriptLoads.loadedCount, 1);
+      assert.equal(row.diagnostics.navigationDiagnostics.scriptLoads.errorCount, 0);
+      assert.equal(row.diagnostics.navigationDiagnostics.scriptLoads.byProtocol['http:'], 1);
+    };
+    const assertNavigationPolicy = (row) => {
+      assert.equal(row.outcome.status, 'failed');
+      assert.equal(row.outcome.bucket, 'navigation-policy');
+      assert.equal(row.outcome.reason, 'unauthorized navigation');
+      assert.equal(row.outcome.creativeRendered, true);
+      assert.equal(row.outcome.terminated, true);
+      assert.ok(row.diagnostics.securityEvents.some((event) =>
+        event.type === 'unauthorized_navigation'
+          && event.details
+          && event.details.variant === 'markup'));
+      assertScriptLoaded(row);
+      assert.equal(row.diagnostics.navigationDiagnostics.windowOpen.count, 0);
+      assert.equal(row.diagnostics.navigationDiagnostics.bridgeCalls.count, 0);
+    };
+
+    const noop = bySlug('noop');
+    assert.ok(noop);
+    assert.equal(noop.outcome.status, 'passed');
+    assert.equal(noop.outcome.bucket, 'passed');
+    assert.equal(noop.outcome.terminated, false);
+    assertScriptLoaded(noop);
+
+    const nestedIframe = bySlug('nested-iframe');
+    assert.ok(nestedIframe);
+    assert.equal(nestedIframe.outcome.status, 'passed');
+    assert.equal(nestedIframe.outcome.bucket, 'passed');
+    assert.equal(nestedIframe.outcome.terminated, false);
+    assertScriptLoaded(nestedIframe);
+
+    assertNavigationPolicy(bySlug('location'));
+    assertNavigationPolicy(bySlug('meta-refresh'));
+    assertNavigationPolicy(bySlug('form-submit'));
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});
+
 test('runner buckets post-render iframe navigation reduction as navigation-policy', () => {
   const privateRoot = resolve('tools/creative-validator/private');
   mkdirSync(privateRoot, { recursive: true });


### PR DESCRIPTION
## Summary
- add synthetic external-script boundary fixtures for the creative validator
- document that no-op external scripts and nested iframe creation pass
- document that same-frame location, meta refresh, and form submit navigation bucket as navigation-policy
- update validator README and CHANGELOG with the boundary behavior

## Validation
- npm run test:creative-validator-runner
- targeted ESLint for changed validator fixtures/tests
- git diff --check
- npm run check