### PR TITLE
test: clarify validator OMID capability triage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,13 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 - **Creative validator OMID triage facet.** Adds `corpusDiagnostics.omid` to the
   private triage summary, aggregating the per-row OMID outcomes the runner records
-  at `diagnostics.measurement.omid`. It reports how far each expected OMID row
-  progressed (sidecar → extension → feature advertised → session started →
-  session finished) via a mutually-exclusive `byOutcome` label, distributes
-  verification-script counts and expected rows by bidder, and surfaces
-  `sessionFailedRowsByBidder` as the actionable "whose OMID breaks" signal. The
-  facet is diagnostics-only and does not affect any pass/fail bucket. It is keyed
-  by real bidder names; the summary is private-tier and must not be shared with
-  bidders. Aggregate-only, no raw markup.
+  at `diagnostics.measurement.omid`. It separates OMID capability signals from
+  actual measurement sidecars: API `7` rows now use `rowsCapabilityDeclared` and
+  `capability-no-sidecar`, while sidecar-bearing rows drive the extension/session
+  progress counters and `sessionNotStartedRowsByBidder`. The facet is
+  diagnostics-only and does not affect any pass/fail bucket. It is keyed by real
+  bidder names; the summary is private-tier and must not be shared with bidders.
+  Aggregate-only, no raw markup.
 
 - **Creative validator normalizer foundation.** Adds the first private-first
   hardening harness layer under `tools/creative-validator/`: cleaned OpenRTB

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -102,14 +102,17 @@ The runner caches the fetched local SDK and bridge-probe source for the lifetime
 of one harness page. This keeps batch runs consistent; a failed local SDK fetch
 causes subsequent bridge cases in the same run to fail the same way.
 
-When an executable case declares OMID via AdCOM API `7` and carries a sanitized
+When an executable case declares OMID capability via AdCOM API `7`, the runner
+records that capability signal separately from actual OMID measurement payloads.
+If the case also carries a sanitized
 `creativeMeta.measurement.omid.verificationScripts` sidecar, the runner enables
-the container's `omidAutoInstall` path with validator-owned HTTPS placeholder
-SDK URLs and an in-page mock OM SDK Session Client. Report rows include
-`diagnostics.measurement.omid` so private corpus triage can distinguish "OMID
-declared but no sidecar" from "OMID sidecar installed and the container-owned
-session started." This validates SHARC's measurement wiring; it does not contact
-real verification vendors or certify OM SDK vendor behavior.
+the container's `omidAutoInstall` path with validator-owned HTTPS placeholder SDK
+URLs and an in-page mock OM SDK Session Client. Report rows include
+`diagnostics.measurement.omid` so private corpus triage can distinguish
+"container can support OMID but the bid supplied no sidecar" from "OMID sidecar
+installed and the container-owned session started." This validates SHARC's
+measurement wiring; it does not contact real verification vendors or certify OM
+SDK vendor behavior.
 
 Report rows also include `diagnostics.network`, a compact summary of
 transport-level failed requests, HTTP error responses, and CORS/CSP-like console
@@ -175,17 +178,19 @@ other corpus diagnostics: they key by real bidder names and ad-server origins,
 so summaries must not be shared with bidders.
 
 OMID facets under `corpusDiagnostics.omid` aggregate the per-row OMID outcomes
-the runner records at `diagnostics.measurement.omid`. They report how far each
-expected OMID row progressed — sidecar present, measurement extension installed,
-feature advertised, session started, session finished — and which bidders fail.
-`byOutcome` assigns each expected row a single mutually-exclusive progress label
-(`expected-no-sidecar`, `sidecar-no-extension`, `extension-no-feature`,
-`feature-no-session`, `session-started`, `session-finished`);
-`sessionFailedRowsByBidder` is the
-actionable signal, counting expected rows that never reached a started session.
-The top-level `rows*` counters count whatever the row's booleans report, while
-`byOutcome`, `byVerificationScriptCount`, and the `*ByBidder` maps only count
-rows where OMID was expected. These facets are diagnostics-only and do not affect
+the runner records at `diagnostics.measurement.omid`. They separate OMID
+capability signals from actual measurement sidecars: AdCOM API `7` increments
+`rowsCapabilityDeclared`, while sanitized verification scripts increment
+`rowsWithSidecar` and drive the extension/session progress counters.
+`byOutcome` assigns each capability-declared row a single mutually-exclusive
+progress label (`capability-no-sidecar`, `sidecar-no-extension`,
+`extension-no-feature`, `feature-no-session`, `session-started`,
+`session-finished`). `capabilityNoSidecarRowsByBidder` is a provenance signal,
+not a failure; `sessionNotStartedRowsByBidder` only counts rows that supplied an
+OMID sidecar but did not reach a started session. The top-level `rows*` counters
+count whatever the row's booleans report, while `byOutcome`,
+`byVerificationScriptCount`, and the `*ByBidder` maps only count rows where OMID
+capability was declared. These facets are diagnostics-only and do not affect
 validator pass/fail classification. They are private-tier for the same reason as
 the other corpus diagnostics: they are keyed by real bidder names, so the summary
 is private-tier and must not be shared with bidders. Aggregate-only, no raw

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -112,7 +112,7 @@ function emptySummary(files) {
       },
       omid: {
         rows: 0,
-        rowsExpected: 0,
+        rowsCapabilityDeclared: 0,
         rowsWithSidecar: 0,
         rowsWithExtension: 0,
         rowsFeatureAdvertised: 0,
@@ -122,8 +122,10 @@ function emptySummary(files) {
         rowsImpressionFired: 0,
         byOutcome: {},
         byVerificationScriptCount: {},
-        expectedRowsByBidder: {},
-        sessionFailedRowsByBidder: {},
+        capabilityRowsByBidder: {},
+        capabilityNoSidecarRowsByBidder: {},
+        sidecarRowsByBidder: {},
+        sessionNotStartedRowsByBidder: {},
       },
     },
     failureGroups: [],
