### PR TITLE
test: capture iframe src property diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,13 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   remains a setup/diagnostic signal, while bridge probe failures remain
   enforced for creatives whose markup is sniffed as MRAID/SafeFrame.
 
+- **Creative validator iframe `src` property diagnostics.** Markup runner
+  document-source diagnostics now capture direct `iframe.src = ...` and
+  `frame.src = ...` assignments in addition to `setAttribute('src', ...)` and
+  mutation scanning when the assigned URL resolves to an origin. This adds
+  attribution for property-driven nested documents without inflating blank
+  `about:` frame noise or changing pass/fail classification.
+
 ## [0.7.6] - 2026-05-24
 
 **Release-doc-first cycle.** Three features shipped in parallel: the headline

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -166,12 +166,13 @@ be shared with bidders.
 
 Document-source facets attribute nested document activity observed inside the
 renderer document. The runner passively records frame discovery, frame `src`
-assignments, form discovery, and form submissions; triage aggregates them by
-source kind, protocol, origin, tag name, and bidder. These diagnostics are meant
-to explain failed-document/CSP clusters without changing validator pass/fail
-classification. They are private-tier for the same reason as the other corpus
-diagnostics: they key by real bidder names and ad-server origins, so summaries
-must not be shared with bidders.
+assignments via attributes and direct property setters when the assigned URL
+resolves to an origin, form discovery, and form submissions; triage aggregates
+them by source kind, protocol, origin, tag name, and bidder. These diagnostics
+are meant to explain failed-document/CSP clusters without changing validator
+pass/fail classification. They are private-tier for the same reason as the
+other corpus diagnostics: they key by real bidder names and ad-server origins,
+so summaries must not be shared with bidders.
 
 OMID facets under `corpusDiagnostics.omid` aggregate the per-row OMID outcomes
 the runner records at `diagnostics.measurement.omid`. They report how far each

--- a/tools/creative-validator/fixtures/navigation-boundary-frame-src-attribute.js
+++ b/tools/creative-validator/fixtures/navigation-boundary-frame-src-attribute.js
@@ -1,0 +1,3 @@
+var frame = document.createElement('iframe');
+document.body.appendChild(frame);
+frame.setAttribute('src', '/tools/creative-validator/fixtures/navigation-boundary-noop.js?frame=attribute');

--- a/tools/creative-validator/fixtures/navigation-boundary-frame-src-property.js
+++ b/tools/creative-validator/fixtures/navigation-boundary-frame-src-property.js
@@ -1,0 +1,3 @@
+var frame = document.createElement('iframe');
+document.body.appendChild(frame);
+frame.src = '/tools/creative-validator/fixtures/navigation-boundary-noop.js?frame=property';

--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -525,7 +525,11 @@ function validatorNavigationPreludeSource(probeNonce) {
           var tag = elementSource(this);
           if ((tag === 'iframe' || tag === 'frame')
               && String(name || '').toLowerCase() === 'src') {
-            postDocumentSource('frame-src', this, Object.assign({ attr: 'src' }, frameSummary(this)));
+            postDocumentSource('frame-src', this, Object.assign({
+              attr: 'src',
+              assignment: 'attribute',
+              assignedUrl: summarizeUrl(value),
+            }, frameSummary(this)));
           }
           return result;
         };
@@ -534,6 +538,43 @@ function validatorNavigationPreludeSource(probeNonce) {
         } catch (_) {}
         Element.prototype.setAttribute = wrappedSetAttribute;
       }
