### PR TITLE
fix: match canonical CORS/CSP console phrasings in validator triage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,12 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   longer get misclassified as `navigation-policy` failures merely because the
   written document completes its normal load after `DOMContentLoaded`.
 
+- **Creative validator CORS/CSP console matching.** Private triage no longer
+  flags `network-cors` on console messages that merely contain the substrings
+  `cors` or `csp` (vendor names, script URLs, base64 blobs). The runner and
+  diagnosis classifier now match the canonical Chrome phrasings (`cors policy`,
+  `access-control-allow-origin`, `content security policy`) instead.
+
 ## [0.7.6] - 2026-05-24
 
 **Release-doc-first cycle.** Three features shipped in parallel: the headline

--- a/tools/creative-validator/src/diagnose.js
+++ b/tools/creative-validator/src/diagnose.js
@@ -59,14 +59,23 @@ function hasRendererSubtype(run, subtype) {
       && event.details.subtype === subtype);
 }
 
+// Match the canonical Chrome console phrasings, not bare `cors`/`csp`
+// substrings (which collide with vendor names, script URLs, and base64 blobs).
+function isCorsConsole(text) {
+  const lower = String(text || '').toLowerCase();
+  return lower.includes('cors policy') || lower.includes('access-control-allow-origin');
+}
+
+function isCspConsole(text) {
+  return String(text || '').toLowerCase().includes('content security policy');
+}
+
 function hasNetworkDiagnostics(run) {
   if (run.failedRequests && run.failedRequests.length > 0) return true;
   if (run.failedResponses && run.failedResponses.length > 0) return true;
   return (run.consoleMessages || []).some((msg) => {
-    const text = String(msg && msg.text ? msg.text : '').toLowerCase();
-    return text.includes('cors policy')
-      || text.includes('access-control-allow-origin')
-      || text.includes('content security policy');
+    const text = msg && msg.text ? msg.text : '';
+    return isCorsConsole(text) || isCspConsole(text);
   });
 }
 
@@ -205,5 +214,7 @@ export {
   classifyOutcome,
   expectedBridges,
   hasNetworkDiagnostics,
+  isCorsConsole,
+  isCspConsole,
   makeEmptyRun,
 };

--- a/tools/creative-validator/src/diagnose.js
+++ b/tools/creative-validator/src/diagnose.js
@@ -64,10 +64,9 @@ function hasNetworkDiagnostics(run) {
   if (run.failedResponses && run.failedResponses.length > 0) return true;
   return (run.consoleMessages || []).some((msg) => {
     const text = String(msg && msg.text ? msg.text : '').toLowerCase();
-    return text.includes('cors')
+    return text.includes('cors policy')
       || text.includes('access-control-allow-origin')
-      || text.includes('content security policy')
-      || text.includes('csp');
+      || text.includes('content security policy');
   });
 }
 

--- a/tools/creative-validator/src/runner.js
+++ b/tools/creative-validator/src/runner.js
@@ -271,10 +271,10 @@ function consoleFacet(messages, kind) {
   return (messages || []).filter((msg) => {
     const text = String(msg && msg.text ? msg.text : '').toLowerCase();
     if (kind === 'cors') {
-      return text.includes('cors') || text.includes('access-control-allow-origin');
+      return text.includes('cors policy') || text.includes('access-control-allow-origin');
     }
     if (kind === 'csp') {
-      return text.includes('content security policy') || text.includes('csp');
+      return text.includes('content security policy');
     }
     return false;
   });

--- a/tools/creative-validator/src/runner.js
+++ b/tools/creative-validator/src/runner.js
@@ -7,7 +7,13 @@ import { createWriteStream, existsSync, mkdirSync, readFileSync } from 'node:fs'
 import http from 'node:http';
 import { dirname, resolve } from 'node:path';
 import puppeteer from 'puppeteer-core';
-import { classifyOutcome, expectedBridges, makeEmptyRun } from './diagnose.js';
+import {
+  classifyOutcome,
+  expectedBridges,
+  isCorsConsole,
+  isCspConsole,
+  makeEmptyRun,
+} from './diagnose.js';
 
 const DEFAULT_PORT = 18865;
 const DEFAULT_RENDERER_PORT = 18866;
@@ -268,16 +274,9 @@ function incrementBucket(map, key) {
 }
 
 function consoleFacet(messages, kind) {
-  return (messages || []).filter((msg) => {
-    const text = String(msg && msg.text ? msg.text : '').toLowerCase();
-    if (kind === 'cors') {
-      return text.includes('cors policy') || text.includes('access-control-allow-origin');
-    }
-    if (kind === 'csp') {
-      return text.includes('content security policy');
-    }
-    return false;
-  });
+  const match = kind === 'cors' ? isCorsConsole : kind === 'csp' ? isCspConsole : null;
+  if (!match) return [];
+  return (messages || []).filter((msg) => match(msg && msg.text ? msg.text : ''));
 }
 
 function summarizeNetwork(run) {

--- a/tools/creative-validator/test/test-diagnose.js
+++ b/tools/creative-validator/test/test-diagnose.js
@@ -6,7 +6,12 @@
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { classifyOutcome, makeEmptyRun } from '../src/diagnose.js';
+import {
+  classifyOutcome,
+  isCorsConsole,
+  isCspConsole,
+  makeEmptyRun,
+} from '../src/diagnose.js';
 
 function makeCase(execute = true, expectations = {}) {
   return {
@@ -159,4 +164,16 @@ test('classifyOutcome buckets expected bridge probe failures', () => {
       } },
     }],
   }, safeframeCase), 'bridge-api-error');
