### PR TITLE
docs: add document source classification reduction

### DIFF
--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -267,6 +267,9 @@ MRAID-active cases and the runtime-only diagnostic boundary when no MRAID signal
 exists. `004-external-script-navigation-boundary` captures the boundary between
 allowed external script/document activity and same-frame renderer navigation
 attempts that remain `navigation-policy` failures.
+`005-document-source-classification` captures normal nested document activity:
+static `srcdoc`/`about:blank` frames and external frame `src` assignments should
+pass while emitting document-source classes for private corpus triage.
 
 ### Security
 

--- a/tools/creative-validator/fixtures/reductions/005-document-source-classification/README.md
+++ b/tools/creative-validator/fixtures/reductions/005-document-source-classification/README.md
@@ -1,0 +1,22 @@
+# 005 Document Source Classification
+
+Synthetic reduction for private corpus rows where HTML creatives create nested
+documents without navigating the renderer document itself.
+
+The fixture pins these validator boundaries:
+
+- static `srcdoc` iframes should pass and report `srcdoc-frame`,
+  `blank-or-opaque-document`, and `observed-frame` diagnostics.
+- static `about:blank` iframes should pass and report
+  `blank-or-opaque-document` and `observed-frame` diagnostics.
+- external frame `src` assignments should pass and report `external-frame`,
+  `insecure-frame`, `frame-src-assignment`, and `observed-frame` diagnostics.
+  The fixture uses the runner's localhost HTTP server, so it intentionally
+  exercises the `insecure-frame` class; HTTPS `secure-frame` classification is
+  covered by triage unit fixtures.
+
+This reduction does not classify nested iframe creation as a SHARC failure.
+Nested documents are common creative behavior. The mechanism being pinned is
+the distinction between allowed child-frame document activity and same-frame
+renderer navigation, which remains covered by
+`004-external-script-navigation-boundary`.

