### PR TITLE
test: add validator document source diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,14 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   diagnosis classifier now match the canonical Chrome phrasings (`cors policy`,
   `access-control-allow-origin`, `content security policy`) instead.
 
+- **Creative validator document-source diagnostics.** Markup runner reports now
+  include passive frame/form source attribution for nested document loads, and
+  private triage aggregates those sources by kind, protocol, origin, tag, and
+  bidder. This is diagnostics-only coverage for the failed-document/CSP cluster;
+  pass/fail classification is unchanged. The summary remains private-tier
+  because real bidder names and ad-server origins are preserved as aggregate
+  keys.
+
 ## [0.7.6] - 2026-05-24
 
 **Release-doc-first cycle.** Three features shipped in parallel: the headline

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -164,6 +164,15 @@ aggregate-only and still avoid raw creative markup. They are still private-tier:
 the facets key by real bidder names and script origins, so summaries must not
 be shared with bidders.
 
+Document-source facets attribute nested document activity observed inside the
+renderer document. The runner passively records frame discovery, frame `src`
+assignments, form discovery, and form submissions; triage aggregates them by
+source kind, protocol, origin, tag name, and bidder. These diagnostics are meant
+to explain failed-document/CSP clusters without changing validator pass/fail
+classification. They are private-tier for the same reason as the other corpus
+diagnostics: they key by real bidder names and ad-server origins, so summaries
+must not be shared with bidders.
+
 The runner tests also document the current navigation-policy boundary for
 external scripts: a script that loads and does nothing passes; a script that
 creates a nested iframe passes; a script that navigates the renderer document

--- a/tools/creative-validator/fixtures/navigation-boundary-static-iframe.js
+++ b/tools/creative-validator/fixtures/navigation-boundary-static-iframe.js
@@ -1,0 +1,3 @@
+var frame = document.createElement('iframe');
+frame.srcdoc = '<!doctype html><html><body>static nested frame</body></html>';
+document.body.appendChild(frame);

--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -328,7 +328,29 @@ function validatorNavigationPreludeSource(probeNonce) {
       };
     }
 
+    function elementSource(element) {
+      if (!element || element.nodeType !== 1) return 'unknown';
+      var tag = '';
+      try {
+        tag = String(element.tagName || '').toLowerCase();
+      } catch (_) {
+        tag = 'unknown';
+      }
+      return tag || 'unknown';
+    }
+
+    function elementUrl(element, attr) {
+      if (!element || element.nodeType !== 1) return summarizeUrl(null);
+      try {
+        return summarizeUrl(element.getAttribute(attr) || element[attr]);
+      } catch (_) {
+        return summarizeUrl(null);
+      }
+    }
+
     var observedScripts = [];
+    var observedFrames = [];
+    var observedForms = [];
 
     function postScriptLoad(script, status) {
       var summary = scriptSummary(script);
@@ -444,12 +466,117 @@ function validatorNavigationPreludeSource(probeNonce) {
       }
     }
 