@@ -191,7 +193,7 @@ function omidDiagnostics(row) {
 }
 
 function omidOutcomeKey(omid) {
-  if (omid.sidecarPresent !== true) return 'expected-no-sidecar';
+  if (omid.sidecarPresent !== true) return 'capability-no-sidecar';
   if (omid.extensionPresent !== true) return 'sidecar-no-extension';
   if (omid.featureAdvertised !== true) return 'extension-no-feature';
   if (omid.sessionStarted !== true) return 'feature-no-session';
@@ -476,12 +478,19 @@ function addOmidCorpusFacets(summary, row, fields) {
 
   if (omid.expected !== true) return;
 
-  facet.rowsExpected += 1;
+  facet.rowsCapabilityDeclared += 1;
   increment(facet.byOutcome, omidOutcomeKey(omid));
   increment(facet.byVerificationScriptCount, networkCount(omid.verificationScriptCount));
-  increment(facet.expectedRowsByBidder, fields.bidder);
+  increment(facet.capabilityRowsByBidder, fields.bidder);
+
+  if (omid.sidecarPresent !== true) {
+    increment(facet.capabilityNoSidecarRowsByBidder, fields.bidder);
+    return;
+  }
+
+  increment(facet.sidecarRowsByBidder, fields.bidder);
   if (omid.sessionStarted !== true) {
-    increment(facet.sessionFailedRowsByBidder, fields.bidder);
+    increment(facet.sessionNotStartedRowsByBidder, fields.bidder);
   }
 }
 
@@ -733,10 +742,14 @@ function triageReports(files) {
     sortEntries(summary.corpusDiagnostics.omid.byOutcome);
   summary.corpusDiagnostics.omid.byVerificationScriptCount =
     sortEntries(summary.corpusDiagnostics.omid.byVerificationScriptCount, { numericKeys: true });
-  summary.corpusDiagnostics.omid.expectedRowsByBidder =
-    sortEntries(summary.corpusDiagnostics.omid.expectedRowsByBidder);
-  summary.corpusDiagnostics.omid.sessionFailedRowsByBidder =
-    sortEntries(summary.corpusDiagnostics.omid.sessionFailedRowsByBidder);
+  summary.corpusDiagnostics.omid.capabilityRowsByBidder =
+    sortEntries(summary.corpusDiagnostics.omid.capabilityRowsByBidder);
+  summary.corpusDiagnostics.omid.capabilityNoSidecarRowsByBidder =
+    sortEntries(summary.corpusDiagnostics.omid.capabilityNoSidecarRowsByBidder);
+  summary.corpusDiagnostics.omid.sidecarRowsByBidder =
+    sortEntries(summary.corpusDiagnostics.omid.sidecarRowsByBidder);
+  summary.corpusDiagnostics.omid.sessionNotStartedRowsByBidder =
+    sortEntries(summary.corpusDiagnostics.omid.sessionNotStartedRowsByBidder);
   summary.failureGroups = sortedGroups(failureGroups);
   summary.reductionCandidates = summary.failureGroups
     .filter(isReductionCandidate)

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -478,7 +478,7 @@ function omidReport(omid, overrides = {}) {
   });
 }
 
