### PR TITLE
test: sample late validator bridge probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ### Added
 
+- **Creative validator late bridge probes.** The private runner now records a
+  small sequence of nonce-verified bridge-probe samples and classifies MRAID /
+  SafeFrame availability from the latest sample. This avoids false
+  `bridge-missing` failures when MRAID auto-install races the first diagnostic
+  tick in parser-active creatives.
+
 - **Creative validator OMID triage facet.** Adds `corpusDiagnostics.omid` to the
   private triage summary, aggregating the per-row OMID outcomes the runner records
   at `diagnostics.measurement.omid`. It separates OMID capability signals from

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -94,9 +94,11 @@ expected bridge absence as `bridge-missing` and method-call failures as
 `bridge-api-error`. They are compatibility smoke tests for corpus triage, not a
 complete MRAID or SafeFrame compliance suite. Probe results are accepted only
 from the current renderer iframe, the expected renderer origin, and the current
-per-case nonce; forged or duplicate probe messages are ignored. If the probe
-does not run, the case falls through to the existing rendered/inconclusive
-buckets instead of being treated as a bridge absence.
+per-case nonce. The runner records a small number of early/late samples and
+classifies against the latest sample so MRAID auto-install timing does not turn
+an eventually installed bridge into a false `bridge-missing` failure. If no probe
+runs, the case falls through to the existing rendered/inconclusive buckets
+instead of being treated as a bridge absence.
 
 The runner caches the fetched local SDK and bridge-probe source for the lifetime
 of one harness page. This keeps batch runs consistent; a failed local SDK fetch

--- a/tools/creative-validator/harness/bridge-probe.js
+++ b/tools/creative-validator/harness/bridge-probe.js
@@ -88,9 +88,12 @@
   }
 
   // The reference renderer imports bridge modules before document.write().
-  // Queueing the probe here lets bridge auto-install timers run first, while
-  // this probe still fires before timers queued by later creative code. If
-  // creative code suppresses this timer, the parent records no probe and the
-  // case falls through to existing rendered/inconclusive buckets.
+  // Queueing probes here lets bridge auto-install timers run first, while
+  // still sampling late enough to cover MRAID creatives whose parser activity
+  // races the first diagnostic tick. If creative code suppresses these timers,
+  // the parent records no probe and the case falls through to existing
+  // rendered/inconclusive buckets.
   setTimeout(runProbe, 0);
+  setTimeout(runProbe, 50);
+  setTimeout(runProbe, 150);
 }());

--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -1012,7 +1012,7 @@ window.__sharcCreativeValidatorHarness = {
           && event.source === container._iframe.contentWindow
           && event.data && event.data.type === 'SHARC:Validator:bridgeProbe'
           && event.data.probeNonce === probeNonce
-          && bridgeProbes.length === 0) {
+          && bridgeProbes.length < 5) {
         bridgeProbes.push(cloneForReport(event.data.payload || {}));
       } else if (event && event.origin === rendererOrigin && container && container._iframe
           && event.source === container._iframe.contentWindow

--- a/tools/creative-validator/src/diagnose.js
+++ b/tools/creative-validator/src/diagnose.js
@@ -99,9 +99,9 @@ function bridgesToValidate(testCase) {
   return ['mraid', 'safeframe'].filter((bridge) => sniffed.has(bridge));
 }
 
-function firstBridgeProbe(run) {
+function latestBridgeProbe(run) {
   return run.bridgeProbes && run.bridgeProbes.length > 0
-    ? run.bridgeProbes[0]
+    ? run.bridgeProbes[run.bridgeProbes.length - 1]
     : null;
 }
 
@@ -188,7 +188,7 @@ function classifyOutcome(testCase, run) {
   }
 
   const expected = bridgesToValidate(testCase);
-  const probe = firstBridgeProbe(run);
+  const probe = latestBridgeProbe(run);
   if (expected.length > 0 && probe) {
     for (const bridge of expected) {
       const bridgeProbe = bridgeProbeFor(probe, bridge);

--- a/tools/creative-validator/test/test-diagnose.js
+++ b/tools/creative-validator/test/test-diagnose.js
@@ -139,6 +139,18 @@ test('classifyOutcome buckets expected bridge probe failures', () => {
   }, sniffedMraidCase), 'bridge-missing');
   assert.equal(bucket({
     creativeRendered: true,
+    bridgeProbes: [
+      { bridges: { mraid: { exists: false, methods: {} } } },
+      {
+        bridges: { mraid: {
+          exists: true,
+          methods: { getState: { exists: true, status: 'ok', value: 'loading' } },
+        } },
+      },
+    ],
+  }, sniffedMraidCase), 'passed');
+  assert.equal(bucket({
+    creativeRendered: true,
     bridgeProbes: [{
       bridges: { mraid: {
         exists: true,

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -755,7 +755,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(typeof htmlReport.outcome.reachedActive, 'boolean');
     assert.ok(Array.isArray(htmlReport.diagnostics.stateHistory));
     assert.equal(htmlReport.outcome.creativeInjected, false);
-    assert.equal(htmlReport.diagnostics.bridgeProbes.length, 1);
+    assert.ok(htmlReport.diagnostics.bridgeProbes.length >= 1);
     assert.equal(htmlReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.installed, false);
     assert.equal(htmlReport.diagnostics.bridgeProbes.at(-1).bridges.safeframe.installed, false);
     assert.equal(htmlReport.diagnostics.measurement.omid.expected, false);
@@ -763,7 +763,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
     const mraidReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-mraid');
     assert.ok(mraidReport);
     assert.equal(mraidReport.outcome.status, 'passed');
-    assert.equal(mraidReport.diagnostics.bridgeProbes.length, 1);
+    assert.ok(mraidReport.diagnostics.bridgeProbes.length >= 1);
     assert.equal(mraidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.exists, true);
     assert.equal(mraidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.installed, true);
     assert.equal(mraidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.methods.getState.status, 'ok');


### PR DESCRIPTION
## Summary
- collect a small sequence of nonce-verified validator bridge probes instead of only the first one
- classify MRAID and SafeFrame availability from the latest probe to avoid false bridge-missing results when MRAID auto-install races the first diagnostic tick
- update validator docs and coverage for late bridge-probe behavior

## Validation
- npm run test:creative-validator-diagnose
- npm run test:creative-validator-runner
- node tools/creative-validator/src/cli.js run tools/creative-validator/private/normalized/openrtb-parsing-20260529-api7-cases.jsonl --out tools/creative-validator/private/reports/openrtb-parsing-20260529-mraid-late-probe-report.jsonl --render-timeout-ms 4000 --settle-ms 100
- node tools/creative-validator/src/cli.js triage tools/creative-validator/private/reports/openrtb-parsing-20260529-mraid-late-probe-report.jsonl --out tools/creative-validator/private/triage/openrtb-parsing-20260529-mraid-late-probe-summary.json
- npx eslint tools/creative-validator/src/diagnose.js tools/creative-validator/test/test-diagnose.js tools/creative-validator/test/test-runner.js --max-warnings=0
- git diff --check
- npm run check

## Corpus result
The enlarged API-7 corpus improved from 939 passed / 805 skipped / 1 bridge-missing failure to 940 passed / 805 skipped / 0 failed.