### PR TITLE
fix: verify Markup document load before navigation backstop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,15 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   iframe creation pass, while same-frame `window.location`, meta refresh, and
   form-submit navigation bucket as `navigation-policy`.
 
+### Fixed
+
+- **Creative Markup document-load backstop.** Markup containers now consume the
+  expected post-`:rendered` iframe `load` produced by `document.write()` before
+  arming the unauthorized-navigation backstop. Parser/static creative scripts,
+  including legacy relative MRAID loader requests that currently 404, no
+  longer get misclassified as `navigation-policy` failures merely because the
+  written document completes its normal load after `DOMContentLoaded`.
+
 ## [0.7.6] - 2026-05-24
 
 **Release-doc-first cycle.** Three features shipped in parallel: the headline

--- a/examples/renderer/index.html
+++ b/examples/renderer/index.html
@@ -472,6 +472,41 @@
     }
   }
 
+  function jsonForInlineScript(value) {
+    return JSON.stringify(String(value)).replace(/</g, '\\u003c');
+  }
+
+  function installLoadProbePrelude(html, placementSessionId, containerOrigin) {
+    var code = ''
+      + '(function(){'
+      + 'var placementSessionId=' + jsonForInlineScript(placementSessionId) + ';'
+      + 'var containerOrigin=' + jsonForInlineScript(containerOrigin) + ';'
+      + 'window.addEventListener("message",function(event){'
+      + 'if(!event||event.source!==window.parent)return;'
+      + 'if(event.origin!==containerOrigin)return;'
+      + 'var probe=event.data;'
+      + 'if(!probe||typeof probe!=="object")return;'
+      + 'if(probe.type!=="SHARC:Renderer:loadProbe")return;'
+      + 'if(probe.placementSessionId!==placementSessionId)return;'
+      + 'try{window.parent.postMessage({'
+      + 'type:"SHARC:Renderer:loadAck",'
+      + 'placementSessionId:placementSessionId,'
+      + 'rendererOrigin:window.location.origin'
+      + '},containerOrigin);}catch(_){}'
+      + '},false);'
+      + '}());';
+    try {
+      var doc = new DOMParser().parseFromString(html, 'text/html');
+      var script = doc.createElement('script');
+      script.text = code;
+      var parent = doc.head || doc.body || doc.documentElement;
+      parent.insertBefore(script, parent.firstChild);
+      return doc.documentElement.outerHTML;
+    } catch (_) {
+      return '<script>' + code + '<\\/script>' + html;
+    }
+  }
+
   // ─────────────────────────────────────────────────────────────────────
   // DOMParser + replaceChildren fallback (proposal AC L1201).
   //
@@ -1142,6 +1177,7 @@
           + (hookErr && hookErr.message ? String(hookErr.message) : 'unknown'),
         { severity: 'warn', reason: 'on_before_render_hook_threw' });
     }