+});
+
+test('console CORS/CSP matchers require canonical phrasings, not bare substrings', () => {
+  assert.equal(isCorsConsole('Access to fetch blocked by CORS policy'), true);
+  assert.equal(isCorsConsole("No 'Access-Control-Allow-Origin' header is present"), true);
+  assert.equal(isCorsConsole('loaded https://cors.example/cors-helper.js'), false);
+  assert.equal(isCorsConsole(''), false);
+  assert.equal(isCorsConsole(undefined), false);
+
+  assert.equal(isCspConsole('Refused to load: Content Security Policy directive'), true);
+  assert.equal(isCspConsole('vendor csp.example loaded'), false);
+  assert.equal(isCspConsole(null), false);
 });

--- a/tools/creative-validator/test/test-diagnose.js
+++ b/tools/creative-validator/test/test-diagnose.js
@@ -105,6 +105,13 @@ test('classifyOutcome covers non-browser buckets', () => {
   assert.equal(bucket({
     consoleMessages: [{ type: 'error', text: 'blocked by CORS policy' }],
   }), 'network-cors');
+  assert.equal(bucket({
+    consoleMessages: [{ type: 'error', text: 'Refused to load: Content Security Policy directive' }],
+  }), 'network-cors');
+  // Bare "csp"/"cors" substrings (vendor names, URLs, base64) must not trip the facet.
+  assert.equal(bucket({
+    consoleMessages: [{ type: 'log', text: 'loaded https://csp.example/cors-helper.js' }],
+  }), 'inconclusive');
   assert.equal(bucket({ pageErrors: [{ message: 'creative threw' }] }), 'creative-broken');
   assert.equal(bucket({}), 'inconclusive');
 });


### PR DESCRIPTION
## Summary

Retrospective audit of the merged creative-validator work (#192–206) surfaced a present false-positive in `network-cors` detection: both the runner facet (`consoleFacet`) and the diagnosis classifier (`hasNetworkDiagnostics`) matched the bare substrings `cors` and `csp`. Any console message incidentally containing them — a vendor name, a script URL like `https://csp.example/cors-helper.js`, or a base64 blob — was counted as a network/CORS diagnostic and could bucket an otherwise-fine row as `network-cors` in private triage.

This matters on the real corpus, where creatives log freely.

## Change

Match the canonical Chrome console phrasings instead of bare substrings:
- `cors policy` (Chrome: "…blocked by CORS policy: …")
- `access-control-allow-origin` (the directive, unchanged)
- `content security policy` (Chrome: "…violates the following Content Security Policy directive…")

Applied symmetrically in `src/diagnose.js` (`hasNetworkDiagnostics`) and `src/runner.js` (`consoleFacet`) so the runner's `corsConsoleCount`/`cspConsoleCount` facets and the diagnosis bucket stay consistent.

## Tests

- `test-diagnose.js` gains a negative case (`loaded https://csp.example/cors-helper.js` → `inconclusive`, not `network-cors`) and a positive CSP-phrasing case. The existing `blocked by CORS policy` case still passes (lowercases to `cors policy`).
- `npm run test:creative-validator-diagnose` ✅
- `eslint` on changed files ✅

## Scope

Deliberately narrow — one isolated bug. The other findings from the same audit (bridge probes never invoking navigation methods; bridge object-identity verification + the misleading `installed` flag; OMID harness fidelity + triage visibility) are filed as separate issues since they need design/implementation, not a one-line correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)