-test('triageReports aggregates OMID outcomes for expected rows', () => {
+test('triageReports aggregates OMID capability and sidecar outcomes', () => {
   const privateRoot = resolve('tools/creative-validator/private');
   mkdirSync(privateRoot, { recursive: true });
   const workDir = mkdtempSync(resolve(privateRoot, 'test-triage-omid-'));
@@ -486,7 +486,7 @@ test('triageReports aggregates OMID outcomes for expected rows', () => {
 
   try {
     writeJsonl(reportPath, [
-      // Expected row reaching a finished session.
+      // Capability-declared row reaching a finished session.
       omidReport({
         expected: true,
         sidecarPresent: true,
@@ -504,7 +504,7 @@ test('triageReports aggregates OMID outcomes for expected rows', () => {
         },
         outcome: { status: 'passed', bucket: 'passed' },
       }),
-      // Expected row that installs the extension but never starts a session.
+      // Capability-declared row that installs the extension but never starts a session.
       omidReport({
         expected: true,
         sidecarPresent: true,
@@ -522,7 +522,7 @@ test('triageReports aggregates OMID outcomes for expected rows', () => {
         },
         outcome: { status: 'failed', bucket: 'measurement-omid' },
       }),
-      // Expected row whose extension installs but never advertises the OMID feature.
+      // Capability-declared row whose extension installs but never advertises the OMID feature.
       omidReport({
         expected: true,
         sidecarPresent: true,
@@ -540,7 +540,7 @@ test('triageReports aggregates OMID outcomes for expected rows', () => {
         },
         outcome: { status: 'failed', bucket: 'measurement-omid' },
       }),
-      // Expected row with a sparse omid object: no fields beyond `expected`.
+      // Capability-only row with no sidecar fields beyond `expected`.
       omidReport({ expected: true }, {
         case: {
           ...report().case,
@@ -548,7 +548,7 @@ test('triageReports aggregates OMID outcomes for expected rows', () => {
         },
         outcome: { status: 'failed', bucket: 'measurement-omid' },
       }),
-      // Non-expected row: present omid object but expected === false.
+      // Non-capability row: present omid object but expected === false.
       omidReport({
         expected: false,
         sidecarPresent: false,
@@ -580,7 +580,7 @@ test('triageReports aggregates OMID outcomes for expected rows', () => {
     const summary = triageReports([reportPath]);
     const omid = summary.corpusDiagnostics.omid;
     assert.equal(omid.rows, 6);
-    assert.equal(omid.rowsExpected, 4);
+    assert.equal(omid.rowsCapabilityDeclared, 4);
     assert.equal(omid.rowsWithSidecar, 3);
     assert.equal(omid.rowsWithExtension, 3);
     assert.equal(omid.rowsFeatureAdvertised, 2);
@@ -589,22 +589,29 @@ test('triageReports aggregates OMID outcomes for expected rows', () => {
     assert.equal(omid.rowsLoadedFired, 1);
     assert.equal(omid.rowsImpressionFired, 1);
     assert.deepEqual(omid.byOutcome, {
-      'expected-no-sidecar': 1,
+      'capability-no-sidecar': 1,
       'extension-no-feature': 1,
       'feature-no-session': 1,
       'session-finished': 1,
     });
     assert.deepEqual(omid.byVerificationScriptCount, { 0: 1, 1: 2, 2: 1 });
-    assert.deepEqual(omid.expectedRowsByBidder, {
+    assert.deepEqual(omid.capabilityRowsByBidder, {
       'bidder-omid-a': 1,
       'bidder-omid-b': 1,
       'bidder-omid-e': 1,
       'bidder-omid-f': 1,
     });
-    assert.deepEqual(omid.sessionFailedRowsByBidder, {
+    assert.deepEqual(omid.capabilityNoSidecarRowsByBidder, {
+      'bidder-omid-f': 1,
+    });
+    assert.deepEqual(omid.sidecarRowsByBidder, {
+      'bidder-omid-a': 1,
       'bidder-omid-b': 1,
       'bidder-omid-e': 1,
-      'bidder-omid-f': 1,
+    });
+    assert.deepEqual(omid.sessionNotStartedRowsByBidder, {
+      'bidder-omid-b': 1,
+      'bidder-omid-e': 1,
     });
   } finally {
     rmSync(workDir, { force: true, recursive: true });
@@ -622,7 +629,7 @@ test('triageReports emits a stable empty OMID facet for a zero-row corpus', () =
     const summary = triageReports([reportPath]);
     assert.deepEqual(summary.corpusDiagnostics.omid, {
       rows: 0,
-      rowsExpected: 0,
+      rowsCapabilityDeclared: 0,
       rowsWithSidecar: 0,
       rowsWithExtension: 0,
       rowsFeatureAdvertised: 0,
@@ -632,8 +639,10 @@ test('triageReports emits a stable empty OMID facet for a zero-row corpus', () =
       rowsImpressionFired: 0,
       byOutcome: {},
       byVerificationScriptCount: {},
-      expectedRowsByBidder: {},
-      sessionFailedRowsByBidder: {},
+      capabilityRowsByBidder: {},
+      capabilityNoSidecarRowsByBidder: {},
+      sidecarRowsByBidder: {},
+      sessionNotStartedRowsByBidder: {},
     });
   } finally {
     rmSync(workDir, { force: true, recursive: true });


### PR DESCRIPTION
## Summary
- rename validator OMID triage from expected/session-failed terminology to capability/sidecar terminology
- keep API 7 without verification sidecars as capability-no-sidecar provenance instead of a session failure
- update README, changelog, and triage coverage for the new summary shape

## Validation
- npm run test:creative-validator-triage
- npx eslint tools/creative-validator/src/triage.js tools/creative-validator/test/test-triage.js --max-warnings=0
- node tools/creative-validator/src/cli.js triage tools/creative-validator/private/reports/openrtb-parsing-20260529-post-215-report.jsonl --out tools/creative-validator/private/triage/openrtb-parsing-20260529-post-215-omid-terminology-summary.json
- npm run check