### PR TITLE
test: flag legacy MRAID loader signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   iframe creation pass, while same-frame `window.location`, meta refresh, and
   form-submit navigation bucket as `navigation-policy`.
 
+- **Creative validator legacy MRAID loader signal.** Executable report rows
+  now flag `mraid.js` script requests as legacy MRAID loader signals and
+  distinguish declared, sniffed, and runtime-only MRAID evidence without
+  changing pass/fail classification. Private triage aggregates the signal by
+  bidder, diagnosis bucket, adm kind, API declaration, and load/error counts.
+
 ### Fixed
 
 - **Creative Markup document-load backstop.** Markup containers now consume the

--- a/tools/creative-validator/fixtures/legacy-mraid-loader/mraid.js
+++ b/tools/creative-validator/fixtures/legacy-mraid-loader/mraid.js
@@ -1,0 +1,1 @@
+window.__sharcValidatorLegacyMraidLoaderFixture = true;

--- a/tools/creative-validator/src/runner.js
+++ b/tools/creative-validator/src/runner.js
@@ -214,6 +214,17 @@ function summarizeRequestOrigin(url) {
   }
 }
 
+function isLegacyMraidLoaderUrl(url) {
+  try {
+    const parsed = new URL(url, 'http://validator.invalid/');
+    const parts = parsed.pathname.toLowerCase().split('/');
+    return parts[parts.length - 1] === 'mraid.js';
+  } catch (_) {
+    const pathname = String(url || '').split('?')[0].toLowerCase();
+    return pathname.endsWith('/mraid.js') || pathname === 'mraid.js';
+  }
+}
+
 function summarizeScriptUrl(url) {
   try {
     const parsed = new URL(url);
@@ -221,9 +232,15 @@ function summarizeScriptUrl(url) {
       present: true,
       protocol: parsed.protocol,
       origin: parsed.origin === 'null' ? null : parsed.origin,
+      legacyMraidLoader: isLegacyMraidLoaderUrl(url),
     };
   } catch (_) {
-    return { present: true, protocol: 'invalid', origin: null };
+    return {
+      present: true,
+      protocol: 'invalid',
+      origin: null,
+      legacyMraidLoader: isLegacyMraidLoaderUrl(url),
+    };
   }
 }
 
