### PR TITLE
test: add corpus runtime triage facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,14 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   changing pass/fail classification. Private triage aggregates the signal by
   bidder, diagnosis bucket, adm kind, API declaration, and load/error counts.
 
+- **Creative validator corpus runtime facets.** Private triage summaries now
+  include all-report `corpusDiagnostics` for non-fatal script-load and network
+  signals, including passed rows. The facets aggregate script load/error
+  counts, script origins/protocols, failed request/response shapes, CORS/CSP
+  console rows, and failed-document clusters without storing raw creative
+  markup. The summary remains private-tier because real bidder names and
+  script origins are preserved as aggregate keys.
+
 ### Fixed
 
 - **Creative Markup document-load backstop.** Markup containers now consume the

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -156,6 +156,14 @@ count/method/protocol. Script-load facets summarize failed rows by script count,
 load/error count, protocol, origin, and load status so navigation-policy
 clusters can be split by likely trigger mechanism.
 
+The `corpusDiagnostics` section covers the full report set, including passed
+rows. Use it for non-fatal runtime signals such as external script-load errors,
+CORS/CSP-like console output, failed document probes, and bidder-specific
+clusters after the fatal failure count is already zero. These facets are
+aggregate-only and still avoid raw creative markup. They are still private-tier:
+the facets key by real bidder names and script origins, so summaries must not
+be shared with bidders.
+
 The runner tests also document the current navigation-policy boundary for
 external scripts: a script that loads and does nothing passes; a script that
 creates a nested iframe passes; a script that navigates the renderer document

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -70,6 +70,41 @@ function emptySummary(files) {
         byLoadedCount: {},
       },
     },
+    corpusDiagnostics: {
+      scriptLoads: {
+        rowsWithScripts: 0,
+        rowsWithErrors: 0,
+        rowsWithLoaded: 0,
+        rowsWithErrorsByBidder: {},
+        rowsWithErrorsByAdmKind: {},
+        rowsWithErrorsByLegacyMraidLoader: {},
+        byCount: {},
+        byLoadedCount: {},
+        byErrorCount: {},
+        byProtocol: {},
+        byOrigin: {},
+        byStatus: {},
+      },
+      network: {
+        rowsWithFailedRequests: 0,
+        rowsWithFailedResponses: 0,
+        rowsWithCorsConsole: 0,
+        rowsWithCspConsole: 0,
+        rowsWithFailedDocuments: 0,
+        byShape: {},
+        byFailedRequestCount: {},
+        byFailedResponseCount: {},
+        byCorsConsoleCount: {},
+        byCspConsoleCount: {},
+        failedRowsByBidder: {},
+        failedRowsByAdmKind: {},
+        corsRowsByBidder: {},
+        cspRowsByBidder: {},
+        failedDocumentRowsByBidder: {},
+        failedResourceType: {},
+        failedResponseStatus: {},
+      },
+    },
     failureGroups: [],
     reductionCandidates: [],
   };
@@ -273,6 +308,91 @@ function addCorpusFacets(summary, row, fields) {
   increment(summary.diagnostics.legacyMraidLoader.byLoadedCount, networkCount(legacy.loadedCount));
 }
 
