### PR TITLE
fix: harden 0.7.7 protocol router (#234, #236, #237) + RTR-D21 test coverage (#235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,30 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ### Fixed
 
+- **Protocol router hardening (0.7.7 follow-ups, #234–#237).** Four surgical
+  hardening fixes to the cross-frame protocol router primitive shipped in
+  0.7.7:
+  - **#234 (MAJ-1)** — `_deriveAndDeliver` now reads `expectedPlacementSessionId()`
+    (and any other pre-`await` work) inside the async body, so a synchronous
+    throw surfaces as the typed `PROTOCOL_DERIVATION_FAILED` rejection the
+    container routes to `feature_load_failed` rather than escaping `register()`
+    synchronously.
+  - **#235 (SEC-M1)** — added integration coverage for the sequential-impression
+    re-derivation ordering invariant (`rederiveAllProtocolNonces()`, RTR-D21).
+    The method is kept — 0.7.8 OMID is its confirmed consumer — and is now backed
+    by a §9.6 test #8 integration test pinning the re-derive-before-gate-accepts
+    contract: a re-mint rotates the protocol nonce, re-fires `onReady` with the
+    new value, and the gate accepts a NEW-nonce envelope while dropping the
+    OLD-nonce one.
+  - **#236 (SEC-M2)** — dispatch now requires a non-empty colon-bounded type
+    segment after the matched prefix, so a bare prefix envelope cannot match and
+    `A:B:` / `A:BC:` stay disjoint. Single-prefix (`SHARC:Renderer:`) behavior is
+    unchanged.
+  - **#237 (SEC-M3)** — a throwing `onReady` callback is now surfaced via
+    `console.warn` with the `[SHARCProtocolRouter]` prefix instead of being
+    silently swallowed; derivation and delivery for other protocols are
+    unaffected.
+
 - **Creative Markup document-load backstop.** Markup containers now consume the
   expected post-`:rendered` iframe `load` produced by `document.write()` before
   arming the unauthorized-navigation backstop. Parser/static creative scripts,

--- a/src/sharc-protocol-router.js
+++ b/src/sharc-protocol-router.js
@@ -330,12 +330,33 @@ class SHARCProtocolRouter {
   // ── Internals ───────────────────────────────────────────────────────────
 
   _deriveAndDeliver(entry) {
-    const placementSessionId = this._expectedPlacementSessionId();
-    return this._derive(entry.prefix, placementSessionId)
+    // MAJ-1: read `_expectedPlacementSessionId()` (and anything else before the
+    // first await) INSIDE the async body so a synchronous throw becomes a
+    // rejection rather than escaping `register()`. The container's load `.catch`
+    // (src/sharc-container.js) routes the typed rejection to
+    // `feature_load_failed`; a synchronous escape would bypass that path.
+    return Promise.resolve()
+      .then(() => this._derive(entry.prefix, this._expectedPlacementSessionId()))
       .then((nonce) => {
         entry.protocolNonce = nonce;
         if (entry.onReady) {
-          try { entry.onReady({ protocolNonce: nonce }); } catch (_) { /* ignore */ }
+          // SEC-M3: surface a throwing onReady instead of swallowing it. The
+          // derivation/delivery flow must NOT break for other protocols, so we
+          // still resolve `ready` and keep going — but a silent swallow left
+          // the container inconsistent with no signal. There is no diagnostic
+          // channel on the router for derivation-side events
+          // (`_onUnauthorizedProtocol` is reserved for inbound-envelope
+          // rejections), so console.warn with the router prefix is the fit.
+          try {
+            entry.onReady({ protocolNonce: nonce });
+          } catch (e) {
+            if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+              console.warn(
+                '[SHARCProtocolRouter] onReady threw for prefix "' + entry.prefix
+                + '": ' + (e && e.message ? e.message : String(e))
+              );
+            }
+          }
         }
         entry._resolveReady({ protocolNonce: nonce });
       })
@@ -387,10 +408,15 @@ class SHARCProtocolRouter {
     // 4. type is string
     if (typeof event.data.type !== 'string') return;
 
-    // 5. prefix registered
+    // 5. prefix registered. SEC-M2: prefixes are colon-terminated (enforced at
+    // register), so `startsWith` already pins the `:`-segment boundary — but
+    // require a non-empty remaining segment too, so a bare prefix (`A:B:` with
+    // no trailing type) cannot match. `A:B:` vs `A:BC:` stay disjoint because
+    // neither colon-terminated prefix is a startsWith of the other.
     let entry = null;
     for (const candidate of this._protocols.values()) {
-      if (event.data.type.startsWith(candidate.prefix)) {
+      if (event.data.type.startsWith(candidate.prefix)
+          && event.data.type.length > candidate.prefix.length) {
         entry = candidate;
         break;
       }

--- a/test/node/test-protocol-router-nonce-derivation.js
+++ b/test/node/test-protocol-router-nonce-derivation.js
@@ -262,6 +262,76 @@ console.log('test-protocol-router-nonce-derivation.js — 0.7.7 HMAC derivation 
   router.destroy();
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// Test #8 (§ 9.6 row #8) — RTR-D21 re-derive-before-gate-accepts integration.
+// SEC-M1's concern: the re-derivation path had no integration coverage proving
+// the gate flips atomically with the re-mint. This drives a single protocol
+// through a sequential-impression re-mint and pins all three invariants on the
+// SAME router instance: (a) the expected nonce rotates to a new value, (b)
+// onReady is re-invoked with that post-mint nonce, (c) an inbound envelope
+// stamped with the NEW nonce passes gate step 7 while the OLD-nonce envelope is
+// dropped — i.e. re-derivation completes before the gate accepts new-session
+// traffic.
+// ────────────────────────────────────────────────────────────────────────────
+{
+  console.log('\n7. RTR-D21 re-derive-before-gate-accepts integration (§ 9.6 #8)');
+  const { router, iframe, setSession } = newRouter({
+    rootNonce: 'integration-root',
+    placementSessionId: 'session-1',
+  });
+
+  let handlerCalls = 0;
+  const handlerNonces = [];
+  const onReadyNonces = [];
+  router.register({
+    prefix: 'R:',
+    types: { 'in': { phases: ['init'], direction: 'inbound' } },
+    handler: (msg) => { handlerCalls++; handlerNonces.push(msg.sharcNonce); },
+    onReady: ({ protocolNonce }) => { onReadyNonces.push(protocolNonce); },
+  });
+
+  const oldNonce = (await router.ready('R:')).protocolNonce;
+  assert(onReadyNonces.length === 1 && onReadyNonces[0] === oldNonce,
+    'onReady delivered the initial nonce before re-mint');
+
+  // Sequential impression: a new placementSessionId is minted, then the router
+  // re-derives every protocol nonce against it.
+  setSession('session-2');
+  await router.rederiveAllProtocolNonces();
+  const newNonce = (await router.ready('R:')).protocolNonce;
+
+  // (a) the expected nonce rotated to a distinct value.
+  assert(newNonce !== oldNonce,
+    '(a) re-mint rotates the protocol nonce to a new value distinct from the initial');
+  assert(router.getProtocol('R:').protocolNonce === newNonce,
+    '(a) router\'s expected nonce is the freshly-derived post-mint value');
+
+  // (b) onReady was re-invoked with the new nonce.
+  assert(onReadyNonces.length === 2 && onReadyNonces[1] === newNonce,
+    '(b) onReady was re-invoked with the post-mint nonce');
+
+  // (c) gate accepts the NEW-nonce envelope and drops the OLD-nonce one.
+  const newEnvelope = new dom.window.MessageEvent('message', {
+    data: { type: 'R:in', sharcNonce: newNonce, placementSessionId: 'session-2' },
+    origin: 'https://renderer.example',
+    source: iframe.contentWindow,
+  });
+  window.dispatchEvent(newEnvelope);
+  assert(handlerCalls === 1 && handlerNonces[0] === newNonce,
+    '(c) inbound envelope stamped with the NEW nonce passes gate step 7 and dispatches');
+
+  const oldEnvelope = new dom.window.MessageEvent('message', {
+    data: { type: 'R:in', sharcNonce: oldNonce, placementSessionId: 'session-2' },
+    origin: 'https://renderer.example',
+    source: iframe.contentWindow,
+  });
+  window.dispatchEvent(oldEnvelope);
+  assert(handlerCalls === 1,
+    '(c) inbound envelope stamped with the OLD nonce is dropped at gate step 7 (re-derive precedes acceptance)');
+
+  router.destroy();
+}
+
 if (failures === 0) {
   console.log('\n✓ All protocol-router-nonce-derivation assertions passed.');
   process.exit(0);

--- a/test/node/test-protocol-router.js
+++ b/test/node/test-protocol-router.js
@@ -652,6 +652,143 @@ console.log('test-protocol-router.js — 0.7.7 router primitive coverage\n');
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// MAJ-1 (#234): a throw before the first await in the derivation path surfaces
+// as a typed rejection out of `register()` → `ready()`, NOT a synchronous
+// throw out of `register()`. The container's load `.catch` depends on the
+// rejection carrying `.code === 'PROTOCOL_DERIVATION_FAILED'`.
+// ────────────────────────────────────────────────────────────────────────────
+{
+  console.log('\n12. MAJ-1 — pre-await throw surfaces as PROTOCOL_DERIVATION_FAILED rejection, not sync throw (#234)');
+  const iframe = freshIframe();
+  let threw = false;
+  const router = new SHARCProtocolRouter({
+    container: {},
+    iframe: () => iframe,
+    expectedRendererOrigin: () => 'https://renderer.example',
+    // Throws synchronously when read inside _deriveAndDeliver.
+    expectedPlacementSessionId: () => { throw new Error('boom from placementSessionId getter'); },
+    rootNonce: 'root-nonce-test-fixture',
+    onUnauthorizedProtocol: () => {},
+  });
+  try {
+    router.register({
+      prefix: 'THROW:',
+      types: { 'msg': { phases: ['init'], direction: 'inbound' } },
+      handler: () => {},
+    });
+  } catch (_) {
+    threw = true;
+  }
+  assert(threw === false,
+    'register() does NOT throw synchronously when the placementSessionId read throws');
+
+  let caught = null;
+  try { await router.ready('THROW:'); }
+  catch (err) { caught = err; }
+  assert(caught !== null, 'ready(prefix) rejects when the pre-await read throws');
+  assert(caught && caught.code === 'PROTOCOL_DERIVATION_FAILED',
+    'rejected error carries .code === "PROTOCOL_DERIVATION_FAILED" so the container routes it to feature_load_failed');
+  router.destroy();
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// SEC-M2 (#236): colon-segment boundary — `A:B:` and `A:BC:` register as
+// disjoint prefixes and an envelope routes to exactly one, never the other.
+// Single existing-prefix behavior (`SHARC:Renderer:`) is unchanged.
+// ────────────────────────────────────────────────────────────────────────────
+{
+  console.log('\n13. SEC-M2 — A:B: vs A:BC: colon-segment boundary (#236)');
+  const { router, iframe } = newRouter();
+  let abCalls = 0;
+  let abcCalls = 0;
+  router.register({
+    prefix: 'A:B:',
+    types: { 'msg': { phases: ['init'], direction: 'inbound' } },
+    handler: () => { abCalls++; },
+  });
+  router.register({
+    prefix: 'A:BC:',
+    types: { 'msg': { phases: ['init'], direction: 'inbound' } },
+    handler: () => { abcCalls++; },
+  });
+  const abNonce = (await router.ready('A:B:')).protocolNonce;
+  const abcNonce = (await router.ready('A:BC:')).protocolNonce;
+  assert(abNonce !== abcNonce, 'A:B: and A:BC: derive distinct nonces (disjoint prefixes)');
+
+  function fire(data) {
+    window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data, origin: 'https://renderer.example', source: iframe.contentWindow,
+    }));
+  }
+
+  // An A:BC: envelope must route ONLY to the A:BC: handler — the A:B: prefix
+  // must not greedily claim it (its remainder after stripping A:B: would be
+  // "C:msg", but A:B: is not a startsWith of "A:BC:msg").
+  fire({ type: 'A:BC:msg', sharcNonce: abcNonce, placementSessionId: 'session-1' });
+  assert(abcCalls === 1 && abCalls === 0,
+    'A:BC:msg routes to A:BC: handler only, never A:B:');
+
+  // An A:B: envelope routes only to A:B:.
+  fire({ type: 'A:B:msg', sharcNonce: abNonce, placementSessionId: 'session-1' });
+  assert(abCalls === 1 && abcCalls === 1,
+    'A:B:msg routes to A:B: handler only');
+
+  // A bare prefix with no trailing type segment must not match (non-empty
+  // remainder required at gate step 5).
+  fire({ type: 'A:B:', sharcNonce: abNonce, placementSessionId: 'session-1' });
+  assert(abCalls === 1,
+    'bare-prefix envelope (no trailing type segment) does not dispatch');
+  router.destroy();
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// SEC-M3 (#237): a throwing onReady is surfaced via console.warn (not silently
+// swallowed) and does NOT break derivation/delivery for other protocols.
+// ────────────────────────────────────────────────────────────────────────────
+{
+  console.log('\n14. SEC-M3 — throwing onReady surfaced, other protocols unaffected (#237)');
+  const { router } = newRouter();
+  const warnings = [];
+  const realWarn = console.warn;
+  console.warn = (...args) => { warnings.push(args.join(' ')); };
+  try {
+    router.register({
+      prefix: 'THROWS:',
+      types: { 'msg': { phases: ['init'], direction: 'inbound' } },
+      handler: () => {},
+      onReady: () => { throw new Error('onReady boom'); },
+    });
+    let otherReadyNonce = null;
+    router.register({
+      prefix: 'OTHER:',
+      types: { 'msg': { phases: ['init'], direction: 'inbound' } },
+      handler: () => {},
+      onReady: ({ protocolNonce }) => { otherReadyNonce = protocolNonce; },
+    });
+
+    // The throwing protocol's ready still resolves (delivery not broken).
+    const throwsNonce = (await router.ready('THROWS:')).protocolNonce;
+    assert(/^[A-Za-z0-9_-]{22}$/.test(throwsNonce),
+      'derivation completes and ready resolves even though onReady threw');
+
+    // The other protocol's derivation + onReady are unaffected.
+    const otherNonce = (await router.ready('OTHER:')).protocolNonce;
+    assert(otherNonce !== null && otherReadyNonce === otherNonce,
+      'a sibling protocol\'s onReady fires normally and ready resolves');
+
+    const surfaced = warnings.find((w) =>
+      /\[SHARCProtocolRouter\] onReady threw for prefix "THROWS:"/.test(w));
+    assert(surfaced != null,
+      'throwing onReady is surfaced via console.warn with the router prefix (not swallowed)');
+    assert(/onReady boom/.test(surfaced || ''),
+      'surfaced warning includes the original onReady error message');
+  } finally {
+    console.warn = realWarn;
+  }
+  router.destroy();
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Summary
 // ────────────────────────────────────────────────────────────────────────────
 if (failures === 0) {


### PR DESCRIPTION
Resolves the four router-hardening follow-ups deferred from the 0.7.7 review (#234–#237). Reviewed by Code Reviewer + Security Engineer (both SHIP); the #235 disposition was decided by Jeffrey after the review surfaced a cross-cutting concern.

## Findings

**#234 (MAJ-1)** — `_expectedPlacementSessionId()` was read synchronously outside `_deriveAndDeliver`'s promise chain, so a throw escaped `register()` synchronously instead of via the typed `PROTOCOL_DERIVATION_FAILED` rejection (→ `feature_load_failed`). Fixed: the read now runs inside `Promise.resolve().then(...)`, so any synchronous throw becomes a rejection routed to the container's load `.catch`. Test #12 forces the throw and asserts no synchronous escape from `register()` + the typed `.code`.

**#236 (SEC-M2)** — dispatch prefix-match tightened with `&& event.data.type.length > candidate.prefix.length`. Since prefixes are colon-terminated at register time, `startsWith` pins the `:`-segment boundary; the length check rejects a bare-prefix envelope and keeps `A:B:`/`A:BC:` disjoint. Test #13 covers bare-prefix drop and `A:BC:`-vs-`A:B:` routing. Security review traced every prefix-confusion input — S1 (envelope-type impersonation) MITIGATED, no routing confusion.

**#237 (SEC-M3)** — a throwing `onReady` was silently swallowed by `catch(_){}`. Now surfaced via `console.warn('[SHARCProtocolRouter] ...')`; the flow still resolves `ready` so sibling protocols are unaffected. `console.warn` over `_onUnauthorizedProtocol` (which is semantically reserved for inbound-envelope rejections). Security confirmed no secret material (nonce/session id) is logged. Test #14 covers surfaced warning + unaffected sibling.

**#235 (SEC-M1) — KEEP + add test (not remove).** The original finding offered "remove the unused `rederiveAllProtocolNonces()`" or "keep + add the missing integration test." The first pass removed it; review flagged that RTR-D21 is a ✅-Locked decision referenced ~10 places in the design doc — including §9.6 test-matrix row #8 and §16.1 item 4, the **OMID 0.7.8 hand-off ledger**. With 0.7.8 OMID confirmed as the next release and its consumer, removing the method to re-add it next release is churn + interim spec drift. Disposition: **keep the method** (restored verbatim — `git diff` vs main shows the method body identical) and **add the RTR-D21 integration test** (§9.6 #8) the review wanted — closing SEC-M1's actual concern (the re-derivation path had no integration coverage):
- re-mint rotates the protocol nonce to a distinct value (atomic expected-nonce update);
- `onReady` re-fires with the new nonce;
- a new-nonce envelope passes gate step 7 and dispatches; an old-nonce envelope is dropped.

## Scope verification
`git diff origin/main -- src/sharc-protocol-router.js` shows **only** #234 + #236 + #237. `rederiveAllProtocolNonces()` and its `ready()` doc clause are byte-identical to main. No version bump (0.7.8 reserved for the OMID arc); `package-lock.json` untouched.

## Validation
- `npm run test:all:built` — pass
- `npm run test:perf` — pass (Markup P95 regression within 600ms budget)
- `npm run build` — pass
- `tsc -p tsconfig.types.json` — clean

## Related
- Reviews: Code Reviewer + Security Engineer, both SHIP / SHIP-WITH-FIXES; the only flagged item (#235 disposition) is resolved above.
- **#240** — Security L1 tripwire: make `placementSessionId` structurally immutable + gate sequential-impression re-mint behind re-derivation. Filed `blocked`, to land WITH the 0.7.8 sequential-impression work — not this PR.
- Closes #234, #236, #237. #235 resolved as keep+test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)