### PR TITLE
test: actively probe bridge navigation methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   `bridge-missing` failures when MRAID auto-install races the first diagnostic
   tick in parser-active creatives.
 
+- **Creative validator active bridge method probes.** Bridge probes now actively
+  exercise MRAID `open`/`expand` and SafeFrame `register`/`redirect` when the
+  methods are present, recording per-method outcomes and separate probe routing
+  observations so broken navigation/placement methods can surface as
+  `bridge-api-error` without inflating creative-initiated bridge-call counts.
+
 - **Creative validator OMID triage facet.** Adds `corpusDiagnostics.omid` to the
   private triage summary, aggregating the per-row OMID outcomes the runner records
   at `diagnostics.measurement.omid`. It separates OMID capability signals from

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -89,16 +89,21 @@ not duplicate raw `creative.html`.
 
 For MRAID and SafeFrame cases, the runner injects a small validator probe into
 the creative document and records `diagnostics.bridgeProbes[].bridges`. These
-probes check bridge presence plus a few read-only/basic methods, then classify
-expected bridge absence as `bridge-missing` and method-call failures as
-`bridge-api-error`. They are compatibility smoke tests for corpus triage, not a
-complete MRAID or SafeFrame compliance suite. Probe results are accepted only
-from the current renderer iframe, the expected renderer origin, and the current
-per-case nonce. The runner records a small number of early/late samples and
-classifies against the latest sample so MRAID auto-install timing does not turn
-an eventually installed bridge into a false `bridge-missing` failure. If no probe
-runs, the case falls through to the existing rendered/inconclusive buckets
-instead of being treated as a bridge absence.
+probes check bridge presence, read-only/basic methods, and, for SHARC-installed
+bridges, a small set of active navigation/placement methods (`mraid.open`,
+`mraid.expand`, `$sf.ext.register`, and `$sf.ext.redirect` when present).
+Expected bridge absence classifies as `bridge-missing`; method-call failures
+classify as `bridge-api-error`. They are compatibility smoke tests for corpus
+triage, not a complete MRAID or SafeFrame compliance suite. Probe-originated
+bridge calls are reported under `navigationDiagnostics.probeBridgeCalls`;
+`navigationDiagnostics.bridgeCalls` remains reserved for creative-initiated
+bridge calls. Probe results are accepted only from the current renderer iframe,
+the expected renderer origin, and the current per-case nonce. The runner records
+a small number of early/late samples and classifies against the latest sample so
+MRAID auto-install timing does not turn an eventually installed bridge into a
+false `bridge-missing` failure. If no probe runs, the case falls through to the
+existing rendered/inconclusive buckets instead of being treated as a bridge
+absence.
 
 The runner caches the fetched local SDK and bridge-probe source for the lifetime
 of one harness page. This keeps batch runs consistent; a failed local SDK fetch

--- a/tools/creative-validator/harness/bridge-probe.js
+++ b/tools/creative-validator/harness/bridge-probe.js
@@ -46,6 +46,56 @@
     return out;
   }
 
