### PR TITLE
chore: sync package-lock.json version to 0.7.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iabtechlab/sharc",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.0.0",


### PR DESCRIPTION
## Summary

`package-lock.json` was stranded at `0.7.6` while `package.json`, `SHARC_VERSION`, README, and all `@version` JSDoc are `0.7.7`. The 0.7.7 bump (#231) propagated the version via `sync-version.js`, which does **not** touch the lockfile — per RELEASING.md the lockfile's version field is updated by `npm version` itself, which wasn't used.

This syncs the two version fields (root `version` and `packages[""].version`) to `0.7.7`.

## Why now

Release-hygiene fix before tagging `v0.7.7` — a release tag should not capture a repo state whose committed lockfile claims an older version. Not CI- or publish-breaking (CI stayed green on the mismatch; `npm publish` uses package.json's version), but worth removing the inconsistency before the tag.

## Validation

- Surgical 2-field edit; no dependency-tree change (`git diff` = 2 lines)
- `npm ci` validated the lockfile is in-sync with package.json (exit 0)

## Process follow-up (not in this PR)

The canonical `npm version <bump>` flow in RELEASING.md updates the lockfile; the 0.7.7 cut bypassed it. Consider a release-checklist guard or a sync-version.js extension so future bumps can't strand the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)