### PR TITLE
test: classify validator document sources

### DIFF
--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -198,6 +198,9 @@ Triage also assigns document-source classes (`external-frame`,
 `secure-frame`, `insecure-frame`, `blank-or-opaque-document`,
 `frame-src-assignment`, `observed-frame`, `form-source`, `srcdoc-frame`) to
 separate normal nested iframe activity from same-frame renderer navigation.
+`blank-or-opaque-document` is limited to frame-like sources whose target is
+`about:` or otherwise opaque, so URL-less form submissions stay in
+`form-source` only.
 Rows can belong to multiple classes, so event-class totals are diagnostic
 facets and are not expected to sum to `rowsWithDocumentSources`.
 

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -194,6 +194,12 @@ are meant to explain failed-document/CSP clusters without changing validator
 pass/fail classification. They are private-tier for the same reason as the
 other corpus diagnostics: they key by real bidder names and ad-server origins,
 so summaries must not be shared with bidders.
+Triage also assigns document-source classes (`external-frame`,
+`secure-frame`, `insecure-frame`, `blank-or-opaque-document`,
+`frame-src-assignment`, `observed-frame`, `form-source`, `srcdoc-frame`) to
+separate normal nested iframe activity from same-frame renderer navigation.
+Rows can belong to multiple classes, so event-class totals are diagnostic
+facets and are not expected to sum to `rowsWithDocumentSources`.
 
 OMID facets under `corpusDiagnostics.omid` aggregate the per-row OMID outcomes
 the runner records at `diagnostics.measurement.omid`. They separate OMID

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -298,6 +298,7 @@ function documentSourceClasses(documentSources) {
   const rows = new Set();
   const events = {};
   const add = (name, count = 1) => {
+    // Row classes are idempotent; event counts preserve repeated observations.
     rows.add(name);
     increment(events, name, count);
   };
@@ -307,8 +308,8 @@ function documentSourceClasses(documentSources) {
   for (const call of calls) {
     if (!call || typeof call !== 'object') continue;
     const url = call.url || {};
-    const assignedUrl = call.assignedUrl || {};
-    const protocol = normalizeKey(url.protocol || assignedUrl.protocol);
+    const protocol = normalizeKey(url.protocol || (call.assignedUrl && call.assignedUrl.protocol));
+    const isFrameLike = call.kind === 'frame' || call.kind === 'frame-src';
     if (call.kind === 'frame-src') add('frame-src-assignment');
     if (call.kind === 'frame') add('observed-frame');
     if (call.kind === 'form' || call.kind === 'form-submit') add('form-source');
@@ -318,13 +319,15 @@ function documentSourceClasses(documentSources) {
     }
     if (protocol === 'https:') add('secure-frame');
     if (protocol === 'http:') add('insecure-frame');
-    if (protocol === 'about:' || protocol === 'unknown') {
+    if (isFrameLike && (protocol === 'about:' || protocol === 'unknown')) {
       add('blank-or-opaque-document');
     }
   }
 
   // Older reports may not include bounded calls. Fall back to aggregate facets
   // so the class fields remain useful when triaging mixed report generations.
+  // The aggregate fallback cannot correlate kind and protocol; current reports
+  // with bounded calls are authoritative for blank/opaque frame classification.
   if (calls.length === 0) {
     const byKind = documentSources && documentSources.byKind ? documentSources.byKind : {};
     const byProtocol = documentSources && documentSources.byProtocol ? documentSources.byProtocol : {};

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -100,6 +100,9 @@ function emptySummary(files) {
         documentSourcesByOrigin: {},
         documentSourcesByTag: {},
         documentSourceRowsByBidder: {},
+        documentSourceRowsByClass: {},
+        documentSourceEventsByClass: {},
+        documentSourceRowsByClassAndBidder: {},
         byShape: {},
         byFailedRequestCount: {},
         byFailedResponseCount: {},
@@ -286,6 +289,60 @@ function scriptErrorClasses(row, scriptLoads, legacy) {
   const unknownScriptErrors = Math.max(0, networkCount(scriptLoads && scriptLoads.errorCount) - knownEvents);
   if (unknownScriptErrors > 0 && scriptFailureEvents === 0) {
     add('script-load-event', unknownScriptErrors);
+  }
+
+  return { rows, events };
+}
+
+function documentSourceClasses(documentSources) {
+  const rows = new Set();
+  const events = {};
+  const add = (name, count = 1) => {
+    rows.add(name);
+    increment(events, name, count);
+  };
+  const calls = documentSources && Array.isArray(documentSources.calls)
+    ? documentSources.calls
+    : [];
+  for (const call of calls) {
+    if (!call || typeof call !== 'object') continue;
+    const url = call.url || {};
+    const assignedUrl = call.assignedUrl || {};
+    const protocol = normalizeKey(url.protocol || assignedUrl.protocol);
+    if (call.kind === 'frame-src') add('frame-src-assignment');
+    if (call.kind === 'frame') add('observed-frame');
+    if (call.kind === 'form' || call.kind === 'form-submit') add('form-source');
+    if (call.srcdoc === true) add('srcdoc-frame');
+    if (protocol === 'http:' || protocol === 'https:') {
+      add('external-frame');
+    }
+    if (protocol === 'https:') add('secure-frame');
+    if (protocol === 'http:') add('insecure-frame');
+    if (protocol === 'about:' || protocol === 'unknown') {
+      add('blank-or-opaque-document');
+    }
+  }
+
+  // Older reports may not include bounded calls. Fall back to aggregate facets
+  // so the class fields remain useful when triaging mixed report generations.
+  if (calls.length === 0) {
+    const byKind = documentSources && documentSources.byKind ? documentSources.byKind : {};
+    const byProtocol = documentSources && documentSources.byProtocol ? documentSources.byProtocol : {};
+    for (const [kind, count] of Object.entries(byKind)) {
+      const n = networkCount(count);
+      if (n === 0) continue;
+      if (kind === 'frame-src') add('frame-src-assignment', n);
+      if (kind === 'frame') add('observed-frame', n);
+      if (kind === 'form' || kind === 'form-submit') add('form-source', n);
+    }
+    for (const [protocol, count] of Object.entries(byProtocol)) {
+      const n = networkCount(count);
+      if (n === 0) continue;
+      if (protocol === 'http:' || protocol === 'https:') add('external-frame', n);
+      if (protocol === 'https:') add('secure-frame', n);
+      if (protocol === 'http:') add('insecure-frame', n);
+      if (protocol === 'about:' || protocol === 'unknown') add('blank-or-opaque-document', n);
+    }
   }
 
   return { rows, events };
@@ -479,6 +536,17 @@ function addRuntimeCorpusFacets(summary, row, fields) {
   if (networkCount(documentSources.count) > 0) {
     summary.corpusDiagnostics.network.rowsWithDocumentSources += 1;
     increment(summary.corpusDiagnostics.network.documentSourceRowsByBidder, fields.bidder);
+    const classes = documentSourceClasses(documentSources);
+    for (const name of classes.rows) {
+      increment(summary.corpusDiagnostics.network.documentSourceRowsByClass, name);
+      increment(
+        summary.corpusDiagnostics.network.documentSourceRowsByClassAndBidder,
+        `${name}|${fields.bidder}`,
+      );
+    }
+    for (const [name, count] of Object.entries(classes.events)) {
+      increment(summary.corpusDiagnostics.network.documentSourceEventsByClass, name, count);
+    }
   }
   const documentSourceByKind = documentSources.byKind || {};
   for (const [kind, count] of Object.entries(documentSourceByKind)) {
@@ -813,6 +881,12 @@ function triageReports(files) {
     sortEntries(summary.corpusDiagnostics.network.documentSourcesByTag);
   summary.corpusDiagnostics.network.documentSourceRowsByBidder =
     sortEntries(summary.corpusDiagnostics.network.documentSourceRowsByBidder);
+  summary.corpusDiagnostics.network.documentSourceRowsByClass =
+    sortEntries(summary.corpusDiagnostics.network.documentSourceRowsByClass);
+  summary.corpusDiagnostics.network.documentSourceEventsByClass =
+    sortEntries(summary.corpusDiagnostics.network.documentSourceEventsByClass);
+  summary.corpusDiagnostics.network.documentSourceRowsByClassAndBidder =
+    sortEntries(summary.corpusDiagnostics.network.documentSourceRowsByClassAndBidder);
   summary.corpusDiagnostics.network.failedRowsByBidder =
     sortEntries(summary.corpusDiagnostics.network.failedRowsByBidder);
   summary.corpusDiagnostics.network.failedRowsByAdmKind =

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -154,23 +154,49 @@ test('triageReports groups private report rows by failure dimensions', () => {
               },
             },
             documentSources: {
-              count: 2,
+              count: 3,
               byKind: {
                 frame: 1,
+                'frame-src': 1,
                 'form-submit': 1,
               },
               byProtocol: {
+                'http:': 1,
                 'https:': 1,
                 unknown: 1,
               },
               byOrigin: {
+                'http://frame.example': 1,
                 'https://click.example': 1,
                 unknown: 1,
               },
               byTag: {
-                iframe: 1,
+                iframe: 2,
                 form: 1,
               },
+              calls: [
+                {
+                  kind: 'frame',
+                  tagName: 'iframe',
+                  url: { present: true, protocol: 'https:', origin: 'https://click.example' },
+                  srcdoc: false,
+                },
+                {
+                  kind: 'form-submit',
+                  tagName: 'form',
+                  url: { present: false, protocol: null, origin: null },
+                  assignedUrl: null,
+                  srcdoc: false,
+                },
+                {
+                  kind: 'frame-src',
+                  tagName: 'iframe',
+                  url: { present: true, protocol: 'http:', origin: 'http://frame.example' },
+                  assignedUrl: { present: true, protocol: 'http:', origin: 'http://frame.example' },
+                  assignment: 'property',
+                  srcdoc: false,
+                },
+              ],
             },
           },
         },
@@ -469,20 +495,50 @@ test('triageReports groups private report rows by failure dimensions', () => {
     assert.equal(summary.corpusDiagnostics.network.rowsWithDocumentSources, 1);
     assert.equal(summary.corpusDiagnostics.network.documentSourceRowsByBidder['bidder-a'], 1);
     assert.deepEqual(summary.corpusDiagnostics.network.documentSourcesByKind, {
+      'frame-src': 1,
       'form-submit': 1,
       frame: 1,
     });
     assert.deepEqual(summary.corpusDiagnostics.network.documentSourcesByProtocol, {
+      'http:': 1,
       'https:': 1,
       unknown: 1,
     });
     assert.deepEqual(summary.corpusDiagnostics.network.documentSourcesByOrigin, {
+      'http://frame.example': 1,
       'https://click.example': 1,
       unknown: 1,
     });
     assert.deepEqual(summary.corpusDiagnostics.network.documentSourcesByTag, {
       form: 1,
-      iframe: 1,
+      iframe: 2,
+    });
+    assert.deepEqual(summary.corpusDiagnostics.network.documentSourceRowsByClass, {
+      'blank-or-opaque-document': 1,
+      'external-frame': 1,
+      'frame-src-assignment': 1,
+      'form-source': 1,
+      'insecure-frame': 1,
+      'observed-frame': 1,
+      'secure-frame': 1,
+    });
+    assert.deepEqual(summary.corpusDiagnostics.network.documentSourceEventsByClass, {
+      'blank-or-opaque-document': 1,
+      'external-frame': 2,
+      'frame-src-assignment': 1,
+      'form-source': 1,
+      'insecure-frame': 1,
+      'observed-frame': 1,
+      'secure-frame': 1,
+    });
+    assert.deepEqual(summary.corpusDiagnostics.network.documentSourceRowsByClassAndBidder, {
+      'blank-or-opaque-document|bidder-a': 1,
+      'external-frame|bidder-a': 1,
+      'frame-src-assignment|bidder-a': 1,
+      'form-source|bidder-a': 1,
+      'insecure-frame|bidder-a': 1,
+      'observed-frame|bidder-a': 1,
+      'secure-frame|bidder-a': 1,
     });
     assert.equal(summary.corpusDiagnostics.network.byShape['request:0 response:0 cors:0 csp:0'], 4);
     assert.equal(summary.corpusDiagnostics.network.byShape['request:10 response:10 cors:10 csp:10'], 2);

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -154,24 +154,26 @@ test('triageReports groups private report rows by failure dimensions', () => {
               },
             },
             documentSources: {
-              count: 3,
+              count: 4,
               byKind: {
-                frame: 1,
+                frame: 2,
                 'frame-src': 1,
                 'form-submit': 1,
               },
               byProtocol: {
+                'about:': 1,
                 'http:': 1,
                 'https:': 1,
                 unknown: 1,
               },
               byOrigin: {
+                'about:blank': 1,
                 'http://frame.example': 1,
                 'https://click.example': 1,
                 unknown: 1,
               },
               byTag: {
-                iframe: 2,
+                iframe: 3,
                 form: 1,
               },
               calls: [
@@ -195,6 +197,12 @@ test('triageReports groups private report rows by failure dimensions', () => {
                   assignedUrl: { present: true, protocol: 'http:', origin: 'http://frame.example' },
                   assignment: 'property',
                   srcdoc: false,
+                },
+                {
+                  kind: 'frame',
+                  tagName: 'iframe',
+                  url: { present: true, protocol: 'about:', origin: 'about:blank' },
+                  srcdoc: true,
                 },
               ],
             },
@@ -497,21 +505,23 @@ test('triageReports groups private report rows by failure dimensions', () => {
     assert.deepEqual(summary.corpusDiagnostics.network.documentSourcesByKind, {
       'frame-src': 1,
       'form-submit': 1,
-      frame: 1,
+      frame: 2,
     });
     assert.deepEqual(summary.corpusDiagnostics.network.documentSourcesByProtocol, {
+      'about:': 1,
       'http:': 1,
       'https:': 1,
       unknown: 1,
     });
     assert.deepEqual(summary.corpusDiagnostics.network.documentSourcesByOrigin, {
+      'about:blank': 1,
       'http://frame.example': 1,
       'https://click.example': 1,
       unknown: 1,
     });
     assert.deepEqual(summary.corpusDiagnostics.network.documentSourcesByTag, {
       form: 1,
-      iframe: 2,
+      iframe: 3,
     });
     assert.deepEqual(summary.corpusDiagnostics.network.documentSourceRowsByClass, {
       'blank-or-opaque-document': 1,
@@ -521,6 +531,7 @@ test('triageReports groups private report rows by failure dimensions', () => {
       'insecure-frame': 1,
       'observed-frame': 1,
       'secure-frame': 1,
+      'srcdoc-frame': 1,
     });
     assert.deepEqual(summary.corpusDiagnostics.network.documentSourceEventsByClass, {
       'blank-or-opaque-document': 1,
@@ -528,8 +539,9 @@ test('triageReports groups private report rows by failure dimensions', () => {
       'frame-src-assignment': 1,
       'form-source': 1,
       'insecure-frame': 1,
-      'observed-frame': 1,
+      'observed-frame': 2,
       'secure-frame': 1,
+      'srcdoc-frame': 1,
     });
     assert.deepEqual(summary.corpusDiagnostics.network.documentSourceRowsByClassAndBidder, {
       'blank-or-opaque-document|bidder-a': 1,
@@ -539,6 +551,7 @@ test('triageReports groups private report rows by failure dimensions', () => {
       'insecure-frame|bidder-a': 1,
       'observed-frame|bidder-a': 1,
       'secure-frame|bidder-a': 1,
+      'srcdoc-frame|bidder-a': 1,
     });
     assert.equal(summary.corpusDiagnostics.network.byShape['request:0 response:0 cors:0 csp:0'], 4);
     assert.equal(summary.corpusDiagnostics.network.byShape['request:10 response:10 cors:10 csp:10'], 2);


### PR DESCRIPTION
## Summary
- add document-source class facets to creative-validator triage summaries
- classify nested document activity as external/secure/insecure/blank-or-opaque/frame-src/observed/form/srcdoc diagnostics
- cover row/event class aggregation and document the diagnostics-only semantics

## Corpus readout
Re-triaged the post-229 private report with the new facets:
- rowsWithDocumentSources: 567
- observed-frame rows: 567
- external-frame rows: 412
- secure-frame rows: 412
- frame-src-assignment rows: 341
- insecure-frame rows: 284
- blank-or-opaque-document rows: 216
- srcdoc-frame rows: 11

## Validation
- npm run test:creative-validator-triage
- npx eslint tools/creative-validator/src/triage.js tools/creative-validator/test/test-triage.js --max-warnings=0
- git diff --check
- node tools/creative-validator/src/cli.js triage tools/creative-validator/private/reports/openrtb-parsing-20260530-post-229-report.jsonl --out tools/creative-validator/private/triage/openrtb-parsing-20260530-document-source-classes-summary.json