### PR TITLE
test: alias legacy MRAID loader in validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   changing pass/fail classification. Private triage aggregates the signal by
   bidder, diagnosis bucket, adm kind, API declaration, and load/error counts.
 
+- **Creative validator legacy MRAID loader alias.** MRAID-active validator
+  runs now satisfy relative `mraid.js` script requests with an empty JavaScript
+  response because the SHARC MRAID bridge already installs `window.mraid`.
+  Runtime-only `mraid.js` requests still surface as diagnostics so missing bid
+  or markup signals remain visible.
+
 - **Creative validator corpus runtime facets.** Private triage summaries now
   include all-report `corpusDiagnostics` for non-fatal script-load and network
   signals, including passed rows. The facets aggregate script load/error

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -170,6 +170,16 @@ creates a nested iframe passes; a script that navigates the renderer document
 with `window.location`, meta refresh, or same-frame form submit is classified
 as `navigation-policy`.
 
+For MRAID-active cases, the runner treats relative `mraid.js` script requests as
+the legacy SDK loader required by MRAID environments. Those requests receive an
+empty successful JavaScript response because SHARC already installs
+`window.mraid` through the injected bridge. If a creative requests `mraid.js`
+without declared or sniffed MRAID evidence, the request is not aliased and still
+surfaces as a runtime-only diagnostic. This is validator-harness fidelity, not
+SHARC product guidance; whether production deployments should serve a no-op
+`mraid.js` endpoint or document the request as benign remains a separate
+operator/spec question.
+
 Committed reductions live under `tools/creative-validator/fixtures/reductions/`
 and must be synthetic. Each reduction directory should include a short README
 describing the private failure pattern it represents and the behavior it pins.

--- a/tools/creative-validator/src/runner.js
+++ b/tools/creative-validator/src/runner.js
@@ -7,7 +7,7 @@ import { createWriteStream, existsSync, mkdirSync, readFileSync } from 'node:fs'
 import http from 'node:http';
 import { dirname, resolve } from 'node:path';
 import puppeteer from 'puppeteer-core';
-import { classifyOutcome, makeEmptyRun } from './diagnose.js';
+import { classifyOutcome, expectedBridges, makeEmptyRun } from './diagnose.js';
 
 const DEFAULT_PORT = 18865;
 const DEFAULT_RENDERER_PORT = 18866;
@@ -397,6 +397,39 @@ function bridgeSignalList(testCase, name) {
   return values.map((value) => String(value).toLowerCase());
 }
 
+function shouldAliasLegacyMraidLoader(testCase) {
+  return expectedBridges(testCase).includes('mraid');
+}
+
+async function installLegacyMraidLoaderAlias(page, testCase) {
+  if (!shouldAliasLegacyMraidLoader(testCase)) return;
+  await page.setRequestInterception(true);
+  page.on('request', async (request) => {
+    try {
+      if (typeof request.isInterceptResolutionHandled === 'function'
+          && request.isInterceptResolutionHandled()) {
+        return;
+      }
+      if (request.resourceType() === 'script' && isLegacyMraidLoaderUrl(request.url())) {
+        await request.respond({
+          status: 200,
+          contentType: 'application/javascript; charset=utf-8',
+          body: '/* SHARC validator: legacy mraid.js satisfied by injected window.mraid bridge. */\n',
+        });
+        return;
+      }
+      await request.continue();
+    } catch (_) {
+      try {
+        await request.continue();
+      } catch (_) {
+        // Page teardown can race with late ad-network requests. The run-level
+        // diagnostics are already collected from completed/failed requests.
+      }
+    }
+  });
+}
+
 function summarizeLegacyMraidLoader(testCase, run) {
   const declared = bridgeSignalList(testCase, 'declared').includes('mraid');
   const sniffed = bridgeSignalList(testCase, 'sniffed').includes('mraid');
@@ -504,6 +537,8 @@ async function runExecutableCase(browser, testCase, options) {
   const failedRequests = [];
   const failedResponses = [];
   const scriptOutcomes = [];
+
+  await installLegacyMraidLoaderAlias(page, testCase);
 
   page.on('console', (msg) => {
     const summarized = summarizeConsoleMessage(msg);

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -932,6 +932,9 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(legacyDeclaredReport.outcome.status, 'passed');
     assert.equal(legacyDeclaredReport.diagnostics.legacyMraidLoader.requested, true);
     assert.ok(legacyDeclaredReport.diagnostics.legacyMraidLoader.count >= 1);
+    assert.ok(legacyDeclaredReport.diagnostics.legacyMraidLoader.loadedCount >= 1);
+    assert.equal(legacyDeclaredReport.diagnostics.legacyMraidLoader.errorCount, 0);
+    assert.equal(legacyDeclaredReport.diagnostics.network.byStatus['404'], undefined);
     assert.equal(legacyDeclaredReport.diagnostics.legacyMraidLoader.signal.declared, true);
     assert.equal(legacyDeclaredReport.diagnostics.legacyMraidLoader.signal.sniffed, true);
     assert.equal(legacyDeclaredReport.diagnostics.legacyMraidLoader.signal.runtimeOnly, false);


### PR DESCRIPTION
## Summary

- satisfy relative legacy `mraid.js` script requests during MRAID-active validator runs with an empty successful JavaScript response
- keep runtime-only `mraid.js` requests unaliased so missing bid/markup MRAID signals remain visible
- document the validator policy and pin the declared/sniffed MRAID case in runner coverage

## Private corpus verification

Ran the 437-case private corpus with the same timing as the post-#206 pass:

- before: 131 legacy MRAID rows, 131 legacy 404 rows, 135 script-error rows, 196 total 404 responses
- after: 131 legacy MRAID rows, 0 legacy 404 rows, 5 script-error rows, 64 total 404 responses
- pass/fail unchanged: 180 passed, 257 skipped, 0 failed

## Validation

- npm run test:creative-validator-runner
- npx eslint tools/creative-validator/src/runner.js tools/creative-validator/test/test-runner.js --max-warnings=0
- git diff --check
- npm run check