+    function postDocumentSource(kind, element, extra) {
+      var payload = {
+        kind: kind,
+        lifecycle: lifecycle(),
+        tagName: elementSource(element),
+      };
+      if (extra) {
+        for (var key in extra) {
+          if (Object.prototype.hasOwnProperty.call(extra, key)) {
+            payload[key] = extra[key];
+          }
+        }
+      }
+      post(payload);
+    }
+
+    function frameSummary(frame) {
+      return {
+        url: elementUrl(frame, 'src'),
+        srcdoc: !!(frame && frame.getAttribute && frame.getAttribute('srcdoc')),
+        name: frame && frame.name ? String(frame.name).slice(0, 80) : '',
+        sandbox: frame && frame.getAttribute ? String(frame.getAttribute('sandbox') || '').slice(0, 160) : '',
+      };
+    }
+
+    function recordForFrame(frame) {
+      for (var i = 0; i < observedFrames.length; i += 1) {
+        if (observedFrames[i] === frame) return frame;
+      }
+      return null;
+    }
+
+    function observeFrame(frame, reason) {
+      if (!frame || frame.nodeType !== 1) return;
+      var tag = elementSource(frame);
+      if (tag !== 'iframe' && tag !== 'frame') return;
+      var already = !!recordForFrame(frame);
+      if (already) return;
+      observedFrames.push(frame);
+      postDocumentSource('frame', frame, Object.assign({ reason: reason || 'observed' }, frameSummary(frame)));
+    }
+
+    function scanFrames(root) {
+      observeFrame(root, 'observed');
+      if (root && typeof root.querySelectorAll === 'function') {
+        var frames = root.querySelectorAll('iframe,frame');
+        for (var i = 0; i < frames.length; i += 1) observeFrame(frames[i], 'observed');
+      }
+    }
+
+    function observeFrameSrcAttribute() {
+      if (typeof Element !== 'function' || !Element.prototype) return;
+      var originalSetAttribute = Element.prototype.setAttribute;
+      if (typeof originalSetAttribute === 'function' && !originalSetAttribute.__sharcValidatorWrapped) {
+        var wrappedSetAttribute = function (name, value) {
+          var result = originalSetAttribute.apply(this, arguments);
+          var tag = elementSource(this);
+          if ((tag === 'iframe' || tag === 'frame')
+              && String(name || '').toLowerCase() === 'src') {
+            postDocumentSource('frame-src', this, Object.assign({ attr: 'src' }, frameSummary(this)));
+          }
+          return result;
+        };
+        try {
+          Object.defineProperty(wrappedSetAttribute, '__sharcValidatorWrapped', { value: true });
+        } catch (_) {}
+        Element.prototype.setAttribute = wrappedSetAttribute;
+      }
+    }
+
+    function observeForm(form) {
+      if (!form || form.nodeType !== 1 || elementSource(form) !== 'form') return;
+      if (form.__sharcValidatorFormObserved) return;
+      observedForms.push(form);
+      try {
+        Object.defineProperty(form, '__sharcValidatorFormObserved', { value: true });
+      } catch (_) {
+        form.__sharcValidatorFormObserved = true;
+      }
+      postDocumentSource('form', form, {
+        url: elementUrl(form, 'action'),
+        method: form.method ? String(form.method).toLowerCase().slice(0, 16) : '',
+        target: form.target ? String(form.target).slice(0, 80) : '',
+      });
+      form.addEventListener('submit', function () {
+        postDocumentSource('form-submit', form, {
+          url: elementUrl(form, 'action'),
+          method: form.method ? String(form.method).toLowerCase().slice(0, 16) : '',
+          target: form.target ? String(form.target).slice(0, 80) : '',
+        });
+      }, true);
+    }
+
+    function scanForms(root) {
+      observeForm(root);
+      if (root && typeof root.querySelectorAll === 'function') {
+        var forms = root.querySelectorAll('form');
+        for (var i = 0; i < forms.length; i += 1) observeForm(forms[i]);
+      }
+    }
+
     if (typeof MutationObserver === 'function') {
       try {
         var observer = new MutationObserver(function (records) {
           for (var i = 0; i < records.length; i += 1) {
             var nodes = records[i].addedNodes || [];
-            for (var j = 0; j < nodes.length; j += 1) scanScripts(nodes[j]);
+            for (var j = 0; j < nodes.length; j += 1) {
+              scanScripts(nodes[j]);
+              scanFrames(nodes[j]);
+              scanForms(nodes[j]);
+            }
           }
         });
         observer.observe(document.documentElement || document, { childList: true, subtree: true });
@@ -566,9 +693,14 @@ function validatorNavigationPreludeSource(probeNonce) {
 
     wrapDocumentMethod('write');
     wrapDocumentMethod('writeln');
+    observeFrameSrcAttribute();
     scanScripts(document);
+    scanFrames(document);
+    scanForms(document);
     window.addEventListener('load', function () {
       scanScripts(document);
+      scanFrames(document);
+      scanForms(document);
       setTimeout(reconcileMissedScriptOutcomes, 0);
       setTimeout(reconcileMissedScriptOutcomes, 100);
     });
@@ -682,6 +814,14 @@ function emptyNavigationDiagnostics() {
       byStatus: {},
       calls: [],
     },
+    documentSources: {
+      count: 0,
+      byKind: {},
+      byProtocol: {},
+      byOrigin: {},
+      byTag: {},
+      calls: [],
+    },
   };
 }
 
@@ -746,6 +886,35 @@ function addNavigationDiagnostic(summary, payload) {
         async: payload.async === true,
         defer: payload.defer === true,
         type: payload.type || '',
+      });
+    }
+    return;
+  }
+  if (payload.kind === 'frame'
+      || payload.kind === 'frame-src'
+      || payload.kind === 'form'
+      || payload.kind === 'form-submit') {
+    const sources = summary.documentSources;
+    sources.count += 1;
+    sources.byKind[payload.kind] = (sources.byKind[payload.kind] || 0) + 1;
+    const protocol = payload.url && payload.url.protocol ? payload.url.protocol : 'unknown';
+    const origin = payload.url && payload.url.origin ? payload.url.origin : 'unknown';
+    const tag = payload.tagName || 'unknown';
+    sources.byProtocol[protocol] = (sources.byProtocol[protocol] || 0) + 1;
+    sources.byOrigin[origin] = (sources.byOrigin[origin] || 0) + 1;
+    sources.byTag[tag] = (sources.byTag[tag] || 0) + 1;
+    if (sources.calls.length < 20) {
+      sources.calls.push({
+        kind: payload.kind,
+        lifecycle: cloneForReport(payload.lifecycle || {}),
+        tagName: tag,
+        url: cloneForReport(payload.url || {}),
+        reason: payload.reason || null,
+        srcdoc: payload.srcdoc === true,
+        name: payload.name || '',
+        sandbox: payload.sandbox || '',
+        method: payload.method || '',
+        target: payload.target || '',
       });
     }
     return;

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -91,6 +91,12 @@ function emptySummary(files) {
         rowsWithCorsConsole: 0,
         rowsWithCspConsole: 0,
         rowsWithFailedDocuments: 0,
+        rowsWithDocumentSources: 0,
+        documentSourcesByKind: {},
+        documentSourcesByProtocol: {},
+        documentSourcesByOrigin: {},
+        documentSourcesByTag: {},
+        documentSourceRowsByBidder: {},
         byShape: {},
         byFailedRequestCount: {},
         byFailedResponseCount: {},
@@ -348,6 +354,36 @@ function addRuntimeCorpusFacets(summary, row, fields) {
   for (const [status, count] of Object.entries(scriptByStatus)) {
     if (networkCount(count) > 0) {
       increment(summary.corpusDiagnostics.scriptLoads.byStatus, status, networkCount(count));
+    }
+  }
+
+  const documentSources = navigation.documentSources || {};
+  if (networkCount(documentSources.count) > 0) {
+    summary.corpusDiagnostics.network.rowsWithDocumentSources += 1;
+    increment(summary.corpusDiagnostics.network.documentSourceRowsByBidder, fields.bidder);
+  }
+  const documentSourceByKind = documentSources.byKind || {};
+  for (const [kind, count] of Object.entries(documentSourceByKind)) {
+    if (networkCount(count) > 0) {
+      increment(summary.corpusDiagnostics.network.documentSourcesByKind, kind, networkCount(count));
+    }
+  }
+  const documentSourceByProtocol = documentSources.byProtocol || {};
+  for (const [protocol, count] of Object.entries(documentSourceByProtocol)) {
+    if (networkCount(count) > 0) {
+      increment(summary.corpusDiagnostics.network.documentSourcesByProtocol, protocol, networkCount(count));
+    }
+  }
+  const documentSourceByOrigin = documentSources.byOrigin || {};
+  for (const [origin, count] of Object.entries(documentSourceByOrigin)) {
+    if (networkCount(count) > 0) {
+      increment(summary.corpusDiagnostics.network.documentSourcesByOrigin, origin, networkCount(count));
+    }
+  }
+  const documentSourceByTag = documentSources.byTag || {};
+  for (const [tag, count] of Object.entries(documentSourceByTag)) {
+    if (networkCount(count) > 0) {
+      increment(summary.corpusDiagnostics.network.documentSourcesByTag, tag, networkCount(count));
     }
   }
 
@@ -612,6 +648,16 @@ function triageReports(files) {
     sortEntries(summary.corpusDiagnostics.network.byCorsConsoleCount, { numericKeys: true });
   summary.corpusDiagnostics.network.byCspConsoleCount =
     sortEntries(summary.corpusDiagnostics.network.byCspConsoleCount, { numericKeys: true });
+  summary.corpusDiagnostics.network.documentSourcesByKind =
+    sortEntries(summary.corpusDiagnostics.network.documentSourcesByKind);
+  summary.corpusDiagnostics.network.documentSourcesByProtocol =
+    sortEntries(summary.corpusDiagnostics.network.documentSourcesByProtocol);
+  summary.corpusDiagnostics.network.documentSourcesByOrigin =
+    sortEntries(summary.corpusDiagnostics.network.documentSourcesByOrigin);
+  summary.corpusDiagnostics.network.documentSourcesByTag =
+    sortEntries(summary.corpusDiagnostics.network.documentSourcesByTag);
+  summary.corpusDiagnostics.network.documentSourceRowsByBidder =
+    sortEntries(summary.corpusDiagnostics.network.documentSourceRowsByBidder);
   summary.corpusDiagnostics.network.failedRowsByBidder =
     sortEntries(summary.corpusDiagnostics.network.failedRowsByBidder);
   summary.corpusDiagnostics.network.failedRowsByAdmKind =

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -1042,6 +1042,7 @@ test('runner documents external-script navigation policy boundary', () => {
     writeFileSync(inputPath, [
       scriptCase('noop', 'navigation-boundary-noop.js'),
       scriptCase('nested-iframe', 'navigation-boundary-nested-iframe.js'),
+      scriptCase('static-iframe', 'navigation-boundary-static-iframe.js'),
       parserScriptCase('parser-script-ok', '/tools/creative-validator/fixtures/navigation-boundary-noop.js'),
       parserScriptCase('parser-script-404', 'mraid.js'),
       scriptCase('location', 'navigation-boundary-location.js'),
@@ -1068,7 +1069,7 @@ test('runner documents external-script navigation policy boundary', () => {
     });
 
     const reports = readJsonl(outPath);
-    assert.equal(reports.length, 7);
+    assert.equal(reports.length, 8);
 
     const bySlug = (slug) => reports.find((row) =>
       row.case.ids.bidId === `bid-runner-boundary-${slug}`);
@@ -1106,6 +1107,18 @@ test('runner documents external-script navigation policy boundary', () => {
     assert.equal(nestedIframe.outcome.bucket, 'passed');
     assert.equal(nestedIframe.outcome.terminated, false);
     assertScriptLoaded(nestedIframe);
+    assert.ok(nestedIframe.diagnostics.navigationDiagnostics.documentSources.count >= 1);
+    assert.ok(nestedIframe.diagnostics.navigationDiagnostics.documentSources.byKind.frame >= 1);
+    assert.ok(nestedIframe.diagnostics.navigationDiagnostics.documentSources.byTag.iframe >= 1);
+
+    const staticIframe = bySlug('static-iframe');
+    assert.ok(staticIframe);
+    assert.equal(staticIframe.outcome.status, 'passed');
+    assert.equal(staticIframe.outcome.bucket, 'passed');
+    assertScriptLoaded(staticIframe);
+    assert.equal(staticIframe.diagnostics.navigationDiagnostics.documentSources.count, 1);
+    assert.equal(staticIframe.diagnostics.navigationDiagnostics.documentSources.byKind.frame, 1);
+    assert.equal(staticIframe.diagnostics.navigationDiagnostics.documentSources.byTag.iframe, 1);
 
     const parserScriptOk = bySlug('parser-script-ok');
     assert.ok(parserScriptOk);
@@ -1127,7 +1140,10 @@ test('runner documents external-script navigation policy boundary', () => {
 
     assertNavigationPolicy(bySlug('location'));
     assertNavigationPolicy(bySlug('meta-refresh'));
-    assertNavigationPolicy(bySlug('form-submit'));
+    const formSubmit = bySlug('form-submit');
+    assertNavigationPolicy(formSubmit);
+    assert.ok(formSubmit.diagnostics.navigationDiagnostics.documentSources.byKind.form >= 1);
+    assert.ok(formSubmit.diagnostics.navigationDiagnostics.documentSources.byOrigin['https://click.example'] >= 1);
   } finally {
     rmSync(workDir, { force: true, recursive: true });
   }

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -123,6 +123,25 @@ test('triageReports groups private report rows by failure dimensions', () => {
                 error: 1,
               },
             },
+            documentSources: {
+              count: 2,
+              byKind: {
+                frame: 1,
+                'form-submit': 1,
+              },
+              byProtocol: {
+                'https:': 1,
+                unknown: 1,
+              },
+              byOrigin: {
+                'https://click.example': 1,
+                unknown: 1,
+              },
+              byTag: {
+                iframe: 1,
+                form: 1,
+              },
+            },
           },
         },
       }),
@@ -403,6 +422,24 @@ test('triageReports groups private report rows by failure dimensions', () => {
     assert.equal(summary.corpusDiagnostics.network.rowsWithCorsConsole, 4);
     assert.equal(summary.corpusDiagnostics.network.rowsWithCspConsole, 4);
     assert.equal(summary.corpusDiagnostics.network.rowsWithFailedDocuments, 1);
+    assert.equal(summary.corpusDiagnostics.network.rowsWithDocumentSources, 1);
+    assert.equal(summary.corpusDiagnostics.network.documentSourceRowsByBidder['bidder-a'], 1);
+    assert.deepEqual(summary.corpusDiagnostics.network.documentSourcesByKind, {
+      'form-submit': 1,
+      frame: 1,
+    });
+    assert.deepEqual(summary.corpusDiagnostics.network.documentSourcesByProtocol, {
+      'https:': 1,
+      unknown: 1,
+    });
+    assert.deepEqual(summary.corpusDiagnostics.network.documentSourcesByOrigin, {
+      'https://click.example': 1,
+      unknown: 1,
+    });
+    assert.deepEqual(summary.corpusDiagnostics.network.documentSourcesByTag, {
+      form: 1,
+      iframe: 1,
+    });
     assert.equal(summary.corpusDiagnostics.network.byShape['request:0 response:0 cors:0 csp:0'], 4);
     assert.equal(summary.corpusDiagnostics.network.byShape['request:10 response:10 cors:10 csp:10'], 2);
     assert.equal(summary.corpusDiagnostics.network.byFailedRequestCount['10'], 2);


### PR DESCRIPTION
## Summary

- add passive validator instrumentation for nested document sources: frame discovery, frame src assignment, form discovery, and form submit
- surface documentSources in runner reports without changing pass/fail classification
- aggregate document-source facets in private triage by kind, protocol, origin, tag, and bidder
- document the diagnostics-only purpose for the failed-document/CSP cluster

## Targeted private verification

Built a 47-case subset from the post-#207 rows with failed document loads and reran it with the new instrumentation:

- 47 reports, 47 passed, 0 failed
- 47 rows with failed document loads
- 47 rows now have document-source diagnostics
- document source kinds: frame=140, frame-src=31
- document source tags: iframe=171
- top source origins include dis.da1.us.criteo.com, googleads.g.doubleclick.net, ep2.adtrafficquality.google, rapids.rpdt.net

This confirms the next cluster is nested iframe/frame-src document activity, not the legacy MRAID loader or same-frame navigation policy.

## Validation

- npm run test:creative-validator-runner
- npm run test:creative-validator-triage
- npx eslint tools/creative-validator/src/triage.js tools/creative-validator/test/test-runner.js tools/creative-validator/test/test-triage.js --max-warnings=0
- git diff --check
- npm run check