+  var activeProbeCache = {
+    mraid: null,
+    safeframe: null,
+  };
+
+  function withActiveProbe(fn) {
+    var hadPrior = Object.prototype.hasOwnProperty.call(window, '__sharcValidatorProbeActive');
+    var prior = window.__sharcValidatorProbeActive;
+    window.__sharcValidatorProbeActive = true;
+    try {
+      return fn();
+    } finally {
+      if (hadPrior) {
+        window.__sharcValidatorProbeActive = prior;
+      } else {
+        try {
+          delete window.__sharcValidatorProbeActive;
+        } catch (_) {
+          window.__sharcValidatorProbeActive = undefined;
+        }
+      }
+    }
+  }
+
+  function activeMraidProbes(mraid) {
+    // Active probes intentionally run once per document: they may call
+    // navigation/placement methods, so later sampling ticks should report the
+    // same active-call outcome instead of generating duplicate probe traffic.
+    if (activeProbeCache.mraid !== null) return activeProbeCache.mraid;
+    activeProbeCache.mraid = withActiveProbe(function () {
+      return {
+        open: probeMethod(mraid, 'open', ['https://sharc-validator.example/mraid-open-probe']),
+        expand: probeMethod(mraid, 'expand'),
+      };
+    });
+    return activeProbeCache.mraid;
+  }
+
+  function activeSafeFrameProbes(sf) {
+    // Active probes intentionally run once per document; see MRAID note above.
+    if (activeProbeCache.safeframe !== null) return activeProbeCache.safeframe;
+    activeProbeCache.safeframe = withActiveProbe(function () {
+      return {
+        register: probeMethod(sf, 'register', [0, 0, function () {}]),
+        redirect: probeMethod(sf, 'redirect', ['https://sharc-validator.example/safeframe-redirect-probe']),
+      };
+    });
+    return activeProbeCache.safeframe;
+  }
+
   function mraidProbe() {
     var mraid = window.mraid;
     var out = {
@@ -58,6 +108,9 @@
     out.methods.getState = probeMethod(mraid, 'getState');
     out.methods.isViewable = probeMethod(mraid, 'isViewable');
     out.methods.supports = probeMethod(mraid, 'supports', ['sms']);
+    if (out.installed) {
+      Object.assign(out.methods, activeMraidProbes(mraid));
+    }
     return out;
   }
 
@@ -71,6 +124,9 @@
     if (!sf) return out;
     out.methods.supports = probeMethod(sf, 'supports');
     out.methods.geom = probeMethod(sf, 'geom');
+    if (out.installed) {
+      Object.assign(out.methods, activeSafeFrameProbes(sf));
+    }
     return out;
   }
 

--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -626,14 +626,15 @@ function validatorNavigationPreludeSource(probeNonce) {
       }
     }
 
