### PR TITLE
test: classify validator script errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,8 +87,11 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 - **Creative validator script-load diagnostics.** The markup runner now records
   sanitized script discovery/load/error events with protocol, origin, lifecycle
   state, and load status. Private triage aggregates script-load counts,
-  protocols, origins, and statuses so navigation-policy failures can be
-  correlated with external script execution without storing raw private URLs.
+  protocols, origins, statuses, and error classes (`legacy-mraid-loader`,
+  `external-script-aborted`, `external-script-dns`, `external-script-transport`,
+  `external-script-http`, `script-csp-blocked`, `script-load-event`) so
+  navigation-policy failures can be correlated with external script execution
+  without storing raw private URLs.
 
 - **Creative validator navigation-boundary coverage.** Synthetic runner cases
   now document the policy line for external scripts: no-op scripts and nested

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -169,6 +169,13 @@ aggregate-only and still avoid raw creative markup. They are still private-tier:
 the facets key by real bidder names and script origins, so summaries must not
 be shared with bidders.
 
+Script-load corpus facets split error rows into diagnostic classes:
+`legacy-mraid-loader`, `external-script-aborted`, `external-script-dns`,
+`external-script-transport`, `external-script-http`, `script-csp-blocked`, and
+`script-load-event`. This keeps the MRAID compatibility alias separate from real
+external dependency failures and makes repeated CDN/DNS/CSP patterns visible
+without exposing raw creative URLs.
+
 Document-source facets attribute nested document activity observed inside the
 renderer document. The runner passively records frame discovery, frame `src`
 assignments via attributes and direct property setters when the assigned URL

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -75,9 +75,12 @@ function emptySummary(files) {
         rowsWithScripts: 0,
         rowsWithErrors: 0,
         rowsWithLoaded: 0,
+        rowsWithErrorsByClass: {},
         rowsWithErrorsByBidder: {},
         rowsWithErrorsByAdmKind: {},
         rowsWithErrorsByLegacyMraidLoader: {},
+        errorEventsByClass: {},
+        errorRowsByClassAndBidder: {},
         byCount: {},
         byLoadedCount: {},
         byErrorCount: {},
@@ -171,6 +174,18 @@ function networkDiagnostics(row) {
     : {};
 }
 
+function failedRequests(row) {
+  return row && row.diagnostics && Array.isArray(row.diagnostics.failedRequests)
+    ? row.diagnostics.failedRequests
+    : [];
+}
+
+function failedResponses(row) {
+  return row && row.diagnostics && Array.isArray(row.diagnostics.failedResponses)
+    ? row.diagnostics.failedResponses
+    : [];
+}
+
 function navigationDiagnostics(row) {
   return row && row.diagnostics && row.diagnostics.navigationDiagnostics
     ? row.diagnostics.navigationDiagnostics
@@ -222,6 +237,52 @@ function networkShape(network) {
     `cors:${networkCount(network.corsConsoleCount)}`,
     `csp:${networkCount(network.cspConsoleCount)}`,
   ].join(' ');
+}
+
+function scriptErrorClasses(row, scriptLoads, legacy) {
+  const rows = new Set();
+  const events = {};
+  const add = (name, count = 1) => {
+    rows.add(name);
+    increment(events, name, count);
+  };
+  const calls = scriptLoads && Array.isArray(scriptLoads.calls) ? scriptLoads.calls : [];
+  const legacyErrorCalls = calls.filter((call) =>
+    call && call.status === 'error' && call.url && call.url.legacyMraidLoader === true);
+  if (networkCount(legacy && legacy.errorCount) > 0 || legacyErrorCalls.length > 0) {
+    add('legacy-mraid-loader', Math.max(networkCount(legacy && legacy.errorCount), legacyErrorCalls.length));
+  }
+
+  let scriptFailureEvents = 0;
+  for (const request of failedRequests(row)) {
+    if (!request || request.resourceType !== 'script') continue;
+    scriptFailureEvents += 1;
+    const text = String(request.errorText || '').toLowerCase();
+    if (text.includes('name_not_resolved')) {
+      add('external-script-dns');
+    } else if (text.includes('err_aborted')) {
+      add('external-script-aborted');
+    } else {
+      add('external-script-transport');
+    }
+  }
+  for (const response of failedResponses(row)) {
+    if (!response || response.resourceType !== 'script') continue;
+    scriptFailureEvents += 1;
+    add('external-script-http');
+  }
+
+  if (networkCount(networkDiagnostics(row).cspConsoleCount) > 0 && networkCount(scriptLoads && scriptLoads.errorCount) > 0) {
+    add('script-csp-blocked', networkCount(networkDiagnostics(row).cspConsoleCount));
+  }
+
+  const knownEvents = Object.values(events).reduce((sum, count) => sum + count, 0);
+  const unknownScriptErrors = Math.max(0, networkCount(scriptLoads && scriptLoads.errorCount) - knownEvents);
+  if (unknownScriptErrors > 0 && scriptFailureEvents === 0) {
+    add('script-load-event', unknownScriptErrors);
+  }
+
+  return { rows, events };
 }
 
 function addDiagnosticFacets(summary, row) {
@@ -352,6 +413,7 @@ function addCorpusFacets(summary, row, fields) {
 function addRuntimeCorpusFacets(summary, row, fields) {
   const navigation = navigationDiagnostics(row);
   const scriptLoads = navigation.scriptLoads || {};
+  const legacy = legacyMraidLoaderDiagnostics(row);
   const scriptCount = networkCount(scriptLoads.count);
   const scriptErrorCount = networkCount(scriptLoads.errorCount);
   const scriptLoadedCount = networkCount(scriptLoads.loadedCount);
@@ -366,8 +428,19 @@ function addRuntimeCorpusFacets(summary, row, fields) {
       increment(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByAdmKind, fields.admKind);
       increment(
         summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByLegacyMraidLoader,
-        legacyMraidLoaderDiagnostics(row).requested === true ? 'present' : 'absent',
+        legacy.requested === true ? 'present' : 'absent',
       );
+      const classes = scriptErrorClasses(row, scriptLoads, legacy);
+      for (const name of classes.rows) {
+        increment(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByClass, name);
+        increment(
+          summary.corpusDiagnostics.scriptLoads.errorRowsByClassAndBidder,
+          `${name}|${fields.bidder}`,
+        );
+      }
+      for (const [name, count] of Object.entries(classes.events)) {
+        increment(summary.corpusDiagnostics.scriptLoads.errorEventsByClass, name, count);
+      }
     }
     if (scriptLoadedCount > 0) {
       summary.corpusDiagnostics.scriptLoads.rowsWithLoaded += 1;
@@ -692,6 +765,12 @@ function triageReports(files) {
     sortEntries(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByAdmKind);
   summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByLegacyMraidLoader =
     sortEntries(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByLegacyMraidLoader);
+  summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByClass =
+    sortEntries(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByClass);
+  summary.corpusDiagnostics.scriptLoads.errorEventsByClass =
+    sortEntries(summary.corpusDiagnostics.scriptLoads.errorEventsByClass);
+  summary.corpusDiagnostics.scriptLoads.errorRowsByClassAndBidder =
+    sortEntries(summary.corpusDiagnostics.scriptLoads.errorRowsByClassAndBidder);
   summary.corpusDiagnostics.scriptLoads.byCount =
     sortEntries(summary.corpusDiagnostics.scriptLoads.byCount, { numericKeys: true });
   summary.corpusDiagnostics.scriptLoads.byLoadedCount =

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -80,6 +80,11 @@ test('triageReports groups private report rows by failure dimensions', () => {
             corsConsoleCount: 0,
             cspConsoleCount: 1,
           },
+          failedRequests: [{
+            url: 'https://cdn.example/tag.js',
+            resourceType: 'script',
+            errorText: 'net::ERR_ABORTED',
+          }],
           navigationDiagnostics: {
             documentWrite: {
               count: 2,
@@ -117,11 +122,11 @@ test('triageReports groups private report rows by failure dimensions', () => {
                 'https://cdn.example': 1,
                 'http://127.0.0.1:18868': 1,
               },
-              byStatus: {
-                discovered: 2,
-                loaded: 1,
-                error: 1,
-              },
+            byStatus: {
+              discovered: 2,
+              loaded: 1,
+              error: 1,
+            },
             },
             documentSources: {
               count: 2,
@@ -401,6 +406,18 @@ test('triageReports groups private report rows by failure dimensions', () => {
     assert.equal(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByBidder['bidder-a'], 1);
     assert.equal(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByAdmKind['html-mraid'], 1);
     assert.equal(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByLegacyMraidLoader.absent, 1);
+    assert.deepEqual(summary.corpusDiagnostics.scriptLoads.rowsWithErrorsByClass, {
+      'external-script-aborted': 1,
+      'script-csp-blocked': 1,
+    });
+    assert.deepEqual(summary.corpusDiagnostics.scriptLoads.errorEventsByClass, {
+      'external-script-aborted': 1,
+      'script-csp-blocked': 1,
+    });
+    assert.deepEqual(summary.corpusDiagnostics.scriptLoads.errorRowsByClassAndBidder, {
+      'external-script-aborted|bidder-a': 1,
+      'script-csp-blocked|bidder-a': 1,
+    });
     assert.equal(summary.corpusDiagnostics.scriptLoads.byCount['2'], 1);
     assert.equal(summary.corpusDiagnostics.scriptLoads.byLoadedCount['1'], 1);
     assert.equal(summary.corpusDiagnostics.scriptLoads.byErrorCount['1'], 1);


### PR DESCRIPTION
## Summary
- add script-error classes to private creative-validator triage
- separate legacy MRAID loader errors, external script aborts, DNS/transport/HTTP failures, CSP-observed script rows, and unclassified script-load events
- document the taxonomy and cover it in triage tests

## Validation
- npm run test:creative-validator-triage
- npx eslint tools/creative-validator/src/triage.js tools/creative-validator/test/test-triage.js --max-warnings=0
- git diff --check
- npm run check
- node tools/creative-validator/src/cli.js triage tools/creative-validator/private/reports/openrtb-parsing-20260530-post-218-report.jsonl --out tools/creative-validator/private/triage/openrtb-parsing-20260530-script-taxonomy-summary.json

## Corpus readout
The post-218 corpus remains 940 passed / 805 skipped / 0 failed. New script classes show 668 rows with external-script-aborted, 141 with script-csp-blocked, 1 with external-script-dns, and 1 with legacy-mraid-loader.