+function addRuntimeCorpusFacets(summary, row, fields) {
+  const navigation = navigationDiagnostics(row);
+  const scriptLoads = navigation.scriptLoads || {};
+  const scriptCount = networkCount(scriptLoads.count);
+  const scriptErrorCount = networkCount(scriptLoads.errorCount);
+  const scriptLoadedCount = networkCount(scriptLoads.loadedCount);
+  if (scriptCount > 0) {
+    summary.corpusDiagnostics.scriptLoads.rowsWithScripts += 1;
+    increment(summary.corpusDiagnostics.scriptLoads.byCount, scriptCount);
+    increment(summary.corpusDiagnostics.scriptLoads.byLoadedCount, scriptLoadedCount);
+    increment(summary.corpusDiagnostics.scriptLoads.byErrorCount, scriptErrorCount);
+    if (scriptErrorCount > 0) {
+      summary.corpusDiagnostics.scriptLoads.rowsWithErrors += 1;
+      increment(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByBidder, fields.bidder);
+      increment(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByAdmKind, fields.admKind);
+      increment(
+        summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByLegacyMraidLoader,
+        legacyMraidLoaderDiagnostics(row).requested === true ? 'present' : 'absent',
+      );
+    }
+    if (scriptLoadedCount > 0) {
+      summary.corpusDiagnostics.scriptLoads.rowsWithLoaded += 1;
+    }
+  }
+  const scriptByProtocol = scriptLoads.byProtocol || {};
+  for (const [protocol, count] of Object.entries(scriptByProtocol)) {
+    if (networkCount(count) > 0) {
+      increment(summary.corpusDiagnostics.scriptLoads.byProtocol, protocol, networkCount(count));
+    }
+  }
+  const scriptByOrigin = scriptLoads.byOrigin || {};
+  for (const [origin, count] of Object.entries(scriptByOrigin)) {
+    if (networkCount(count) > 0) {
+      increment(summary.corpusDiagnostics.scriptLoads.byOrigin, origin, networkCount(count));
+    }
+  }
+  const scriptByStatus = scriptLoads.byStatus || {};
+  for (const [status, count] of Object.entries(scriptByStatus)) {
+    if (networkCount(count) > 0) {
+      increment(summary.corpusDiagnostics.scriptLoads.byStatus, status, networkCount(count));
+    }
+  }
+
+  const network = networkDiagnostics(row);
+  const failedRequestCount = networkCount(network.failedRequestCount);
+  const failedResponseCount = networkCount(network.failedResponseCount);
+  const corsConsoleCount = networkCount(network.corsConsoleCount);
+  const cspConsoleCount = networkCount(network.cspConsoleCount);
+  increment(summary.corpusDiagnostics.network.byShape, networkShape(network));
+  increment(summary.corpusDiagnostics.network.byFailedRequestCount, failedRequestCount);
+  increment(summary.corpusDiagnostics.network.byFailedResponseCount, failedResponseCount);
+  increment(summary.corpusDiagnostics.network.byCorsConsoleCount, corsConsoleCount);
+  increment(summary.corpusDiagnostics.network.byCspConsoleCount, cspConsoleCount);
+  if (failedRequestCount > 0) summary.corpusDiagnostics.network.rowsWithFailedRequests += 1;
+  if (failedResponseCount > 0) summary.corpusDiagnostics.network.rowsWithFailedResponses += 1;
+  if (failedRequestCount > 0 || failedResponseCount > 0) {
+    increment(summary.corpusDiagnostics.network.failedRowsByBidder, fields.bidder);
+    increment(summary.corpusDiagnostics.network.failedRowsByAdmKind, fields.admKind);
+  }
+  if (corsConsoleCount > 0) {
+    summary.corpusDiagnostics.network.rowsWithCorsConsole += 1;
+    increment(summary.corpusDiagnostics.network.corsRowsByBidder, fields.bidder);
+  }
+  if (cspConsoleCount > 0) {
+    summary.corpusDiagnostics.network.rowsWithCspConsole += 1;
+    increment(summary.corpusDiagnostics.network.cspRowsByBidder, fields.bidder);
+  }
+  const failedResourceType = network.byResourceType || {};
+  for (const [resourceType, count] of Object.entries(failedResourceType)) {
+    if (networkCount(count) > 0) {
+      increment(summary.corpusDiagnostics.network.failedResourceType, resourceType, networkCount(count));
+    }
+  }
+  if (networkCount(failedResourceType.document) > 0) {
+    summary.corpusDiagnostics.network.rowsWithFailedDocuments += 1;
+    increment(summary.corpusDiagnostics.network.failedDocumentRowsByBidder, fields.bidder);
+  }
+  const failedResponseStatus = network.byStatus || {};
+  for (const [status, count] of Object.entries(failedResponseStatus)) {
+    if (networkCount(count) > 0) {
+      increment(summary.corpusDiagnostics.network.failedResponseStatus, status, networkCount(count));
+    }
+  }
+}
+
 function reportFields(row) {
   const source = (row.case && row.case.source) || {};
   const creative = (row.case && row.case.creative) || {};
@@ -384,6 +504,7 @@ function triageReports(files) {
         increment(summary.byExpectedBridge, bridge);
       }
       addCorpusFacets(summary, row, fields);
+      addRuntimeCorpusFacets(summary, row, fields);
 
       if (fields.status === 'passed') summary.totals.passed += 1;
       else if (fields.status === 'skipped') summary.totals.skipped += 1;
@@ -463,6 +584,48 @@ function triageReports(files) {
     sortEntries(summary.diagnostics.legacyMraidLoader.byErrorCount, { numericKeys: true });
   summary.diagnostics.legacyMraidLoader.byLoadedCount =
     sortEntries(summary.diagnostics.legacyMraidLoader.byLoadedCount, { numericKeys: true });
+  summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByBidder =
+    sortEntries(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByBidder);
+  summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByAdmKind =
+    sortEntries(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByAdmKind);
+  summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByLegacyMraidLoader =
+    sortEntries(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByLegacyMraidLoader);
+  summary.corpusDiagnostics.scriptLoads.byCount =
+    sortEntries(summary.corpusDiagnostics.scriptLoads.byCount, { numericKeys: true });
+  summary.corpusDiagnostics.scriptLoads.byLoadedCount =
+    sortEntries(summary.corpusDiagnostics.scriptLoads.byLoadedCount, { numericKeys: true });
+  summary.corpusDiagnostics.scriptLoads.byErrorCount =
+    sortEntries(summary.corpusDiagnostics.scriptLoads.byErrorCount, { numericKeys: true });
+  summary.corpusDiagnostics.scriptLoads.byProtocol =
+    sortEntries(summary.corpusDiagnostics.scriptLoads.byProtocol);
+  summary.corpusDiagnostics.scriptLoads.byOrigin =
+    sortEntries(summary.corpusDiagnostics.scriptLoads.byOrigin);
+  summary.corpusDiagnostics.scriptLoads.byStatus =
+    sortEntries(summary.corpusDiagnostics.scriptLoads.byStatus);
+  summary.corpusDiagnostics.network.byShape =
+    sortEntries(summary.corpusDiagnostics.network.byShape);
+  summary.corpusDiagnostics.network.byFailedRequestCount =
+    sortEntries(summary.corpusDiagnostics.network.byFailedRequestCount, { numericKeys: true });
+  summary.corpusDiagnostics.network.byFailedResponseCount =
+    sortEntries(summary.corpusDiagnostics.network.byFailedResponseCount, { numericKeys: true });
+  summary.corpusDiagnostics.network.byCorsConsoleCount =
+    sortEntries(summary.corpusDiagnostics.network.byCorsConsoleCount, { numericKeys: true });
+  summary.corpusDiagnostics.network.byCspConsoleCount =
+    sortEntries(summary.corpusDiagnostics.network.byCspConsoleCount, { numericKeys: true });
+  summary.corpusDiagnostics.network.failedRowsByBidder =
+    sortEntries(summary.corpusDiagnostics.network.failedRowsByBidder);
+  summary.corpusDiagnostics.network.failedRowsByAdmKind =
+    sortEntries(summary.corpusDiagnostics.network.failedRowsByAdmKind);
+  summary.corpusDiagnostics.network.corsRowsByBidder =
+    sortEntries(summary.corpusDiagnostics.network.corsRowsByBidder);
+  summary.corpusDiagnostics.network.cspRowsByBidder =
+    sortEntries(summary.corpusDiagnostics.network.cspRowsByBidder);
+  summary.corpusDiagnostics.network.failedDocumentRowsByBidder =
+    sortEntries(summary.corpusDiagnostics.network.failedDocumentRowsByBidder);
+  summary.corpusDiagnostics.network.failedResourceType =
+    sortEntries(summary.corpusDiagnostics.network.failedResourceType);
+  summary.corpusDiagnostics.network.failedResponseStatus =
+    sortEntries(summary.corpusDiagnostics.network.failedResponseStatus, { numericKeys: true });
   summary.failureGroups = sortedGroups(failureGroups);
   summary.reductionCandidates = summary.failureGroups
     .filter(isReductionCandidate)

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -152,6 +152,13 @@ test('triageReports groups private report rows by failure dimensions', () => {
             failedResponseCount: 1,
             corsConsoleCount: 1,
             cspConsoleCount: 0,
+            byResourceType: {
+              document: 1,
+              script: 2,
+            },
+            byStatus: {
+              404: 1,
+            },
           },
           navigationDiagnostics: {
             documentWrite: {
@@ -369,6 +376,53 @@ test('triageReports groups private report rows by failure dimensions', () => {
     assert.equal(summary.diagnostics.legacyMraidLoader.byErrorCount['1'], 1);
     assert.equal(summary.diagnostics.legacyMraidLoader.byLoadedCount['0'], 1);
     assert.equal(summary.diagnostics.legacyMraidLoader.byLoadedCount['1'], 1);
+    assert.equal(summary.corpusDiagnostics.scriptLoads.rowsWithScripts, 1);
+    assert.equal(summary.corpusDiagnostics.scriptLoads.rowsWithErrors, 1);
+    assert.equal(summary.corpusDiagnostics.scriptLoads.rowsWithLoaded, 1);
+    assert.equal(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByBidder['bidder-a'], 1);
+    assert.equal(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByAdmKind['html-mraid'], 1);
+    assert.equal(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByLegacyMraidLoader.absent, 1);
+    assert.equal(summary.corpusDiagnostics.scriptLoads.byCount['2'], 1);
+    assert.equal(summary.corpusDiagnostics.scriptLoads.byLoadedCount['1'], 1);
+    assert.equal(summary.corpusDiagnostics.scriptLoads.byErrorCount['1'], 1);
+    assert.deepEqual(summary.corpusDiagnostics.scriptLoads.byProtocol, {
+      'http:': 1,
+      'https:': 1,
+    });
+    assert.deepEqual(summary.corpusDiagnostics.scriptLoads.byOrigin, {
+      'http://127.0.0.1:18868': 1,
+      'https://cdn.example': 1,
+    });
+    assert.deepEqual(summary.corpusDiagnostics.scriptLoads.byStatus, {
+      discovered: 2,
+      error: 1,
+      loaded: 1,
+    });
+    assert.equal(summary.corpusDiagnostics.network.rowsWithFailedRequests, 4);
+    assert.equal(summary.corpusDiagnostics.network.rowsWithFailedResponses, 4);
+    assert.equal(summary.corpusDiagnostics.network.rowsWithCorsConsole, 4);
+    assert.equal(summary.corpusDiagnostics.network.rowsWithCspConsole, 4);
+    assert.equal(summary.corpusDiagnostics.network.rowsWithFailedDocuments, 1);
+    assert.equal(summary.corpusDiagnostics.network.byShape['request:0 response:0 cors:0 csp:0'], 4);
+    assert.equal(summary.corpusDiagnostics.network.byShape['request:10 response:10 cors:10 csp:10'], 2);
+    assert.equal(summary.corpusDiagnostics.network.byFailedRequestCount['10'], 2);
+    assert.equal(summary.corpusDiagnostics.network.byFailedResponseCount['10'], 2);
+    assert.equal(summary.corpusDiagnostics.network.byCorsConsoleCount['10'], 2);
+    assert.equal(summary.corpusDiagnostics.network.byCspConsoleCount['10'], 2);
+    assert.equal(summary.corpusDiagnostics.network.failedRowsByBidder['bidder-a'], 4);
+    assert.equal(summary.corpusDiagnostics.network.failedRowsByBidder['bidder-b'], 1);
+    assert.equal(summary.corpusDiagnostics.network.failedRowsByAdmKind['html-mraid'], 4);
+    assert.equal(summary.corpusDiagnostics.network.failedRowsByAdmKind.html, 1);
+    assert.equal(summary.corpusDiagnostics.network.corsRowsByBidder['bidder-a'], 3);
+    assert.equal(summary.corpusDiagnostics.network.cspRowsByBidder['bidder-a'], 3);
+    assert.equal(summary.corpusDiagnostics.network.failedDocumentRowsByBidder['bidder-a'], 1);
+    assert.deepEqual(summary.corpusDiagnostics.network.failedResourceType, {
+      document: 1,
+      script: 2,
+    });
+    assert.deepEqual(summary.corpusDiagnostics.network.failedResponseStatus, {
+      404: 1,
+    });
     assert.equal(summary.failureGroups.length, 1);
     assert.equal(summary.failureGroups[0].bucket, 'bridge-missing');
     assert.equal(summary.failureGroups[0].count, 4);


### PR DESCRIPTION
## Summary
- add all-report `corpusDiagnostics` to private creative-validator triage summaries
- aggregate non-fatal script-load and network signals across passed, skipped, failed, and other rows
- document the new section and pin the summary shape in triage tests

## Post-#205 corpus check
Ran the current 437-row private OpenRTB corpus on merged `main` before this change:
- status: 180 passed, 257 skipped, 0 failed
- script-load rows: 156
- script-load error rows: 134
- script-load error rows with legacy MRAID loader signal: 130
- non-legacy script-load error rows: 4
- CORS-console rows: 3
- CSP-console rows: 46
- failed-document rows: 47

After this PR, those numbers are available directly under `corpusDiagnostics`
instead of requiring ad hoc private scripts.

## Validation
- node tools/creative-validator/src/cli.js run tools/creative-validator/private/normalized/openrtb-parsing-20260527-cases.jsonl --out tools/creative-validator/private/reports/openrtb-parsing-20260527-post-205-report.jsonl --render-timeout-ms 4000 --settle-ms 1500
- node tools/creative-validator/src/cli.js triage tools/creative-validator/private/reports/openrtb-parsing-20260527-post-205-report.jsonl --out tools/creative-validator/private/triage/openrtb-parsing-20260527-corpus-runtime-summary.json
- npm run test:creative-validator-triage
- npx eslint tools/creative-validator/src/triage.js tools/creative-validator/test/test-triage.js --max-warnings=0
- git diff --check
- npm run check