@@ -314,6 +331,18 @@ function backfillScriptLoadDiagnostics(navigationDiagnostics, scriptOutcomes) {
   const scriptLoads = navigationDiagnostics && navigationDiagnostics.scriptLoads;
   if (!scriptLoads || !Array.isArray(scriptLoads.calls)) return;
 
+  const legacyMraidByKey = {};
+  for (const outcome of scriptOutcomes) {
+    if (outcome && outcome.url && outcome.url.legacyMraidLoader === true) {
+      legacyMraidByKey[scriptOutcomeKey(outcome)] = true;
+    }
+  }
+  for (const call of scriptLoads.calls) {
+    if (call && call.url && legacyMraidByKey[scriptCallKey(call)] === true) {
+      call.url.legacyMraidLoader = true;
+    }
+  }
+
   const terminalByKey = {};
   for (const call of scriptLoads.calls) {
     if (!call || (call.status !== 'loaded' && call.status !== 'error')) continue;
@@ -345,7 +374,7 @@ function backfillScriptLoadDiagnostics(navigationDiagnostics, scriptOutcomes) {
       scriptLoads.calls.push({
         status,
         lifecycle: call.lifecycle || {},
-        url: call.url || {},
+        url: outcome.url || call.url || {},
         async: call.async === true,
         defer: call.defer === true,
         type: call.type || '',
@@ -357,6 +386,97 @@ function backfillScriptLoadDiagnostics(navigationDiagnostics, scriptOutcomes) {
       delete call.urlHash;
     }
   }
+}
+
+function bridgeSignalList(testCase, name) {
+  const values = testCase
+    && testCase.expectations
+    && Array.isArray(testCase.expectations[name])
+    ? testCase.expectations[name]
+    : [];
+  return values.map((value) => String(value).toLowerCase());
+}
+
+function summarizeLegacyMraidLoader(testCase, run) {
+  const declared = bridgeSignalList(testCase, 'declared').includes('mraid');
+  const sniffed = bridgeSignalList(testCase, 'sniffed').includes('mraid');
+  const summary = {
+    requested: false,
+    count: 0,
+    loadedCount: 0,
+    errorCount: 0,
+    byStatus: {},
+    byProtocol: {},
+    byOrigin: {},
+    signal: {
+      declared,
+      sniffed,
+      runtimeOnly: false,
+    },
+  };
+  const scriptLoads = run
+    && run.navigationDiagnostics
+    && run.navigationDiagnostics.scriptLoads;
+  const calls = scriptLoads && Array.isArray(scriptLoads.calls) ? scriptLoads.calls : [];
+  const scriptOutcomes = run && Array.isArray(run.scriptOutcomes) ? run.scriptOutcomes : [];
+  const discoveredByKey = {};
+  const terminalByKey = {};
+
+  for (const call of calls) {
+    if (!call || !call.url || call.url.legacyMraidLoader !== true) continue;
+    const status = call.status || 'unknown';
+    const key = scriptCallKey(call);
+    incrementBucket(summary.byStatus, status);
+    incrementBucket(summary.byProtocol, call.url.protocol);
+    incrementBucket(summary.byOrigin, call.url.origin);
+    if (status === 'discovered') {
+      incrementBucket(discoveredByKey, key);
+      summary.count += 1;
+    } else if (status === 'loaded') {
+      incrementBucket(terminalByKey, key);
+      summary.loadedCount += 1;
+    } else if (status === 'error') {
+      incrementBucket(terminalByKey, key);
+      summary.errorCount += 1;
+    }
+  }
+
+  for (const outcome of scriptOutcomes) {
+    if (!outcome || !outcome.url || outcome.url.legacyMraidLoader !== true) continue;
+    const key = scriptOutcomeKey(outcome);
+    const status = outcome.status >= 400 || outcome.failed === true ? 'error' : 'loaded';
+    if (discoveredByKey[key] > 0) {
+      discoveredByKey[key] -= 1;
+    } else {
+      summary.count += 1;
+    }
+    if (terminalByKey[key] > 0) {
+      terminalByKey[key] -= 1;
+      continue;
+    }
+    incrementBucket(summary.byStatus, status);
+    incrementBucket(summary.byProtocol, outcome.url.protocol);
+    incrementBucket(summary.byOrigin, outcome.url.origin);
+    if (status === 'loaded') summary.loadedCount += 1;
+    else if (status === 'error') summary.errorCount += 1;
+  }
+
+  if (summary.count === 0 && summary.loadedCount === 0 && summary.errorCount === 0) {
+    const failedScripts = [
+      ...((run && run.failedRequests) || []),
+      ...((run && run.failedResponses) || []),
+    ].filter((entry) => entry && entry.resourceType === 'script' && isLegacyMraidLoaderUrl(entry.url));
+    for (const entry of failedScripts) {
+      summary.count += 1;
+      summary.errorCount += 1;
+      incrementBucket(summary.byStatus, entry.status ? String(entry.status) : 'error');
+      incrementBucket(summary.byOrigin, summarizeRequestOrigin(entry.url));
+    }
+  }
+
+  summary.requested = summary.count > 0 || summary.loadedCount > 0 || summary.errorCount > 0;
+  summary.signal.runtimeOnly = summary.requested && !declared && !sniffed;
+  return summary;
 }
 
 function chromeLaunchArgs() {
@@ -410,17 +530,20 @@ async function runExecutableCase(browser, testCase, options) {
       });
     }
   });
