### PR TITLE
test: add validator OMID triage facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ### Added
 
+- **Creative validator OMID triage facet.** Adds `corpusDiagnostics.omid` to the
+  private triage summary, aggregating the per-row OMID outcomes the runner records
+  at `diagnostics.measurement.omid`. It reports how far each expected OMID row
+  progressed (sidecar → extension → feature advertised → session started →
+  session finished) via a mutually-exclusive `byOutcome` label, distributes
+  verification-script counts and expected rows by bidder, and surfaces
+  `sessionFailedRowsByBidder` as the actionable "whose OMID breaks" signal. The
+  facet is diagnostics-only and does not affect any pass/fail bucket. It is keyed
+  by real bidder names; the summary is private-tier and must not be shared with
+  bidders. Aggregate-only, no raw markup.
+
 - **Creative validator normalizer foundation.** Adds the first private-first
   hardening harness layer under `tools/creative-validator/`: cleaned OpenRTB
   corpus normalization, API provenance extraction, `admKind` classification,

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -173,6 +173,23 @@ classification. They are private-tier for the same reason as the other corpus
 diagnostics: they key by real bidder names and ad-server origins, so summaries
 must not be shared with bidders.
 
+OMID facets under `corpusDiagnostics.omid` aggregate the per-row OMID outcomes
+the runner records at `diagnostics.measurement.omid`. They report how far each
+expected OMID row progressed — sidecar present, measurement extension installed,
+feature advertised, session started, session finished — and which bidders fail.
+`byOutcome` assigns each expected row a single mutually-exclusive progress label
+(`expected-no-sidecar`, `sidecar-no-extension`, `extension-no-feature`,
+`feature-no-session`, `session-started`, `session-finished`);
+`sessionFailedRowsByBidder` is the
+actionable signal, counting expected rows that never reached a started session.
+The top-level `rows*` counters count whatever the row's booleans report, while
+`byOutcome`, `byVerificationScriptCount`, and the `*ByBidder` maps only count
+rows where OMID was expected. These facets are diagnostics-only and do not affect
+validator pass/fail classification. They are private-tier for the same reason as
+the other corpus diagnostics: they are keyed by real bidder names, so the summary
+is private-tier and must not be shared with bidders. Aggregate-only, no raw
+markup.
+
 The runner tests also document the current navigation-policy boundary for
 external scripts: a script that loads and does nothing passes; a script that
 creates a nested iframe passes; a script that navigates the renderer document

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -110,6 +110,21 @@ function emptySummary(files) {
         failedResourceType: {},
         failedResponseStatus: {},
       },
+      omid: {
+        rows: 0,
+        rowsExpected: 0,
+        rowsWithSidecar: 0,
+        rowsWithExtension: 0,
+        rowsFeatureAdvertised: 0,
+        rowsSessionStarted: 0,
+        rowsSessionFinished: 0,
+        rowsLoadedFired: 0,
+        rowsImpressionFired: 0,
+        byOutcome: {},
+        byVerificationScriptCount: {},
+        expectedRowsByBidder: {},
+        sessionFailedRowsByBidder: {},
+      },
     },
     failureGroups: [],
     reductionCandidates: [],
@@ -164,6 +179,24 @@ function legacyMraidLoaderDiagnostics(row) {
   return row && row.diagnostics && row.diagnostics.legacyMraidLoader
     ? row.diagnostics.legacyMraidLoader
     : {};
+}
+
+function omidDiagnostics(row) {
+  return row
+    && row.diagnostics
+    && row.diagnostics.measurement
+    && row.diagnostics.measurement.omid
+    ? row.diagnostics.measurement.omid
+    : {};
+}
+
+function omidOutcomeKey(omid) {
+  if (omid.sidecarPresent !== true) return 'expected-no-sidecar';
+  if (omid.extensionPresent !== true) return 'sidecar-no-extension';
+  if (omid.featureAdvertised !== true) return 'extension-no-feature';
+  if (omid.sessionStarted !== true) return 'feature-no-session';
+  if (omid.sessionFinished !== true) return 'session-started';
+  return 'session-finished';
 }
 
 function msSinceRenderBin(value) {
@@ -429,6 +462,29 @@ function addRuntimeCorpusFacets(summary, row, fields) {
   }
 }
 