+    html = installLoadProbePrelude(html, placementSessionId, containerOrigin);
 
     // ─── DOMContentLoaded listener BEFORE document.open ────────────────
     // After document.open(), the existing script context is replaced

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -2939,10 +2939,14 @@ class SHARCContainer {
     // matches existing precedent.
     if (this._iframe) {
       this._iframe.setAttribute('data-sharc-creative-rendered', 'true');
-      // Phase D deliverable 1: load-event navigation backstop. Extracted to
-      // `_armRendererBackstop()` so future Phase E work (Creative URL load-
-      // count backstop per spec line 841 hint) has the seam already in place.
-      this._armRendererBackstop();
+      // Markup's renderer posts :rendered at DOMContentLoaded so the SHARC
+      // SDK is ready before the MessageChannel bootstrap starts. The written
+      // document's normal window load may still be pending while parser/static
+      // scripts and other subresources finish. Verify that first load with a
+      // renderer probe so the expected document.write completion is allowed,
+      // but a real cross-document navigation still fails if the renderer does
+      // not answer.
+      this._armRendererBackstop({ verifyFirstLoad: true });
     }
 
     // Standard bootstrap — 200ms delay then initChannel.
@@ -4175,9 +4179,13 @@ class SHARCContainer {
    *
    * @private
    */
-  _armRendererBackstop() {
+  _armRendererBackstop(options = {}) {
     if (this._terminated || !this._iframe) return;
-    const backstop = (loadEvent) => {
+    const verifyFirstLoad = options && options.verifyFirstLoad === true;
+    let verifiedFirstLoad = false;
+    let pendingFirstLoadProbe = false;
+    let loadWhileProbePending = false;
+    const emitUnauthorizedNavigation = () => {
       if (this._terminated) return;
       // _emitSecurityEventAndTerminate is the chokepoint — fires
       // onSecurityEvent first (with details.{variant, msSinceRender}), then
@@ -4199,7 +4207,7 @@ class SHARCContainer {
       // delay — DOM-injected redirects, setTimeout-based redirects).
       // Field name is preserved across variants for grep-stable operator
       // dashboards. Phase D round-4 SRE HIGH-1; widened in Phase E.
-      void loadEvent;
+      //
       // `creativeSource` is constructor-set and stable across the
       // container's lifetime — see field doc at the constructor. Safe
       // to read at fire time; no stale-state hazard. Type is constrained
@@ -4237,6 +4245,66 @@ class SHARCContainer {
           + 'action=).',
         { variant: variant, msSinceRender: msSinceRender }
       );
+    };
+    const backstop = (loadEvent) => {
+      if (this._terminated) return;
+      if (verifyFirstLoad && !verifiedFirstLoad) {
+        if (pendingFirstLoadProbe) {
+          loadWhileProbePending = true;
+          return;
+        }
+        pendingFirstLoadProbe = true;
+        loadWhileProbePending = false;
+        const iframeWindow = this._iframe && this._iframe.contentWindow;
+        const expectedOrigin = this._rendererOrigin;
+        let timeoutId = null;
+        const cleanup = () => {
+          try { window.removeEventListener('message', onProbeAck, false); } catch (_) { /* ignore */ }
+          if (timeoutId !== null) clearTimeout(timeoutId);
+        };
+        const onProbeAck = (event) => {
+          if (this._terminated) {
+            cleanup();
+            return;
+          }
+          if (!event || event.source !== iframeWindow || event.origin !== expectedOrigin) return;
+          const data = event.data;
+          if (!data || typeof data !== 'object') return;
+          if (data.type !== 'SHARC:Renderer:loadAck') return;
+          if (data.placementSessionId !== this.placementSessionId) return;
+          cleanup();
+          verifiedFirstLoad = true;
+          pendingFirstLoadProbe = false;
+          if (loadWhileProbePending) {
+            loadWhileProbePending = false;
+            emitUnauthorizedNavigation();
+          }
+        };
+        window.addEventListener('message', onProbeAck, false);
+        timeoutId = setTimeout(() => {
+          cleanup();
+          pendingFirstLoadProbe = false;
+          loadWhileProbePending = false;
+          emitUnauthorizedNavigation();
+        }, 100);
+        try {
+          if (!iframeWindow || typeof iframeWindow.postMessage !== 'function') {
+            throw new Error('renderer contentWindow unavailable');
+          }
+          iframeWindow.postMessage({
+            type: 'SHARC:Renderer:loadProbe',
+            placementSessionId: this.placementSessionId,
+          }, expectedOrigin);
+        } catch (_) {
+          cleanup();
+          pendingFirstLoadProbe = false;
+          loadWhileProbePending = false;
+          emitUnauthorizedNavigation();
+        }
+        return;
+      }
+      void loadEvent;
+      emitUnauthorizedNavigation();
     };
     this._rendererBackstopHandler = backstop;
     this._iframe.addEventListener('load', backstop, false);

--- a/test/node/test-creative-sources-load.js
+++ b/test/node/test-creative-sources-load.js
@@ -1812,8 +1812,9 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       'post-:rendered: creativeRendered === true (sanity)');
   }
 
-  // 14b — Subsequent load event after :rendered → 2118 + onSecurityEvent
-  //       fires with type=`unauthorized_navigation`, details carries
+  // 14b — Markup consumes the expected document.write load after :rendered;
+  //       the following load event → 2118 + onSecurityEvent fires with
+  //       type=`unauthorized_navigation`, details carries
   //       variant: 'markup' (Phase E will extend with variant: 'url').
   //       console.error includes `[unauthorized_navigation]` and
   //       `[<placementSessionId>]`.
@@ -1824,13 +1825,32 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
     const errorOutput = [];
     console.error = (...args) => { errorOutput.push(args.join(' ')); };
     try {
-      // Simulate the renderer iframe navigating: dispatch a second `load`
+      // Markup's normal document.write completion can fire after :rendered
+      // because the renderer replies at DOMContentLoaded. That expected load
+      // must not be treated as navigation when the renderer answers the
+      // load-probe.
+      iframe.dispatchEvent(new dom.window.Event('load'));
+      window.dispatchEvent(new dom.window.MessageEvent('message', {
+        data: {
+          type: 'SHARC:Renderer:loadAck',
+          placementSessionId: container.placementSessionId,
+          rendererOrigin: RENDERER_ORIGIN,
+        },
+        origin: RENDERER_ORIGIN,
+        source: iframe.contentWindow,
+      }));
+      await new Promise((r) => setTimeout(r, 10));
+      assert(errors.length === 0,
+        'first post-:rendered Markup load is verified as document.write completion');
+      assert(securityEvents.length === 0,
+        'first post-:rendered Markup load does not emit unauthorized_navigation');
+      // Now simulate the renderer iframe navigating: dispatch the next `load`
       // event. (jsdom never actually navigates the cross-origin iframe; we
       // synthesize the event the browser would have fired.)
       iframe.dispatchEvent(new dom.window.Event('load'));
       // Allow the chokepoint's onSecurityEvent + console.error + handleFatalError
       // to drain.
-      await new Promise((r) => setTimeout(r, 60));
+      await new Promise((r) => setTimeout(r, 140));
     } finally {
       console.error = originalError;
     }
@@ -1876,7 +1896,33 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       'unauthorized_navigation event.timestamp is a number (Date.now)');
   }
 
-  // 14c — Backstop detached on _terminate. The iframe is removed from the
+  // 14c — If a second iframe load arrives while the first-load probe is
+  //       still pending, latch it and classify it as unauthorized after the
+  //       expected document.write load is verified.
+  {
+    const { container, errors, securityEvents } = await buildPostRender();
+    const iframe = container._iframe;
+    iframe.dispatchEvent(new dom.window.Event('load'));
+    iframe.dispatchEvent(new dom.window.Event('load'));
+    window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: {
+        type: 'SHARC:Renderer:loadAck',
+        placementSessionId: container.placementSessionId,
+        rendererOrigin: RENDERER_ORIGIN,
+      },
+      origin: RENDERER_ORIGIN,
+      source: iframe.contentWindow,
+    }));
+    await new Promise((r) => setTimeout(r, 140));
+    assert(errors.length >= 1 && errors[0].code === ErrorCodes.RENDERER_UNAUTHORIZED_NAVIGATION,
+      'load during first-load probe → classified as RENDERER_UNAUTHORIZED_NAVIGATION after ack');
+    assert(securityEvents.some((e) => e.type === 'unauthorized_navigation'),
+      'load during first-load probe → emits unauthorized_navigation');
+    assert(container._terminated === true,
+      'load during first-load probe → container terminated');
+  }
+
+  // 14d — Backstop detached on _terminate. The iframe is removed from the
   //       DOM by _terminate (so further events would be impossible anyway),
   //       but explicit detach is still verified — the field is nulled.
   {
@@ -1889,7 +1935,7 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       'post-terminate: backstop handler is nulled out (defense-in-depth detach)');
   }
 
