### PR TITLE
docs: add legacy mraid loader reduction

### DIFF
--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -237,10 +237,25 @@ The checked-in cleaned-corpus JSON is the canonical fixture input. Avoid keeping
 duplicate creative markup in companion files unless tooling derives one copy
 from the other or the companion is explicitly marked non-canonical.
 
+Promotion workflow:
+
+1. Identify a repeated private-corpus pattern from report/triage output.
+2. Reduce it to the smallest synthetic cleaned-corpus fixture that preserves the
+   mechanism and removes bidder domains, tracking URLs, private IDs, creative
+   artwork, and raw vendor markup.
+3. Add a README that names the public mechanism being pinned and explicitly says
+   what the reduction does not decide when the product/spec question is still
+   open.
+4. Add or reuse validator tests that exercise the reduction's behavior. Keep the
+   private corpus report path out of committed files and PR text.
+
 `001-normalizer-cleaned-corpus` pins the cleaned export shape and normalizer
 classification/extraction behavior. `002-navigation-policy-post-render`
 captures the current Creative Markup behavior for a creative that renders and
 then navigates its own iframe: the validator buckets it as `navigation-policy`.
+`003-legacy-mraid-loader-alias` captures relative `mraid.js` loader aliasing for
+MRAID-active cases and the runtime-only diagnostic boundary when no MRAID signal
+exists.
 
 ### Security
 

--- a/tools/creative-validator/fixtures/reductions/003-legacy-mraid-loader-alias/README.md
+++ b/tools/creative-validator/fixtures/reductions/003-legacy-mraid-loader-alias/README.md
@@ -1,0 +1,27 @@
+# 003 Legacy MRAID Loader Alias
+
+Synthetic reduction for private corpus rows that request a relative
+`mraid.js` script as part of the MRAID environment contract.
+
+The fixture pins the validator boundary:
+
+- declared or sniffed MRAID evidence means the runner may satisfy relative
+  `mraid.js` with an empty successful script response, because SHARC already
+  installs `window.mraid` through the compatibility bridge.
+- runtime-only `mraid.js` evidence without bid-declared or markup-sniffed MRAID
+  is diagnostic only. The request is not aliased and should remain visible as a
+  runtime-only signal.
+
+The declared case uses `imp.banner.api: [3, 5]` (OpenRTB MRAID API codes). The
+sniffed case has no API declaration, but its markup contains
+`<script src="mraid.js">`, so the normalizer classifies it as `html-mraid`.
+The runtime-only case deliberately constructs the URL as `'m' + 'raid.js'` so
+the static normalizer does not sniff MRAID before the creative runs; that case
+stays `html` and only records the runtime request. Aliased MRAID-active loads
+should have `legacyMraidLoader.errorCount: 0`; unrelated probe or network 404
+noise may still appear elsewhere in the report and is not the signal this
+reduction pins.
+
+This is a harness-fidelity reduction, not production SHARC guidance. It exists
+so follow-up spec/operator discussions can point at public synthetic mechanics
+instead of private `adm`.

--- a/tools/creative-validator/fixtures/reductions/003-legacy-mraid-loader-alias/cleaned-corpus.fixture.json
+++ b/tools/creative-validator/fixtures/reductions/003-legacy-mraid-loader-alias/cleaned-corpus.fixture.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "auction-row-legacy-mraid-loader-alias",
+    "auction": [
+      {
+        "bidder": "synthetic-legacy-mraid-declared",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-legacy-mraid-declared",
+          "imp": [
+            {
+              "id": "imp-legacy-mraid-declared",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50,
+                "api": [3, 5]
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-legacy-mraid-declared",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-legacy-mraid-declared",
+                  "impid": "imp-legacy-mraid-declared",
+                  "crid": "creative-legacy-mraid-declared",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><script src=\"mraid.js\"></script><script>window.__fixture = 'declared';</script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "bidder": "synthetic-legacy-mraid-sniffed",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-legacy-mraid-sniffed",
+          "imp": [
+            {
+              "id": "imp-legacy-mraid-sniffed",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-legacy-mraid-sniffed",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-legacy-mraid-sniffed",
+                  "impid": "imp-legacy-mraid-sniffed",
+                  "crid": "creative-legacy-mraid-sniffed",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><script src=\"mraid.js\"></script><script>window.__fixture = 'sniffed';</script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "bidder": "synthetic-legacy-mraid-runtime-only",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-legacy-mraid-runtime-only",
+          "imp": [
+            {
+              "id": "imp-legacy-mraid-runtime-only",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-legacy-mraid-runtime-only",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-legacy-mraid-runtime-only",
+                  "impid": "imp-legacy-mraid-runtime-only",
+                  "crid": "creative-legacy-mraid-runtime-only",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><script>window.addEventListener('load', function(){ var script = document.createElement('script'); script.src = 'm' + 'raid.js'; document.body.appendChild(script); });</script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add synthetic reduction 003 for relative mraid.js loader aliasing
- document the private-to-synthetic promotion workflow
- capture declared/sniffed MRAID aliasing and runtime-only diagnostic boundary without private corpus data

## Validation
- node tools/creative-validator/src/cli.js normalize tools/creative-validator/fixtures/reductions/003-legacy-mraid-loader-alias/cleaned-corpus.fixture.json --out tools/creative-validator/private/normalized/003-legacy-mraid-loader-alias-cases.jsonl
- node tools/creative-validator/src/cli.js run tools/creative-validator/private/normalized/003-legacy-mraid-loader-alias-cases.jsonl --out tools/creative-validator/private/reports/003-legacy-mraid-loader-alias-report.jsonl --render-timeout-ms 4000 --settle-ms 500
- node tools/creative-validator/src/cli.js triage tools/creative-validator/private/reports/003-legacy-mraid-loader-alias-report.jsonl --out tools/creative-validator/private/triage/003-legacy-mraid-loader-alias-summary.json
- git diff --check