### PR TITLE
docs: add external script navigation reduction

### DIFF
--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -255,7 +255,9 @@ captures the current Creative Markup behavior for a creative that renders and
 then navigates its own iframe: the validator buckets it as `navigation-policy`.
 `003-legacy-mraid-loader-alias` captures relative `mraid.js` loader aliasing for
 MRAID-active cases and the runtime-only diagnostic boundary when no MRAID signal
-exists.
+exists. `004-external-script-navigation-boundary` captures the boundary between
+allowed external script/document activity and same-frame renderer navigation
+attempts that remain `navigation-policy` failures.
 
 ### Security
 

--- a/tools/creative-validator/fixtures/reductions/004-external-script-navigation-boundary/README.md
+++ b/tools/creative-validator/fixtures/reductions/004-external-script-navigation-boundary/README.md
@@ -1,0 +1,22 @@
+# 004 External Script Navigation Boundary
+
+Synthetic reduction for private corpus rows where ordinary HTML creatives load
+third-party JavaScript and the loaded script either creates nested document
+content or attempts to navigate the renderer document.
+
+The fixture pins the validator boundary:
+
+- an external script that loads and does nothing should pass.
+- an external script that creates a nested iframe should pass and report
+  document-source diagnostics. The iframe creates new document content within
+  the renderer frame without navigating the renderer document itself.
+- an external script that assigns `window.location.href` should fail with the
+  `navigation-policy` bucket.
+
+This reduction does not decide whether particular vendors, CDNs, or wrapper
+flows are good or bad. External scripts are a normal creative dependency. The
+mechanism being pinned is narrower: loading script resources is allowed, while
+script-driven same-frame navigation remains a renderer navigation-policy
+violation. The bid requests use `secure: 1` to match the surrounding synthetic
+OpenRTB fixture convention; during validator runs, local fixture scripts are
+served over the runner's localhost HTTP server.

--- a/tools/creative-validator/fixtures/reductions/004-external-script-navigation-boundary/cleaned-corpus.fixture.json
+++ b/tools/creative-validator/fixtures/reductions/004-external-script-navigation-boundary/cleaned-corpus.fixture.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "auction-row-external-script-boundary",
+    "auction": [
+      {
+        "bidder": "synthetic-external-script-noop",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-external-script-noop",
+          "imp": [
+            {
+              "id": "imp-external-script-noop",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-external-script-noop",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-external-script-noop",
+                  "impid": "imp-external-script-noop",
+                  "crid": "creative-external-script-noop",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><div>synthetic external script no-op</div><script src=\"/tools/creative-validator/fixtures/navigation-boundary-noop.js\"></script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "bidder": "synthetic-external-script-document",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-external-script-document",
+          "imp": [
+            {
+              "id": "imp-external-script-document",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-external-script-document",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-external-script-nested-iframe",
+                  "impid": "imp-external-script-document",
+                  "crid": "creative-external-script-nested-iframe",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><div>synthetic external script nested iframe</div><script src=\"/tools/creative-validator/fixtures/navigation-boundary-nested-iframe.js\"></script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "bidder": "synthetic-external-script-navigation",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-external-script-navigation",
+          "imp": [
+            {
+              "id": "imp-external-script-navigation",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-external-script-navigation",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-external-script-location-navigation",
+                  "impid": "imp-external-script-navigation",
+                  "crid": "creative-external-script-location-navigation",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><div>synthetic external script navigation</div><script src=\"/tools/creative-validator/fixtures/navigation-boundary-location.js\"></script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add synthetic reduction 004 for external-script navigation boundary behavior
- pin no-op and nested-iframe external scripts as passing cases
- pin external script window.location navigation as a navigation-policy failure
- index the reduction from the creative validator README

## Validation
- node tools/creative-validator/src/cli.js normalize tools/creative-validator/fixtures/reductions/004-external-script-navigation-boundary/cleaned-corpus.fixture.json --out tools/creative-validator/private/normalized/004-external-script-navigation-boundary-cases.jsonl
- node tools/creative-validator/src/cli.js run tools/creative-validator/private/normalized/004-external-script-navigation-boundary-cases.jsonl --out tools/creative-validator/private/reports/004-external-script-navigation-boundary-report.jsonl --render-timeout-ms 4000 --settle-ms 1500
- node tools/creative-validator/src/cli.js triage tools/creative-validator/private/reports/004-external-script-navigation-boundary-report.jsonl --out tools/creative-validator/private/triage/004-external-script-navigation-boundary-summary.json
- reduction assertions ok
- git diff --cached --check