-  // 14d — Re-entrancy: a backstop fire on an ALREADY-terminated container
+  // 14e — Re-entrancy: a backstop fire on an ALREADY-terminated container
   //       is a no-op (the chokepoint's `_terminated` guard short-circuits).
   //       Probe by manually invoking the saved backstop handler after
   //       termination — expect: no double-fire of onError or

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -640,7 +640,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
       '--render-timeout-ms',
       '4000',
       '--settle-ms',
-      '100',
+      '500',
     ], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -798,8 +798,8 @@ test('runner executes HTML cases and writes one report row per case', () => {
     const staticScriptLoadOkReport = reports.find((row) =>
       row.case.ids.bidId === 'bid-runner-static-script-load-ok');
     assert.ok(staticScriptLoadOkReport);
-    assert.equal(staticScriptLoadOkReport.outcome.status, 'failed');
-    assert.equal(staticScriptLoadOkReport.outcome.bucket, 'navigation-policy');
+    assert.equal(staticScriptLoadOkReport.outcome.status, 'passed');
+    assert.equal(staticScriptLoadOkReport.outcome.bucket, 'passed');
     assert.equal(staticScriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.count, 1);
     assert.equal(staticScriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.loadedCount, 1);
     assert.equal(staticScriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.errorCount, 0);
@@ -808,8 +808,8 @@ test('runner executes HTML cases and writes one report row per case', () => {
     const staticScriptLoadMissingReport = reports.find((row) =>
       row.case.ids.bidId === 'bid-runner-static-script-load-missing');
     assert.ok(staticScriptLoadMissingReport);
-    assert.equal(staticScriptLoadMissingReport.outcome.status, 'failed');
-    assert.equal(staticScriptLoadMissingReport.outcome.bucket, 'navigation-policy');
+    assert.equal(staticScriptLoadMissingReport.outcome.status, 'passed');
+    assert.equal(staticScriptLoadMissingReport.outcome.bucket, 'passed');
     assert.equal(staticScriptLoadMissingReport.diagnostics.navigationDiagnostics.scriptLoads.count, 1);
     assert.equal(staticScriptLoadMissingReport.diagnostics.navigationDiagnostics.scriptLoads.loadedCount, 0);
     assert.equal(staticScriptLoadMissingReport.diagnostics.navigationDiagnostics.scriptLoads.errorCount, 1);
@@ -880,11 +880,34 @@ test('runner documents external-script navigation policy boundary', () => {
       transformations: [],
     },
   });
+  const parserScriptCase = (slug, scriptSrc) => makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: `bid-runner-boundary-${slug}`,
+      impId: 'imp-runner-test',
+      crid: `creative-runner-boundary-${slug}`,
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html',
+      html: '<!doctype html><html><body><div>navigation boundary</div>'
+        + `<script src="${scriptSrc}"></script>`
+        + '</body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+  });
 
   try {
     writeFileSync(inputPath, [
       scriptCase('noop', 'navigation-boundary-noop.js'),
       scriptCase('nested-iframe', 'navigation-boundary-nested-iframe.js'),
+      parserScriptCase('parser-script-ok', '/tools/creative-validator/fixtures/navigation-boundary-noop.js'),
+      parserScriptCase('parser-script-404', 'mraid.js'),
       scriptCase('location', 'navigation-boundary-location.js'),
       scriptCase('meta-refresh', 'navigation-boundary-meta-refresh.js'),
       scriptCase('form-submit', 'navigation-boundary-form-submit.js'),
@@ -909,7 +932,7 @@ test('runner documents external-script navigation policy boundary', () => {
     });
 
     const reports = readJsonl(outPath);
-    assert.equal(reports.length, 5);
+    assert.equal(reports.length, 7);
 
     const bySlug = (slug) => reports.find((row) =>
       row.case.ids.bidId === `bid-runner-boundary-${slug}`);
@@ -947,6 +970,22 @@ test('runner documents external-script navigation policy boundary', () => {
     assert.equal(nestedIframe.outcome.bucket, 'passed');
     assert.equal(nestedIframe.outcome.terminated, false);
     assertScriptLoaded(nestedIframe);
+
+    const parserScriptOk = bySlug('parser-script-ok');
+    assert.ok(parserScriptOk);
+    assert.equal(parserScriptOk.outcome.status, 'passed');
+    assert.equal(parserScriptOk.outcome.bucket, 'passed');
+    assert.equal(parserScriptOk.outcome.terminated, false);
+    assertScriptLoaded(parserScriptOk);
+
+    const parserScript404 = bySlug('parser-script-404');
+    assert.ok(parserScript404);
+    assert.equal(parserScript404.outcome.status, 'passed');
+    assert.equal(parserScript404.outcome.bucket, 'passed');
+    assert.equal(parserScript404.outcome.terminated, false);
+    assert.equal(parserScript404.diagnostics.navigationDiagnostics.scriptLoads.count, 1);
+    assert.equal(parserScript404.diagnostics.navigationDiagnostics.scriptLoads.loadedCount, 0);
+    assert.equal(parserScript404.diagnostics.navigationDiagnostics.scriptLoads.errorCount, 1);
 
     assertNavigationPolicy(bySlug('location'));
     assertNavigationPolicy(bySlug('meta-refresh'));


### PR DESCRIPTION
## Summary
- verifies the first post-render Markup iframe load with a renderer load-probe before treating later loads as unauthorized navigation
- injects a small renderer-owned load-probe prelude into written Markup documents so normal document.write load completion can be distinguished from cross-document navigation
- updates validator coverage so static/parser script loads pass while real same-frame navigation remains navigation-policy

## Private corpus validation
- Before: 168 navigation-policy failures, including 83 Liftoff rows
- After: 0 navigation-policy failures; 180 passed / 257 skipped
- Liftoff: 83 previously failing rows now pass
- Legacy relative */mraid.js loader requests remain visible as script 404 diagnostics: 134 rows, all passed. Per the MRAID bridge design, this is a separate MRAID compatibility/routing follow-up: SHARC should intentionally capture or route that legacy loader pattern to the container/reference MRAID bridge surface, not treat it as a missing asset or a navigation-policy failure.

## Validation
- npm run build
- npm run test:creative-sources-load
- npm run test:creative-validator-runner
- npm run lint
- npx eslint tools/creative-validator/test/test-runner.js src/sharc-container.js --max-warnings=0
- git diff --check
- npm run check
- private static parser-script reduction
- private 437-case corpus run + triage