+    }
+
+    function observeFrameSrcPropertyOn(constructor) {
+      if (typeof constructor !== 'function' || !constructor.prototype) return;
+      var descriptor = Object.getOwnPropertyDescriptor(constructor.prototype, 'src');
+      if (!descriptor || typeof descriptor.set !== 'function') return;
+      if (descriptor.set.__sharcValidatorWrapped) return;
+      var originalSet = descriptor.set;
+      var originalGet = descriptor.get;
+      var wrappedSet = function (value) {
+        var result = originalSet.call(this, value);
+        var assignedUrl = summarizeUrl(value);
+        if (!assignedUrl.origin) return result;
+        postDocumentSource('frame-src', this, Object.assign({
+          attr: 'src',
+          assignment: 'property',
+          assignedUrl: assignedUrl,
+        }, frameSummary(this)));
+        return result;
+      };
+      try {
+        Object.defineProperty(wrappedSet, '__sharcValidatorWrapped', { value: true });
+        Object.defineProperty(constructor.prototype, 'src', {
+          configurable: descriptor.configurable,
+          enumerable: descriptor.enumerable,
+          get: originalGet,
+          set: wrappedSet,
+        });
+      } catch (_) {
+        // Some engines may expose non-configurable DOM accessors. In that case
+        // setAttribute/mutation scanning still provide best-effort coverage.
+      }
+    }
+
+    function observeFrameSrcProperties() {
+      observeFrameSrcPropertyOn(window.HTMLIFrameElement);
+      observeFrameSrcPropertyOn(window.HTMLFrameElement);
     }
 
     function observeForm(form) {
@@ -694,6 +735,7 @@ function validatorNavigationPreludeSource(probeNonce) {
     wrapDocumentMethod('write');
     wrapDocumentMethod('writeln');
     observeFrameSrcAttribute();
+    observeFrameSrcProperties();
     scanScripts(document);
     scanFrames(document);
     scanForms(document);
@@ -897,8 +939,11 @@ function addNavigationDiagnostic(summary, payload) {
     const sources = summary.documentSources;
     sources.count += 1;
     sources.byKind[payload.kind] = (sources.byKind[payload.kind] || 0) + 1;
-    const protocol = payload.url && payload.url.protocol ? payload.url.protocol : 'unknown';
-    const origin = payload.url && payload.url.origin ? payload.url.origin : 'unknown';
+    const sourceUrl = payload.kind === 'frame-src' && payload.assignedUrl
+      ? payload.assignedUrl
+      : payload.url;
+    const protocol = sourceUrl && sourceUrl.protocol ? sourceUrl.protocol : 'unknown';
+    const origin = sourceUrl && sourceUrl.origin ? sourceUrl.origin : 'unknown';
     const tag = payload.tagName || 'unknown';
     sources.byProtocol[protocol] = (sources.byProtocol[protocol] || 0) + 1;
     sources.byOrigin[origin] = (sources.byOrigin[origin] || 0) + 1;
@@ -909,6 +954,8 @@ function addNavigationDiagnostic(summary, payload) {
         lifecycle: cloneForReport(payload.lifecycle || {}),
         tagName: tag,
         url: cloneForReport(payload.url || {}),
+        assignedUrl: cloneForReport(payload.assignedUrl || null),
+        assignment: payload.assignment || '',
         reason: payload.reason || null,
         srcdoc: payload.srcdoc === true,
         name: payload.name || '',

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -1043,6 +1043,8 @@ test('runner documents external-script navigation policy boundary', () => {
       scriptCase('noop', 'navigation-boundary-noop.js'),
       scriptCase('nested-iframe', 'navigation-boundary-nested-iframe.js'),
       scriptCase('static-iframe', 'navigation-boundary-static-iframe.js'),
+      scriptCase('frame-src-attribute', 'navigation-boundary-frame-src-attribute.js'),
+      scriptCase('frame-src-property', 'navigation-boundary-frame-src-property.js'),
       parserScriptCase('parser-script-ok', '/tools/creative-validator/fixtures/navigation-boundary-noop.js'),
       parserScriptCase('parser-script-404', 'mraid.js'),
       scriptCase('location', 'navigation-boundary-location.js'),
@@ -1069,7 +1071,7 @@ test('runner documents external-script navigation policy boundary', () => {
     });
 
     const reports = readJsonl(outPath);
-    assert.equal(reports.length, 8);
+    assert.equal(reports.length, 10);
 
     const bySlug = (slug) => reports.find((row) =>
       row.case.ids.bidId === `bid-runner-boundary-${slug}`);
@@ -1119,6 +1121,44 @@ test('runner documents external-script navigation policy boundary', () => {
     assert.equal(staticIframe.diagnostics.navigationDiagnostics.documentSources.count, 1);
     assert.equal(staticIframe.diagnostics.navigationDiagnostics.documentSources.byKind.frame, 1);
     assert.equal(staticIframe.diagnostics.navigationDiagnostics.documentSources.byTag.iframe, 1);
+
+    const frameSrcAttribute = bySlug('frame-src-attribute');
+    assert.ok(frameSrcAttribute);
+    assert.equal(frameSrcAttribute.outcome.status, 'passed');
+    assert.equal(frameSrcAttribute.outcome.bucket, 'passed');
+    assertScriptLoaded(frameSrcAttribute);
+    assert.equal(frameSrcAttribute.diagnostics.navigationDiagnostics.documentSources.count, 2);
+    assert.equal(frameSrcAttribute.diagnostics.navigationDiagnostics.documentSources.byKind.frame, 1);
+    assert.equal(frameSrcAttribute.diagnostics.navigationDiagnostics.documentSources.byKind['frame-src'], 1);
+    assert.equal(frameSrcAttribute.diagnostics.navigationDiagnostics.documentSources.byProtocol['http:'], 2);
+    assert.ok(
+      frameSrcAttribute.diagnostics.navigationDiagnostics.documentSources.calls.some((call) =>
+        call.kind === 'frame-src'
+          && call.assignment === 'attribute'
+          && call.assignedUrl
+          && call.assignedUrl.origin === 'http://localhost:18872'
+          && call.url
+          && call.url.origin === 'http://localhost:18872'),
+    );
+
+    const frameSrcProperty = bySlug('frame-src-property');
+    assert.ok(frameSrcProperty);
+    assert.equal(frameSrcProperty.outcome.status, 'passed');
+    assert.equal(frameSrcProperty.outcome.bucket, 'passed');
+    assertScriptLoaded(frameSrcProperty);
+    assert.equal(frameSrcProperty.diagnostics.navigationDiagnostics.documentSources.count, 2);
+    assert.equal(frameSrcProperty.diagnostics.navigationDiagnostics.documentSources.byKind.frame, 1);
+    assert.equal(frameSrcProperty.diagnostics.navigationDiagnostics.documentSources.byKind['frame-src'], 1);
+    assert.equal(frameSrcProperty.diagnostics.navigationDiagnostics.documentSources.byProtocol['http:'], 2);
+    assert.ok(
+      frameSrcProperty.diagnostics.navigationDiagnostics.documentSources.calls.some((call) =>
+        call.kind === 'frame-src'
+          && call.assignment === 'property'
+          && call.assignedUrl
+          && call.assignedUrl.origin === 'http://localhost:18872'
+          && call.url
+          && call.url.origin === 'http://localhost:18872'),
+    );
 
     const parserScriptOk = bySlug('parser-script-ok');
     assert.ok(parserScriptOk);


### PR DESCRIPTION
## Summary
- capture direct iframe/frame src property assignments in validator document-source diagnostics when the assigned URL resolves to an origin
- preserve assignment and assignedUrl on bounded document-source calls so triage can distinguish property vs attribute sources
- add synthetic runner coverage for append-then-frame-src behavior and document the private-tier facets

## Validation
- npm run test:creative-validator-runner
- npm run test:creative-validator-triage
- npx eslint tools/creative-validator/test/test-runner.js --max-warnings=0
- git diff --check
- npm run check
- private 78-row unknown-source subset: 78 passed, 0 failed; known property frame-src events 0 -> 7; unknown source events 135 -> 129