--- a/tools/creative-validator/fixtures/reductions/005-document-source-classification/cleaned-corpus.fixture.json
+++ b/tools/creative-validator/fixtures/reductions/005-document-source-classification/cleaned-corpus.fixture.json
@@ -1,0 +1,151 @@
+[
+  {
+    "id": "auction-row-document-source-classes",
+    "auction": [
+      {
+        "bidder": "synthetic-document-source-srcdoc",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-document-source-srcdoc",
+          "imp": [
+            {
+              "id": "imp-document-source-srcdoc",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-document-source-srcdoc",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-document-source-srcdoc",
+                  "impid": "imp-document-source-srcdoc",
+                  "crid": "creative-document-source-srcdoc",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><div>synthetic srcdoc frame</div><iframe srcdoc=\"<!doctype html><html><body>srcdoc nested frame</body></html>\"></iframe></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "bidder": "synthetic-document-source-about",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-document-source-about",
+          "imp": [
+            {
+              "id": "imp-document-source-about",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-document-source-about",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-document-source-about",
+                  "impid": "imp-document-source-about",
+                  "crid": "creative-document-source-about",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><div>synthetic about frame</div><iframe src=\"about:blank\"></iframe></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "bidder": "synthetic-document-source-frame-src-attribute",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-document-source-frame-src-attribute",
+          "imp": [
+            {
+              "id": "imp-document-source-frame-src-attribute",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-document-source-frame-src-attribute",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-document-source-frame-src-attribute",
+                  "impid": "imp-document-source-frame-src-attribute",
+                  "crid": "creative-document-source-frame-src-attribute",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><div>synthetic frame src attribute</div><script src=\"/tools/creative-validator/fixtures/navigation-boundary-frame-src-attribute.js\"></script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "bidder": "synthetic-document-source-frame-src-property",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-document-source-frame-src-property",
+          "imp": [
+            {
+              "id": "imp-document-source-frame-src-property",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-document-source-frame-src-property",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-document-source-frame-src-property",
+                  "impid": "imp-document-source-frame-src-property",
+                  "crid": "creative-document-source-frame-src-property",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><div>synthetic frame src property</div><script src=\"/tools/creative-validator/fixtures/navigation-boundary-frame-src-property.js\"></script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -21,6 +21,9 @@ const cliPath = resolve('tools/creative-validator/src/cli.js');
 const navigationReductionPath = resolve(
   'tools/creative-validator/fixtures/reductions/002-navigation-policy-post-render/cleaned-corpus.fixture.json',
 );
+const documentSourceReductionPath = resolve(
+  'tools/creative-validator/fixtures/reductions/005-document-source-classification/cleaned-corpus.fixture.json',
+);
 
 function makeCase(overrides) {
   return {
@@ -1322,6 +1325,107 @@ test('runner buckets post-render iframe navigation reduction as navigation-polic
       lifecycleMarkers.find((marker) => marker.name === 'before-navigation').readyState,
       'complete',
     );
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});
+
+test('runner documents nested document-source reduction as passing diagnostics', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-runner-document-sources-'));
+  const inputPath = resolve(workDir, 'cases.jsonl');
+  const outPath = resolve(workDir, 'reports.jsonl');
+  const summaryPath = resolve(workDir, 'summary.json');
+
+  try {
+    execFileSync('node', [cliPath, 'normalize', documentSourceReductionPath, '--out', inputPath], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    execFileSync('node', [
+      cliPath,
+      'run',
+      inputPath,
+      '--out',
+      outPath,
+      '--port',
+      '18877',
+      '--renderer-port',
+      '18878',
+      '--render-timeout-ms',
+      '4000',
+      '--settle-ms',
+      '1500',
+    ], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    execFileSync('node', [cliPath, 'triage', outPath, '--out', summaryPath], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const reports = readJsonl(outPath);
+    assert.equal(reports.length, 4);
+    assert.equal(reports.filter((row) => row.outcome.status === 'passed').length, 4);
+    assert.equal(reports.filter((row) => row.outcome.bucket === 'passed').length, 4);
+
+    const byBid = (bidId) => reports.find((row) => row.case.ids.bidId === bidId);
+    const srcdoc = byBid('bid-document-source-srcdoc');
+    assert.ok(srcdoc);
+    assert.equal(srcdoc.diagnostics.navigationDiagnostics.documentSources.byKind.frame, 1);
+    assert.equal(srcdoc.diagnostics.navigationDiagnostics.documentSources.byProtocol.unknown, 1);
+    assert.ok(srcdoc.diagnostics.navigationDiagnostics.documentSources.calls.some((call) =>
+      call.kind === 'frame' && call.srcdoc === true));
+
+    const about = byBid('bid-document-source-about');
+    assert.ok(about);
+    assert.equal(about.diagnostics.navigationDiagnostics.documentSources.byKind.frame, 1);
+    assert.equal(about.diagnostics.navigationDiagnostics.documentSources.byProtocol['about:'], 1);
+
+    const attribute = byBid('bid-document-source-frame-src-attribute');
+    assert.ok(attribute);
+    assert.equal(attribute.diagnostics.navigationDiagnostics.documentSources.byKind.frame, 1);
+    assert.equal(attribute.diagnostics.navigationDiagnostics.documentSources.byKind['frame-src'], 1);
+    assert.ok(attribute.diagnostics.navigationDiagnostics.documentSources.calls.some((call) =>
+      call.kind === 'frame-src' && call.assignment === 'attribute'));
+
+    const property = byBid('bid-document-source-frame-src-property');
+    assert.ok(property);
+    assert.equal(property.diagnostics.navigationDiagnostics.documentSources.byKind.frame, 1);
+    assert.equal(property.diagnostics.navigationDiagnostics.documentSources.byKind['frame-src'], 1);
+    assert.ok(property.diagnostics.navigationDiagnostics.documentSources.calls.some((call) =>
+      call.kind === 'frame-src' && call.assignment === 'property'));
+
+    const summary = JSON.parse(readFileSync(summaryPath, 'utf8'));
+    const network = summary.corpusDiagnostics.network;
+    assert.equal(summary.totals.passed, 4);
+    assert.equal(summary.totals.failed, 0);
+    assert.equal(network.rowsWithDocumentSources, 4);
+    assert.deepEqual(network.documentSourceRowsByClass, {
+      'observed-frame': 4,
+      'blank-or-opaque-document': 2,
+      'external-frame': 2,
+      'frame-src-assignment': 2,
+      'insecure-frame': 2,
+      'srcdoc-frame': 1,
+    });
+    assert.deepEqual(network.documentSourceRowsByClassAndBidder, {
+      'blank-or-opaque-document|synthetic-document-source-about': 1,
+      'blank-or-opaque-document|synthetic-document-source-srcdoc': 1,
+      'external-frame|synthetic-document-source-frame-src-attribute': 1,
+      'external-frame|synthetic-document-source-frame-src-property': 1,
+      'frame-src-assignment|synthetic-document-source-frame-src-attribute': 1,
+      'frame-src-assignment|synthetic-document-source-frame-src-property': 1,
+      'insecure-frame|synthetic-document-source-frame-src-attribute': 1,
+      'insecure-frame|synthetic-document-source-frame-src-property': 1,
+      'observed-frame|synthetic-document-source-about': 1,
+      'observed-frame|synthetic-document-source-frame-src-attribute': 1,
+      'observed-frame|synthetic-document-source-frame-src-property': 1,
+      'observed-frame|synthetic-document-source-srcdoc': 1,
+      'srcdoc-frame|synthetic-document-source-srcdoc': 1,
+    });
   } finally {
     rmSync(workDir, { force: true, recursive: true });
   }


### PR DESCRIPTION
## Summary
- add synthetic reduction 005 for normal nested document-source behavior
- cover srcdoc/about:blank frames and frame src assignment diagnostics
- add runner coverage that normalizes, executes, triages, and asserts the reduction passes with document-source classes

## Validation
- npm run test:creative-validator-runner
- npx eslint tools/creative-validator/test/test-runner.js --max-warnings=0
- JSON fixture parse check
- git diff --check