### PR TITLE
docs: 0.7.7 SHARC cross-frame protocol router design

### DIFF
--- a/docs/design/0.7.7-cross-frame-protocol-router.md
+++ b/docs/design/0.7.7-cross-frame-protocol-router.md
@@ -83,8 +83,9 @@ Only the throw-on-legacy enforcement of unexpected behavior:
 The router is constructed exactly once per `SHARCContainer` instance, owned by the container, and exposed at `container.protocolRouter` for extension code to call `.register(...)`. It is **not** part of the public creative-facing API.
 
 ```javascript
-// In src/sharc-container.js, near the existing _stateMachine construction
-// (currently `:1322`):
+// In src/sharc-container.js, inside the container constructor, *before*
+// `SHARCContainer._resolveExtensions({...})` at `:1180` so extension
+// constructors can call `container.protocolRouter.register(...)`:
 this.protocolRouter = new SHARCProtocolRouter({
   container: this,
   iframe: () => this._iframe,                              // lazy — iframe is created later
@@ -114,7 +115,7 @@ container.protocolRouter.register({
   types: {
     'rendered': { phases: ['attaching-renderer'], direction: 'inbound' },
     'failed':   { phases: ['attaching-renderer'], direction: 'inbound' },
-    'loadAck':  { phases: ['attaching-renderer'], direction: 'inbound' },
+    'loadAck':  { phases: ['attaching-renderer', 'rendered'], direction: 'inbound' },
     'render':   { phases: ['attaching-renderer'], direction: 'outbound' },
     'loadProbe':{ phases: ['attaching-renderer', 'rendered'], direction: 'outbound' },
   },
@@ -150,7 +151,7 @@ container.protocolRouter.register({
 
 | Property | Behavior |
 |----------|----------|
-| **Registration ordering** | First-come-first-served. The renderer protocol is registered by the container itself during `container.load()` setup, before any extension's `register(...)` call. Extensions register inside their constructor or attach-time hook. |
+| **Registration ordering** | First-come-first-served. The renderer protocol is registered by the container itself during container construction — specifically, before `SHARCContainer._resolveExtensions({...})` at `src/sharc-container.js:1180` runs, so the renderer prefix is already taken before any extension constructor executes. Extensions register inside their constructor or in a later `'load'` lifecycle hook (`_notifyExtensionsLifecycle('load')` at `:1457`). |
 | **Prefix collisions** | `register({prefix: 'SHARC:Renderer:'})` called twice throws synchronously on the second call with `Error('[SHARCProtocolRouter] prefix "SHARC:Renderer:" already registered')`. No alias path, no warning, no override. (Decision RTR-D5.) |
 | **Type collisions across protocols** | Cannot occur if prefixes are unique. The router routes by prefix first; types are scoped to their owning protocol. |
 | **Deregistration** | Not supported in 0.7.7. The renderer-protocol's existing teardown is handled at container `_terminate()` — the router itself is torn down with the container. Extensions get a `destroy()` lifecycle from the container, which is sufficient; no per-protocol `unregister()` is exposed. (Decision RTR-D6.) |
@@ -724,7 +725,7 @@ The Puppeteer suite (`npm run test:browser`) runs the full renderer-protocol pat
 
 - `npm run test` (jsdom) must pass with the new router tests added.
 - `npm run test:browser` (Puppeteer) must pass unchanged.
-- `npm run test:all` and `npm run test:all:built` must pass.
+- `npm run test:all` and `npm run test:all:built` must pass. The four new router test scripts (§ 12.1) must each be appended to the `test:all:built` `&&`-chain in `package.json` — that chain is the explicit list of file-level scripts CI runs and does not auto-discover.
 
 ### 9.6 Required pinning tests (review-locked)
 
@@ -957,9 +958,9 @@ The router throws at envelope-construction time (`buildOutbound`) on:
 
 | File | Change |
 |------|--------|
-| `src/sharc-container.js` | Construct `this.protocolRouter` near `:1322`. Register the renderer protocol immediately after. Remove `_isValidRendererEnvelope`. Replace inline `window.addEventListener('message', ...)` at `:2211` with the router's listener (already attached at router construction). Migrate `_dispatchRendererMessage` body into the renderer handler. Remove the second `message` listener at `:4283`; route `:loadAck` through the handler. Replace `this._sharcNonce` reads in `_resolvedIframeSrc` and the renderer envelope with `this._rendererProtocolNonce`. Add `unauthorized_protocol` to the `SHARCSecurityEvent` discriminated union typedef at `:237-283`. Add `protocolRouter.transitionTo(...)` calls at the four documented transition points (§ 4.2). |
+| `src/sharc-container.js` | Construct `this.protocolRouter` in the container constructor **before** `SHARCContainer._resolveExtensions({...})` at `:1180` (so extension constructors can call `container.protocolRouter.register(...)`). Register the renderer protocol immediately after router construction and before the `_resolveExtensions` call. Remove `_isValidRendererEnvelope`. Replace inline `window.addEventListener('message', ...)` at `:2211` with the router's listener (already attached at router construction). Migrate `_dispatchRendererMessage` body into the renderer handler. Remove the second `message` listener at `:4283`; route `:loadAck` through the handler. Replace `this._sharcNonce` reads in `_resolvedIframeSrc` and the renderer envelope with `this._rendererProtocolNonce`. Add `unauthorized_protocol` to the `SHARCSecurityEvent` discriminated union typedef at `:237-283`. Add `protocolRouter.transitionTo(...)` calls at the four documented transition points (§ 4.2). |
 | `src/sharc-protocol.js` | No change (state machine is unrelated to the router). |
-| `package.json` | Add `"test:protocol-router": "node test/node/test-protocol-router.js"` script for focused dev iteration. Not added to `test:all` (the file-by-file scripts aren't typically there; jsdom suite picks it up via the existing `test` aggregator). |
+| `package.json` | Add `"test:protocol-router": "node test/node/test-protocol-router.js"` script for focused dev iteration. **Must be appended to the `test:all:built` chain** alongside the other named file-level scripts — `test:all:built` is an explicit `&&`-chain of named test scripts (`test:smoke && test:treeshake && ... && test:creative-validator-triage`), not an aggregator that auto-discovers files. The companion router test scripts (`test:protocol-router-nonce-derivation`, `test:renderer-protocol-retrofit`, `test:renderer-out-of-phase`) must each be added to `test:all:built` the same way. |
 | `rollup.config.js` | Add `sharc-protocol-router.js` to the bundle inputs so it's emitted into `dist/`. (Confirm pattern matches the existing bridge bundling.) |
 | `CHANGELOG.md` | Entry per § 11.4. |
 | `docs/api-reference.md` (if router gets a public-facing entry) or in-source JSDoc only | Document `container.protocolRouter.register(...)` for extension authors. Recommendation: in-source JSDoc only for 0.7.7; promote to `api-reference.md` when the first non-renderer protocol registers (0.7.8 OMID). (Decision RTR-D18.) |
@@ -970,7 +971,7 @@ The router throws at envelope-construction time (`buildOutbound`) on:
 |------|-------------|----------|
 | 1 | Implement `SHARCProtocolRouter` standalone (no container wiring) — registry, gate, phase tracking, nonce derivation, `unauthorized_protocol` emission | 4 hours |
 | 2 | Write unit tests for the router in isolation (§ 12.1 first two files) | 3 hours |
-| 3 | Wire `this.protocolRouter` into `SHARCContainer` construction. Renderer registration must run before any extension's constructor — extension load happens in `_initExtensions()` which is called from `container.load()`, well after construction, so the ordering holds. (See § 7.2 threat.) | 1 hour |
+| 3 | Wire `this.protocolRouter` into `SHARCContainer` construction. The router must be constructed **before** `SHARCContainer._resolveExtensions({...})` at `src/sharc-container.js:1180` (the call site that instantiates extension instances during the container's own constructor), and the renderer protocol must register against it on the same line — so extension constructors that call `container.protocolRouter.register(...)` always see the renderer prefix already taken. The `'load'` lifecycle notification at `_notifyExtensionsLifecycle('load')` (`:1457`, inside `container.load()`) is the later attach-time hook where extensions that defer registration past their constructor can register; the renderer is already registered well before that point. (See § 7.2 threat for why first-registered ordering matters.) | 1 hour |
 | 4 | Migrate the renderer protocol's dispatch into the registered handler. Delete `_isValidRendererEnvelope`. Replace inline listener with router-resolved dispatch. | 3 hours |
 | 5 | Replace `_sharcNonce` reads with `_rendererProtocolNonce` in renderer URL assembly and outbound envelope construction. Verify `_assertResolvedIframeSrcAllowed` still passes with the derived nonce in the fragment. | 1 hour |
 | 6 | Migrate the load-event backstop's `:loadAck` listener into the registered renderer handler. Remove the second `message` listener at `:4283`. | 2 hours |
@@ -1067,7 +1068,7 @@ _All three previously-flagged decisions (RTR-J1 open-set phases, RTR-J2 HMAC-SHA
 
 ### Code paths refactored
 
-- `src/sharc-container.js:1322` — router construction site (next to existing `_stateMachine` construction)
+- `src/sharc-container.js` — router construction site (in the container constructor, immediately before `SHARCContainer._resolveExtensions({...})` at `:1180`, so the renderer protocol is registered before any extension constructor runs)
 - `src/sharc-container.js:1943-2004` — `_resolvedIframeSrc` + `_assertResolvedIframeSrcAllowed` (reads renderer-protocol nonce, not root nonce, after retrofit)
 - `src/sharc-container.js:2164-2305` — `_wireRendererProtocol` (the inline `message` listener at `:2211` and `_isValidRendererEnvelope` go away)
 - `src/sharc-container.js:2340-2540` — `_dispatchRendererMessage` (migrates to a router-registered handler; payload validation preserved)

--- a/docs/design/0.7.7-cross-frame-protocol-router.md
+++ b/docs/design/0.7.7-cross-frame-protocol-router.md
@@ -509,14 +509,20 @@ This surfaces the failure at `new SHARCContainer(...)` time, before `container.l
 Error('[SHARCProtocolRouter] HMAC derivation failed for prefix "X": <underlying error message>')
 ```
 
-The container catches this rejection in its `container.load()` flow and emits a `feature_load_failed` security event (reusing the existing non-terminating chokepoint established in 0.7.4) with `feature: 'protocol-router-derivation'`, then aborts the load. The container does **not** emit `unauthorized_protocol` for this case — that event is reserved for phase-membership failures (§ 8.2). Derivation failure is a pre-load infrastructure failure, not an envelope-validation failure.
+The container catches this rejection in its `container.load()` flow and emits a `feature_load_failed` security event (reusing the existing non-terminating chokepoint established in 0.7.4) by invoking the existing `_emitFeatureLoadFailed(featureName, reason, scriptUrl)` helper at `src/sharc-container.js:4538` with no signature change. Field assignments:
+
+- `featureName: 'protocol-router-derivation'` — string identifier for the failing "feature" (router-side per-protocol nonce derivation).
+- `reason: 'crypto_subtle_sign_rejected'` — bounded enum value naming the cause. The helper accepts any non-empty string per its existing JSDoc, so this is additive to the existing token set (`'timeout'`, `'network'`, `'evaluation_throw'`, etc.) — no enum or typedef change required.
+- `scriptUrl: ''` — empty string, passed explicitly. The helper's safe-typed-string guard at `:4547` accepts a string and slices to 500 chars; passing `null` or `undefined` would degrade to `''` via the guard, but the call site MUST pass `''` explicitly to make the "no script URL is involved" intent legible at the call site. There is no script URL associated with HMAC-derivation failure.
+
+The resulting emitted event's `details` shape is `{ featureName: 'protocol-router-derivation', reason: 'crypto_subtle_sign_rejected', scriptUrl: '' }` — matching the existing `FeatureLoadFailedEvent` typedef at `src/sharc-container.js:440-449` exactly. After emission, the container aborts the load. The container does **not** emit `unauthorized_protocol` for this case — that event is reserved for phase-membership failures (§ 8.2). Derivation failure is a pre-load infrastructure failure, not an envelope-validation failure.
 
 | Failure | Surface | Operator-visible signal |
 |---------|---------|-------------------------|
 | `crypto.subtle` unavailable (non-secure context) | Synchronous throw at router construction (inside `new SHARCContainer(...)`) | Exception propagates to the publisher's container instantiation site |
-| `crypto.subtle.sign()` async rejection during derivation | `protocolRouter.ready(prefix)` rejects | `feature_load_failed` security event with `feature: 'protocol-router-derivation'`; container load aborts |
+| `crypto.subtle.sign()` async rejection during derivation | `protocolRouter.ready(prefix)` rejects | `feature_load_failed` security event with `details: { featureName: 'protocol-router-derivation', reason: 'crypto_subtle_sign_rejected', scriptUrl: '' }`; container load aborts |
 
-The `feature_load_failed` plumbing established in 0.7.4 (`docs/design/0.7.4-omid-hardening.md`) is the right channel: it's non-terminating from the page's perspective (the container stops loading but doesn't crash the page), and operators already consume it.
+The `feature_load_failed` plumbing established in 0.7.4 (`docs/design/0.7.4-omid-hardening.md`) is the right channel: it's non-terminating from the page's perspective (the container stops loading but doesn't crash the page), and operators already consume it. 0.7.7 reuses the helper's existing `(featureName, reason, scriptUrl)` signature unchanged — no new variant, no `feature` alias, no schema migration.
 
 #### 5.5.3 Sequential re-mint await ordering (RTR-D21 expanded)
 
@@ -1133,7 +1139,7 @@ Numbered summary of the locked decisions for fast scanning. Full justification i
 | **RTR-D16** | `unauthorized_protocol` emission reuses `_invokeSecurityCallback` chokepoint | ✅ Locked | § 8.4 |
 | **RTR-D17** | No router-side cap on `unauthorized_protocol`; payload minimized to `{type, phase, reason}`; operator-side rate-limiting | ✅ Locked | § 8.6, § 8.7 |
 | **RTR-D18** | In-source JSDoc for the router; public `api-reference.md` entry deferred to 0.7.8 | ✅ Locked | § 12.2, § 13 |
-| **RTR-D22** | `crypto.subtle` is a hard requirement; non-secure contexts (HTTP iframes lacking SubtleCrypto) cause the `SHARCContainer` constructor to throw with an explicit error. No fallback to `crypto.getRandomValues`-derived random nonce — fallback would break per-protocol non-derivability. Async `crypto.subtle.sign()` rejections during derivation reject `protocolRouter.ready(prefix)` with a typed error; container emits `feature_load_failed` (not `unauthorized_protocol`) and aborts the load | ✅ Locked | § 5.5.2 |
+| **RTR-D22** | `crypto.subtle` is a hard requirement; non-secure contexts (HTTP iframes lacking SubtleCrypto) cause the `SHARCContainer` constructor to throw with an explicit error. No fallback to `crypto.getRandomValues`-derived random nonce — fallback would break per-protocol non-derivability. Async `crypto.subtle.sign()` rejections during derivation reject `protocolRouter.ready(prefix)` with a typed error; container emits `feature_load_failed` via the existing `_emitFeatureLoadFailed('protocol-router-derivation', 'crypto_subtle_sign_rejected', '')` helper at `src/sharc-container.js:4538` (not `unauthorized_protocol`, no helper signature change) and aborts the load | ✅ Locked | § 5.5.2 |
 
 ### 14.1 Judgment calls (originally beyond issue #219 acceptance criteria)
 

--- a/docs/design/0.7.7-cross-frame-protocol-router.md
+++ b/docs/design/0.7.7-cross-frame-protocol-router.md
@@ -1,0 +1,1113 @@
+# 0.7.7 — SHARC Protocol Router (cross-frame protocol registry + renderer retrofit)
+
+**Status:** Proposed (design under review)
+**Target version:** 0.7.7
+**Issue:** [#219](https://github.com/jeffreycarlson/SHARC/issues/219)
+**Predecessors:**
+- 0.6.x renderer protocol (`src/sharc-container.js` — `_wireRendererProtocol`, `_isValidRendererEnvelope`, `_dispatchRendererMessage`, `_emitSecurityEventAndTerminate`)
+- 0.7.1 bridges field (`docs/design/0.7.1-bridges-field.md`) — established `KNOWN_BRIDGE_IDENTIFIERS` and renderer-loaded compat shims
+- 0.7.3 OMID wiring (`docs/design/0.7.3-omid-wiring.md`) — established container-owned OMID lifecycle and the extension-vs-bridge distinction
+- 0.7.4 OMID hardening (`docs/design/0.7.4-omid-hardening.md`) — `feature_load_failed` plumbing, non-terminating security-event variant
+- 0.7.6 bfcache wiring (`docs/design/0.7.6-bfcache-puppeteer-wiring.md`) — most recent release-design doc; format reference
+
+**Related (downstream consumer, not in scope):**
+- Parked OMID redesign at `docs/design/0.7.8-omid-spec-compliant-bridge.md` — target 0.7.8, issue [#217](https://github.com/jeffreycarlson/SHARC/issues/217). Consumes this router. Specifically the parked design's S1 finding (cross-channel envelope-type collision) and B1/B2 findings (nonce hygiene) drove the router's extraction; they are addressed structurally here.
+
+**Scope lock:** This release ships the `SHARCProtocolRouter` primitive plus the renderer-protocol retrofit. MRAID, SafeFrame, and OMID router retrofits are explicitly out of scope (§ 13). The router is designed so they can migrate later without churning the registration API.
+
+---
+
+## Table of contents
+
+1. [Release framing](#1-release-framing)
+2. [Router API surface](#2-router-api-surface)
+3. [Envelope contract](#3-envelope-contract)
+4. [Lifecycle phase enumeration](#4-lifecycle-phase-enumeration)
+5. [Per-protocol nonce derivation](#5-per-protocol-nonce-derivation)
+6. [Renderer-protocol retrofit](#6-renderer-protocol-retrofit)
+7. [Security model](#7-security-model)
+8. [`unauthorized_protocol` security event](#8-unauthorized_protocol-security-event)
+9. [Test strategy](#9-test-strategy)
+10. [Architecture diagrams](#10-architecture-diagrams)
+11. [Migration plan (0.7.6 → 0.7.7)](#11-migration-plan)
+12. [Implementation plan](#12-implementation-plan)
+13. [Out of scope](#13-out-of-scope)
+14. [Decision log](#14-decision-log)
+15. [References](#15-references)
+16. [0.7.8 OMID extension dependencies (hand-off)](#16-078-omid-extension-dependencies-hand-off)
+
+---
+
+## 1. Release framing
+
+0.7.7 introduces a single new primitive — `SHARCProtocolRouter` — and retrofits one existing surface — the renderer protocol — to consume it. The release does **not** introduce new cross-frame functionality or change any public API the creative sees. From a creative's perspective, 0.7.7 is a no-op refactor of the renderer protocol's dispatch internals.
+
+### 1.1 Why now
+
+The parked 0.7.8 OMID design (`docs/design/0.7.8-omid-spec-compliant-bridge.md`) proposes installing a `sharc-omid-shim.js` script into the creative iframe to expose `window.omid3p`. Security Engineer review surfaced finding S1: the existence of any in-iframe shim retroactively weakens the renderer-protocol channel's trust posture. Today, the renderer protocol's envelope gate (`event.source === iframe.contentWindow && event.origin === _rendererOrigin`) is airtight because **no creative-readable JS runs in the iframe with the renderer's privileges**. The moment any extension drops a script into the iframe that can call `window.parent.postMessage`, the creative gains the ability to forge `SHARC:Renderer:*` envelopes from a context that passes `(source, origin)` validation.
+
+The structural fix is phase-scoping: `SHARC:Renderer:rendered` is only valid during the `attaching-renderer` phase. Once the container has accepted a `:rendered` envelope and transitioned past that phase, any further `SHARC:Renderer:rendered` envelope — forged or genuine — is rejected. Generalizing this discipline so every protocol gets the same enforcement, applied at a single chokepoint rather than re-implemented per extension, is what this primitive provides.
+
+### 1.2 What changes structurally
+
+Today, the renderer protocol's gating discipline lives inline in `src/sharc-container.js`:
+
+- The `message` listener at `:2211` (`window.addEventListener('message', handler, false)`)
+- The envelope validator at `:2293-2305` (`_isValidRendererEnvelope`)
+- The type dispatcher at `:2382` (`_dispatchRendererMessage`)
+- The `loadAck` probe at `:4283` (separate `message` listener attached during the load-event backstop)
+
+0.7.7 collapses these into a single registry-driven dispatch path. The renderer-protocol logic moves into a router handler; the gating moves into the router's uniform validator.
+
+### 1.3 Sequencing
+
+| PR | Type | Rough scope |
+|----|------|-------------|
+| R1 | New module + retrofit | `src/sharc-protocol-router.js` (new), `src/sharc-container.js` (renderer retrofit), unit tests for both. No public API change. |
+| R2 | Release close-out | CHANGELOG `[Unreleased]` → `[0.7.7]`, `current-status.md` "What Shipped in 0.7.7" stanza, `npm version patch`, `dist/` rebuild. Mirrors 0.7.6 PR H shape. |
+
+### 1.4 Breaking-change inventory
+
+Only the throw-on-legacy enforcement of unexpected behavior:
+
+- Any caller that registered an external `window.addEventListener('message', handler)` and expected to intercept `SHARC:Renderer:*` envelopes before the container saw them will continue to receive those envelopes (browsers dispatch `message` to all listeners), but the **container's own dispatch is now router-mediated** — the renderer protocol's behavior is unchanged from the creative's perspective.
+- Any extension code that relied on the existence of an inline `_isValidRendererEnvelope` method on `SHARCContainer` will break. (Not expected — `_` prefix indicates internal; flagged for completeness.)
+- Pre-1.0 throw-on-legacy convention applies: no deprecation period, no alias.
+
+---
+
+## 2. Router API surface
+
+### 2.1 Construction
+
+The router is constructed exactly once per `SHARCContainer` instance, owned by the container, and exposed at `container.protocolRouter` for extension code to call `.register(...)`. It is **not** part of the public creative-facing API.
+
+```javascript
+// In src/sharc-container.js, near the existing _stateMachine construction
+// (currently `:1322`):
+this.protocolRouter = new SHARCProtocolRouter({
+  container: this,
+  iframe: () => this._iframe,                              // lazy — iframe is created later
+  expectedRendererOrigin: () => this._rendererOrigin,      // lazy — set during construction
+  expectedPlacementSessionId: () => this.placementSessionId, // lazy — re-read on each envelope and on re-derivation (§ 4.5, § 5.3)
+  rootNonce: this._sharcNonce,                             // see § 5 for derivation
+  onUnauthorizedProtocol: (event) => {
+    this._invokeSecurityCallback(event);  // reuses existing chokepoint
+  },
+  initialPhase: 'init',
+});
+```
+
+The router constructor takes lazy getters for the iframe, expected origin, and `placementSessionId` because those values are populated during `container.load()` (iframe, origin) or change on sequential-impression re-derivation (`placementSessionId`, § 4.5). This mirrors how `_isValidRendererEnvelope` today reads `this._rendererOrigin` lazily. The container is responsible for calling `protocolRouter.rederiveAllProtocolNonces()` when it mints a new `placementSessionId`.
+
+### 2.2 `register({...})` — protocol registration
+
+```javascript
+container.protocolRouter.register({
+  // REQUIRED. Must end in ':'. Globally unique within this container.
+  // Collisions throw at register-time per pre-1.0 throw-on-legacy convention.
+  prefix: 'SHARC:Renderer:',
+
+  // REQUIRED. Maps the trailing portion of `data.type` (after the prefix) to
+  // its phase membership and direction. `phases` is an array of LifecyclePhase
+  // strings — see § 4 for the enumeration.
+  types: {
+    'rendered': { phases: ['attaching-renderer'], direction: 'inbound' },
+    'failed':   { phases: ['attaching-renderer'], direction: 'inbound' },
+    'loadAck':  { phases: ['attaching-renderer'], direction: 'inbound' },
+    'render':   { phases: ['attaching-renderer'], direction: 'outbound' },
+    'loadProbe':{ phases: ['attaching-renderer', 'rendered'], direction: 'outbound' },
+  },
+
+  // REQUIRED. Called for every inbound envelope that passes the router's
+  // uniform gate. Receives the envelope and a frozen context object.
+  //
+  // The handler must NOT re-implement the gate — `(source, origin, nonce,
+  // placementSessionId, prefix, type membership, phase membership)` are
+  // already validated. The handler is responsible only for payload-shape
+  // checks and protocol-specific dispatch.
+  handler: function (envelope, context) {
+    // envelope: the raw `event.data` (frozen).
+    // context: { type, phase, protocolNonce, raisedAt }
+    // See § 2.4 for the context contract.
+    // NOTE: the raw MessageEvent is intentionally NOT exposed — handlers must
+    // not reach for `event.source` / `event.ports`. If a future protocol
+    // legitimately needs the source window, expose `sourceWindow` as a
+    // separate explicit field gated by a registration flag (out of scope).
+  },
+
+  // OPTIONAL. Called once at registration completion. Receives the
+  // protocol-derived nonce (see § 5) for the extension to use when constructing
+  // OUTBOUND envelopes. Delivered here rather than read from any markup-
+  // accessible surface.
+  onReady: function ({ protocolNonce }) {
+    // Extension stores protocolNonce for outbound envelope construction.
+  },
+});
+```
+
+### 2.3 Registration semantics
+
+| Property | Behavior |
+|----------|----------|
+| **Registration ordering** | First-come-first-served. The renderer protocol is registered by the container itself during `container.load()` setup, before any extension's `register(...)` call. Extensions register inside their constructor or attach-time hook. |
+| **Prefix collisions** | `register({prefix: 'SHARC:Renderer:'})` called twice throws synchronously on the second call with `Error('[SHARCProtocolRouter] prefix "SHARC:Renderer:" already registered')`. No alias path, no warning, no override. (Decision RTR-D5.) |
+| **Type collisions across protocols** | Cannot occur if prefixes are unique. The router routes by prefix first; types are scoped to their owning protocol. |
+| **Deregistration** | Not supported in 0.7.7. The renderer-protocol's existing teardown is handled at container `_terminate()` — the router itself is torn down with the container. Extensions get a `destroy()` lifecycle from the container, which is sufficient; no per-protocol `unregister()` is exposed. (Decision RTR-D6.) |
+| **Registration-after-listen** | The router's single `message` listener attaches at router construction time (before any protocol registers). Late registrations are honored; envelopes for unregistered prefixes are silently dropped per the existing "any frame can postMessage" policy. |
+| **Async-nonce gate window** | For a registered prefix awaiting async nonce delivery via `onReady`, the gate is closed (silent-drop) until `onReady` resolves. The renderer protocol is shielded from this race because `_createIframe()` is held behind `await protocolRouter.ready('SHARC:Renderer:')` (RTR-D10); future extensions that don't have that ordering must accept silent-drop behavior in the brief async window between `register()` returning and `onReady` firing. |
+
+### 2.4 Handler context
+
+```javascript
+context = Object.freeze({
+  /** The dispatched type, with prefix stripped. E.g. 'rendered'. */
+  type: 'rendered',
+
+  /** The container's current lifecycle phase at dispatch time. */
+  phase: 'attaching-renderer',
+
+  /** The protocol-derived nonce delivered at registration. Same value the
+   *  handler may use to construct outbound envelopes. NOT the root nonce. */
+  protocolNonce: '<derived nonce string>',
+
+  /** Wall-clock at which the router accepted the envelope (Date.now()). */
+  raisedAt: 1716000000000,
+});
+```
+
+### 2.5 What the router does NOT do
+
+- **Does not validate payload shape beyond the envelope contract.** Per-type payload validation (e.g. `data.rendererOrigin` is a non-empty string) remains the handler's responsibility — matches the current `_dispatchRendererMessage` split between envelope (router) and payload (handler).
+- **Does not own `MessageChannel` ports.** The SHARC creative-SDK port (`SHARC:Container:init` ↔ `SHARC:Creative:init`) is a separate transport with its own lifecycle; it is not in scope for the router. (Decision RTR-D8.)
+- **Does not throttle, rate-limit, or sample.** Including for `unauthorized_protocol` emission (§ 8.6). Operators handle downstream rate-limiting at SIEM ingest per their own pipeline cost model. Per-protocol DoS mitigations (e.g. registration caps in the parked 0.7.8 OMID design) remain protocol-specific.
+
+---
+
+## 3. Envelope contract
+
+### 3.1 Required fields
+
+Every inbound envelope the router accepts must satisfy:
+
+```typescript
+{
+  type: string;               // e.g. 'SHARC:Renderer:rendered'
+  sharcNonce: string;         // protocol-derived nonce, see § 5
+  placementSessionId: string; // matches container.placementSessionId
+  // ...payload (protocol-specific)
+}
+```
+
+The router validates `type`, `sharcNonce`, and `placementSessionId`. Everything else is passed through to the handler verbatim.
+
+### 3.2 Gate sequence
+
+Every inbound envelope passes through this sequence before dispatch. Any failure short-circuits to silent drop (the existing "any frame can postMessage" policy) **except** the phase-membership check, which raises `unauthorized_protocol` (§ 8).
+
+| # | Check | On fail | Code reuse |
+|---|-------|---------|------------|
+| 1 | `typeof event.data === 'object' && event.data !== null` | silent drop | Mirrors `_isValidRendererEnvelope` `:2300` |
+| 2 | `event.source === iframe.contentWindow` (iframe getter resolved at envelope time) | silent drop | Mirrors `:2301` |
+| 3 | `event.origin === expectedRendererOrigin` (origin getter resolved at envelope time) | silent drop | Mirrors `:2302` |
+| 4 | `typeof event.data.type === 'string'` | silent drop | Mirrors `:2303` |
+| 5 | `event.data.type` starts with a **registered prefix** | silent drop | New — protocol dispatch |
+| 6 | `event.data.placementSessionId === expectedPlacementSessionId` | silent drop | Mirrors `_dispatchRendererMessage` `:2406` |
+| 7 | `event.data.sharcNonce === <protocol-derived nonce>` (router compares against the cached derived nonce for the current `placementSessionId`; step 6 has already enforced that the envelope's `placementSessionId` matches the expected one, so envelope and router agree on the salt; see § 5) | silent drop | New — defends per-protocol nonce |
+| 8 | The dispatched type (with prefix stripped) is **declared by the protocol** in its `types` map | silent drop | New — unknown types within a known prefix are silently ignored (matches `_dispatchRendererMessage` "future protocol version" policy at `:2393`) |
+| 9 | The current lifecycle phase is in the type's declared `phases` | **`unauthorized_protocol` raised + drop** | New — § 7.1, § 8 |
+
+The phase check (#9) is the load-bearing security primitive this primitive provides. It is the only check whose failure is observable to operators; everything else is by-design silent.
+
+### 3.3 Outbound envelopes
+
+The router does not gate outbound envelopes (the container is trusted to construct them correctly), but it provides a convenience helper:
+
+```javascript
+const envelope = container.protocolRouter.buildOutbound('SHARC:Renderer:', 'render', {
+  bridges: ['mraid'],
+  containerOrigin: window.location.origin,
+  creativeHtml: html,
+  rendererProtocolVersion: 1,
+  sharcVersion: '0.7.7',
+});
+// envelope: {
+//   type: 'SHARC:Renderer:render',
+//   sharcNonce: '<rendererProtocolNonce>',
+//   placementSessionId: container.placementSessionId,
+//   bridges: ['mraid'],
+//   containerOrigin: '...',
+//   creativeHtml: '...',
+//   rendererProtocolVersion: 1,
+//   sharcVersion: '0.7.7',
+// }
+```
+
+The helper:
+
+1. Asserts the type is declared in the protocol's `types` map with `direction: 'outbound'` or `direction: 'bidirectional'`. (Decision RTR-D7: outbound discipline is symmetric with inbound discipline.)
+2. Stamps the protocol's derived nonce (NOT the root `_sharcNonce`). The derived nonce is itself bound to the container's current `placementSessionId` per the derivation in § 5; if a new `placementSessionId` has been minted (sequential-impression case, § 4.5), the protocol's derived nonce must be re-derived before the next outbound envelope.
+3. Stamps the container's `placementSessionId`.
+4. Merges the caller's payload. **Throws synchronously on key collision** with any router-controlled field (`type`, `sharcNonce`, `placementSessionId`) — matches the pre-1.0 throw-on-legacy convention applied elsewhere in this design (RTR-D2, RTR-D5). A caller that attempts to set its own `sharcNonce` or `placementSessionId` indicates a programming error; silent overwrite would mask it. Error shape: `Error('[SHARCProtocolRouter] buildOutbound payload collides with router-controlled field "<key>" on protocol "<prefix>"')`.
+
+The renderer protocol's outbound `SHARC:Renderer:render` and `SHARC:Renderer:loadProbe` calls go through this helper post-retrofit.
+
+---
+
+## 4. Lifecycle phase enumeration
+
+### 4.1 Phases
+
+A **lifecycle phase** is a router-internal slicing of the container's existence into windows during which specific envelopes are valid. It is **not** a parallel state machine to `SHARCStateMachine` (which models the page-lifecycle-aligned creative-visible states `loading`/`ready`/`active`/`passive`/`hidden`/`frozen`/`terminated` per `src/sharc-protocol.js:122-130`). The router's phases are coarser: they model "what cross-frame protocol surface is active right now."
+
+| Phase | When entered | When exited | Notes |
+|-------|--------------|-------------|-------|
+| `init` | Router constructed; before `container.load()` is called | `container.load()` begins iframe setup | Pre-load. No iframe yet; nothing should be sending envelopes. All protocols' types are out-of-phase here. |
+| `attaching-renderer` | `_wireRendererProtocol()` enters its iframe-load handler | Envelope-validated `SHARC:Renderer:rendered` accepted (Markup variant); or initial iframe `load` event fires (URL variant) | Renderer-protocol active window. `SHARC:Renderer:rendered`, `:failed`, `:loadAck` are valid. |
+| `rendered` | `:rendered` accepted (or iframe `load` for URL variant) | Container `_stateMachine` reaches `ACTIVE` | Renderer handshake complete; the load-event backstop's `:loadAck` probe lives here (the probe spans `attaching-renderer` and `rendered`). |
+| `omid-active` | (placeholder for 0.7.8) Container's OMID session has started — `AdSession.start()` returned successfully | OMID session finished or container terminated | **Informational only in 0.7.7.** Reserved so the 0.7.8 OMID router consumer can declare `SHARC:Omid:Event`/`:Register`/`:Unregister` types with this phase membership. Not entered by any code that ships in 0.7.7. |
+| `creative-active` | Container `_stateMachine` reaches `ACTIVE` (any path) | Container `_terminate()` | The container's main steady state. Renderer protocol is fully past; any `SHARC:Renderer:*` envelope arriving here is out-of-phase. |
+| `terminated` | `_terminate()` called | n/a | All protocols' types are out-of-phase here. Defense in depth against post-termination stragglers. |
+
+### 4.2 Phase transitions
+
+Transitions are driven by container internals, not by the router. The router exposes `protocolRouter.transitionTo(phaseName)`; the container calls it at the existing transition points:
+
+```javascript
+// In container constructor (after router construction):
+// router is in 'init' by default
+
+// In _wireRendererProtocol's iframe `load` handler (currently `:2179`):
+this.protocolRouter.transitionTo('attaching-renderer');
+
+// In _onRendererRendered (currently `:2471` invocation site,
+// `_onRendererRendered` defined elsewhere):
+this.protocolRouter.transitionTo('rendered');
+
+// In setState() when newState === ACTIVE (in the existing setState chokepoint):
+this.protocolRouter.transitionTo('creative-active');
+
+// In _terminate() at the top:
+this.protocolRouter.transitionTo('terminated');
+```
+
+For the URL variant (no renderer handshake), the router skips straight from `init` → `rendered` → `creative-active` because there is no `attaching-renderer` window — the container does not wire the renderer protocol at all (`_wireRendererProtocol` is Markup-only). Decision RTR-D9.
+
+### 4.3 Phase enumeration is forward-extensible
+
+Future protocols may need additional phases. The enumeration is implemented as a plain string set, and `protocolRouter.transitionTo(phase)` accepts any string. The 0.7.8 consumer can declare `omid-active`/`omid-finishing` without a router code change (just a `transitionTo` call site).
+
+**Locked (RTR-J1):** Phase enumeration is intentionally extensible-by-convention rather than enforced-by-enum. Protocols document their own phase memberships; collisions in phase names across protocols are not detected by the registry. The alternative — a registered-phase namespace — was rejected as overengineering for 0.7.7's single-protocol scope.
+
+To mitigate the typo risk inherent in open-set strings, § 9 pins a test that asserts every phase string declared by any registered protocol's `types` map appears in some `transitionTo(...)` call site in the container. A typo'd phase in a `types` map (`'attaching-rendrer'`) would have no matching `transitionTo` and the test fails.
+
+### 4.4 Phase ≠ state
+
+The relationship between router phases and `ContainerStates` is one-way (state drives phase, never the reverse):
+
+```
+ContainerStates.LOADING   → phase 'init' or 'attaching-renderer' (Markup)
+ContainerStates.READY     → phase 'rendered' or 'creative-active' (Markup)
+                            phase 'creative-active' (URL, after first ACTIVE)
+ContainerStates.ACTIVE    → phase 'creative-active'
+ContainerStates.PASSIVE   → phase 'creative-active'   (no router transition)
+ContainerStates.HIDDEN    → phase 'creative-active'   (no router transition)
+ContainerStates.FROZEN    → phase 'creative-active'   (no router transition)
+ContainerStates.TERMINATED→ phase 'terminated'
+```
+
+Passive/hidden/frozen do not transition the router because no protocol's phase membership distinguishes them — they are all "creative live, no handshake in progress." This is intentional: the router is about cross-frame protocol surfaces, not about creative viewability state.
+
+### 4.5 Container instance vs lifecycle events
+
+Per-protocol nonces are tied to the **`SHARCContainer` instance lifetime + per-impression session boundary** (`placementSessionId`), not to page or app lifecycle events. The principle:
+
+- **Nonce regeneration triggers** are tied to identifier changes: a fresh `_sharcNonce` is minted at container construction; fresh per-protocol nonces are derived whenever `placementSessionId` is minted (creative load).
+- **Events that preserve container + session** preserve all nonces:
+  - Web: bfcache restore (`pageshow.persisted === true`, per 0.7.6 ADR-178-C)
+  - Mobile: WebView freeze and resume across app-switching (JS heap intact)
+  - HTML lifecycle adapter transitions through `HIDDEN` / `FROZEN` / `ACTIVE`
+- **Events that produce a fresh container** produce fresh root nonces and fresh derived nonces:
+  - Page reload (Ctrl+R, programmatic `location.reload()`)
+  - Navigation to a new ad URL
+  - bfcache eviction → next Back navigation = full page load
+  - Mobile cold start (OS-killed process re-launches)
+- **Events that produce a fresh impression within a long-lived container** (mobile SDK sequential-ad pattern) produce fresh derived nonces without rotating `_sharcNonce`:
+  - New creative load → new `placementSessionId` → per-protocol nonces re-derived via the `placementSessionId`-salted HMAC (§ 5.2)
+
+**Future implementers MUST NOT add nonce rotation on freeze/restore events.** Doing so puts the creative into a "weird state": verification scripts holding a captured nonce silently fail after rotation, envelopes signed with the new nonce go through normally, measurement becomes asymmetric and partial, and the operator sees `unauthorized_protocol` floods from legitimate creatives after every app-switch. The nonce isn't compromised by freeze/restore — the container is the same and the session is the same — so rotation actively makes measurement worse without security benefit.
+
+---
+
+## 5. Per-protocol nonce derivation
+
+### 5.1 Problem
+
+Today, `this._sharcNonce` is constructed in `_resolvedIframeSrc()` (`src/sharc-container.js:1955`) via `crypto.randomUUID()` and appended to the renderer URL as a fragment: `creativeRendererUrl + '#sharcNonce=' + this._sharcNonce`. The renderer reads it from `location.hash`, and the container then validates inbound envelopes' `sharcNonce` against the same value (`_dispatchRendererMessage` does session-id check; the fragment-derived nonce is the trust anchor on the renderer side).
+
+The fragment-derived nonce works for the renderer because:
+
+1. Browsers do not transmit fragments to the server (so the nonce isn't logged in CDN access logs).
+2. The renderer is operator-deployed and partially trusted — it owns the fragment-read.
+3. The creative iframe is loaded via the renderer; the nonce stays in the renderer's window context.
+
+The parked 0.7.8 OMID design's B1/B2 findings flagged that **reusing the same `_sharcNonce` across protocols** (renderer + OMID + future extensions) widens the blast radius of a nonce leak. If the OMID shim were compromised and leaked its nonce, the attacker could forge renderer-protocol envelopes too. Per-protocol nonce derivation removes that coupling.
+
+The second concern: the OMID design's `omid3p` shim runs **inside the creative iframe**, where the creative can read `document.location.hash`. If OMID needed a nonce, it could not get it via the fragment — the creative would see it. A non-markup-readable delivery channel is required.
+
+**Acknowledgment: SHARC-specific vs OMID-borrowed.** The cross-frame back-channel between publisher-page extension handlers and creative-iframe shims is a SHARC-specific architectural feature — IAB OMID's canonical architecture has verification scripts running in container-loaded verification iframes with direct same-window `omid3p` access, no cross-frame channel, and no nonce. SHARC's nonce design is engineering judgment grounded in standard cryptographic primitives (HMAC-SHA-256 / Web Crypto), not an IAB spec citation. However, the *binding model* — deriving the per-protocol nonce from the per-impression session identifier — is borrowed from OMID's AdSession-keyed measurement architecture. Same session = same security context; new session = new security context.
+
+### 5.2 Decision: HMAC-like derivation salted with `placementSessionId`, delivered via `register()`
+
+The router computes a per-protocol nonce by deriving from the root nonce, the protocol prefix, **and the per-impression session identifier**:
+
+```
+protocolNonce = HMAC-SHA-256(
+  key:     _sharcNonce,                          // root, container-lifetime
+  message: prefix || ":" || placementSessionId,  // protocol + session binding
+).slice(0, 16) → base64url → 22 chars
+```
+
+The `":"` is a literal separator to prevent message-prefix collision if `placementSessionId` were ever empty (the prefix already ends in `:` by registration contract, so the construction is `"SHARC:Renderer::<placementSessionId>"` in practice — the double colon is intentional and unambiguous). The output shape is unchanged from the prior single-input derivation (16 bytes → 22 base64url chars, UUID parity).
+
+```javascript
+async function deriveProtocolNonce(rootNonce, prefix, placementSessionId) {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(rootNonce),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const message = prefix + ':' + placementSessionId;
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(message));
+  // base64url-encode the first 16 bytes; truncate to 22 chars (UUID parity).
+  return base64url(new Uint8Array(sig).slice(0, 16));
+}
+```
+
+**Why salt with `placementSessionId`.** SHARC's `placementSessionId` is the per-impression identifier — structurally the analog of OMID's `AdSession` instance. By including it in the derivation salt, the transport nonce inherits the same session boundary that OMID already defines for measurement events. New creative load → new `placementSessionId` → new derived per-protocol nonces, by construction. Same impression → same nonces. This borrows OMID's session-binding pattern (not its terminology) — the nonce is bound to the session it claims to serve. It also enables the mobile-SDK sequential-impression model (§ 4.5): a long-lived container loading creative after creative gets fresh per-protocol nonces on each `placementSessionId` mint without rotating the root `_sharcNonce`.
+
+Properties:
+
+- **Deterministic per (rootNonce, prefix, placementSessionId).** The container and the registering extension always agree on the protocol nonce for the current impression.
+- **Non-invertible.** An attacker who learns the OMID nonce cannot recover the root nonce, and therefore cannot derive the renderer-protocol nonce.
+- **Non-markup-readable.** The protocol nonce is computed in the publisher-page context and delivered to the registering extension via the `onReady({protocolNonce})` callback at registration time, and re-delivered (or re-derived) on each subsequent `placementSessionId` mint. It is never written to any markup, fragment, query string, or DOM attribute by the router.
+- **CSPRNG-rooted.** `rootNonce` is the existing `_sharcNonce` (CSPRNG via `crypto.randomUUID()` per `:1948-1955`); the HMAC inherits its entropy.
+- **Session-scoped, not lifecycle-scoped.** Per-protocol nonces are tied to the container instance + `placementSessionId`, not to page or app lifecycle events. See § 4.5 for the full container-instance-vs-lifecycle-events principle covering bfcache restore (web), WebView freeze/resume (mobile), and sequential-impression re-derivation. Phase enforcement remains in effect across all freeze/restore cycles; **future implementers MUST NOT add nonce rotation on freeze/restore events** — see § 4.5 for the failure mode.
+
+**Note on `placementSessionId` as a public envelope field.** `placementSessionId` already appears in every envelope (§ 3.1) and is therefore readable by anyone who can observe the wire. This is fine for the derivation salt — `placementSessionId`'s role here is to bind the nonce to a session boundary, not to add entropy. The non-invertibility property comes from `_sharcNonce` (the HMAC key, which never appears on the wire), not from the message. An attacker who reads `placementSessionId` from an envelope still cannot derive `protocolNonce` without `_sharcNonce`; an attacker who somehow obtains `protocolNonce` for one session cannot project it to a different session (different `placementSessionId` → different HMAC output). The salt's job is session-binding, not secrecy.
+
+**Caveat on derivation as a sub-key source.** Protocol nonces are output values, not derivation keys. A future protocol that wants to derive sub-keys from its protocol nonce should switch to HKDF-Expand at that protocol's layer — HMAC-SHA-256 is sufficient for the single-output derivation the router performs (one nonce per registered prefix) but is not the right primitive for further key expansion downstream.
+
+### 5.3 Delivery mechanism
+
+```javascript
+container.protocolRouter.register({
+  prefix: 'SHARC:Renderer:',
+  types: { /* ... */ },
+  handler: function (envelope, context) { /* ... */ },
+  onReady: function ({ protocolNonce }) {
+    // The router has computed the renderer-protocol-specific nonce.
+    // The renderer protocol uses it for outbound `SHARC:Renderer:render`.
+    this._rendererProtocolNonce = protocolNonce;
+  }.bind(this),
+});
+```
+
+For the renderer protocol specifically, the protocol nonce is **also** the value the renderer reads from `location.hash` — the container computes `protocolNonce = derive(rootNonce, 'SHARC:Renderer:', placementSessionId)` and passes it as `creativeRendererUrl + '#sharcNonce=' + protocolNonce`. The root `_sharcNonce` stops appearing in the URL fragment. (Decision RTR-D3.)
+
+**Sequential-impression re-derivation (mobile SDK pattern).** When a long-lived `SHARCContainer` mints a new `placementSessionId` for a subsequent creative load (per § 4.5), every registered protocol's derived nonce changes. The router re-derives each registered protocol's nonce and re-invokes the registered `onReady({protocolNonce})` callback so extensions update their cached value. Outbound envelopes constructed after the mint use the new nonce; inbound envelopes are gated against the new nonce. Envelopes still in flight signed with the previous-session nonce are dropped at gate step 7 (silent drop, matching the existing nonce-mismatch policy) — they belong to a session that has ended.
+
+**Ordering invariant (RTR-D21).** When `placementSessionId` is re-minted (sequential-impression case), the router MUST:
+
+1. Atomically update its expected per-protocol nonces from the old `placementSessionId` to the new one. This happens in the same synchronous block that mints the new `placementSessionId`.
+2. Re-fire `onReady({protocolNonce})` to each registered extension's handler with the newly-derived per-protocol nonce. This MUST complete before the next iframe-wiring step (`_createIframe()` or equivalent).
+3. Only after both (1) and (2) complete, the next iframe is created and the new shim injected with the new nonce via the trusted-injection mechanism.
+
+Envelopes still in flight from the previous iframe, signed with the previous derived nonce, are silent-dropped at gate step 7 (per § 3.2). This is correct: those envelopes are session-scoped to the previous `placementSessionId` and are no longer valid under the new session.
+
+A reverse race — new iframe shim wired with new nonce while the gate still expects the old nonce — is structurally prevented by the ordering requirement that (1) and (2) complete before iframe creation. This is the sequential-impression analogue of the first-impression ordering already locked by RTR-D10 (container awaits `protocolRouter.ready('SHARC:Renderer:')` before `_createIframe()`).
+
+This is a **breaking change to the renderer's wire contract**: the value the renderer reads from `location.hash` is no longer the root nonce; it is the derived renderer nonce. Renderers built against 0.6.x–0.7.6 echo the fragment back as `sharcNonce`; the post-0.7.7 container expects the derived value to come back. Because the derivation is deterministic and the renderer just echoes whatever it reads, **the renderer code does not need to change** — it has always been opaque-string passthrough. The only observable difference is the fragment value's bit pattern. (Decision RTR-D3 logged this and § 14 confirms no renderer code change.)
+
+### 5.4 Why HMAC-SHA-256 over an alternative (HKDF, plain SHA-256), and why salt with `placementSessionId`
+
+- **HKDF.** Adds an unnecessary extract+expand step for a single-output derivation. HMAC is HKDF's underlying primitive; using HMAC directly is the minimum that achieves the security property. (Judgment call — see RTR-J2.)
+- **Plain SHA-256(rootNonce + prefix + placementSessionId).** Vulnerable to length-extension attacks on Merkle-Damgård constructions. SHA-256 is M-D; HMAC is the standard fix. Negligible practical risk here given the protocol nonce isn't itself a key, but HMAC is the textbook answer and doesn't cost more.
+- **Why `placementSessionId` in the salt rather than container construction time, container ID, or another identifier.** `placementSessionId` is the per-impression boundary that SHARC already exposes on every envelope and that downstream measurement (OMID `AdSession`, viewability events, etc.) is already keyed against. Binding the transport nonce to the same boundary aligns the security context with the measurement context — they advance together. Container construction time would couple to wall-clock and break determinism across re-derivation; container ID would not advance on sequential impressions inside a long-lived mobile container, leaving stale nonces valid across distinct impressions. `placementSessionId` is the right granularity.
+- **Native crypto availability.** `crypto.subtle` is universally available in SHARC's lowest-supported targets (iOS WKWebView 15.4+, WebView 92+) — same baseline as `crypto.randomUUID()` at `:1948`.
+
+### 5.5 Async derivation in a sync constructor
+
+`crypto.subtle.sign()` returns a Promise. The router's registration API is synchronous in calling shape. Two options:
+
+| Option | Mechanism | Tradeoff |
+|--------|-----------|----------|
+| **(a)** `register()` returns a Promise; `onReady` fires async | Standard async API; `register({...}).then(...)` | Extensions must handle async — minor surface complexity |
+| **(b)** `register()` is sync; `onReady` callback receives the nonce when the async derivation resolves | Sync `register()`, async `onReady` | Decouples calling shape from underlying async — but extensions can't synchronously read the nonce after register |
+
+**Decision (RTR-D4):** Option (b). The renderer protocol's outbound `render` envelope is constructed inside the iframe-`load` handler, which is async-relative-to-construction anyway; the renderer protocol registers at container construction time and uses the nonce in a handler that fires after async derivation completes. For all reasonable protocols, the nonce is needed at envelope-construction time, which is downstream of registration. The async `onReady` is sufficient.
+
+Edge case: if `_resolvedIframeSrc()` (`:1943`) runs synchronously during `container.load()` and needs the renderer-protocol nonce to assemble the URL fragment, the nonce must be ready by then. The container therefore awaits `protocolRouter.ready('SHARC:Renderer:')` before `_createIframe()`. `placementSessionId` is minted before `container.load()` proceeds (it's already an envelope field in 0.7.6), so it is available as a derivation input at this point. This is an extra `await` in the container's load path; existing `container.load()` is already synchronous-returning, so the await is internal. (Decision RTR-D10.)
+
+---
+
+## 6. Renderer-protocol retrofit
+
+### 6.1 What moves into the router
+
+The renderer protocol's dispatch and gating moves to a registered protocol handler. Specifically:
+
+| Before (0.7.6) | After (0.7.7) |
+|----------------|---------------|
+| `window.addEventListener('message', handler, false)` inside `_wireRendererProtocol` `:2211` — one of two `message` listeners on the publisher window | Router's single `message` listener (constructed at container construction) — only one publisher-side `message` listener for SHARC protocols total |
+| `_isValidRendererEnvelope` (`:2293-2305`) | Router's uniform gate — checks 1, 2, 3, 4, 6 from § 3.2 |
+| Type-routing in `_dispatchRendererMessage` (`:2382-2399`) | Router's prefix + type-membership dispatch (checks 5, 8 from § 3.2) |
+| Session-correlation check at `_dispatchRendererMessage` `:2406` | Router's `placementSessionId` check (step 6) |
+| Payload-shape checks (`rendererOrigin`, `reason`) | Stay in the handler — payload validation is protocol-specific |
+| `_emitSecurityEventAndTerminate` calls for payload failures | Stay in the handler — uses the existing chokepoint unchanged |
+| Second `message` listener for `SHARC:Renderer:loadAck` at `_setupLoadBackstop` `:4283` | Folded into the router as part of the renderer protocol's registered handler |
+
+### 6.2 The renderer protocol's registration shape
+
+```javascript
+// Called once at container construction, before _createIframe().
+container.protocolRouter.register({
+  prefix: 'SHARC:Renderer:',
+  types: {
+    'rendered':  { phases: ['attaching-renderer'], direction: 'inbound' },
+    'failed':    { phases: ['attaching-renderer'], direction: 'inbound' },
+    'loadAck':   { phases: ['attaching-renderer', 'rendered'], direction: 'inbound' },
+    'render':    { phases: ['attaching-renderer'], direction: 'outbound' },
+    'loadProbe': { phases: ['attaching-renderer', 'rendered'], direction: 'outbound' },
+  },
+  handler: this._handleRendererEnvelope.bind(this),
+  onReady: ({ protocolNonce }) => {
+    this._rendererProtocolNonce = protocolNonce;
+  },
+});
+```
+
+`_handleRendererEnvelope` replaces the existing `_dispatchRendererMessage`. It receives only envelopes that the router has already validated — no `event.source`/`event.origin`/`event.data.type` checks, no session-id check, no `sharcNonce` check, no phase-membership check. The handler is exclusively responsible for **payload shape** (the existing `rendererOrigin`/`reason` validation) and **protocol-specific dispatch** (which type triggers which container state transition).
+
+### 6.3 Vocabulary preservation
+
+Every existing `SHARC:Renderer:*` envelope type continues to exist with the same shape, the same payload contract, and the same dispatch behavior. The only changes are:
+
+1. The fragment value the renderer reads from `location.hash` is now the derived renderer-protocol nonce (§ 5.3) — `HMAC-SHA-256(_sharcNonce, 'SHARC:Renderer:' || ':' || placementSessionId)`, base64url-truncated to 22 chars. Renderer code unchanged because it's opaque-string passthrough.
+2. The `sharcNonce` field on outbound `SHARC:Renderer:render` is the derived nonce, not the root nonce.
+3. Inbound envelopes are router-gated; payload validation in `_handleRendererEnvelope` is identical to today's `_dispatchRendererMessage` from line 2410 onward.
+
+### 6.4 What stays in the container
+
+- `_resolvedIframeSrc()` — still constructs the iframe `src`, now reads the renderer-protocol nonce from `this._rendererProtocolNonce` (set by the `onReady` callback) instead of `this._sharcNonce`. `_sharcNonce` remains the root nonce, kept private.
+- `_assertResolvedIframeSrcAllowed()` — unchanged structurally, asserts against the derived-nonce-bearing URL.
+- `_emitSecurityEventAndTerminate()` — unchanged. The handler calls it directly for payload failures (`RENDERER_PROTOCOL_ERROR`, `RENDERER_ORIGIN_MISMATCH`, `RENDERER_FAILED`, `BRIDGE_LOAD_FAILED`).
+- `_setupLoadBackstop()` — unchanged in shape; the probe's second listener at `:4283` is removed and the probe's `:loadAck` reception migrates into the router-registered handler.
+
+### 6.5 Breaking changes from the renderer retrofit
+
+- **The renderer protocol's `:loadProbe` outbound and `:loadAck` inbound are now in the same registered protocol** as `:render` / `:rendered` / `:failed`. Today they're handled by a separate inline `message` listener in `_setupLoadBackstop`. Behavior is preserved; the second listener goes away. (Decision RTR-D11.)
+- **Out-of-phase `SHARC:Renderer:rendered` is now actively rejected.** Before 0.7.7, a second `:rendered` envelope arriving after the renderer handshake succeeded would dispatch through `_dispatchRendererMessage`, fail the `_terminated` guard (`_emitSecurityEventAndTerminate :4455`), and silently no-op. After 0.7.7, it's rejected at the router with `unauthorized_protocol` raised. Per pre-1.0 throw-on-legacy: no deprecation — operators see the new event on out-of-phase delivery. (Decision RTR-D12.)
+- **The root `_sharcNonce` no longer appears anywhere on the wire.** Operators or test code that asserted on the URL fragment value being the same string as some other observable nonce will break. (Decision RTR-D13.)
+
+---
+
+## 7. Security model
+
+### 7.1 Cross-protocol impersonation prevention
+
+The attack the parked 0.7.8 OMID review surfaced (S1):
+
+> If `sharc-omid-shim.js` runs in the creative iframe with the ability to `window.parent.postMessage`, the creative can forge `{type:'SHARC:Renderer:rendered', sharcNonce:<value>, ...}`. With the same `(source, origin)` validation that the renderer protocol uses, the forged envelope passes the gate.
+
+The router's mitigation has two layers:
+
+**Layer 1 — per-protocol nonces.** Even if the OMID shim's nonce leaks into the creative iframe (e.g. via a hostile verification script reading shim internals), the renderer-protocol nonce stays in the publisher page (it's only used to construct the fragment URL and to validate inbound envelopes; never delivered to any iframe-side code). Forging `SHARC:Renderer:rendered` requires the renderer-protocol nonce, which the creative cannot get.
+
+This is the load-bearing defense. The forged-envelope attack is **structurally impossible** as long as the renderer-protocol nonce isn't leaked into the iframe.
+
+**Layer 2 — phase enforcement.** Even if the renderer-protocol nonce leaked through some future channel, phase enforcement adds defense in depth. By the time the OMID shim is running in the creative iframe (which is *after* the renderer handshake completes, since the shim is injected by the renderer before `document.write(creativeHtml)`), the container has transitioned to `rendered` or `creative-active`. The router will reject any `SHARC:Renderer:rendered` envelope with `unauthorized_protocol` because `rendered` is only valid in phase `attaching-renderer`.
+
+**The check order matters.** Phase enforcement (step 9 in § 3.2) runs after the envelope has been claimed by a registered protocol via its prefix (step 5), so the `unauthorized_protocol` event correctly identifies which protocol was being targeted. Phase enforcement runs after `sharcNonce` (step 7), so a forged envelope without the correct nonce fails silently at the nonce step — it never reaches the phase check. The phase check is the **last gate**: it triggers only on envelopes that look legitimate by every other measure but arrive at the wrong time.
+
+### 7.2 Threat: rogue extension registers a colliding prefix
+
+A hostile extension installed into `extensions: [...]` could try to register `prefix: 'SHARC:Renderer:'` and intercept renderer-protocol envelopes.
+
+**Mitigation:** prefix collisions throw at registration time. The renderer protocol registers first (during container construction, before any extension has run); an extension's later `register({prefix: 'SHARC:Renderer:'})` throws.
+
+The container does not load the extension's code until after the renderer registration completes (decision RTR-D5). This is a code-ordering constraint, called out in the implementation plan (§ 12.3).
+
+### 7.3 Threat: rogue extension reads another protocol's nonce
+
+The protocol nonce is delivered to the registering extension via `onReady({protocolNonce})`. A rogue extension could try to register multiple protocols (its own + a foreign one's) and harvest nonces.
+
+**Mitigation:** the router's `register()` is called from container-trusted code paths. The renderer protocol's registration is owned by the container itself, not by any extension. An extension that successfully calls `register({prefix: 'SHARC:Renderer:'})` would throw on the prefix-collision check (the renderer is already registered).
+
+For protocols an extension legitimately owns (e.g. the future OMID shim), the extension knows its own nonce — that's the point. The threat model accepts that any code that owns a registered protocol can forge envelopes within its own protocol. Across-protocol forgery is what the router prevents.
+
+### 7.4 Threat: out-of-order phase transitions
+
+What happens if `transitionTo('rendered')` is called before the renderer handshake actually completes? The container's `_wireRendererProtocol` is the only call site for `transitionTo('attaching-renderer')` and `_onRendererRendered` is the only call site for `transitionTo('rendered')`. Both are private; both are guarded by `_terminated` checks. No public surface allows an extension or external code to drive phase transitions.
+
+**Mitigation:** `transitionTo()` is called only from container-internal code paths. The router does not expose `transitionTo()` to extensions. (Decision RTR-D14.)
+
+If the container's own logic has a transition bug — e.g. transitions to `rendered` before `_isValidRendererEnvelope` accepts `:rendered` — that's a container bug, not a router bug, and it surfaces as silent acceptance of post-handshake `:rendered` envelopes. The test strategy (§ 9) pins the transitions to specific lifecycle events.
+
+### 7.5 Trust anchors summary
+
+| Anchor | Source | Validated by |
+|--------|--------|--------------|
+| `event.source === iframe.contentWindow` | Browser-set, unforgeable | Router gate step 2 |
+| `event.origin === expectedRendererOrigin` | Browser-set, unforgeable | Router gate step 3 |
+| `event.data.sharcNonce === protocolNonce` | Container-derived via HMAC over `(_sharcNonce, prefix, placementSessionId)`; never on the wire as root nonce | Router gate step 7 |
+| `event.data.placementSessionId === container.placementSessionId` | Container-derived UUID | Router gate step 6 |
+| Type prefix is registered + type is declared | Container-controlled registration | Router gate steps 5, 8 |
+| Current phase ∈ type's declared phases | Container-controlled transitions | Router gate step 9 |
+
+---
+
+## 8. `unauthorized_protocol` security event
+
+### 8.1 Shape
+
+Discriminated-union variant added to `SHARCSecurityEvent` at `src/sharc-container.js:237-283`. The `details` payload is **deliberately minimized** to three enumerated, attacker-uncontrolled fields — see § 8.7 for rationale.
+
+```javascript
+/**
+ * @typedef {SHARCSecurityEventBase & {
+ *   type: 'unauthorized_protocol',
+ *   severity: 'error',
+ *   details: {
+ *     // A registered prefix (e.g. 'SHARC:Renderer:') or the literal
+ *     // 'unknown-prefix' for prefix-unregistered envelopes.
+ *     type: string,
+ *     // One of the six enumerated phases (§ 4.1).
+ *     phase: 'init' | 'attaching-renderer' | 'rendered'
+ *          | 'omid-active' | 'creative-active' | 'terminated',
+ *     // Which gate-step failure produced this event.
+ *     reason: 'out-of-phase' | 'nonce-mismatch' | 'prefix-unregistered',
+ *   },
+ * }} UnauthorizedProtocolEvent
+ */
+```
+
+No attacker-controlled string (envelope `payload`, raw `event.data.type`, etc.) is included.
+
+### 8.2 What triggers it
+
+Exactly the phase-membership check failure in § 3.2 step 9. Triggered when:
+
+- The envelope passes every prior gate (source, origin, nonce, placementSessionId, registered prefix, declared type).
+- The envelope's declared type is **not** valid in the container's current phase.
+
+By construction, this means the envelope is well-formed from a trust-anchor perspective but arrived at the wrong time. Either the creative is replaying a captured envelope after the protocol's window closed, or a forging script is trying to inject an envelope outside its protocol's active window.
+
+### 8.3 Severity & terminating behavior
+
+| Property | Value | Rationale |
+|----------|-------|-----------|
+| `severity` | `'error'` | Distinct from `wrapper_top_frame_inaccessible`'s `'warning'`; matches the existing terminating events. |
+| Terminating | **No** | Out-of-phase envelopes are dropped, not fatal. Continuing to run is the right behavior: the renderer protocol has already completed successfully (otherwise we wouldn't be past `attaching-renderer`); a late stray envelope is suspicious but not actionable as a container shutdown. This matches the parked 0.7.8 OMID design's "silent drop on iframe side" envelope policy plus an observable signal. (Decision RTR-D15.) |
+| `errorCode` | none | No 21xx code — extensions are not in the renderer-error-code namespace (matches `feature_load_failed`'s pattern at `:259-265`). |
+
+### 8.4 Where it's emitted
+
+The router holds the chokepoint:
+
+```javascript
+// In src/sharc-protocol-router.js
+//
+// `reason` is passed in by the caller — one of 'out-of-phase',
+// 'nonce-mismatch', 'prefix-unregistered'. For 'prefix-unregistered',
+// `protocol` is null and the literal 'unknown-prefix' is used.
+function _emitUnauthorizedProtocol(protocol, reason) {
+  const payload = {
+    type: 'unauthorized_protocol',
+    severity: 'error',
+    timestamp: Date.now(),
+    placementSessionId: this._expectedPlacementSessionId,
+    // Static message — no attacker-controlled interpolation. The discriminating
+    // fields are in `details`; the message exists only for log-grep ergonomics.
+    message: 'Envelope rejected by router (' + reason + ')',
+    details: {
+      type: protocol ? protocol.prefix : 'unknown-prefix',
+      phase: this._currentPhase,
+      reason: reason,
+    },
+  };
+  this._onUnauthorizedProtocol(payload);
+}
+```
+
+The function takes no `event` reference. Any code path that would have echoed `event.data.*` is structurally unable to do so.
+
+The container wires `onUnauthorizedProtocol` (router constructor option in § 2.1) to its existing `_invokeSecurityCallback` — reuse of the established chokepoint. (Decision RTR-D16.)
+
+### 8.5 Dev-channel log
+
+`console.warn` (not `console.error` — non-terminating) with the standard SHARC tag format. The log line is built from the three enumerated `details` fields only — no attacker-controlled interpolation:
+
+```
+[SHARCContainer] [<placementSessionId>] [unauthorized_protocol] type=SHARC:Renderer: phase=creative-active reason=out-of-phase
+```
+
+The `[type]` tag is `unauthorized_protocol` — grep-able alongside the other internal types (`renderer_origin_mismatch`, `bridge_load_failed`, etc.).
+
+### 8.6 No router-side rate limit; operator responsibility
+
+The router does **not** rate-limit or cap `unauthorized_protocol` emission. There is no per-(protocol, type) counter, no per-second budget, no backoff state. Every envelope that fails phase enforcement emits exactly one `unauthorized_protocol` event.
+
+The architectural rationale:
+
+> SHARC's gate rejects forged envelopes before any state change; the container's security posture is invariant to envelope volume. `unauthorized_protocol` events are emit-only (non-terminating) and per-envelope. Operators handling SHARC events through SIEM / telemetry are responsible for downstream rate-limiting or sampling per their own pipeline cost model.
+
+A hostile creative spamming out-of-phase envelopes can fill an operator's monitoring pipeline if the operator forwards every event verbatim. That cost is bounded by the operator's pipeline (rate-limit at SIEM ingest, sample at the collector, drop after N/sec at the edge — operator-side choices). The router pushing a cap upward would (a) hide the volume signal from operators that want it, (b) silently lose forensic evidence of an attack, and (c) introduce a counter the attacker could probe.
+
+**Operator responsibility.** Operators consuming `onSecurityEvent` should apply their own rate-limiting, sampling, or aggregation appropriate to their telemetry pipeline cost model. Exponential backoff at the router layer is a future option if real-world telemetry pressure justifies it; for 0.7.7 it is an explicit non-goal.
+
+### 8.7 Payload minimization
+
+To close the side-channel exfiltration concern that a rate-limit would have addressed (a hostile creative encoding data into `event.data.payload` and relying on operator log forwarding to leak it), the `unauthorized_protocol` event payload is restricted to three bounded fields. Each is an enumerated, attacker-uncontrolled string:
+
+| Field | Domain | Source |
+|-------|--------|--------|
+| `type` | A registered prefix (e.g. `'SHARC:Renderer:'`) **or** the literal string `'unknown-prefix'` | Router-determined from the registry; falls back to the literal for prefix-unregistered envelopes |
+| `phase` | One of the six enumerated phases (§ 4.1): `'init'`, `'attaching-renderer'`, `'rendered'`, `'omid-active'`, `'creative-active'`, `'terminated'` | Router-internal state |
+| `reason` | One of: `'out-of-phase'`, `'nonce-mismatch'`, `'prefix-unregistered'` | Router-determined from which gate step failed |
+
+The `reason` enum reserves three labels so the event shape is stable across future protocol opt-ins. **In 0.7.7, only `'out-of-phase'` is actually emitted** — § 3.2 steps 5 and 7 (prefix not registered, nonce mismatch) remain silent drops per the existing "any frame can postMessage" policy. The other two labels exist so a future protocol can opt in to surfacing those failures (e.g. for forensic telemetry) without changing the event's shape.
+
+**The router does NOT include the raw envelope `payload`, `details`, `event.data`, or any attacker-controlled string in the event.** Specifically: no `envelopeType` field with the full attacker-supplied `event.data.type`; no `currentPhase` echo of attacker-supplied fields; no `message` field with attacker-controlled substrings interpolated in. Attacker-controlled content cannot reach `onSecurityEvent` via this event. (This supersedes the field shape sketched in § 8.1 — see § 8.1 for the corrected typedef.)
+
+---
+
+## 9. Test strategy
+
+### 9.1 Pinning surfaces
+
+The four behaviors that must be pinned in CI per acceptance criteria on issue #219:
+
+| Behavior | Test approach |
+|----------|---------------|
+| **Phase-scoped envelope rejection** | For each `(protocol, type, phase)` triple in the renderer protocol's `types` declaration, assert valid envelopes dispatch in the declared phases and out-of-phase envelopes raise `unauthorized_protocol`. |
+| **Prefix-collision throw** | Direct unit test: construct a router, register `SHARC:Renderer:`, then attempt a second register of `SHARC:Renderer:` — assert it throws. |
+| **Routing correctness for the renderer protocol** | Re-run the existing renderer-protocol test suite without modification. No regression on `:rendered`/`:failed`/`:loadAck` handling. |
+| **`unauthorized_protocol` event emission** | Drive the container past `attaching-renderer` (e.g. into `creative-active`), post a forged `SHARC:Renderer:rendered` with a valid nonce, assert `onSecurityEvent` fires with `type: 'unauthorized_protocol'` and the expected `details` shape. |
+
+### 9.2 New tests (jsdom)
+
+| File | Coverage |
+|------|----------|
+| `test/node/test-protocol-router.js` (new) | Router primitive in isolation — construction, register, prefix collision throw, gate sequence (each step 1–9 in § 3.2), phase transitions, `unauthorized_protocol` emission with payload-minimized shape (§ 8.7), no-cap policy (§ 9.6 pins). |
+| `test/node/test-protocol-router-nonce-derivation.js` (new) | HMAC-SHA-256 derivation — determinism per `(rootNonce, prefix, placementSessionId)`, distinct prefixes produce distinct nonces for the same session, distinct `placementSessionId`s produce distinct nonces for the same prefix, async `onReady` delivery, edge case where `crypto.subtle` is unavailable (throw with clear error message), pinned HMAC vector test (known `_sharcNonce` + known `placementSessionId` + known prefix → expected base64url output). |
+| `test/node/test-renderer-protocol-retrofit.js` (new) | Renderer-protocol-via-router parity: every assertion from the existing `_dispatchRendererMessage` test surface, replayed through the router. Confirms zero behavior regression. |
+| `test/node/test-renderer-out-of-phase.js` (new) | Post-handshake `:rendered` and `:failed` envelopes raise `unauthorized_protocol`. Pins the S1 mitigation directly. |
+
+### 9.3 Existing test impact
+
+| Test file | Impact |
+|-----------|--------|
+| `test/node/test-sharc-container.js` (renderer-protocol assertions) | No semantic change. May need minor refactor if it asserts on `_isValidRendererEnvelope` directly — that method goes away. Replace with assertions on observable behavior (`onSecurityEvent`, `onError`). |
+| `test/browser/test-creative-sources-puppeteer.js` | No change. End-to-end behavior preserved. |
+| `test/browser/test-html-lifecycle-adapter-bfcache.js` | No change. |
+| `test/node/test-html-lifecycle-adapter.js` | No change. Lifecycle adapter is unrelated to the router. |
+
+### 9.4 Browser-side regression
+
+The Puppeteer suite (`npm run test:browser`) runs the full renderer-protocol path against real Chrome. No new fixture is needed for 0.7.7 — the existing creative-sources fixture exercises every renderer envelope type. The browser suite is the "this didn't break real-world dispatch" gate.
+
+### 9.5 Coverage gates
+
+- `npm run test` (jsdom) must pass with the new router tests added.
+- `npm run test:browser` (Puppeteer) must pass unchanged.
+- `npm run test:all` and `npm run test:all:built` must pass.
+
+### 9.6 Required pinning tests (review-locked)
+
+These tests are explicitly required by the Code Reviewer / Security Engineer pass and must ship in the 0.7.7 PR. Each pins a load-bearing locked decision.
+
+| # | Test | Pins which decision |
+|---|------|---------------------|
+| 1 | **Phase-string typo detection.** Assert that every phase string declared by any registered protocol's `types` map appears in some `protocolRouter.transitionTo(...)` call site inside `src/sharc-container.js`. Implementation: AST-scan or regex-grep the container source for the phase string; fail the test if a declared phase has no matching transition site. | RTR-J1 (open-set phases) |
+| 2 | **No-cap policy.** Drive the container into `creative-active`, then post 100 sequential forged `SHARC:Renderer:rendered` envelopes (each carrying the valid renderer-protocol nonce). Assert: exactly 100 `unauthorized_protocol` events fire on `onSecurityEvent`; the container does not terminate; `onError` is not called. | RTR-D17 (no cap) |
+| 3 | **Single-listener invariant.** After construction + retrofit, assert that exactly one `window.addEventListener('message', ...)` call exists in `src/sharc-container.js` (the load-event backstop's previously-second listener at the original `:4283` is subsumed by the router). Implementation: regex-count `addEventListener\(\s*['"]message['"]` occurrences in the container source. | § 6.1 retrofit; SF-3 |
+| 4 | **Payload-minimization invariant.** Trigger an `unauthorized_protocol` event with an attacker-supplied envelope carrying `payload: '<script>...'`, `details: {leak: 'secret'}`, and a long `type` string. Assert: the emitted event's `details` has exactly the keys `type`, `phase`, `reason`; no attacker-controlled string appears anywhere in the event (deep walk of the event object). | RTR-D17 / § 8.7 |
+| 5 | **bfcache nonce persistence.** Round-trip the container through `pagehide(persisted=true)` / `pageshow(persisted=true)` with the same `placementSessionId` throughout. Assert: `_rendererProtocolNonce` is the same string before and after; a valid envelope arriving post-restore in the same phase still dispatches; no `unauthorized_protocol` is raised for the round-trip alone. | SF-2, § 4.5 |
+| 6 | **Per-creative-load nonce rotation.** Drive the container to `creative-active`, capture the current `_rendererProtocolNonce`. Simulate a new creative load by minting a fresh `placementSessionId` on the same container. Assert: an inbound envelope signed with the old derived nonce is silently dropped (gate step 7); an inbound envelope signed with the new derived nonce (re-derived via `HMAC-SHA-256(_sharcNonce, 'SHARC:Renderer:' || ':' || newPlacementSessionId)`) is accepted; `_rendererProtocolNonce` after the mint differs from the pre-mint value; `_sharcNonce` is unchanged. | § 4.5, § 5.2, § 5.3 |
+| 7 | **`placementSessionId` in derivation (HMAC vector).** Envelope-construction test that pins the HMAC formula: with a known `_sharcNonce` and known `placementSessionId`, `protocolRouter.buildOutbound('SHARC:Renderer:', 'render', {...})` produces an envelope whose `sharcNonce` matches the expected base64url-truncated HMAC output computed independently in the test. Fails any future refactor that drops `placementSessionId` from the message or changes the separator. | § 5.2 |
+| 8 | **Re-derive ordering test.** Simulate sequential-impression re-mint: after `placementSessionId` changes on a long-lived container, assert that (a) the router's expected nonce updated atomically with the mint, (b) `onReady` was re-invoked with the new nonce before the next iframe-wiring step, and (c) an envelope signed with the new nonce posted before the iframe is wired is correctly held until the iframe is ready (or silent-dropped per the documented behavior). Pins the sequential-impression analogue of RTR-D10. | RTR-D21, § 5.3 |
+
+---
+
+## 10. Architecture diagrams
+
+### 10.1 C4 Level 2 — Container internals after retrofit
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  SHARCContainer (publisher page)                                      │
+│                                                                       │
+│  ┌────────────────────────────────────────────────────────────────┐  │
+│  │  SHARCProtocolRouter                                            │  │
+│  │  ┌────────────────────────────────────────────────────────┐    │  │
+│  │  │  window.addEventListener('message', ...)               │    │  │
+│  │  │  — single listener for ALL SHARC cross-frame protocols │    │  │
+│  │  └─────────────────────────┬──────────────────────────────┘    │  │
+│  │                            │                                    │  │
+│  │              ┌─────────────▼─────────────┐                     │  │
+│  │              │  Uniform gate (§ 3.2)     │                     │  │
+│  │              │  1. object check          │                     │  │
+│  │              │  2. source === iframe.cw  │                     │  │
+│  │              │  3. origin matches        │                     │  │
+│  │              │  4. type is string        │                     │  │
+│  │              │  5. prefix registered     │                     │  │
+│  │              │  6. placementSessionId    │                     │  │
+│  │              │  7. protocol nonce        │                     │  │
+│  │              │  8. type declared         │                     │  │
+│  │              │  9. phase membership ─────┼─FAIL→ unauthorized  │  │
+│  │              └────────────┬──────────────┘       _protocol     │  │
+│  │                           │                                    │  │
+│  │              ┌────────────▼──────────────┐                     │  │
+│  │              │  Protocol registry        │                     │  │
+│  │              │  {                        │                     │  │
+│  │              │    'SHARC:Renderer:': {   │                     │  │
+│  │              │      types: {...},        │                     │  │
+│  │              │      handler: fn,         │                     │  │
+│  │              │      nonce: '<derived>'   │                     │  │
+│  │              │    },                     │                     │  │
+│  │              │    // future:             │                     │  │
+│  │              │    // 'SHARC:Omid:': ...  │                     │  │
+│  │              │  }                        │                     │  │
+│  │              └────────────┬──────────────┘                     │  │
+│  │                           │                                    │  │
+│  └───────────────────────────┼────────────────────────────────────┘  │
+│                              │                                       │
+│                              ▼                                       │
+│  ┌────────────────────────────────────────────────────────────────┐  │
+│  │  Renderer-protocol handler                                      │  │
+│  │  ─ payload shape (rendererOrigin, reason)                       │  │
+│  │  ─ origin echo check (rendererOrigin === _rendererOrigin)       │  │
+│  │  ─ accept → _onRendererRendered() / _emitSecurityEventAndTerm.. │  │
+│  └────────────────────────────────────────────────────────────────┘  │
+│                                                                       │
+│  ┌────────────────────────────────────────────────────────────────┐  │
+│  │  Phase driver — calls protocolRouter.transitionTo(...) at:     │  │
+│  │   • _wireRendererProtocol iframe `load` → 'attaching-renderer' │  │
+│  │   • _onRendererRendered                  → 'rendered'          │  │
+│  │   • setState(ACTIVE) chokepoint          → 'creative-active'   │  │
+│  │   • _terminate()                         → 'terminated'        │  │
+│  └────────────────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### 10.2 Inbound envelope sequence (Markup variant)
+
+```mermaid
+sequenceDiagram
+    participant Renderer as Renderer iframe<br/>(cross-origin)
+    participant Win as window.message<br/>(publisher)
+    participant Router as SHARCProtocolRouter
+    participant Handler as Renderer handler
+    participant Container as SHARCContainer
+
+    Note over Container: container.load()
+    Container->>Router: register({prefix: 'SHARC:Renderer:', ...})
+    Router-->>Handler: onReady({ protocolNonce })
+    Note over Container: phase: 'init'
+
+    Container->>Container: _wireRendererProtocol(iframe)
+    Note over Container: iframe `load` fires
+    Container->>Router: transitionTo('attaching-renderer')
+    Container->>Renderer: postMessage SHARC:Renderer:render<br/>(via router.buildOutbound)
+
+    Renderer->>Win: postMessage SHARC:Renderer:rendered
+    Win->>Router: dispatch event
+
+    Router->>Router: § 3.2 gate steps 1–9
+    Note over Router: phase 'attaching-renderer' ∈ ['attaching-renderer'] ✓
+    Router->>Handler: handler(envelope, context)
+    Handler->>Handler: payload shape check<br/>(rendererOrigin)
+    Handler->>Handler: origin echo check
+    Handler->>Container: _onRendererRendered()
+    Container->>Router: transitionTo('rendered')
+
+    Note over Container: ...later, container ACTIVE...
+    Container->>Router: transitionTo('creative-active')
+
+    Note over Renderer: hostile creative shim replays<br/>SHARC:Renderer:rendered
+    Renderer->>Win: postMessage (replay)
+    Win->>Router: dispatch event
+    Router->>Router: § 3.2 gate steps 1–8 pass
+    Router->>Router: step 9: phase 'creative-active' ∉ ['attaching-renderer']
+    Router->>Container: onUnauthorizedProtocol(event)
+    Container->>Container: _invokeSecurityCallback({<br/>  type: 'unauthorized_protocol',<br/>  ...<br/>})
+    Note over Container: non-terminating; container continues
+```
+
+---
+
+## 11. Migration plan
+
+### 11.1 Pre-1.0 clean break
+
+Per `feedback_pre_1_breaking_changes` and SHARC project convention: no deprecation period, no aliases, no migration warnings. Breaking changes ship clean in 0.7.7.
+
+### 11.2 Behavior matrix
+
+| Caller / configuration | 0.7.6 behavior | 0.7.7 behavior | Breaking? |
+|------------------------|----------------|----------------|-----------|
+| `new SHARCContainer({creativeRendererUrl, ...})`, normal handshake | Renderer reads `#sharcNonce=<UUID>`, echoes in `sharcNonce` field; container validates | Renderer reads `#sharcNonce=<derived>`, echoes in `sharcNonce` field; router validates | No — renderer code is opaque-string passthrough; fragment value differs, behavior identical |
+| External code with `window.addEventListener('message', handler)` reading `SHARC:Renderer:*` envelopes | Receives the same envelopes the container does (browser dispatches to all listeners) | Same | No |
+| Post-handshake replay of `SHARC:Renderer:rendered` | Silently no-ops via `_terminated` guard in `_emitSecurityEventAndTerminate` | Raises `unauthorized_protocol` security event (non-terminating) | Yes — new observable event |
+| Test code calling `container._isValidRendererEnvelope(...)` directly | Method exists | Method removed | Yes — `_` prefix indicates internal; not part of public API |
+| Test code asserting on `container._sharcNonce` matching the URL fragment | Match | Mismatch (fragment is derived) | Yes |
+| Extension calling `container.protocolRouter.register(...)` | Did not exist | Available | No (additive) |
+
+### 11.3 Throw-on-legacy enforcement
+
+The router throws synchronously at registration time on:
+
+- Prefix collision (§ 2.3) — `Error('[SHARCProtocolRouter] prefix "X" already registered')`
+- Prefix not ending in `:` — `Error('[SHARCProtocolRouter] prefix must end with ":" — got "X"')`
+- Missing/invalid `types` map — `Error('[SHARCProtocolRouter] types must be a non-empty object')`
+- Invalid phase declared in a type — the router currently accepts any phase string (§ 4.3), so no throw; future hardening per RTR-J1
+
+The router throws at envelope-construction time (`buildOutbound`) on:
+
+- Unknown protocol prefix — `Error('[SHARCProtocolRouter] no protocol registered for prefix "X"')`
+- Type not declared `outbound` or `bidirectional` — `Error('[SHARCProtocolRouter] type "X" is not outbound on protocol "Y"')`
+- Caller payload colliding with a router-controlled field (`type`, `sharcNonce`, `placementSessionId`) — `Error('[SHARCProtocolRouter] buildOutbound payload collides with router-controlled field "X" on protocol "Y"')` (§ 3.3 step 4; locked per C5)
+
+### 11.4 CHANGELOG entry (proposed)
+
+```markdown
+## [0.7.7] — 2026-MM-DD
+
+### Added
+- `SHARCProtocolRouter` — new internal primitive owning the single
+  publisher-side `window` `message` listener. Validates every inbound
+  envelope uniformly: `(source, origin, prefix, placementSessionId,
+  protocol nonce, type declaration, current lifecycle phase)`. Provides
+  `container.protocolRouter.register({prefix, types, handler})` for
+  extensions; prefix collisions throw at registration time.
+- New `unauthorized_protocol` security event. Non-terminating. Fires
+  when an inbound envelope passes every trust-anchor check but arrives
+  in a lifecycle phase outside the type's declared phase membership.
+  Defends against cross-protocol envelope-type impersonation when
+  iframe-side extensions land in later releases.
+- Per-protocol nonce derivation via HMAC-SHA-256(`_sharcNonce`,
+  `prefix || ":" || placementSessionId`). The renderer protocol's
+  wire-level `sharcNonce` is now the renderer-protocol-derived,
+  session-bound nonce; the root nonce never appears on the wire.
+  New `placementSessionId` (sequential-impression case on long-lived
+  containers) re-derives every protocol's nonce by construction. Lays
+  groundwork for safe iframe-side extensions (e.g. the 0.7.8 OMID shim)
+  that cannot leak the renderer's trust anchor and aligns the transport
+  security context with OMID's `AdSession`-keyed measurement boundary.
+
+### Changed
+- The renderer protocol is retrofitted onto the router. No semantic
+  change to the renderer protocol's vocabulary or behavior; dispatch
+  and gating move from inline `_wireRendererProtocol` / `_dispatch-
+  RendererMessage` to a router-registered handler. The publisher-side
+  `message` listener at `:2211` and the second listener at `:4283`
+  (load-event backstop `:loadAck` probe) are replaced by the router's
+  single listener.
+- The renderer URL fragment value (`#sharcNonce=...`) is now the
+  HMAC-derived renderer-protocol nonce, not the root nonce. Renderer
+  code is unchanged (opaque-string passthrough).
+
+### Breaking
+- Post-handshake `SHARC:Renderer:rendered` envelopes now raise the
+  `unauthorized_protocol` security event instead of silently no-opping
+  via the `_terminated` guard. Operators consuming `onSecurityEvent`
+  will observe a new event type for any extension or future code path
+  that delivers a stray `:rendered`. The event is non-terminating;
+  container behavior is unchanged.
+- Internal method `_isValidRendererEnvelope` removed. Test code or
+  third-party tooling that reached into the `_` prefix will break.
+  Pre-1.0 convention: no deprecation, no alias.
+- The container's `_sharcNonce` no longer appears on the wire as the
+  renderer-protocol's `sharcNonce` field. The two values are now
+  distinct: `_sharcNonce` is the root nonce kept private to the
+  publisher page; the renderer protocol echoes the derived nonce.
+  Test code asserting on the URL fragment matching `container._sharcNonce`
+  will break.
+```
+
+---
+
+## 12. Implementation plan
+
+### 12.1 New files
+
+| File | Purpose | Approximate size |
+|------|---------|------------------|
+| `src/sharc-protocol-router.js` | Router primitive — registry, gate, phase tracking, nonce derivation, `unauthorized_protocol` emission | 350 LOC |
+| `test/node/test-protocol-router.js` | Router primitive unit tests | 400 LOC |
+| `test/node/test-protocol-router-nonce-derivation.js` | HMAC derivation unit tests | 100 LOC |
+| `test/node/test-renderer-protocol-retrofit.js` | Renderer-via-router parity tests | 250 LOC |
+| `test/node/test-renderer-out-of-phase.js` | `unauthorized_protocol` pinning for the renderer protocol | 150 LOC |
+
+### 12.2 Modified files
+
+| File | Change |
+|------|--------|
+| `src/sharc-container.js` | Construct `this.protocolRouter` near `:1322`. Register the renderer protocol immediately after. Remove `_isValidRendererEnvelope`. Replace inline `window.addEventListener('message', ...)` at `:2211` with the router's listener (already attached at router construction). Migrate `_dispatchRendererMessage` body into the renderer handler. Remove the second `message` listener at `:4283`; route `:loadAck` through the handler. Replace `this._sharcNonce` reads in `_resolvedIframeSrc` and the renderer envelope with `this._rendererProtocolNonce`. Add `unauthorized_protocol` to the `SHARCSecurityEvent` discriminated union typedef at `:237-283`. Add `protocolRouter.transitionTo(...)` calls at the four documented transition points (§ 4.2). |
+| `src/sharc-protocol.js` | No change (state machine is unrelated to the router). |
+| `package.json` | Add `"test:protocol-router": "node test/node/test-protocol-router.js"` script for focused dev iteration. Not added to `test:all` (the file-by-file scripts aren't typically there; jsdom suite picks it up via the existing `test` aggregator). |
+| `rollup.config.js` | Add `sharc-protocol-router.js` to the bundle inputs so it's emitted into `dist/`. (Confirm pattern matches the existing bridge bundling.) |
+| `CHANGELOG.md` | Entry per § 11.4. |
+| `docs/api-reference.md` (if router gets a public-facing entry) or in-source JSDoc only | Document `container.protocolRouter.register(...)` for extension authors. Recommendation: in-source JSDoc only for 0.7.7; promote to `api-reference.md` when the first non-renderer protocol registers (0.7.8 OMID). (Decision RTR-D18.) |
+
+### 12.3 Step ordering
+
+| Step | Description | Estimate |
+|------|-------------|----------|
+| 1 | Implement `SHARCProtocolRouter` standalone (no container wiring) — registry, gate, phase tracking, nonce derivation, `unauthorized_protocol` emission | 4 hours |
+| 2 | Write unit tests for the router in isolation (§ 12.1 first two files) | 3 hours |
+| 3 | Wire `this.protocolRouter` into `SHARCContainer` construction. Renderer registration must run before any extension's constructor — extension load happens in `_initExtensions()` which is called from `container.load()`, well after construction, so the ordering holds. (See § 7.2 threat.) | 1 hour |
+| 4 | Migrate the renderer protocol's dispatch into the registered handler. Delete `_isValidRendererEnvelope`. Replace inline listener with router-resolved dispatch. | 3 hours |
+| 5 | Replace `_sharcNonce` reads with `_rendererProtocolNonce` in renderer URL assembly and outbound envelope construction. Verify `_assertResolvedIframeSrcAllowed` still passes with the derived nonce in the fragment. | 1 hour |
+| 6 | Migrate the load-event backstop's `:loadAck` listener into the registered renderer handler. Remove the second `message` listener at `:4283`. | 2 hours |
+| 7 | Add `protocolRouter.transitionTo(...)` calls at the four documented sites (§ 4.2). Add the `unauthorized_protocol` typedef variant. | 1 hour |
+| 8 | Write renderer-via-router parity tests + out-of-phase tests (§ 12.1 last two files) | 3 hours |
+| 9 | Run existing test suite; fix any test that asserts on `_isValidRendererEnvelope` or fragment-value-equals-`_sharcNonce` | 2 hours |
+| 10 | CHANGELOG, in-source JSDoc, current-status entry | 1 hour |
+| 11 | Code Reviewer + Security Engineer pass | 2 hours |
+
+**Total estimate:** ~23 hours (3–4 working days).
+
+---
+
+## 13. Out of scope
+
+| Item | Why deferred | Tracking |
+|------|--------------|----------|
+| **MRAID router retrofit** | MRAID's `window.mraid` shim runs in the creative iframe (loaded by the renderer per `bridges: ['mraid']`). It does not currently go through a publisher-side `message` listener — it communicates over the SHARC creative-SDK port (MessageChannel). The router is for `window.message`-based protocols; MRAID would migrate only if/when its transport changed. No 0.7.7 work. | Future release if MRAID transport ever moves to `window.message`. |
+| **SafeFrame router retrofit** | Same as MRAID — SafeFrame's `$sf.ext` runs over the SHARC port, not `window.message`. | Same as MRAID. |
+| **OMID consumer** | The 0.7.8 OMID design (`docs/design/0.7.8-omid-spec-compliant-bridge.md`) is the router's first non-renderer occupant. The router is designed to accommodate it — the `omid-active` phase is reserved in § 4.1, and the parked design's transport (§ 3 of that doc) maps cleanly onto the router's API. **Not in 0.7.7's scope** — 0.7.8 implements it. | Issue [#217](https://github.com/jeffreycarlson/SHARC/issues/217), 0.7.8. |
+| **`SHARC:Renderer:loadProbe`/`:loadAck` redesign** | The probe is in scope as part of the renderer retrofit (§ 6.5) — its second `message` listener at `:4283` collapses into the router. But the probe's semantics (`load-event backstop` for unauthorized navigation detection) are preserved as-is. Any redesign of the probe's correctness model is a separate concern. | Not tracked; preservation-only in 0.7.7. |
+| **Deregistration / unregister API** | Decided RTR-D6: extensions get container `destroy()` for cleanup; no protocol-level unregister surface in 0.7.7. Add if a future protocol demonstrates a need. | Future, only if needed. |
+| **Phase enumeration as a closed set** | Decided RTR-J1: phases are strings, not enums. Closed-set phase declaration would reject typo'd phase names at registration but at the cost of forcing every new phase through a router code change. Reconsider when there are ≥3 protocols with distinct phase needs. | Future. |
+| **Router-side rate-limiting / sampling for `unauthorized_protocol`** | The router emits every phase-membership failure (§ 8.6); operators rate-limit at SIEM ingest per their own pipeline cost model. Per-protocol DoS mitigations on registration counts (e.g. the parked 0.7.8 OMID design's `MAX_OMID_SUBSCRIPTIONS = 64`) remain protocol-specific concerns, not router concerns. Exponential backoff at the router layer is reserved as a future option if real-world telemetry pressure justifies it. | Per-operator (downstream); router non-goal for 0.7.7. |
+| **Public `api-reference.md` documentation for extension authors** | RTR-D18: in-source JSDoc only for 0.7.7. The router is publicly accessible (`container.protocolRouter`) but the only consumer in 0.7.7 is the container itself. Promote to public docs when 0.7.8's OMID shim lands and demonstrates the registration pattern from an extension. | 0.7.8. |
+
+---
+
+## 14. Decision log
+
+Numbered summary of the locked decisions for fast scanning. Full justification in the body sections referenced.
+
+| ID | Decision | Status | Rationale source |
+|----|----------|--------|------------------|
+| **RTR-D1** | Single router primitive owns the publisher-side `message` listener for all SHARC cross-frame protocols | ✅ Locked | Issue #219 problem statement; § 1, § 7 |
+| **RTR-D2** | Registry is keyed on prefix (string); collisions throw at registration time | ✅ Locked | § 2.3; pre-1.0 throw-on-legacy convention |
+| **RTR-D3** | Renderer protocol's wire-level `sharcNonce` is HMAC-SHA-256-derived over `(_sharcNonce, prefix, placementSessionId)`; root `_sharcNonce` never on the wire | ✅ Locked | § 5.2, § 5.3 |
+| **RTR-D19** | Derivation salt includes `placementSessionId` (per-impression session binding); re-derivation occurs on every `placementSessionId` mint within a long-lived container; OMID `AdSession`-binding model borrowed structurally, not by terminology | ✅ Locked | § 4.5, § 5.1 acknowledgment, § 5.2, § 5.4 |
+| **RTR-D20** | Lifecycle framing: per-protocol nonces tied to container instance + `placementSessionId`, not to page/app lifecycle events; rotation on freeze/restore is explicitly forbidden | ✅ Locked | § 4.5 |
+| **RTR-D4** | `register()` is synchronous; `onReady` callback delivers protocol nonce when async derivation completes | ✅ Locked | § 5.5 |
+| **RTR-D5** | Prefix collisions throw; extensions cannot override a registered prefix | ✅ Locked | § 2.3, § 7.2 |
+| **RTR-D6** | No protocol-level deregistration API in 0.7.7 | ✅ Locked | § 2.3 |
+| **RTR-D7** | `buildOutbound` helper asserts type is declared `outbound` or `bidirectional` | ✅ Locked | § 3.3 |
+| **RTR-D8** | Router does not own `MessageChannel` ports; SHARC creative-SDK port stays separate | ✅ Locked | § 2.5 |
+| **RTR-D9** | URL variant skips `attaching-renderer` phase (no renderer protocol wired in URL variant) | ✅ Locked | § 4.2 |
+| **RTR-D10** | Container awaits `protocolRouter.ready('SHARC:Renderer:')` before `_createIframe()` (first-impression case; sequential-impression analogue is RTR-D21 ordering invariant) | ✅ Locked | § 5.5, § 5.3 ordering invariant |
+| **RTR-D21** | Sequential-impression re-derivation ordering invariant: on `placementSessionId` re-mint, the router atomically updates expected nonces, completes all `onReady` re-fires, and only then is the next iframe wired. Reverse-race (new iframe with new nonce while gate still expects old) is structurally prevented | ✅ Locked | § 5.3, § 9.6 test #8 |
+| **RTR-D11** | `:loadProbe`/`:loadAck` migrates into the renderer-protocol registration (single handler, single listener) | ✅ Locked | § 6.5 |
+| **RTR-D12** | Out-of-phase `SHARC:Renderer:rendered` raises `unauthorized_protocol` (was: silent no-op via `_terminated` guard) | ✅ Locked | § 6.5, § 8.2 |
+| **RTR-D13** | Root `_sharcNonce` is no longer wire-observable; tests asserting on its appearance break | ✅ Locked | § 6.5, § 11.2 |
+| **RTR-D14** | `transitionTo()` is container-internal; not exposed to extensions | ✅ Locked | § 7.4 |
+| **RTR-D15** | `unauthorized_protocol` is non-terminating | ✅ Locked | § 8.3 |
+| **RTR-D16** | `unauthorized_protocol` emission reuses `_invokeSecurityCallback` chokepoint | ✅ Locked | § 8.4 |
+| **RTR-D17** | No router-side cap on `unauthorized_protocol`; payload minimized to `{type, phase, reason}`; operator-side rate-limiting | ✅ Locked | § 8.6, § 8.7 |
+| **RTR-D18** | In-source JSDoc for the router; public `api-reference.md` entry deferred to 0.7.8 | ✅ Locked | § 12.2, § 13 |
+
+### 14.1 Judgment calls (originally beyond issue #219 acceptance criteria)
+
+These are architectural decisions made by the architect that go beyond the issue #219 acceptance criteria. RTR-J1 and RTR-J2 were resolved during the Code Reviewer / Security Engineer pass and are now locked (see § 14.2). RTR-J4 remains a non-blocking architectural note.
+
+| ID | Judgment | Status | Why it was a judgment call |
+|----|----------|--------|----------------------------|
+| **RTR-J1** | Phase names are open-set strings, not a closed enum | ✅ Locked open-set + § 9.6 typo test | Issue #219 names `attaching-renderer`, `rendered`, `omid-active`, `terminated`, but doesn't lock the enumeration shape. Closed-set would reject typos at registration but force every new phase through a router code change. Open-set keeps the router extensible-by-convention. |
+| **RTR-J2** | HMAC-SHA-256 over HKDF for per-protocol nonce derivation | ✅ Locked HMAC-SHA-256 + sub-key caveat at § 5.2 | Issue #219 names "HMAC-like derivation" but doesn't pin the primitive. HMAC is the minimum that achieves the non-invertibility property; HKDF would add extract+expand for a single-output derivation. Sub-key derivation is explicitly out of scope (protocols needing it switch to HKDF-Expand at their own layer). |
+| **RTR-J4** | Router phases are coarser than `ContainerStates` (no per-state phase transitions for passive/hidden/frozen) | 🟡 Architectural note, non-blocking | Could alternatively expose every state transition as a phase transition. Chose not to because no protocol in scope distinguishes those states. Reconsider if a future protocol needs per-visibility phase scoping. |
+
+### 14.2 Review-resolved decisions
+
+_All three previously-flagged decisions (RTR-J1 open-set phases, RTR-J2 HMAC-SHA-256, RTR-D17 rate cap) were resolved during the Code Reviewer / Security Engineer pass:_
+
+- **RTR-J1 — locked open-set.** Phase names remain strings; § 9 adds a phase-string-typo test that asserts every phase declared in any registered protocol's `types` map appears in some `transitionTo(...)` call site.
+- **RTR-J2 — locked HMAC-SHA-256.** Caveat added at § 5.2 that protocol nonces are output values, not derivation keys; a future protocol wanting sub-keys should switch to HKDF-Expand at its own layer.
+- **RTR-D17 — locked: no router-side cap.** Payload minimization (§ 8.7) and operator-responsibility paragraph (§ 8.6) replace the cap. No counter, no per-(protocol, type) tracking.
+
+---
+
+## 15. References
+
+### Closes
+
+- [#219](https://github.com/jeffreycarlson/SHARC/issues/219) — SHARC cross-frame protocol router: protocol registry + renderer retrofit (0.7.7)
+
+### Related (downstream consumer, separate releases)
+
+- [#217](https://github.com/jeffreycarlson/SHARC/issues/217) — OMID Spec-Compliant Bridge (0.7.8). Consumes the router as its first non-renderer occupant.
+- `docs/design/0.7.8-omid-spec-compliant-bridge.md` (parked) — § 3 transport, § 6 event flow, § 7 trust boundary motivated this primitive's extraction.
+
+### Prior design docs (format and pattern reuse)
+
+- [`docs/design/0.7.6-bfcache-puppeteer-wiring.md`](./0.7.6-bfcache-puppeteer-wiring.md) — most recent release-design doc; format reference
+- [`docs/design/0.7.3-omid-wiring.md`](./0.7.3-omid-wiring.md) — established the extension-vs-bridge architectural split; this design preserves it (the router is for cross-frame protocols, not for bridges in the renderer-loaded sense)
+- [`docs/design/0.7.4-omid-hardening.md`](./0.7.4-omid-hardening.md) — established the non-terminating security-event pattern (`feature_load_failed`) which `unauthorized_protocol` (§ 8) mirrors
+- [`docs/design/0.7.1-bridges-field.md`](./0.7.1-bridges-field.md) — established `KNOWN_BRIDGE_IDENTIFIERS`; this design preserves the rule that OMID is not a renderer-loaded bridge
+
+### Code paths refactored
+
+- `src/sharc-container.js:1322` — router construction site (next to existing `_stateMachine` construction)
+- `src/sharc-container.js:1943-2004` — `_resolvedIframeSrc` + `_assertResolvedIframeSrcAllowed` (reads renderer-protocol nonce, not root nonce, after retrofit)
+- `src/sharc-container.js:2164-2305` — `_wireRendererProtocol` (the inline `message` listener at `:2211` and `_isValidRendererEnvelope` go away)
+- `src/sharc-container.js:2340-2540` — `_dispatchRendererMessage` (migrates to a router-registered handler; payload validation preserved)
+- `src/sharc-container.js:4259-4310` — load-event backstop `:loadAck` probe (second `message` listener at `:4283` collapses into the router-registered handler)
+- `src/sharc-container.js:4437-4505` — `_emitSecurityEventAndTerminate` (unchanged structurally; the renderer handler still calls it for payload failures)
+- `src/sharc-container.js:237-411` — `SHARCSecurityEvent` typedef union (gets `unauthorized_protocol` variant appended)
+- `src/sharc-protocol.js:122-160` — `ContainerStates` and transitions (unchanged; router phases are orthogonal)
+
+### IAB references
+
+- IAB OMID API v1.5 (referenced via parked 0.7.8 design) — the eventual consumer that motivated extraction
+- IAB AdCOM `APIFramework` enum — referenced for context only; the router does not interact with AdCOM mapping (`ADCOM_API_TO_BRIDGE` remains in `sharc-container.js` unchanged per 0.7.3 D4)
+- No new IAB references introduced in 0.7.7 — the router is a SHARC-internal primitive
+
+---
+
+## 16. 0.7.8 OMID extension dependencies (hand-off)
+
+The OMID compatibility cross-walk surfaced seven items that the 0.7.8 OMID implementation MUST deliver. These items live **outside the router's scope by design** — the router doesn't constrain them; they belong one layer up in the OMID extension itself and in the iframe-side shim. They are captured here so the 0.7.8 implementation knows what it owes for OMID spec compliance, and so nothing is lost across the 0.7.7 → 0.7.8 hand-off.
+
+### 16.1 Items
+
+1. **Shim install ordering.** `window.omid3p` exposed synchronously inside the creative iframe before verification scripts run; iframe-side methods return sync after queueing locally. (OMID `isSupported()` contract: `omid3p && typeof omid3p['registerSessionObserver'] === 'function' && typeof omid3p['addEventListener'] === 'function'`.)
+
+2. **Trusted nonce injection into the iframe shim.** Not via `location.hash` (creative-readable). Renderer-injected or `MessageChannel` transferred at iframe creation are both viable. Router does not constrain mechanism.
+
+3. **Phase-membership declarations.** Registration types (`registerSessionObserver`, `addEventListener`) valid in `rendered` / `creative-active` (pre-`AdSession.start()`); downstream metric events gated to `omid-active`. Per IAB's "call upon initialization" semantics for `registerSessionObserver`. Open-set phases (RTR-J1) accommodate an `omid-finishing` phase for OMID v1.5's ~1.0s `sessionFinish` grace window if 0.7.8 wants explicit gating.
+
+4. **Sequential-impression discipline.** On `placementSessionId` re-mint, defer constructing the new OMID AdSession-equivalent (and its first `setClientInfo` emission) until post-mint `onReady({protocolNonce})` resolves. Sequential-impression analogue of RTR-D10 / the ordering invariant locked at RTR-D21 (§ 5.3).
+
+5. **Cross-vendor isolation transport.** Shim-to-vendor delivery via direct function call (canonical OMID same-window dispatch), NOT `postMessage` broadcast — `postMessage` to the creative iframe is broadcast-visible to all in-iframe `message` listeners cross-vendor. Or per-vendor `MessageChannel` ports. Router correctly draws the boundary at "one protocol = one nonce + one handler"; cross-vendor isolation is 0.7.8's responsibility.
+
+6. **Protocol nonce never reaches vendor JS.** `protocolNonce` is operator-private transport authenticator; must not appear in any payload, return value, or observer callback addressed to a vendor. Pin with a 0.7.8 test.
+
+7. **Response correlation.** Implement OMID's GUID-keyed `callbackMap` pattern inside the 0.7.8 OMID extension handler for request/response patterns (e.g. `registerSessionObserver` ack). Mirrors OMID's own internal architecture.
+
+### 16.2 Why captured here
+
+These dependencies are router-neutral but spec-critical. The router locks OMID compatibility in (zero router-side adjustments needed per the cross-walk), but compatibility-locked at the transport layer does not mean spec-compliant at the OMID layer. The 0.7.8 implementation owns the seven items above; this section is the hand-off ledger.
+
+---
+
+*End of design.*

--- a/docs/design/0.7.7-cross-frame-protocol-router.md
+++ b/docs/design/0.7.7-cross-frame-protocol-router.md
@@ -82,10 +82,15 @@ Only the throw-on-legacy enforcement of unexpected behavior:
 
 The router is constructed exactly once per `SHARCContainer` instance, owned by the container, and exposed at `container.protocolRouter` for extension code to call `.register(...)`. It is **not** part of the public creative-facing API.
 
+Extensions do not receive a container reference at construction time (explicit extensions in `options.extensions` are pre-instantiated objects; auto-created extensions inside `_resolveExtensions(...)` are not passed the container). Extensions access the container via the `event.container` field on the lifecycle event delivered to `onContainerLifecycleEvent(event)` (`src/sharc-container.js:1662-1681`), and register their own protocols from that hook (typically when `event.type === 'load'`).
+
 ```javascript
 // In src/sharc-container.js, inside the container constructor, *before*
-// `SHARCContainer._resolveExtensions({...})` at `:1180` so extension
-// constructors can call `container.protocolRouter.register(...)`:
+// `SHARCContainer._resolveExtensions({...})` at `:1180` runs and *before*
+// any `_notifyExtensionsLifecycle(...)` call fires — so that by the time
+// an extension's `onContainerLifecycleEvent(event)` hook can call
+// `event.container.protocolRouter.register(...)`, the renderer prefix is
+// already taken:
 this.protocolRouter = new SHARCProtocolRouter({
   container: this,
   iframe: () => this._iframe,                              // lazy — iframe is created later
@@ -151,7 +156,7 @@ container.protocolRouter.register({
 
 | Property | Behavior |
 |----------|----------|
-| **Registration ordering** | First-come-first-served. The renderer protocol is registered by the container itself during container construction — specifically, before `SHARCContainer._resolveExtensions({...})` at `src/sharc-container.js:1180` runs, so the renderer prefix is already taken before any extension constructor executes. Extensions register inside their constructor or in a later `'load'` lifecycle hook (`_notifyExtensionsLifecycle('load')` at `:1457`). |
+| **Registration ordering** | First-come-first-served. The renderer protocol is registered by the container itself during container construction — specifically, before `SHARCContainer._resolveExtensions({...})` at `src/sharc-container.js:1180` runs and before any `_notifyExtensionsLifecycle(...)` call fires, so the renderer prefix is already taken before any extension lifecycle hook can execute. Extensions register their own protocols from `onContainerLifecycleEvent(event)` (`src/sharc-container.js:1662-1681`) — typically on `event.type === 'load'` (`_notifyExtensionsLifecycle('load')` at `:1457`) — using `event.container.protocolRouter.register({...})`. |
 | **Prefix collisions** | `register({prefix: 'SHARC:Renderer:'})` called twice throws synchronously on the second call with `Error('[SHARCProtocolRouter] prefix "SHARC:Renderer:" already registered')`. No alias path, no warning, no override. (Decision RTR-D5.) |
 | **Type collisions across protocols** | Cannot occur if prefixes are unique. The router routes by prefix first; types are scoped to their owning protocol. |
 | **Deregistration** | Not supported in 0.7.7. The renderer-protocol's existing teardown is handled at container `_terminate()` — the router itself is torn down with the container. Extensions get a `destroy()` lifecycle from the container, which is sufficient; no per-protocol `unregister()` is exposed. (Decision RTR-D6.) |
@@ -538,9 +543,9 @@ This is the load-bearing defense. The forged-envelope attack is **structurally i
 
 A hostile extension installed into `extensions: [...]` could try to register `prefix: 'SHARC:Renderer:'` and intercept renderer-protocol envelopes.
 
-**Mitigation:** prefix collisions throw at registration time. The renderer protocol registers first (during container construction, before any extension has run); an extension's later `register({prefix: 'SHARC:Renderer:'})` throws.
+**Mitigation:** prefix collisions throw at registration time. The renderer protocol registers first — during container construction, before `_resolveExtensions(...)` runs and before any extension lifecycle hook can fire. An extension can only call `protocolRouter.register({...})` from its `onContainerLifecycleEvent(event)` hook (via `event.container.protocolRouter`), which the container fires after the renderer is already registered. A later `register({prefix: 'SHARC:Renderer:'})` from an extension therefore throws.
 
-The container does not load the extension's code until after the renderer registration completes (decision RTR-D5). This is a code-ordering constraint, called out in the implementation plan (§ 12.3).
+This is a code-ordering constraint inside the container constructor (decision RTR-D5), called out in the implementation plan (§ 12.3). It does not require any change to the extension API: extensions are still constructed (or passed in pre-constructed) the same way they are today — they simply gain a new affordance, namely calling `event.container.protocolRouter.register(...)` from `onContainerLifecycleEvent`.
 
 ### 7.3 Threat: rogue extension reads another protocol's nonce
 
@@ -958,7 +963,7 @@ The router throws at envelope-construction time (`buildOutbound`) on:
 
 | File | Change |
 |------|--------|
-| `src/sharc-container.js` | Construct `this.protocolRouter` in the container constructor **before** `SHARCContainer._resolveExtensions({...})` at `:1180` (so extension constructors can call `container.protocolRouter.register(...)`). Register the renderer protocol immediately after router construction and before the `_resolveExtensions` call. Remove `_isValidRendererEnvelope`. Replace inline `window.addEventListener('message', ...)` at `:2211` with the router's listener (already attached at router construction). Migrate `_dispatchRendererMessage` body into the renderer handler. Remove the second `message` listener at `:4283`; route `:loadAck` through the handler. Replace `this._sharcNonce` reads in `_resolvedIframeSrc` and the renderer envelope with `this._rendererProtocolNonce`. Add `unauthorized_protocol` to the `SHARCSecurityEvent` discriminated union typedef at `:237-283`. Add `protocolRouter.transitionTo(...)` calls at the four documented transition points (§ 4.2). |
+| `src/sharc-container.js` | Construct `this.protocolRouter` in the container constructor **before** `SHARCContainer._resolveExtensions({...})` at `:1180` and before any `_notifyExtensionsLifecycle(...)` call site (so that when an extension's `onContainerLifecycleEvent(event)` hook fires and calls `event.container.protocolRouter.register(...)`, the renderer prefix is already taken). Register the renderer protocol immediately after router construction and before the `_resolveExtensions` call. Remove `_isValidRendererEnvelope`. Replace inline `window.addEventListener('message', ...)` at `:2211` with the router's listener (already attached at router construction). Migrate `_dispatchRendererMessage` body into the renderer handler. Remove the second `message` listener at `:4283`; route `:loadAck` through the handler. Replace `this._sharcNonce` reads in `_resolvedIframeSrc` and the renderer envelope with `this._rendererProtocolNonce`. Add `unauthorized_protocol` to the `SHARCSecurityEvent` discriminated union typedef at `:237-283`. Add `protocolRouter.transitionTo(...)` calls at the four documented transition points (§ 4.2). |
 | `src/sharc-protocol.js` | No change (state machine is unrelated to the router). |
 | `package.json` | Add `"test:protocol-router": "node test/node/test-protocol-router.js"` script for focused dev iteration. **Must be appended to the `test:all:built` chain** alongside the other named file-level scripts — `test:all:built` is an explicit `&&`-chain of named test scripts (`test:smoke && test:treeshake && ... && test:creative-validator-triage`), not an aggregator that auto-discovers files. The companion router test scripts (`test:protocol-router-nonce-derivation`, `test:renderer-protocol-retrofit`, `test:renderer-out-of-phase`) must each be added to `test:all:built` the same way. |
 | `rollup.config.js` | Add `sharc-protocol-router.js` to the bundle inputs so it's emitted into `dist/`. (Confirm pattern matches the existing bridge bundling.) |
@@ -971,7 +976,7 @@ The router throws at envelope-construction time (`buildOutbound`) on:
 |------|-------------|----------|
 | 1 | Implement `SHARCProtocolRouter` standalone (no container wiring) — registry, gate, phase tracking, nonce derivation, `unauthorized_protocol` emission | 4 hours |
 | 2 | Write unit tests for the router in isolation (§ 12.1 first two files) | 3 hours |
-| 3 | Wire `this.protocolRouter` into `SHARCContainer` construction. The router must be constructed **before** `SHARCContainer._resolveExtensions({...})` at `src/sharc-container.js:1180` (the call site that instantiates extension instances during the container's own constructor), and the renderer protocol must register against it on the same line — so extension constructors that call `container.protocolRouter.register(...)` always see the renderer prefix already taken. The `'load'` lifecycle notification at `_notifyExtensionsLifecycle('load')` (`:1457`, inside `container.load()`) is the later attach-time hook where extensions that defer registration past their constructor can register; the renderer is already registered well before that point. (See § 7.2 threat for why first-registered ordering matters.) | 1 hour |
+| 3 | Wire `this.protocolRouter` into `SHARCContainer` construction. The router must be constructed **before** `SHARCContainer._resolveExtensions({...})` at `src/sharc-container.js:1180` (the call site that instantiates auto-created extensions during the container's own constructor), and the renderer protocol must register against it on the same line — so that by the time any extension lifecycle hook can fire and call `event.container.protocolRouter.register(...)`, the renderer prefix is already taken. The `'load'` lifecycle notification at `_notifyExtensionsLifecycle('load')` (`:1457`, inside `container.load()`) is the primary attach-time hook where extensions register their own protocols via `onContainerLifecycleEvent(event)` (`:1662-1681`); the renderer is already registered well before that point. (See § 7.2 threat for why first-registered ordering matters.) | 1 hour |
 | 4 | Migrate the renderer protocol's dispatch into the registered handler. Delete `_isValidRendererEnvelope`. Replace inline listener with router-resolved dispatch. | 3 hours |
 | 5 | Replace `_sharcNonce` reads with `_rendererProtocolNonce` in renderer URL assembly and outbound envelope construction. Verify `_assertResolvedIframeSrcAllowed` still passes with the derived nonce in the fragment. | 1 hour |
 | 6 | Migrate the load-event backstop's `:loadAck` listener into the registered renderer handler. Remove the second `message` listener at `:4283`. | 2 hours |
@@ -1068,7 +1073,7 @@ _All three previously-flagged decisions (RTR-J1 open-set phases, RTR-J2 HMAC-SHA
 
 ### Code paths refactored
 
-- `src/sharc-container.js` — router construction site (in the container constructor, immediately before `SHARCContainer._resolveExtensions({...})` at `:1180`, so the renderer protocol is registered before any extension constructor runs)
+- `src/sharc-container.js` — router construction site (in the container constructor, immediately before `SHARCContainer._resolveExtensions({...})` at `:1180`, so the renderer protocol is registered before any extension lifecycle hook can fire via `_notifyExtensionsLifecycle(...)` / `onContainerLifecycleEvent(event)` at `:1662-1681`)
 - `src/sharc-container.js:1943-2004` — `_resolvedIframeSrc` + `_assertResolvedIframeSrcAllowed` (reads renderer-protocol nonce, not root nonce, after retrofit)
 - `src/sharc-container.js:2164-2305` — `_wireRendererProtocol` (the inline `message` listener at `:2211` and `_isValidRendererEnvelope` go away)
 - `src/sharc-container.js:2340-2540` — `_dispatchRendererMessage` (migrates to a router-registered handler; payload validation preserved)

--- a/docs/design/0.7.7-cross-frame-protocol-router.md
+++ b/docs/design/0.7.7-cross-frame-protocol-router.md
@@ -142,10 +142,13 @@ container.protocolRouter.register({
     // separate explicit field gated by a registration flag (out of scope).
   },
 
-  // OPTIONAL. Called once at registration completion. Receives the
-  // protocol-derived nonce (see § 5) for the extension to use when constructing
-  // OUTBOUND envelopes. Delivered here rather than read from any markup-
-  // accessible surface.
+  // OPTIONAL. Called once at registration completion AND once per
+  // sequential-impression re-mint of `placementSessionId` (§ 5.3, RTR-D21) —
+  // never more often than that. The extension MUST handle re-invocation
+  // idempotently: each call replaces the previously-delivered nonce.
+  // Receives the protocol-derived nonce (see § 5) for the extension to use
+  // when constructing OUTBOUND envelopes. Delivered here rather than read
+  // from any markup-accessible surface.
   onReady: function ({ protocolNonce }) {
     // Extension stores protocolNonce for outbound envelope construction.
   },
@@ -157,7 +160,7 @@ container.protocolRouter.register({
 | Property | Behavior |
 |----------|----------|
 | **Registration ordering** | First-come-first-served. The renderer protocol is registered by the container itself during container construction — specifically, before `SHARCContainer._resolveExtensions({...})` at `src/sharc-container.js:1180` runs and before any `_notifyExtensionsLifecycle(...)` call fires, so the renderer prefix is already taken before any extension lifecycle hook can execute. Extensions register their own protocols from `onContainerLifecycleEvent(event)` (`src/sharc-container.js:1662-1681`) — typically on `event.type === 'load'` (`_notifyExtensionsLifecycle('load')` at `:1457`) — using `event.container.protocolRouter.register({...})`. |
-| **Prefix collisions** | `register({prefix: 'SHARC:Renderer:'})` called twice throws synchronously on the second call with `Error('[SHARCProtocolRouter] prefix "SHARC:Renderer:" already registered')`. No alias path, no warning, no override. (Decision RTR-D5.) |
+| **Prefix collisions** | Bidirectional prefix-of-prefix check. On `register({prefix: P})`, the router scans every already-registered prefix `E` and throws synchronously if `P === E`, `P.startsWith(E)`, or `E.startsWith(P)`. Exact-match-only would let an extension register `'SHARC:'` and intercept every existing and future SHARC protocol's envelopes (via gate step 5's prefix match); bidirectional check forecloses both directions. Throws with `Error('[SHARCProtocolRouter] prefix "P" collides with already-registered prefix "E"')`. No alias, no warning, no override. (Decision RTR-D5, refined by SEC-4 review.) |
 | **Type collisions across protocols** | Cannot occur if prefixes are unique. The router routes by prefix first; types are scoped to their owning protocol. |
 | **Deregistration** | Not supported in 0.7.7. The renderer-protocol's existing teardown is handled at container `_terminate()` — the router itself is torn down with the container. Extensions get a `destroy()` lifecycle from the container, which is sufficient; no per-protocol `unregister()` is exposed. (Decision RTR-D6.) |
 | **Registration-after-listen** | The router's single `message` listener attaches at router construction time (before any protocol registers). Late registrations are honored; envelopes for unregistered prefixes are silently dropped per the existing "any frame can postMessage" policy. |
@@ -181,6 +184,8 @@ context = Object.freeze({
   raisedAt: 1716000000000,
 });
 ```
+
+**Naming convention.** The canonical name for the router's runtime lifecycle field is **`phase`** (matches the envelope shape and the `unauthorized_protocol` event's `details.phase`). The router's internal class-private storage is `_currentPhase` (single underscore-prefix is the project's convention for non-public instance state); the lowercase `phase` is the only name exposed in any external surface — handler context (above), security-event payload (§ 8.1), and dev-channel log lines (§ 8.5). Implementers and reviewers should treat `lifecyclePhase` and `currentPhase` (no underscore) as forbidden alternative spellings in new code.
 
 ### 2.5 What the router does NOT do
 
@@ -297,7 +302,17 @@ this.protocolRouter.transitionTo('creative-active');
 this.protocolRouter.transitionTo('terminated');
 ```
 
-For the URL variant (no renderer handshake), the router skips straight from `init` → `rendered` → `creative-active` because there is no `attaching-renderer` window — the container does not wire the renderer protocol at all (`_wireRendererProtocol` is Markup-only). Decision RTR-D9.
+For the URL variant (no renderer handshake), the router transitions `init` → `rendered` → `creative-active`. There is no `attaching-renderer` window — the container does not wire the renderer protocol at all (`_wireRendererProtocol` is Markup-only). Decision RTR-D9.
+
+**URL-variant transition call sites (explicit):**
+
+| Phase entered | Call site | Trigger |
+|---------------|-----------|---------|
+| `rendered` | Inside the container's URL-variant iframe-load path (current `_loadCreativeUrl()` / equivalent — the same site that signals "iframe content has loaded" in the URL variant), immediately on the iframe's `load` event firing | iframe `load` event in URL variant. There is no envelope-validated `:rendered` to wait for; the browser-fired `load` event is the moral equivalent. |
+| `creative-active` | Inside `setState()` when `newState === ACTIVE`, same chokepoint as the Markup variant | State machine reaches `ACTIVE`. The Markup-variant transition site (`_onRendererRendered`) is skipped; the `creative-active` transition is identical across variants. |
+| `terminated` | `_terminate()`, same as Markup | identical |
+
+The URL variant explicitly does NOT enter `attaching-renderer`. Implementers must NOT add a `transitionTo('attaching-renderer')` call on the URL path — there is no protocol active in that window because `_wireRendererProtocol` is not called.
 
 ### 4.3 Phase enumeration is forward-extensible
 
@@ -365,14 +380,15 @@ The second concern: the OMID design's `omid3p` shim runs **inside the creative i
 
 ### 5.2 Decision: HMAC-like derivation salted with `placementSessionId`, delivered via `register()`
 
-The router computes a per-protocol nonce by deriving from the root nonce, the protocol prefix, **and the per-impression session identifier**:
+The router computes a per-protocol nonce by deriving from the root nonce, the protocol prefix, **and the per-impression session identifier**. The operation order is significant — the slice must happen on the **raw HMAC byte output** (before base64url encoding), not on the encoded string, to preserve 128 bits of entropy:
 
 ```
-protocolNonce = HMAC-SHA-256(
-  key:     _sharcNonce,                          // root, container-lifetime
-  message: prefix || ":" || placementSessionId,  // protocol + session binding
-).slice(0, 16) → base64url → 22 chars
+rawNonce       = HMAC-SHA-256(key=_sharcNonce, message=prefix || ":" || placementSessionId)  // 32 bytes
+truncated      = rawNonce.slice(0, 16)                                                       // 16 bytes = 128 bits entropy
+protocolNonce  = base64url(truncated)                                                        // 22 chars
 ```
+
+**Entropy claim: 128 bits.** The truncation is applied to the 32-byte raw HMAC output, yielding 16 bytes = 128 bits of entropy before encoding. Base64url of 16 bytes is 22 characters (no padding, since `ceil(16 * 4 / 3) = 22`). Any future refactor that reverses this order (encode first, then slice the string) would silently drop entropy to 96 bits (16 base64url chars = 12 bytes); test #7 in § 9.6 pins the byte-level vector to catch that regression.
 
 The `":"` is a literal separator to prevent message-prefix collision if `placementSessionId` were ever empty (the prefix already ends in `:` by registration contract, so the construction is `"SHARC:Renderer::<placementSessionId>"` in practice — the double colon is intentional and unambiguous). The output shape is unchanged from the prior single-input derivation (16 bytes → 22 base64url chars, UUID parity).
 
@@ -388,7 +404,9 @@ async function deriveProtocolNonce(rootNonce, prefix, placementSessionId) {
   );
   const message = prefix + ':' + placementSessionId;
   const sig = await crypto.subtle.sign('HMAC', key, enc.encode(message));
-  // base64url-encode the first 16 bytes; truncate to 22 chars (UUID parity).
+  // Slice the raw 32-byte HMAC output to 16 bytes (128 bits of entropy),
+  // then base64url-encode. Order matters: encoding first and slicing the
+  // string would drop entropy to 96 bits. Result is 22 chars, UUID parity.
   return base64url(new Uint8Array(sig).slice(0, 16));
 }
 ```
@@ -445,7 +463,7 @@ This is a **breaking change to the renderer's wire contract**: the value the ren
 - **Why `placementSessionId` in the salt rather than container construction time, container ID, or another identifier.** `placementSessionId` is the per-impression boundary that SHARC already exposes on every envelope and that downstream measurement (OMID `AdSession`, viewability events, etc.) is already keyed against. Binding the transport nonce to the same boundary aligns the security context with the measurement context — they advance together. Container construction time would couple to wall-clock and break determinism across re-derivation; container ID would not advance on sequential impressions inside a long-lived mobile container, leaving stale nonces valid across distinct impressions. `placementSessionId` is the right granularity.
 - **Native crypto availability.** `crypto.subtle` is universally available in SHARC's lowest-supported targets (iOS WKWebView 15.4+, WebView 92+) — same baseline as `crypto.randomUUID()` at `:1948`.
 
-### 5.5 Async derivation in a sync constructor
+### 5.5 Async derivation, `ready()` contract, and `crypto.subtle` failure model
 
 `crypto.subtle.sign()` returns a Promise. The router's registration API is synchronous in calling shape. Two options:
 
@@ -456,7 +474,71 @@ This is a **breaking change to the renderer's wire contract**: the value the ren
 
 **Decision (RTR-D4):** Option (b). The renderer protocol's outbound `render` envelope is constructed inside the iframe-`load` handler, which is async-relative-to-construction anyway; the renderer protocol registers at container construction time and uses the nonce in a handler that fires after async derivation completes. For all reasonable protocols, the nonce is needed at envelope-construction time, which is downstream of registration. The async `onReady` is sufficient.
 
-Edge case: if `_resolvedIframeSrc()` (`:1943`) runs synchronously during `container.load()` and needs the renderer-protocol nonce to assemble the URL fragment, the nonce must be ready by then. The container therefore awaits `protocolRouter.ready('SHARC:Renderer:')` before `_createIframe()`. `placementSessionId` is minted before `container.load()` proceeds (it's already an envelope field in 0.7.6), so it is available as a derivation input at this point. This is an extra `await` in the container's load path; existing `container.load()` is already synchronous-returning, so the await is internal. (Decision RTR-D10.)
+#### 5.5.1 `protocolRouter.ready(prefix)` contract
+
+The router exposes `protocolRouter.ready(prefix)` returning a Promise that resolves with `{protocolNonce}` once derivation for that prefix has completed for the current `placementSessionId`. The container awaits it before `_createIframe()`. The Promise:
+
+- **Resolves** once when initial derivation for the current `placementSessionId` completes (same value `onReady` receives).
+- **Re-arms** on sequential-impression re-mint (§ 5.3 / RTR-D21). After a re-mint, the next call to `ready(prefix)` resolves with the newly-derived nonce. A previously-resolved Promise from before the mint is not retroactively invalidated; callers that need the post-mint nonce must call `ready()` again after the mint, which the container does as part of the re-mint sequence.
+- **Rejects** with a typed `Error` if derivation fails (see § 5.5.2).
+
+`placementSessionId` is minted before `container.load()` proceeds (it's already an envelope field in 0.7.6), so it is available as a derivation input at this point. The await is internal to `container.load()`; the existing synchronous-returning shape of `container.load()` is preserved by the container's existing async wrapping. (Decision RTR-D10.)
+
+#### 5.5.2 `crypto.subtle` failure modes — typed rejection contract
+
+`crypto.subtle` can fail two ways:
+
+1. **Unavailable** — the property does not exist on `globalThis.crypto`. Happens in **non-secure contexts** (HTTP iframes, common in ad-tech test/staging) where the Web Crypto SubtleCrypto interface is gated behind the `[SecureContext]` IDL attribute. Detectable synchronously at router construction time: `typeof crypto?.subtle?.sign !== 'function'`.
+2. **Rejects** — `crypto.subtle.sign()` returns a Promise that rejects (e.g. `OperationError` from an unsupported algorithm in an unusual runtime, or a `DOMException` from a security policy block). Detectable only async.
+
+**Decision (RTR-D22): `crypto.subtle` is a hard requirement; non-secure contexts throw at container construction.**
+
+The router checks `crypto.subtle` availability synchronously in its constructor. If unavailable, the constructor throws:
+
+```
+Error('[SHARCProtocolRouter] crypto.subtle is unavailable — SHARC requires a secure context (HTTPS or localhost). Non-secure contexts cannot derive per-protocol nonces.')
+```
+
+This surfaces the failure at `new SHARCContainer(...)` time, before `container.load()`, before any iframe creation — the operator sees a clear synchronous error in their integration flow. No silent hang, no half-initialized container.
+
+**Why not a fallback.** A fallback to `crypto.getRandomValues`-derived random nonce would break per-protocol non-derivability: the nonce would still be CSPRNG-quality, but it would no longer be deterministic per `(rootNonce, prefix, placementSessionId)`, so the renderer's URL-fragment-passed nonce and the container's expected nonce would diverge unless the random value were threaded through the same delivery channel. That's not a real fallback — it's a parallel architecture. Better to fail loud.
+
+**Async rejection path.** If `crypto.subtle.sign()` rejects despite availability, `protocolRouter.ready(prefix)` rejects with a typed error:
+
+```
+Error('[SHARCProtocolRouter] HMAC derivation failed for prefix "X": <underlying error message>')
+```
+
+The container catches this rejection in its `container.load()` flow and emits a `feature_load_failed` security event (reusing the existing non-terminating chokepoint established in 0.7.4) with `feature: 'protocol-router-derivation'`, then aborts the load. The container does **not** emit `unauthorized_protocol` for this case — that event is reserved for phase-membership failures (§ 8.2). Derivation failure is a pre-load infrastructure failure, not an envelope-validation failure.
+
+| Failure | Surface | Operator-visible signal |
+|---------|---------|-------------------------|
+| `crypto.subtle` unavailable (non-secure context) | Synchronous throw at router construction (inside `new SHARCContainer(...)`) | Exception propagates to the publisher's container instantiation site |
+| `crypto.subtle.sign()` async rejection during derivation | `protocolRouter.ready(prefix)` rejects | `feature_load_failed` security event with `feature: 'protocol-router-derivation'`; container load aborts |
+
+The `feature_load_failed` plumbing established in 0.7.4 (`docs/design/0.7.4-omid-hardening.md`) is the right channel: it's non-terminating from the page's perspective (the container stops loading but doesn't crash the page), and operators already consume it.
+
+#### 5.5.3 Sequential re-mint await ordering (RTR-D21 expanded)
+
+Re-derivation on `placementSessionId` re-mint (§ 5.3) involves the same async `crypto.subtle.sign()` step as the initial derivation. The RTR-D21 ordering invariant requires (1) atomic update of expected nonces, (2) re-fire of all `onReady` callbacks, and (3) iframe creation — in that order. Step (3) MUST await steps (1) and (2):
+
+```javascript
+// In SHARCContainer, sequential-impression re-mint sequence:
+this.placementSessionId = newPlacementSessionId;       // (1a) synchronous mint
+await this.protocolRouter.rederiveAllProtocolNonces(); // (1b) + (2): atomic re-derive + re-fire onReady
+// Only after the await resolves:
+await this.protocolRouter.ready('SHARC:Renderer:');    // belt-and-braces; resolves immediately after rederive
+this._createIframe();                                  // (3)
+```
+
+`rederiveAllProtocolNonces()` returns a Promise that resolves only after every registered protocol's derivation has completed and every `onReady` callback has been invoked. The function is the choke-point that makes the ordering invariant enforceable.
+
+**Envelopes in flight during the await window** (between the synchronous `placementSessionId` mint and the resolution of `rederiveAllProtocolNonces()`):
+
+- Envelopes signed with the **previous** `placementSessionId`'s derived nonce: dropped at gate step 6 (`placementSessionId` mismatch) — they belong to the prior session.
+- Envelopes signed with the **new** `placementSessionId`'s derived nonce: cannot exist yet, because the new iframe hasn't been wired (step 3 hasn't run). If somehow constructed and posted, they pass step 6 but may fail step 7 if the router's expected nonce hasn't finished re-deriving — silent drop (gate step 7 already handles nonce mismatch silently). They do NOT raise `unauthorized_protocol` because step 7 is silent-drop per § 3.2 and § 8.7. (See SEC-3 alignment in § 8.7.)
+
+A reverse race — new iframe shim wired with new nonce while the router's gate still expects the old nonce — is structurally prevented because step (3) is gated by the `await` on `rederiveAllProtocolNonces()`. This is what locks RTR-D21.
 
 ---
 
@@ -502,7 +584,7 @@ container.protocolRouter.register({
 
 Every existing `SHARC:Renderer:*` envelope type continues to exist with the same shape, the same payload contract, and the same dispatch behavior. The only changes are:
 
-1. The fragment value the renderer reads from `location.hash` is now the derived renderer-protocol nonce (§ 5.3) — `HMAC-SHA-256(_sharcNonce, 'SHARC:Renderer:' || ':' || placementSessionId)`, base64url-truncated to 22 chars. Renderer code unchanged because it's opaque-string passthrough.
+1. The fragment value the renderer reads from `location.hash` is now the derived renderer-protocol nonce (§ 5.3) — the 32-byte HMAC-SHA-256 output over `(_sharcNonce, 'SHARC:Renderer:' || ':' || placementSessionId)`, sliced to its first 16 bytes (128 bits entropy) and then base64url-encoded to 22 chars. Renderer code unchanged because it's opaque-string passthrough.
 2. The `sharcNonce` field on outbound `SHARC:Renderer:render` is the derived nonce, not the root nonce.
 3. Inbound envelopes are router-gated; payload validation in `_handleRendererEnvelope` is identical to today's `_dispatchRendererMessage` from line 2410 onward.
 
@@ -619,6 +701,7 @@ By construction, this means the envelope is well-formed from a trust-anchor pers
 | `severity` | `'error'` | Distinct from `wrapper_top_frame_inaccessible`'s `'warning'`; matches the existing terminating events. |
 | Terminating | **No** | Out-of-phase envelopes are dropped, not fatal. Continuing to run is the right behavior: the renderer protocol has already completed successfully (otherwise we wouldn't be past `attaching-renderer`); a late stray envelope is suspicious but not actionable as a container shutdown. This matches the parked 0.7.8 OMID design's "silent drop on iframe side" envelope policy plus an observable signal. (Decision RTR-D15.) |
 | `errorCode` | none | No 21xx code — extensions are not in the renderer-error-code namespace (matches `feature_load_failed`'s pattern at `:259-265`). |
+| `details.phase` timing | **Phase at time of rejection** (i.e. the phase the router was in when gate step 9 ran), captured synchronously into the event payload before `_invokeSecurityCallback` is called | The rejection-phase is what makes the event diagnostically useful — it answers "what phase was the router in when this envelope showed up?" Emit is synchronous from gate step 9, so rejection-time and emit-time are the same JS task; capturing the field at rejection time is defensive against any future change that would defer the emit (a `setTimeout` or microtask boundary between the failed check and the callback would otherwise produce a stale or surprising phase). The router MUST NOT re-read `_currentPhase` inside `_emitUnauthorizedProtocol` — the value is passed in or closed over at the point of rejection. |
 
 ### 8.4 Where it's emitted
 
@@ -627,10 +710,20 @@ The router holds the chokepoint:
 ```javascript
 // In src/sharc-protocol-router.js
 //
-// `reason` is passed in by the caller — one of 'out-of-phase',
-// 'nonce-mismatch', 'prefix-unregistered'. For 'prefix-unregistered',
-// `protocol` is null and the literal 'unknown-prefix' is used.
-function _emitUnauthorizedProtocol(protocol, reason) {
+// `reason` is one of 'out-of-phase', 'nonce-mismatch',
+// 'prefix-unregistered'. The function signature accepts all three for
+// shape stability, but in 0.7.7 only 'out-of-phase' is ever passed in
+// — gate steps 5 and 7 (prefix-unregistered, nonce-mismatch) silently
+// drop in 0.7.7 per § 8.7 (the "Restricted emission set" subsection).
+// For 'prefix-unregistered', `protocol` would be null and the literal
+// 'unknown-prefix' is used; the path exists for future protocol opt-in
+// but is not exercised by any 0.7.7 emit site.
+function _emitUnauthorizedProtocol(protocol, reason, rejectionPhase) {
+  // `rejectionPhase` is captured by the caller at the exact point gate step 9
+  // failed and passed in here — see § 8.3 "details.phase timing". The router
+  // does NOT re-read `this._currentPhase` inside this function; doing so
+  // would be vulnerable to any future microtask boundary inserted between
+  // the failed check and the callback.
   const payload = {
     type: 'unauthorized_protocol',
     severity: 'error',
@@ -641,7 +734,7 @@ function _emitUnauthorizedProtocol(protocol, reason) {
     message: 'Envelope rejected by router (' + reason + ')',
     details: {
       type: protocol ? protocol.prefix : 'unknown-prefix',
-      phase: this._currentPhase,
+      phase: rejectionPhase,
       reason: reason,
     },
   };
@@ -685,7 +778,7 @@ To close the side-channel exfiltration concern that a rate-limit would have addr
 | `phase` | One of the six enumerated phases (§ 4.1): `'init'`, `'attaching-renderer'`, `'rendered'`, `'omid-active'`, `'creative-active'`, `'terminated'` | Router-internal state |
 | `reason` | One of: `'out-of-phase'`, `'nonce-mismatch'`, `'prefix-unregistered'` | Router-determined from which gate step failed |
 
-The `reason` enum reserves three labels so the event shape is stable across future protocol opt-ins. **In 0.7.7, only `'out-of-phase'` is actually emitted** — § 3.2 steps 5 and 7 (prefix not registered, nonce mismatch) remain silent drops per the existing "any frame can postMessage" policy. The other two labels exist so a future protocol can opt in to surfacing those failures (e.g. for forensic telemetry) without changing the event's shape.
+**Restricted emission set in 0.7.7.** The `reason` enum reserves three labels so the event shape is stable across future protocol opt-ins, but only **one** of those labels — `'out-of-phase'` — is actually emitted by any 0.7.7 code path. Gate steps 5 and 7 (prefix-unregistered, nonce-mismatch) remain silent drops per the existing "any frame can postMessage" policy. Test #4 in § 9.6 (payload-minimization invariant) is driven by an out-of-phase envelope to align with this restriction. The other two labels exist so a future protocol can opt in to surfacing those failures (e.g. for forensic telemetry) without changing the event's shape — but no 0.7.7 test drives them, and no 0.7.7 emit site passes them.
 
 **The router does NOT include the raw envelope `payload`, `details`, `event.data`, or any attacker-controlled string in the event.** Specifically: no `envelopeType` field with the full attacker-supplied `event.data.type`; no `currentPhase` echo of attacker-supplied fields; no `message` field with attacker-controlled substrings interpolated in. Attacker-controlled content cannot reach `onSecurityEvent` via this event. (This supersedes the field shape sketched in § 8.1 — see § 8.1 for the corrected typedef.)
 
@@ -740,12 +833,13 @@ These tests are explicitly required by the Code Reviewer / Security Engineer pas
 |---|------|---------------------|
 | 1 | **Phase-string typo detection.** Assert that every phase string declared by any registered protocol's `types` map appears in some `protocolRouter.transitionTo(...)` call site inside `src/sharc-container.js`. Implementation: AST-scan or regex-grep the container source for the phase string; fail the test if a declared phase has no matching transition site. | RTR-J1 (open-set phases) |
 | 2 | **No-cap policy.** Drive the container into `creative-active`, then post 100 sequential forged `SHARC:Renderer:rendered` envelopes (each carrying the valid renderer-protocol nonce). Assert: exactly 100 `unauthorized_protocol` events fire on `onSecurityEvent`; the container does not terminate; `onError` is not called. | RTR-D17 (no cap) |
-| 3 | **Single-listener invariant.** After construction + retrofit, assert that exactly one `window.addEventListener('message', ...)` call exists in `src/sharc-container.js` (the load-event backstop's previously-second listener at the original `:4283` is subsumed by the router). Implementation: regex-count `addEventListener\(\s*['"]message['"]` occurrences in the container source. | § 6.1 retrofit; SF-3 |
-| 4 | **Payload-minimization invariant.** Trigger an `unauthorized_protocol` event with an attacker-supplied envelope carrying `payload: '<script>...'`, `details: {leak: 'secret'}`, and a long `type` string. Assert: the emitted event's `details` has exactly the keys `type`, `phase`, `reason`; no attacker-controlled string appears anywhere in the event (deep walk of the event object). | RTR-D17 / § 8.7 |
+| 3 | **Single-listener invariant.** After container construction completes, assert that exactly one `'message'`-type listener has been registered on `window`. Implementation: install a spy on `window.addEventListener` in test setup before constructing the container; record every call whose first argument is the string `'message'`; after `new SHARCContainer(...)` returns and any synchronously-attached listeners have run, assert the recorded count is exactly 1. A runtime spy is more reliable than a source-regex scan: it won't false-positive on `addEventListener('message',...)` substrings appearing inside comments or string literals, and it directly observes the production behavior the invariant pins. | § 6.1 retrofit; SF-3 |
+| 4 | **Payload-minimization invariant.** Drive the container to `creative-active`, then post a forged but otherwise-valid `SHARC:Renderer:rendered` envelope (correct derived nonce, correct `placementSessionId`, registered prefix — only failure is phase membership, the one case that emits in 0.7.7 per § 8.7). Decorate the envelope with attacker-controlled garbage: `payload: '<script>...'`, `details: {leak: 'secret'}`, a long extra `extraType` string. Assert: exactly one `unauthorized_protocol` event fires; the emitted event's `details` has exactly the keys `type`, `phase`, `reason`; no attacker-controlled string appears anywhere in the event (deep walk of the event object). | RTR-D17 / § 8.7 |
 | 5 | **bfcache nonce persistence.** Round-trip the container through `pagehide(persisted=true)` / `pageshow(persisted=true)` with the same `placementSessionId` throughout. Assert: `_rendererProtocolNonce` is the same string before and after; a valid envelope arriving post-restore in the same phase still dispatches; no `unauthorized_protocol` is raised for the round-trip alone. | SF-2, § 4.5 |
 | 6 | **Per-creative-load nonce rotation.** Drive the container to `creative-active`, capture the current `_rendererProtocolNonce`. Simulate a new creative load by minting a fresh `placementSessionId` on the same container. Assert: an inbound envelope signed with the old derived nonce is silently dropped (gate step 7); an inbound envelope signed with the new derived nonce (re-derived via `HMAC-SHA-256(_sharcNonce, 'SHARC:Renderer:' || ':' || newPlacementSessionId)`) is accepted; `_rendererProtocolNonce` after the mint differs from the pre-mint value; `_sharcNonce` is unchanged. | § 4.5, § 5.2, § 5.3 |
 | 7 | **`placementSessionId` in derivation (HMAC vector).** Envelope-construction test that pins the HMAC formula: with a known `_sharcNonce` and known `placementSessionId`, `protocolRouter.buildOutbound('SHARC:Renderer:', 'render', {...})` produces an envelope whose `sharcNonce` matches the expected base64url-truncated HMAC output computed independently in the test. Fails any future refactor that drops `placementSessionId` from the message or changes the separator. | § 5.2 |
 | 8 | **Re-derive ordering test.** Simulate sequential-impression re-mint: after `placementSessionId` changes on a long-lived container, assert that (a) the router's expected nonce updated atomically with the mint, (b) `onReady` was re-invoked with the new nonce before the next iframe-wiring step, and (c) an envelope signed with the new nonce posted before the iframe is wired is correctly held until the iframe is ready (or silent-dropped per the documented behavior). Pins the sequential-impression analogue of RTR-D10. | RTR-D21, § 5.3 |
+| 9 | **Prefix-of-prefix collision throw.** Register `'SHARC:Renderer:'` first (matches the container's startup ordering), then attempt to register `'SHARC:'` (would shadow Renderer at gate step 5). Assert: the second registration throws synchronously with the collision error. Conversely, register `'SHARC:'` first on a fresh router, then attempt `'SHARC:Renderer:'`. Assert: the second registration also throws. Both directions of prefix-of-prefix containment must be rejected. | § 2.3 prefix-collision algorithm (SEC-4) |
 
 ---
 
@@ -872,14 +966,16 @@ Per `feedback_pre_1_breaking_changes` and SHARC project convention: no deprecati
 | Test code calling `container._isValidRendererEnvelope(...)` directly | Method exists | Method removed | Yes — `_` prefix indicates internal; not part of public API |
 | Test code asserting on `container._sharcNonce` matching the URL fragment | Match | Mismatch (fragment is derived) | Yes |
 | Extension calling `container.protocolRouter.register(...)` | Did not exist | Available | No (additive) |
+| `new SHARCContainer(...)` in a non-secure context (HTTP iframe lacking `window.crypto.subtle`) | Constructs; renderer protocol used plain UUID via `crypto.randomUUID()` | Throws synchronously — `crypto.subtle` required for HMAC-derivation (§ 5.5.2, RTR-D22) | Yes — staging on plain HTTP no longer supported |
 
 ### 11.3 Throw-on-legacy enforcement
 
 The router throws synchronously at registration time on:
 
-- Prefix collision (§ 2.3) — `Error('[SHARCProtocolRouter] prefix "X" already registered')`
+- Prefix collision (§ 2.3) — `Error('[SHARCProtocolRouter] prefix "P" collides with already-registered prefix "E"')`. Covers exact-match, new-prefix-shadows-existing (P shorter), and existing-prefix-shadows-new (P longer) cases per the bidirectional algorithm.
 - Prefix not ending in `:` — `Error('[SHARCProtocolRouter] prefix must end with ":" — got "X"')`
 - Missing/invalid `types` map — `Error('[SHARCProtocolRouter] types must be a non-empty object')`
+- `crypto.subtle` unavailable at router construction (non-secure context) — `Error('[SHARCProtocolRouter] crypto.subtle is unavailable — SHARC requires a secure context (HTTPS or localhost). Non-secure contexts cannot derive per-protocol nonces.')` (§ 5.5.2, RTR-D22)
 - Invalid phase declared in a type — the router currently accepts any phase string (§ 4.3), so no throw; future hardening per RTR-J1
 
 The router throws at envelope-construction time (`buildOutbound`) on:
@@ -928,6 +1024,11 @@ The router throws at envelope-construction time (`buildOutbound`) on:
   code is unchanged (opaque-string passthrough).
 
 ### Breaking
+- `SHARCContainer` now requires a secure context at construction time
+  (`window.crypto.subtle` must be available). Non-secure contexts —
+  HTTP iframes lacking `SubtleCrypto` — cause `new SHARCContainer(...)`
+  to throw synchronously. Operators running staging on plain HTTP must
+  move to HTTPS or `localhost` before upgrading. (RTR-D22.)
 - Post-handshake `SHARC:Renderer:rendered` envelopes now raise the
   `unauthorized_protocol` security event instead of silently no-opping
   via the `_terminated` guard. Operators consuming `onSecurityEvent`
@@ -1017,7 +1118,7 @@ Numbered summary of the locked decisions for fast scanning. Full justification i
 | **RTR-D19** | Derivation salt includes `placementSessionId` (per-impression session binding); re-derivation occurs on every `placementSessionId` mint within a long-lived container; OMID `AdSession`-binding model borrowed structurally, not by terminology | ✅ Locked | § 4.5, § 5.1 acknowledgment, § 5.2, § 5.4 |
 | **RTR-D20** | Lifecycle framing: per-protocol nonces tied to container instance + `placementSessionId`, not to page/app lifecycle events; rotation on freeze/restore is explicitly forbidden | ✅ Locked | § 4.5 |
 | **RTR-D4** | `register()` is synchronous; `onReady` callback delivers protocol nonce when async derivation completes | ✅ Locked | § 5.5 |
-| **RTR-D5** | Prefix collisions throw; extensions cannot override a registered prefix | ✅ Locked | § 2.3, § 7.2 |
+| **RTR-D5** | Prefix collisions throw; extensions cannot override a registered prefix. Collision algorithm is **bidirectional prefix-of-prefix** (refined by SEC-4 review): a new registration `P` collides if any existing prefix `E` satisfies `P === E`, `P.startsWith(E)`, or `E.startsWith(P)`. Forecloses shadowing attacks via shorter-prefix registration | ✅ Locked | § 2.3, § 7.2 |
 | **RTR-D6** | No protocol-level deregistration API in 0.7.7 | ✅ Locked | § 2.3 |
 | **RTR-D7** | `buildOutbound` helper asserts type is declared `outbound` or `bidirectional` | ✅ Locked | § 3.3 |
 | **RTR-D8** | Router does not own `MessageChannel` ports; SHARC creative-SDK port stays separate | ✅ Locked | § 2.5 |
@@ -1032,6 +1133,7 @@ Numbered summary of the locked decisions for fast scanning. Full justification i
 | **RTR-D16** | `unauthorized_protocol` emission reuses `_invokeSecurityCallback` chokepoint | ✅ Locked | § 8.4 |
 | **RTR-D17** | No router-side cap on `unauthorized_protocol`; payload minimized to `{type, phase, reason}`; operator-side rate-limiting | ✅ Locked | § 8.6, § 8.7 |
 | **RTR-D18** | In-source JSDoc for the router; public `api-reference.md` entry deferred to 0.7.8 | ✅ Locked | § 12.2, § 13 |
+| **RTR-D22** | `crypto.subtle` is a hard requirement; non-secure contexts (HTTP iframes lacking SubtleCrypto) cause the `SHARCContainer` constructor to throw with an explicit error. No fallback to `crypto.getRandomValues`-derived random nonce — fallback would break per-protocol non-derivability. Async `crypto.subtle.sign()` rejections during derivation reject `protocolRouter.ready(prefix)` with a typed error; container emits `feature_load_failed` (not `unauthorized_protocol`) and aborts the load | ✅ Locked | § 5.5.2 |
 
 ### 14.1 Judgment calls (originally beyond issue #219 acceptance criteria)
 
@@ -1098,13 +1200,18 @@ The OMID compatibility cross-walk surfaced seven items that the 0.7.8 OMID imple
 
 1. **Shim install ordering.** `window.omid3p` exposed synchronously inside the creative iframe before verification scripts run; iframe-side methods return sync after queueing locally. (OMID `isSupported()` contract: `omid3p && typeof omid3p['registerSessionObserver'] === 'function' && typeof omid3p['addEventListener'] === 'function'`.)
 
-2. **Trusted nonce injection into the iframe shim.** Not via `location.hash` (creative-readable). Renderer-injected or `MessageChannel` transferred at iframe creation are both viable. Router does not constrain mechanism.
+2. **Trusted nonce injection into the iframe shim.** Not via `location.hash` (creative-readable). Renderer-injected (shim source pre-rewritten with the nonce baked in before `document.write`) or `MessageChannel`-transferred at iframe creation are both viable. Router does not constrain mechanism — and specifically, **a `MessageChannel`-delivered OMID nonce does not interact with the router at all**: the router owns `window.message` envelopes and does not own `MessageChannel` ports (RTR-D8 / § 2.5). The OMID extension's port-receive handler in the creative iframe consumes the nonce directly, stashes it on the shim's private state, and the router never sees it. The router's gate validates `window.message` envelopes signed with the **renderer-protocol** derived nonce (a different per-protocol nonce); the OMID per-protocol nonce is OMID's responsibility to validate at OMID's transport layer (whichever the 0.7.8 design picks).
 
 3. **Phase-membership declarations.** Registration types (`registerSessionObserver`, `addEventListener`) valid in `rendered` / `creative-active` (pre-`AdSession.start()`); downstream metric events gated to `omid-active`. Per IAB's "call upon initialization" semantics for `registerSessionObserver`. Open-set phases (RTR-J1) accommodate an `omid-finishing` phase for OMID v1.5's ~1.0s `sessionFinish` grace window if 0.7.8 wants explicit gating.
 
 4. **Sequential-impression discipline.** On `placementSessionId` re-mint, defer constructing the new OMID AdSession-equivalent (and its first `setClientInfo` emission) until post-mint `onReady({protocolNonce})` resolves. Sequential-impression analogue of RTR-D10 / the ordering invariant locked at RTR-D21 (§ 5.3).
 
-5. **Cross-vendor isolation transport.** Shim-to-vendor delivery via direct function call (canonical OMID same-window dispatch), NOT `postMessage` broadcast — `postMessage` to the creative iframe is broadcast-visible to all in-iframe `message` listeners cross-vendor. Or per-vendor `MessageChannel` ports. Router correctly draws the boundary at "one protocol = one nonce + one handler"; cross-vendor isolation is 0.7.8's responsibility.
+5. **Cross-vendor isolation transport.** Shim-to-vendor delivery options:
+   - **Direct function call, same iframe JS context.** The shim and the vendor verification script both execute in the creative iframe's window. The shim invokes the vendor's exposed callback (e.g. the function the vendor registered via `omid3p.registerSessionObserver(callback)`) directly within that same JS context — no cross-frame transit. This is the canonical OMID same-window dispatch model and is what "direct function call" means here. It is NOT a cross-frame function call (which would require a shared reference; not possible without a transport).
+   - **Per-vendor `MessageChannel` port.** If the vendor's verification script lives in its own iframe (uncommon for OMID v1.5 in-shim integration but possible), a dedicated `MessageChannel` port per vendor avoids the broadcast leak — only the targeted port receives the message.
+   - **Forbidden: `postMessage` broadcast.** `iframe.contentWindow.postMessage(...)` is broadcast-visible to every `message` listener in that iframe — including hostile vendor scripts that subscribed in order to harvest other vendors' events. This is the cross-vendor isolation failure mode OMID's same-window dispatch model is designed to avoid.
+
+   Router correctly draws the boundary at "one protocol = one nonce + one handler"; cross-vendor isolation is 0.7.8's responsibility.
 
 6. **Protocol nonce never reaches vendor JS.** `protocolNonce` is operator-private transport authenticator; must not appear in any payload, return value, or observer callback addressed to a vendor. Pin with a 0.7.8 test.
 


### PR DESCRIPTION
## Summary

Design doc for the SHARC Protocol Router primitive (0.7.7) + renderer protocol retrofit. Resolves #219. Prerequisite for #217 (0.7.8 OMID bridge redesign).

The router owns the single `window.addEventListener('message', ...)` on the publisher side, validates `(origin, source, nonce, type-prefix, lifecycle-phase)` uniformly for every inbound envelope, and routes valid envelopes to registered extension handlers. Extensions register protocols via `{prefix, types, handler, onReady}`. Prefix collisions throw at registration time.

## Architecture highlights

- **Per-protocol nonce derivation:** `HMAC-SHA-256(_sharcNonce, prefix + ':' + placementSessionId).slice(0,16) → base64url`. Container-private root key, per-impression session binding (borrowed from OMID's AdSession model). Non-invertible across protocols; per-creative rotation.
- **`onReady` async delivery** in publisher context — nonces never reach markup. Gate is silent-drop for registered prefixes awaiting async nonce delivery.
- **Six-phase open-set lifecycle:** `init`, `attaching-renderer`, `rendered`, `omid-active` (reserved for 0.7.8), `creative-active`, `terminated`. Phase enforcement before type dispatch.
- **Payload-minimized `unauthorized_protocol` security event** (`{type, phase, reason}` only). No router-side rate limit; operators handle downstream telemetry sampling. Emit-only (non-terminating).
- **Container-instance + per-impression session lifetime:** nonces persist across web bfcache restore and mobile WebView freeze/resume; re-derive only on new creative load (new `placementSessionId`).
- **Sequential-impression re-derivation ordering invariant** (RTR-D21): on re-mint, expected nonces update atomically, `onReady` re-fire completes, only then the next iframe is wired.
- **Renderer protocol retrofitted** as the first router occupant. Semantic vocabulary unchanged; only dispatch and gating move to the router.

## Resolves parked 0.7.8 OMID design findings at the router layer

Security Engineer review of the parked 0.7.8 OMID design surfaced:
- **B1** — cross-channel nonce reuse with creative-readable delivery
- **B2** — undefined nonce-delivery channel to the iframe shim
- **S1** — cross-channel envelope-type impersonation (the in-iframe shim's existence retroactively weakens the renderer-protocol trust posture)

All three resolved at the router infrastructure layer; 0.7.8 inherits the resolution.

## Review history

1. Code Reviewer pass — citation accuracy + internal consistency
2. Security Engineer pass — B1/B2/S1 resolution confirmed
3. Architect revision (locked RTR-J1, RTR-J2, RTR-D17; addressed SF-1, SF-2, S1, S3, S4, C5)
4. Architect revision 2 — `placementSessionId`-salted nonce + generalized container-instance-lifetime framing + OMID session-binding acknowledgment
5. Second Security Engineer pass — salt-vs-key argument cryptographically verified; B1/B2/S1 resolution preserved under the new salt
6. OMID spec compatibility cross-walk (6 parallel angle investigators + synthesis) — router locks OMID spec compliance in; zero router-side adjustments needed; **definitive answer: OMID has no nonce/token/signature/shared-secret mechanism, so there is nothing for SHARC's nonce model to align against — the placementSessionId-salted HMAC solves a cross-frame transport problem OMID's same-realm architecture never had**
7. Final architect revision — RTR-D21 ordering invariant locked + §16 OMID 0.7.8-dependencies hand-off appendix added

## 0.7.8 dependencies captured (§16)

Seven items the 0.7.8 OMID extension owes per OMID spec, router-neutral:
1. Shim install ordering (`window.omid3p` exposed synchronously)
2. Trusted nonce injection (not via `location.hash`)
3. Phase-membership declarations (registration types valid in `rendered`/`creative-active`)
4. Sequential-impression discipline (sequential-impression analogue of RTR-D10/RTR-D21)
5. Cross-vendor isolation transport (direct function call, not postMessage broadcast)
6. Protocol nonce never reaches vendor JS
7. Response correlation via GUID-keyed callbackMap

## Next steps

- 0.7.7 *implementation* PR follows once this design doc is reviewed and merged.
- 0.7.8 OMID design doc (parked at `docs/design/0.7.8-omid-spec-compliant-bridge.md` on its own branch) gets rebased onto this router primitive after the router implementation lands.

## Validation

- 1113 lines, no code changes (design-only).
- `git diff --check` clean (manual verification — no whitespace issues introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)