+function addOmidCorpusFacets(summary, row, fields) {
+  const omid = omidDiagnostics(row);
+  const facet = summary.corpusDiagnostics.omid;
+  facet.rows += 1;
+  if (omid.sidecarPresent === true) facet.rowsWithSidecar += 1;
+  if (omid.extensionPresent === true) facet.rowsWithExtension += 1;
+  if (omid.featureAdvertised === true) facet.rowsFeatureAdvertised += 1;
+  if (omid.sessionStarted === true) facet.rowsSessionStarted += 1;
+  if (omid.sessionFinished === true) facet.rowsSessionFinished += 1;
+  if (omid.loadedFired === true) facet.rowsLoadedFired += 1;
+  if (omid.impressionFired === true) facet.rowsImpressionFired += 1;
+
+  if (omid.expected !== true) return;
+
+  facet.rowsExpected += 1;
+  increment(facet.byOutcome, omidOutcomeKey(omid));
+  increment(facet.byVerificationScriptCount, networkCount(omid.verificationScriptCount));
+  increment(facet.expectedRowsByBidder, fields.bidder);
+  if (omid.sessionStarted !== true) {
+    increment(facet.sessionFailedRowsByBidder, fields.bidder);
+  }
+}
+
 function reportFields(row) {
   const source = (row.case && row.case.source) || {};
   const creative = (row.case && row.case.creative) || {};
@@ -541,6 +597,7 @@ function triageReports(files) {
       }
       addCorpusFacets(summary, row, fields);
       addRuntimeCorpusFacets(summary, row, fields);
+      addOmidCorpusFacets(summary, row, fields);
 
       if (fields.status === 'passed') summary.totals.passed += 1;
       else if (fields.status === 'skipped') summary.totals.skipped += 1;
@@ -672,6 +729,14 @@ function triageReports(files) {
     sortEntries(summary.corpusDiagnostics.network.failedResourceType);
   summary.corpusDiagnostics.network.failedResponseStatus =
     sortEntries(summary.corpusDiagnostics.network.failedResponseStatus, { numericKeys: true });
+  summary.corpusDiagnostics.omid.byOutcome =
+    sortEntries(summary.corpusDiagnostics.omid.byOutcome);
+  summary.corpusDiagnostics.omid.byVerificationScriptCount =
+    sortEntries(summary.corpusDiagnostics.omid.byVerificationScriptCount, { numericKeys: true });
+  summary.corpusDiagnostics.omid.expectedRowsByBidder =
+    sortEntries(summary.corpusDiagnostics.omid.expectedRowsByBidder);
+  summary.corpusDiagnostics.omid.sessionFailedRowsByBidder =
+    sortEntries(summary.corpusDiagnostics.omid.sessionFailedRowsByBidder);
   summary.failureGroups = sortedGroups(failureGroups);
   summary.reductionCandidates = summary.failureGroups
     .filter(isReductionCandidate)

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -471,6 +471,175 @@ test('triageReports groups private report rows by failure dimensions', () => {
   }
 });
 
+function omidReport(omid, overrides = {}) {
+  return report({
+    diagnostics: { measurement: { omid } },
+    ...overrides,
+  });
+}
+
+test('triageReports aggregates OMID outcomes for expected rows', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-triage-omid-'));
+  const reportPath = resolve(workDir, 'report.jsonl');
+
+  try {
+    writeJsonl(reportPath, [
+      // Expected row reaching a finished session.
+      omidReport({
+        expected: true,
+        sidecarPresent: true,
+        extensionPresent: true,
+        featureAdvertised: true,
+        sessionStarted: true,
+        sessionFinished: true,
+        loadedFired: true,
+        impressionFired: true,
+        verificationScriptCount: 2,
+      }, {
+        case: {
+          ...report().case,
+          source: { ...report().case.source, bidder: 'bidder-omid-a', rowIndex: 0 },
+        },
+        outcome: { status: 'passed', bucket: 'passed' },
+      }),
+      // Expected row that installs the extension but never starts a session.
+      omidReport({
+        expected: true,
+        sidecarPresent: true,
+        extensionPresent: true,
+        featureAdvertised: true,
+        sessionStarted: false,
+        sessionFinished: false,
+        loadedFired: false,
+        impressionFired: false,
+        verificationScriptCount: 1,
+      }, {
+        case: {
+          ...report().case,
+          source: { ...report().case.source, bidder: 'bidder-omid-b', rowIndex: 1 },
+        },
+        outcome: { status: 'failed', bucket: 'measurement-omid' },
+      }),
+      // Expected row whose extension installs but never advertises the OMID feature.
+      omidReport({
+        expected: true,
+        sidecarPresent: true,
+        extensionPresent: true,
+        featureAdvertised: false,
+        sessionStarted: false,
+        sessionFinished: false,
+        loadedFired: false,
+        impressionFired: false,
+        verificationScriptCount: 1,
+      }, {
+        case: {
+          ...report().case,
+          source: { ...report().case.source, bidder: 'bidder-omid-e', rowIndex: 4 },
+        },
+        outcome: { status: 'failed', bucket: 'measurement-omid' },
+      }),
+      // Expected row with a sparse omid object: no fields beyond `expected`.
+      omidReport({ expected: true }, {
+        case: {
+          ...report().case,
+          source: { ...report().case.source, bidder: 'bidder-omid-f', rowIndex: 5 },
+        },
+        outcome: { status: 'failed', bucket: 'measurement-omid' },
+      }),
+      // Non-expected row: present omid object but expected === false.
+      omidReport({
+        expected: false,
+        sidecarPresent: false,
+        extensionPresent: false,
+        featureAdvertised: false,
+        sessionStarted: false,
+        sessionFinished: false,
+        loadedFired: false,
+        impressionFired: false,
+        verificationScriptCount: 0,
+      }, {
+        case: {
+          ...report().case,
+          source: { ...report().case.source, bidder: 'bidder-omid-c', rowIndex: 2 },
+        },
+        outcome: { status: 'passed', bucket: 'passed' },
+      }),
+      // Row with no measurement diagnostics at all.
+      report({
+        case: {
+          ...report().case,
+          source: { ...report().case.source, bidder: 'bidder-omid-d', rowIndex: 3 },
+        },
+        outcome: { status: 'passed', bucket: 'passed' },
+        diagnostics: {},
+      }),
+    ]);
+
+    const summary = triageReports([reportPath]);
+    const omid = summary.corpusDiagnostics.omid;
+    assert.equal(omid.rows, 6);
+    assert.equal(omid.rowsExpected, 4);
+    assert.equal(omid.rowsWithSidecar, 3);
+    assert.equal(omid.rowsWithExtension, 3);
+    assert.equal(omid.rowsFeatureAdvertised, 2);
+    assert.equal(omid.rowsSessionStarted, 1);
+    assert.equal(omid.rowsSessionFinished, 1);
+    assert.equal(omid.rowsLoadedFired, 1);
+    assert.equal(omid.rowsImpressionFired, 1);
+    assert.deepEqual(omid.byOutcome, {
+      'expected-no-sidecar': 1,
+      'extension-no-feature': 1,
+      'feature-no-session': 1,
+      'session-finished': 1,
+    });
+    assert.deepEqual(omid.byVerificationScriptCount, { 0: 1, 1: 2, 2: 1 });
+    assert.deepEqual(omid.expectedRowsByBidder, {
+      'bidder-omid-a': 1,
+      'bidder-omid-b': 1,
+      'bidder-omid-e': 1,
+      'bidder-omid-f': 1,
+    });
+    assert.deepEqual(omid.sessionFailedRowsByBidder, {
+      'bidder-omid-b': 1,
+      'bidder-omid-e': 1,
+      'bidder-omid-f': 1,
+    });
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});
+
+test('triageReports emits a stable empty OMID facet for a zero-row corpus', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-triage-omid-empty-'));
+  const reportPath = resolve(workDir, 'report.jsonl');
+
+  try {
+    writeFileSync(reportPath, '');
+    const summary = triageReports([reportPath]);
+    assert.deepEqual(summary.corpusDiagnostics.omid, {
+      rows: 0,
+      rowsExpected: 0,
+      rowsWithSidecar: 0,
+      rowsWithExtension: 0,
+      rowsFeatureAdvertised: 0,
+      rowsSessionStarted: 0,
+      rowsSessionFinished: 0,
+      rowsLoadedFired: 0,
+      rowsImpressionFired: 0,
+      byOutcome: {},
+      byVerificationScriptCount: {},
+      expectedRowsByBidder: {},
+      sessionFailedRowsByBidder: {},
+    });
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});
+
 test('triage CLI writes private summary and rejects public output by default', () => {
   const privateRoot = resolve('tools/creative-validator/private');
   mkdirSync(privateRoot, { recursive: true });


### PR DESCRIPTION
## Summary

Closes the OMID blind spot in private triage (issue #211, **Part B**). The validator runner already records per-row OMID outcomes at `diagnostics.measurement.omid`, but `triage.js` aggregated none of them — so corpus-scale OMID outcomes (how many sessions start, which bidders' OMID breaks) were invisible.

Adds `corpusDiagnostics.omid`, mirroring the existing `scriptLoads`/`network` facets (#206/#212):
- **`rows*` counters** — raw signal telemetry across the corpus (`rowsExpected`, `rowsWithSidecar`, `rowsWithExtension`, `rowsFeatureAdvertised`, `rowsSessionStarted/Finished`, `rowsLoadedFired`, `rowsImpressionFired`).
- **`byOutcome`** — a mutually-exclusive progress cascade, computed only for expected rows: `expected-no-sidecar → sidecar-no-extension → extension-no-feature → feature-no-session → session-started → session-finished`.
- **`byVerificationScriptCount`**, **`expectedRowsByBidder`**, and **`sessionFailedRowsByBidder`** (the actionable "whose OMID breaks" signal — expected rows that never reached a started session).

The `extension-no-feature` and `feature-no-session` stages are deliberately distinct: the validator's own pass/fail logic (`diagnose.js`) treats a missing feature advertisement (creative/AdM problem) and a session that never starts (vendor-script problem) as different `measurement-omid` failure causes, so triage shouldn't collapse them.

## Scope
- Diagnostics-only — `diagnose.js` / `classifyOutcome` untouched; no pass/fail bucket is affected.
- Private-tier — keyed by real bidder names; README + CHANGELOG carry the "must not be shared with bidders" caveat, consistent with the #206/#212 facets.
- Part A of #211 (making the harness OMID SDK-load failure path reachable) is **not** in scope — it's gated on the data this facet will surface.

## Review
Implemented by a Senior Developer agent; reviewed by a fresh-context Code Reviewer (which caught the missing `featureAdvertised` stage, now fixed) plus a main-agent pass.

## Tests
- `node --test tools/creative-validator/test/test-triage.js` → 4 pass, 0 fail
- `npx eslint tools/creative-validator/src/triage.js tools/creative-validator/test/test-triage.js --max-warnings=0` → clean
- New tests pin: session-finished, feature-no-session, extension-no-feature, expected-no-sidecar (sparse omid object), non-expected exclusion, and a zero-row stable-empty-shape assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)