### PR TITLE
test: treat declared-only MRAID as validator capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,12 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   because real bidder names and ad-server origins are preserved as aggregate
   keys.
 
+- **Creative validator declared-only MRAID capability.** Validator diagnosis no
+  longer fails rendered HTML creatives solely because the bid response declares
+  MRAID support but the markup does not sniff as MRAID. Declared API support
+  remains a setup/diagnostic signal, while bridge probe failures remain
+  enforced for creatives whose markup is sniffed as MRAID/SafeFrame.
+
 ## [0.7.6] - 2026-05-24
 
 **Release-doc-first cycle.** Three features shipped in parallel: the headline

--- a/tools/creative-validator/src/diagnose.js
+++ b/tools/creative-validator/src/diagnose.js
@@ -84,9 +84,19 @@ function expectedBridges(testCase) {
     ...((testCase.expectations && testCase.expectations.declared) || []),
     ...((testCase.expectations && testCase.expectations.sniffed) || []),
   ]);
-  // Phase 3 validates renderer bridges only. OMID remains a measurement signal
-  // and is handled by measurement-omid buckets.
+  // Capability/alias set: declared OpenRTB APIs plus sniffed markup signals.
+  // Validation is stricter and handled by bridgesToValidate below.
   return ['mraid', 'safeframe'].filter((bridge) => values.has(bridge));
+}
+
+function bridgesToValidate(testCase) {
+  const sniffed = new Set((testCase.expectations && testCase.expectations.sniffed) || []);
+  // Declared OpenRTB APIs mean the placement is capable of a bridge. They do
+  // not prove the creative will use that bridge, so plain HTML ads should not
+  // fail only because a declared-but-unsniffed bridge is absent from the probe.
+  // If such a creative really depends on a missing bridge, runtime errors still
+  // surface under creative-broken rather than the bridge-missing bucket.
+  return ['mraid', 'safeframe'].filter((bridge) => sniffed.has(bridge));
 }
 
 function firstBridgeProbe(run) {
@@ -177,7 +187,7 @@ function classifyOutcome(testCase, run) {
     }
   }
 
-  const expected = expectedBridges(testCase);
+  const expected = bridgesToValidate(testCase);
   const probe = firstBridgeProbe(run);
   if (expected.length > 0 && probe) {
     for (const bridge of expected) {

--- a/tools/creative-validator/test/test-diagnose.js
+++ b/tools/creative-validator/test/test-diagnose.js
@@ -130,7 +130,13 @@ test('classifyOutcome buckets expected bridge probe failures', () => {
   assert.equal(bucket({
     creativeRendered: true,
     bridgeProbes: [{ bridges: { mraid: { exists: false, methods: {} } } }],
-  }, mraidCase), 'bridge-missing');
+  }, mraidCase), 'passed');
+
+  const sniffedMraidCase = makeCase(true, { sniffed: ['mraid'] });
+  assert.equal(bucket({
+    creativeRendered: true,
+    bridgeProbes: [{ bridges: { mraid: { exists: false, methods: {} } } }],
+  }, sniffedMraidCase), 'bridge-missing');
   assert.equal(bucket({
     creativeRendered: true,
     bridgeProbes: [{
@@ -139,7 +145,7 @@ test('classifyOutcome buckets expected bridge probe failures', () => {
         methods: { getState: { exists: true, status: 'threw', error: 'boom' } },
       } },
     }],
-  }, mraidCase), 'bridge-api-error');
+  }, sniffedMraidCase), 'bridge-api-error');
   assert.equal(bucket({
     creativeRendered: true,
     bridgeProbes: [{
@@ -148,7 +154,7 @@ test('classifyOutcome buckets expected bridge probe failures', () => {
         methods: { getState: { exists: true, status: 'ok', value: 'loading' } },
       } },
     }],
-  }, mraidCase), 'passed');
+  }, sniffedMraidCase), 'passed');
 
   const safeframeCase = makeCase(true, { sniffed: ['safeframe'] });
   assert.equal(bucket({

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -779,8 +779,8 @@ test('runner executes HTML cases and writes one report row per case', () => {
 
     const missingMraidReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-mraid-missing');
     assert.ok(missingMraidReport);
-    assert.equal(missingMraidReport.outcome.status, 'failed');
-    assert.equal(missingMraidReport.outcome.bucket, 'bridge-missing');
+    assert.equal(missingMraidReport.outcome.status, 'passed');
+    assert.equal(missingMraidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.exists, false);
 
     const mraidApiErrorReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-mraid-api-error');
     assert.ok(mraidApiErrorReport);


### PR DESCRIPTION
## Summary
- treat declared-only MRAID/SafeFrame API support as validator setup/diagnostic metadata, not a bridge-probe failure condition
- keep bridge probe failures enforced for markup sniffed as MRAID/SafeFrame
- update runner and diagnosis coverage for declared-only MRAID HTML creatives

## Validation
- node --test tools/creative-validator/test/test-diagnose.js
- npm run test:creative-validator-runner
- npm run test:creative-validator-triage
- npx eslint tools/creative-validator/src/diagnose.js tools/creative-validator/test/test-diagnose.js tools/creative-validator/test/test-runner.js --max-warnings=0
- npm run check
- reran the 5 fresh declared-MRAID failures: 5 passed, 0 failed
- reclassified the fresh 1,265-row report with new diagnosis logic: 523 passed, 742 skipped, 0 failed