-    function bridgeCall(bridge, method, url) {
+    function bridgeCall(bridge, method, url, hasUrl) {
       var candidateUrl = url && typeof url === 'object' && 'url' in url ? url.url : url;
       post({
         kind: 'bridge-call',
         bridge: bridge,
         method: method,
+        probe: window.__sharcValidatorProbeActive === true,
         lifecycle: lifecycle(),
-        url: summarizeUrl(candidateUrl),
+        url: hasUrl ? summarizeUrl(candidateUrl) : null,
       });
     }
 
@@ -642,7 +643,8 @@ function validatorNavigationPreludeSource(probeNonce) {
       if (target[method].__sharcValidatorWrapped) return;
       var original = target[method];
       var wrapped = function () {
-        bridgeCall(bridge, method, arguments[urlIndex || 0]);
+        var hasUrl = urlIndex !== null;
+        bridgeCall(bridge, method, hasUrl ? arguments[urlIndex || 0] : null, hasUrl);
         return original.apply(this, arguments);
       };
       try {
@@ -662,9 +664,11 @@ function validatorNavigationPreludeSource(probeNonce) {
 
     function wrapSafeFrame(value) {
       if (value && value.ext) {
-        wrapMethod(value.ext, 'safeframe', 'expand', 0);
-        wrapMethod(value.ext, 'safeframe', 'collapse', 0);
-        wrapMethod(value.ext, 'safeframe', 'message', 0);
+        wrapMethod(value.ext, 'safeframe', 'register', null);
+        wrapMethod(value.ext, 'safeframe', 'redirect', 0);
+        wrapMethod(value.ext, 'safeframe', 'expand', null);
+        wrapMethod(value.ext, 'safeframe', 'collapse', null);
+        wrapMethod(value.ext, 'safeframe', 'message', null);
       }
       return value;
     }
@@ -847,6 +851,12 @@ function emptyNavigationDiagnostics() {
       byProtocol: {},
       calls: [],
     },
+    probeBridgeCalls: {
+      count: 0,
+      byMethod: {},
+      byProtocol: {},
+      calls: [],
+    },
     scriptLoads: {
       count: 0,
       loadedCount: 0,
@@ -967,14 +977,18 @@ function addNavigationDiagnostic(summary, payload) {
     return;
   }
   if (payload.kind === 'bridge-call') {
-    const bridgeCalls = summary.bridgeCalls;
-    bridgeCalls.count += 1;
     const method = payload.bridge && payload.method
       ? payload.bridge + '.' + payload.method
       : 'unknown';
+    const bridgeCalls = payload.probe === true
+      ? summary.probeBridgeCalls
+      : summary.bridgeCalls;
+    bridgeCalls.count += 1;
     bridgeCalls.byMethod[method] = (bridgeCalls.byMethod[method] || 0) + 1;
-    const protocol = payload.url && payload.url.protocol ? payload.url.protocol : 'unknown';
-    bridgeCalls.byProtocol[protocol] = (bridgeCalls.byProtocol[protocol] || 0) + 1;
+    if (payload.url && payload.url.present === true) {
+      const protocol = payload.url.protocol || 'unknown';
+      bridgeCalls.byProtocol[protocol] = (bridgeCalls.byProtocol[protocol] || 0) + 1;
+    }
     if (bridgeCalls.calls.length < 20) {
       bridgeCalls.calls.push({
         bridge: payload.bridge || 'unknown',

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -347,6 +347,10 @@ function addDiagnosticFacets(summary, row) {
     summary.diagnostics.navigationSources.bridgeCallByCount,
     networkCount(bridgeCalls.count),
   );
+  // Intentionally aggregate only creative-initiated bridgeCalls here.
+  // probeBridgeCalls are validator self-check traffic; runner tests assert they
+  // stay separated so corpus triage can read bridgeCall facets as creative
+  // behavior without subtracting a probe baseline.
   const bridgeByMethod = bridgeCalls.byMethod || {};
   for (const [method, count] of Object.entries(bridgeByMethod)) {
     if (networkCount(count) > 0) {

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -225,7 +225,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
       admKind: 'html-mraid',
       html: '<!doctype html><html><body><script>'
         + 'Object.defineProperty(window,"mraid",{configurable:true,set:function(value){'
-        + 'value.getState=function(){throw new Error("probe boom")};'
+        + 'value.open=function(){throw new Error("probe boom")};'
         + 'Object.defineProperty(window,"mraid",{configurable:true,value:value});'
         + '}});'
         + '</script></body></html>',
@@ -768,6 +768,13 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(mraidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.installed, true);
     assert.equal(mraidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.methods.getState.status, 'ok');
     assert.equal(mraidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.methods.getVersion.status, 'ok');
+    assert.equal(mraidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.methods.open.status, 'ok');
+    assert.equal(mraidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.methods.expand.status, 'ok');
+    assert.equal(mraidReport.diagnostics.navigationDiagnostics.bridgeCalls.count, 0);
+    assert.equal(mraidReport.diagnostics.navigationDiagnostics.bridgeCalls.byMethod['mraid.open'], undefined);
+    assert.equal(mraidReport.diagnostics.navigationDiagnostics.probeBridgeCalls.byMethod['mraid.open'], 1);
+    assert.equal(mraidReport.diagnostics.navigationDiagnostics.probeBridgeCalls.byMethod['mraid.expand'], 1);
+    assert.equal(mraidReport.diagnostics.navigationDiagnostics.probeBridgeCalls.byMethod['sharc.requestNavigation'], 1);
 
     const safeframeReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-safeframe');
     assert.ok(safeframeReport);
@@ -776,6 +783,20 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(safeframeReport.diagnostics.bridgeProbes.at(-1).bridges.safeframe.installed, true);
     assert.equal(safeframeReport.diagnostics.bridgeProbes.at(-1).bridges.safeframe.methods.geom.status, 'ok');
     assert.equal(safeframeReport.diagnostics.bridgeProbes.at(-1).bridges.safeframe.methods.supports.status, 'ok');
+    assert.equal(safeframeReport.diagnostics.bridgeProbes.at(-1).bridges.safeframe.methods.register.status, 'ok');
+    // The current SHARC SafeFrame bridge does not expose redirect(), so the
+    // active redirect probe is only reachable as an absent method here.
+    assert.equal(safeframeReport.diagnostics.bridgeProbes.at(-1).bridges.safeframe.methods.redirect.status, 'absent');
+    assert.equal(safeframeReport.diagnostics.navigationDiagnostics.bridgeCalls.count, 0);
+    assert.equal(safeframeReport.diagnostics.navigationDiagnostics.bridgeCalls.byMethod['safeframe.register'], undefined);
+    assert.equal(
+      safeframeReport.diagnostics.navigationDiagnostics.probeBridgeCalls.byMethod['safeframe.register'],
+      1,
+    );
+    assert.equal(
+      safeframeReport.diagnostics.navigationDiagnostics.probeBridgeCalls.byProtocol.unknown,
+      undefined,
+    );
 
     const missingMraidReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-mraid-missing');
     assert.ok(missingMraidReport);
@@ -787,17 +808,29 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(mraidApiErrorReport.outcome.status, 'failed');
     assert.equal(mraidApiErrorReport.outcome.bucket, 'bridge-api-error');
     assert.equal(
-      mraidApiErrorReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.methods.getState.status,
+      mraidApiErrorReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.methods.open.status,
       'threw',
+    );
+    assert.equal(
+      mraidApiErrorReport.diagnostics.navigationDiagnostics.probeBridgeCalls.byMethod['mraid.open'],
+      1,
     );
 
     const mraidOpenReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-mraid-open');
     assert.ok(mraidOpenReport);
     assert.equal(mraidOpenReport.outcome.status, 'passed');
     assert.equal(mraidOpenReport.diagnostics.navigationDiagnostics.bridgeCalls.byMethod['mraid.open'], 1);
+    assert.equal(mraidOpenReport.diagnostics.navigationDiagnostics.bridgeCalls.byMethod['mraid.expand'], undefined);
     assert.equal(mraidOpenReport.diagnostics.navigationDiagnostics.bridgeCalls.byMethod['sharc.requestNavigation'], 1);
     assert.equal(mraidOpenReport.diagnostics.navigationDiagnostics.bridgeCalls.byProtocol['https:'], 2);
-    assert.equal(mraidOpenReport.diagnostics.navigationDiagnostics.bridgeCalls.calls[0].url.origin, 'https://click.example');
+    assert.equal(mraidOpenReport.diagnostics.navigationDiagnostics.probeBridgeCalls.byMethod['mraid.open'], 1);
+    assert.equal(mraidOpenReport.diagnostics.navigationDiagnostics.probeBridgeCalls.byMethod['mraid.expand'], 1);
+    assert.equal(
+      mraidOpenReport.diagnostics.navigationDiagnostics.probeBridgeCalls.byMethod['sharc.requestNavigation'],
+      1,
+    );
+    assert.ok(mraidOpenReport.diagnostics.navigationDiagnostics.bridgeCalls.calls.some((call) =>
+      call.bridge === 'mraid' && call.method === 'open' && call.url.origin === 'https://click.example'));
 
     const sharcSyncReport = reports.find((row) =>
       row.case.ids.bidId === 'bid-runner-sharc-request-navigation-sync');
@@ -807,10 +840,8 @@ test('runner executes HTML cases and writes one report row per case', () => {
       sharcSyncReport.diagnostics.navigationDiagnostics.bridgeCalls.byMethod['sharc.requestNavigation'],
       1,
     );
-    assert.equal(
-      sharcSyncReport.diagnostics.navigationDiagnostics.bridgeCalls.calls[0].url.origin,
-      'https://click.example',
-    );
+    assert.ok(sharcSyncReport.diagnostics.navigationDiagnostics.bridgeCalls.calls.some((call) =>
+      call.bridge === 'sharc' && call.method === 'requestNavigation' && call.url.origin === 'https://click.example'));
 
     const omidReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-omid');
     assert.ok(omidReport);


### PR DESCRIPTION
## Summary
- actively probe SHARC-installed MRAID open/expand and SafeFrame register/redirect methods
- record SafeFrame register/redirect calls in navigation diagnostics when present
- pin bridge-api-error reachability on a throwing mraid.open fixture and assert routing observations
- document the active probe behavior in the validator README and changelog

Closes #209.

## Validation
- npm run test:creative-validator-runner
- npm run test:creative-validator-diagnose
- npm run test:creative-validator-triage
- npx eslint tools/creative-validator/harness/bridge-probe.js tools/creative-validator/test/test-runner.js --max-warnings=0
- git diff --check
- npm run build
- npm run lint
- npm run check