+  page.on('requestfinished', (request) => {
+    if (isFaviconRequest(request.url())) return;
+    if (request.resourceType() !== 'script') return;
+    const response = request.response();
+    scriptOutcomes.push({
+      urlHash: hashUrl(request.url()),
+      url: summarizeScriptUrl(request.url()),
+      failed: false,
+      status: response ? response.status() : 0,
+    });
+  });
   page.on('response', (response) => {
     const status = response.status();
     const request = response.request();
-    if (!isFaviconRequest(response.url()) && request.resourceType() === 'script') {
-      scriptOutcomes.push({
-        urlHash: hashUrl(response.url()),
-        url: summarizeScriptUrl(response.url()),
-        failed: false,
-        status,
-      });
-    }
     if (status < 400) return;
     if (isFaviconRequest(response.url())) return;
     failedResponses.push({
@@ -464,6 +587,7 @@ async function runExecutableCase(browser, testCase, options) {
         pageErrors,
         failedRequests,
         failedResponses,
+        scriptOutcomes,
       };
     }
 
@@ -485,6 +609,7 @@ async function runExecutableCase(browser, testCase, options) {
       pageErrors,
       failedRequests,
       failedResponses,
+      scriptOutcomes,
     };
   } catch (err) {
     return makeEmptyRun({
@@ -493,6 +618,7 @@ async function runExecutableCase(browser, testCase, options) {
       pageErrors,
       failedRequests,
       failedResponses,
+      scriptOutcomes,
     });
   } finally {
     await context.close();
@@ -538,6 +664,7 @@ function buildReport(testCase, run) {
       failedRequests: run.failedRequests,
       failedResponses: run.failedResponses,
       network: summarizeNetwork(run),
+      legacyMraidLoader: summarizeLegacyMraidLoader(testCase, run),
     },
   };
 }

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -58,6 +58,17 @@ function emptySummary(files) {
         byCorsConsoleCount: {},
         byCspConsoleCount: {},
       },
+      legacyMraidLoader: {
+        byPresence: {},
+        bySignal: {},
+        byStatus: {},
+        byBucket: {},
+        byBidder: {},
+        byAdmKind: {},
+        byApi: {},
+        byErrorCount: {},
+        byLoadedCount: {},
+      },
     },
     failureGroups: [],
     reductionCandidates: [],
@@ -105,6 +116,12 @@ function networkDiagnostics(row) {
 function navigationDiagnostics(row) {
   return row && row.diagnostics && row.diagnostics.navigationDiagnostics
     ? row.diagnostics.navigationDiagnostics
+    : {};
+}
+
+function legacyMraidLoaderDiagnostics(row) {
+  return row && row.diagnostics && row.diagnostics.legacyMraidLoader
+    ? row.diagnostics.legacyMraidLoader
     : {};
 }
 
@@ -231,6 +248,31 @@ function addDiagnosticFacets(summary, row) {
   }
 }
 
+function legacyMraidSignalKey(legacy) {
+  const signal = legacy && legacy.signal ? legacy.signal : {};
+  if (signal.declared === true && signal.sniffed === true) return 'declared+sniffed';
+  if (signal.declared === true) return 'declared-only';
+  if (signal.sniffed === true) return 'sniffed-only';
+  if (signal.runtimeOnly === true) return 'runtime-only';
+  return 'unknown';
+}
+
+function addCorpusFacets(summary, row, fields) {
+  const legacy = legacyMraidLoaderDiagnostics(row);
+  const requested = legacy.requested === true;
+  increment(summary.diagnostics.legacyMraidLoader.byPresence, requested ? 'present' : 'absent');
+  if (!requested) return;
+
+  increment(summary.diagnostics.legacyMraidLoader.bySignal, legacyMraidSignalKey(legacy));
+  increment(summary.diagnostics.legacyMraidLoader.byStatus, fields.status);
+  increment(summary.diagnostics.legacyMraidLoader.byBucket, fields.bucket);
+  increment(summary.diagnostics.legacyMraidLoader.byBidder, fields.bidder);
+  increment(summary.diagnostics.legacyMraidLoader.byAdmKind, fields.admKind);
+  increment(summary.diagnostics.legacyMraidLoader.byApi, fields.api);
+  increment(summary.diagnostics.legacyMraidLoader.byErrorCount, networkCount(legacy.errorCount));
+  increment(summary.diagnostics.legacyMraidLoader.byLoadedCount, networkCount(legacy.loadedCount));
+}
+
 function reportFields(row) {
   const source = (row.case && row.case.source) || {};
   const creative = (row.case && row.case.creative) || {};
@@ -341,6 +383,7 @@ function triageReports(files) {
       for (const bridge of expectedBridgeKeys(row)) {
         increment(summary.byExpectedBridge, bridge);
       }
+      addCorpusFacets(summary, row, fields);
 
       if (fields.status === 'passed') summary.totals.passed += 1;
       else if (fields.status === 'skipped') summary.totals.skipped += 1;
@@ -402,6 +445,24 @@ function triageReports(files) {
     sortEntries(summary.diagnostics.network.byCorsConsoleCount, { numericKeys: true });
   summary.diagnostics.network.byCspConsoleCount =
     sortEntries(summary.diagnostics.network.byCspConsoleCount, { numericKeys: true });
+  summary.diagnostics.legacyMraidLoader.byPresence =
+    sortEntries(summary.diagnostics.legacyMraidLoader.byPresence);
+  summary.diagnostics.legacyMraidLoader.bySignal =
+    sortEntries(summary.diagnostics.legacyMraidLoader.bySignal);
+  summary.diagnostics.legacyMraidLoader.byStatus =
+    sortEntries(summary.diagnostics.legacyMraidLoader.byStatus);
+  summary.diagnostics.legacyMraidLoader.byBucket =
+    sortEntries(summary.diagnostics.legacyMraidLoader.byBucket);
+  summary.diagnostics.legacyMraidLoader.byBidder =
+    sortEntries(summary.diagnostics.legacyMraidLoader.byBidder);
+  summary.diagnostics.legacyMraidLoader.byAdmKind =
+    sortEntries(summary.diagnostics.legacyMraidLoader.byAdmKind);
+  summary.diagnostics.legacyMraidLoader.byApi =
+    sortEntries(summary.diagnostics.legacyMraidLoader.byApi);
+  summary.diagnostics.legacyMraidLoader.byErrorCount =
+    sortEntries(summary.diagnostics.legacyMraidLoader.byErrorCount, { numericKeys: true });
+  summary.diagnostics.legacyMraidLoader.byLoadedCount =
+    sortEntries(summary.diagnostics.legacyMraidLoader.byLoadedCount, { numericKeys: true });
   summary.failureGroups = sortedGroups(failureGroups);
   summary.reductionCandidates = summary.failureGroups
     .filter(isReductionCandidate)

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -581,6 +581,99 @@ test('runner executes HTML cases and writes one report row per case', () => {
       transformations: [],
     },
   });
+  const legacyMraidLoaderRuntimeOnly = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-legacy-mraid-loader-runtime-only',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-legacy-mraid-loader-runtime-only',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html',
+      html: '<!doctype html><html><body><script src="mraid.js"></script></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+  });
+  const legacyMraidLoaderDeclared = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-legacy-mraid-loader-declared',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-legacy-mraid-loader-declared',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html-mraid',
+      html: '<!doctype html><html><body><script src="mraid.js"></script></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+    bidSignals: {
+      apis: { raw: [5], sanitized: [5], sources: [{ path: 'bid.api', values: [5], role: 'bid' }] },
+      mtype: 'banner',
+      adomain: ['runner.example'],
+      cat: [],
+      battr: [],
+      attr: [],
+      placement: { id: 'imp-runner-test', instl: 0, secure: 1, mediaTypes: ['banner'] },
+      measurement: { omid: { declaredByApi: false, sidecarPresent: false, sources: [] } },
+    },
+    expectations: {
+      declared: ['mraid'],
+      sniffed: ['mraid'],
+      execute: true,
+      skipReason: null,
+    },
+    sharcOptions: {
+      creativeMeta: { apis: [5] },
+      requireSharcInit: false,
+      placementType: 'inline',
+    },
+  });
+  const legacyMraidLoaderAfterCallCap = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-legacy-mraid-loader-after-call-cap',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-legacy-mraid-loader-after-call-cap',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html',
+      html: '<!doctype html><html><body><script>'
+        + 'window.addEventListener("load",function(){'
+        + 'for(var i=0;i<20;i++){'
+        + 'var script=document.createElement("script");'
+        + 'script.src="/tools/creative-validator/fixtures/script-load-ok.js?i="+i;'
+        + 'document.body.appendChild(script);'
+        + '}'
+        + 'function appendMraidScript(index){'
+        + 'var mraidScript=document.createElement("script");'
+        + 'mraidScript.src="/tools/creative-validator/fixtures/legacy-mraid-loader/mraid.js";'
+        + 'if(index<1){mraidScript.onload=function(){appendMraidScript(index+1)};}'
+        + 'document.body.appendChild(mraidScript);'
+        + '}'
+        + 'appendMraidScript(0);'
+        + '});'
+        + '</script></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+  });
   const skipped = makeCase({
     ids: {
       requestId: 'request-runner-test',
@@ -625,6 +718,9 @@ test('runner executes HTML cases and writes one report row per case', () => {
       scriptLoadNavigation,
       staticScriptLoadOk,
       staticScriptLoadMissing,
+      legacyMraidLoaderRuntimeOnly,
+      legacyMraidLoaderDeclared,
+      legacyMraidLoaderAfterCallCap,
       skipped,
     ].map((item) => JSON.stringify(item)).join('\n') + '\n');
     execFileSync('node', [
@@ -647,7 +743,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
     });
 
     const reports = readJsonl(outPath);
-    assert.equal(reports.length, 17);
+    assert.equal(reports.length, 20);
 
     const htmlReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-test');
     assert.ok(htmlReport);
@@ -814,6 +910,43 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(staticScriptLoadMissingReport.diagnostics.navigationDiagnostics.scriptLoads.loadedCount, 0);
     assert.equal(staticScriptLoadMissingReport.diagnostics.navigationDiagnostics.scriptLoads.errorCount, 1);
     assert.equal(staticScriptLoadMissingReport.diagnostics.navigationDiagnostics.scriptLoads.byStatus.error, 1);
+
+    const legacyRuntimeReport = reports.find((row) =>
+      row.case.ids.bidId === 'bid-runner-legacy-mraid-loader-runtime-only');
+    assert.ok(legacyRuntimeReport);
+    assert.equal(legacyRuntimeReport.outcome.status, 'passed');
+    assert.equal(legacyRuntimeReport.outcome.bucket, 'passed');
+    assert.equal(legacyRuntimeReport.diagnostics.legacyMraidLoader.requested, true);
+    assert.ok(legacyRuntimeReport.diagnostics.legacyMraidLoader.count >= 1);
+    assert.equal(legacyRuntimeReport.diagnostics.legacyMraidLoader.loadedCount, 0);
+    assert.ok(legacyRuntimeReport.diagnostics.legacyMraidLoader.errorCount >= 1);
+    assert.ok(legacyRuntimeReport.diagnostics.legacyMraidLoader.byStatus.discovered >= 1);
+    assert.ok(legacyRuntimeReport.diagnostics.legacyMraidLoader.byStatus.error >= 1);
+    assert.equal(legacyRuntimeReport.diagnostics.legacyMraidLoader.signal.declared, false);
+    assert.equal(legacyRuntimeReport.diagnostics.legacyMraidLoader.signal.sniffed, false);
+    assert.equal(legacyRuntimeReport.diagnostics.legacyMraidLoader.signal.runtimeOnly, true);
+
+    const legacyDeclaredReport = reports.find((row) =>
+      row.case.ids.bidId === 'bid-runner-legacy-mraid-loader-declared');
+    assert.ok(legacyDeclaredReport);
+    assert.equal(legacyDeclaredReport.outcome.status, 'passed');
+    assert.equal(legacyDeclaredReport.diagnostics.legacyMraidLoader.requested, true);
+    assert.ok(legacyDeclaredReport.diagnostics.legacyMraidLoader.count >= 1);
+    assert.equal(legacyDeclaredReport.diagnostics.legacyMraidLoader.signal.declared, true);
+    assert.equal(legacyDeclaredReport.diagnostics.legacyMraidLoader.signal.sniffed, true);
+    assert.equal(legacyDeclaredReport.diagnostics.legacyMraidLoader.signal.runtimeOnly, false);
+
+    const legacyAfterCallCapReport = reports.find((row) =>
+      row.case.ids.bidId === 'bid-runner-legacy-mraid-loader-after-call-cap');
+    assert.ok(legacyAfterCallCapReport);
+    assert.equal(legacyAfterCallCapReport.outcome.status, 'passed');
+    assert.equal(legacyAfterCallCapReport.diagnostics.navigationDiagnostics.scriptLoads.count, 22);
+    assert.equal(legacyAfterCallCapReport.diagnostics.navigationDiagnostics.scriptLoads.calls.length, 20);
+    assert.equal(legacyAfterCallCapReport.diagnostics.legacyMraidLoader.requested, true);
+    assert.equal(legacyAfterCallCapReport.diagnostics.legacyMraidLoader.count, 2);
+    assert.equal(legacyAfterCallCapReport.diagnostics.legacyMraidLoader.loadedCount, 2);
+    assert.equal(legacyAfterCallCapReport.diagnostics.legacyMraidLoader.errorCount, 0);
+    assert.equal(legacyAfterCallCapReport.diagnostics.legacyMraidLoader.signal.runtimeOnly, true);
 
     const nativeReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-native');
     assert.ok(nativeReport);
@@ -986,6 +1119,8 @@ test('runner documents external-script navigation policy boundary', () => {
     assert.equal(parserScript404.diagnostics.navigationDiagnostics.scriptLoads.count, 1);
     assert.equal(parserScript404.diagnostics.navigationDiagnostics.scriptLoads.loadedCount, 0);
     assert.equal(parserScript404.diagnostics.navigationDiagnostics.scriptLoads.errorCount, 1);
+    assert.equal(parserScript404.diagnostics.legacyMraidLoader.requested, true);
+    assert.equal(parserScript404.diagnostics.legacyMraidLoader.signal.runtimeOnly, true);
 
     assertNavigationPolicy(bySlug('location'));
     assertNavigationPolicy(bySlug('meta-refresh'));

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -204,6 +204,45 @@ test('triageReports groups private report rows by failure dimensions', () => {
       report({
         case: {
           ...report().case,
+          source: { ...report().case.source, bidder: 'bidder-c', rowIndex: 20 },
+          ids: { bidId: 'bid-runtime-mraid', crid: 'creative-runtime-mraid' },
+          creative: { admKind: 'html' },
+          expectations: { declared: [], sniffed: [] },
+          bidSignals: { ...report().case.bidSignals, apis: { sanitized: [] } },
+        },
+        outcome: { status: 'passed', bucket: 'passed' },
+        diagnostics: {
+          legacyMraidLoader: {
+            requested: true,
+            count: 1,
+            loadedCount: 0,
+            errorCount: 1,
+            byStatus: { discovered: 1, error: 1 },
+            signal: { declared: false, sniffed: false, runtimeOnly: true },
+          },
+        },
+      }),
+      report({
+        case: {
+          ...report().case,
+          source: { ...report().case.source, rowIndex: 21 },
+          ids: { bidId: 'bid-declared-mraid', crid: 'creative-declared-mraid' },
+        },
+        outcome: { status: 'passed', bucket: 'passed' },
+        diagnostics: {
+          legacyMraidLoader: {
+            requested: true,
+            count: 1,
+            loadedCount: 1,
+            errorCount: 0,
+            byStatus: { discovered: 1, loaded: 1 },
+            signal: { declared: true, sniffed: false, runtimeOnly: false },
+          },
+        },
+      }),
+      report({
+        case: {
+          ...report().case,
           source: { ...report().case.source, rowIndex: 3 },
           ids: { bidId: 'bid-4', crid: 'creative-4' },
         },
@@ -244,8 +283,8 @@ test('triageReports groups private report rows by failure dimensions', () => {
     ]);
 
     const summary = triageReports([reportPath]);
-    assert.equal(summary.totals.reports, 7);
-    assert.equal(summary.totals.passed, 1);
+    assert.equal(summary.totals.reports, 9);
+    assert.equal(summary.totals.passed, 3);
     assert.equal(summary.totals.failed, 4);
     assert.equal(summary.totals.skipped, 1);
     assert.equal(summary.totals.other, 1);
@@ -253,13 +292,13 @@ test('triageReports groups private report rows by failure dimensions', () => {
       summary.totals.passed + summary.totals.failed + summary.totals.skipped + summary.totals.other,
       summary.totals.reports,
     );
-    assert.deepEqual(summary.byStatus, { failed: 4, error: 1, passed: 1, skipped: 1 });
+    assert.deepEqual(summary.byStatus, { failed: 4, passed: 3, error: 1, skipped: 1 });
     assert.equal(summary.byBucket['bridge-missing'], 4);
-    assert.equal(summary.byBidder['bidder-a'], 6);
-    assert.equal(summary.byMtype.banner, 7);
-    assert.equal(summary.byAdmKind['html-mraid'], 6);
-    assert.equal(summary.byApi['5'], 6);
-    assert.equal(summary.byExpectedBridge.mraid, 6);
+    assert.equal(summary.byBidder['bidder-a'], 7);
+    assert.equal(summary.byMtype.banner, 9);
+    assert.equal(summary.byAdmKind['html-mraid'], 7);
+    assert.equal(summary.byApi['5'], 7);
+    assert.equal(summary.byExpectedBridge.mraid, 7);
     assert.equal(summary.diagnostics.bySecurityEvent.unauthorized_navigation, 1);
     assert.equal(summary.diagnostics.bySecurityEvent.bridge_load_failed, 1);
     assert.equal(summary.diagnostics.bySecurityEvent.renderer_failed, 2);
@@ -312,6 +351,24 @@ test('triageReports groups private report rows by failure dimensions', () => {
     assert.deepEqual(Object.keys(summary.diagnostics.network.byFailedResponseCount), ['0', '1', '2', '10']);
     assert.equal(summary.diagnostics.network.byCorsConsoleCount['1'], 1);
     assert.equal(summary.diagnostics.network.byCspConsoleCount['1'], 1);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byPresence.present, 2);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byPresence.absent, 7);
+    assert.equal(summary.diagnostics.legacyMraidLoader.bySignal['runtime-only'], 1);
+    assert.equal(summary.diagnostics.legacyMraidLoader.bySignal['declared-only'], 1);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byStatus.passed, 2);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byStatus.failed, undefined);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byBucket.passed, 2);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byBucket['bridge-missing'], undefined);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byBidder['bidder-a'], 1);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byBidder['bidder-c'], 1);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byAdmKind.html, 1);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byAdmKind['html-mraid'], 1);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byApi.none, 1);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byApi['5'], 1);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byErrorCount['0'], 1);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byErrorCount['1'], 1);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byLoadedCount['0'], 1);
+    assert.equal(summary.diagnostics.legacyMraidLoader.byLoadedCount['1'], 1);
     assert.equal(summary.failureGroups.length, 1);
     assert.equal(summary.failureGroups[0].bucket, 'bridge-missing');
     assert.equal(summary.failureGroups[0].count, 4);


### PR DESCRIPTION
## Summary
- add privacy-preserving `diagnostics.legacyMraidLoader` report data for script requests ending in `mraid.js`
- split the signal into declared, sniffed, and runtime-only MRAID evidence without changing pass/fail classification
- add corpus-level triage facets for legacy loader presence by bidder, bucket, adm kind, API declaration, and load/error counts

## Private corpus check
Ran the 437-row private OpenRTB corpus with the new diagnostic:
- status: 180 passed, 257 skipped, 0 failed
- legacy MRAID loader present: 131 rows
- signal split: 103 declared-only, 28 declared+sniffed, 0 runtime-only
- all 131 legacy-loader rows passed; all had loader errors and zero loaded `mraid.js` scripts

Top bidders for the signal: liftoff 83, loopme 17, aarki 6, kayzen 6, rubiconweststatic 6, rubiconstatic 5.

## Validation
- npm run build
- npm run test:creative-validator-runner
- npm run test:creative-validator-triage
- npx eslint tools/creative-validator/src/runner.js tools/creative-validator/src/triage.js tools/creative-validator/test/test-runner.js tools/creative-validator/test/test-triage.js --max-warnings=0
- git diff --check
- npm run check
