### PR TITLE
chore: add version-consistency CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Version consistency guard — package.json ↔ lockfile ↔ source (#238)
+        run: node scripts/sync-version.js --check
+
       - name: Build all modules
         run: npm run build
 

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -4,6 +4,11 @@
  *
  * Run automatically via the npm "version" lifecycle script, or manually:
  *   node scripts/sync-version.js
+ *
+ * With --check, writes nothing and exits non-zero if any tracked file (source,
+ * README, or package-lock.json) disagrees with package.json's version. CI runs
+ * this to catch a non-canonical bump that strands a file — the failure mode
+ * that left package-lock.json at 0.7.6 during the 0.7.7 cut (#238).
  */
 
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -13,10 +18,12 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 
+const CHECK = process.argv.includes('--check');
+
 const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
 const version = pkg.version;
 
-console.log(`Syncing version ${version} across source files...`);
+console.log(`${CHECK ? 'Checking' : 'Syncing'} version ${version} across source files...`);
 
 const replacements = [
   // SHARC_VERSION constant (single source of truth)
@@ -28,52 +35,52 @@ const replacements = [
   // @version JSDoc tags
   {
     file: 'src/sharc-protocol.js',
-    pattern: /(@version )\S+/,
+    pattern: /(@version )\S+/g,
     replacement: `$1${version}`,
   },
   {
     file: 'src/sharc-container.js',
-    pattern: /(@version )\S+/,
+    pattern: /(@version )\S+/g,
     replacement: `$1${version}`,
   },
   {
     file: 'src/lifecycle-adapters/base-adapter.js',
-    pattern: /(@version )\S+/,
+    pattern: /(@version )\S+/g,
     replacement: `$1${version}`,
   },
   {
     file: 'src/lifecycle-adapters/html-adapter.js',
-    pattern: /(@version )\S+/,
+    pattern: /(@version )\S+/g,
     replacement: `$1${version}`,
   },
   {
     file: 'src/sharc-creative.js',
-    pattern: /(@version )\S+/,
+    pattern: /(@version )\S+/g,
     replacement: `$1${version}`,
   },
   {
     file: 'src/sharc-mraid-bridge.js',
-    pattern: /(@version )\S+/,
+    pattern: /(@version )\S+/g,
     replacement: `$1${version}`,
   },
   {
     file: 'src/sharc-safeframe-bridge.js',
-    pattern: /(@version )\S+/,
+    pattern: /(@version )\S+/g,
     replacement: `$1${version}`,
   },
   {
     file: 'src/sharc-omid-bridge.js',
-    pattern: /(@version )\S+/,
+    pattern: /(@version )\S+/g,
     replacement: `$1${version}`,
   },
   {
     file: 'src/sharc-navigation-bridge.js',
-    pattern: /(@version )\S+/,
+    pattern: /(@version )\S+/g,
     replacement: `$1${version}`,
   },
   {
     file: 'src/sharc-protocol-router.js',
-    pattern: /(@version )\S+/,
+    pattern: /(@version )\S+/g,
     replacement: `$1${version}`,
   },
   // README badge
@@ -91,18 +98,52 @@ const replacements = [
 ];
 
 let updated = 0;
+const drift = [];
 
 for (const { file, pattern, replacement } of replacements) {
   const filepath = resolve(root, file);
   const content = readFileSync(filepath, 'utf8');
   const newContent = content.replace(pattern, replacement);
   if (newContent !== content) {
-    writeFileSync(filepath, newContent, 'utf8');
-    console.log(`  ✓ ${file}`);
-    updated++;
+    if (CHECK) {
+      drift.push(file);
+      console.log(`  ✗ ${file} (out of sync)`);
+    } else {
+      writeFileSync(filepath, newContent, 'utf8');
+      console.log(`  ✓ ${file}`);
+      updated++;
+    }
   } else {
-    console.log(`  – ${file} (already up to date)`);
+    console.log(`  – ${file} (matches ${version})`);
   }
 }
 
-console.log(`\nDone. ${updated} file(s) updated to ${version}.`);
+// package-lock.json is updated by `npm version` itself, not by the replacement
+// table above. Check mode verifies it anyway because a non-canonical bump that
+// skips `npm version` strands it (see header / #238).
+const lock = JSON.parse(readFileSync(resolve(root, 'package-lock.json'), 'utf8'));
+const lockVersions = {
+  'package-lock.json (root .version)': lock.version,
+  'package-lock.json (.packages[""].version)': lock.packages?.['']?.version,
+};
+for (const [label, lockVersion] of Object.entries(lockVersions)) {
+  if (lockVersion !== version) {
+    drift.push(label);
+    console.log(`  ✗ ${label}: ${lockVersion} (expected ${version})`);
+  } else {
+    console.log(`  – ${label} (matches ${version})`);
+  }
+}
+
+if (CHECK) {
+  if (drift.length > 0) {
+    console.error(
+      `\nVersion drift: ${drift.length} target(s) disagree with package.json (${version}).`
+      + `\nRun \`npm version <bump>\` (not a manual edit) so package-lock.json stays in sync, then \`node scripts/sync-version.js\`.`,
+    );
+    process.exit(1);
+  }
+  console.log(`\nOK. All tracked targets match ${version}.`);
+} else {
+  console.log(`\nDone. ${updated} file(s) updated to ${version}.`);
+}


### PR DESCRIPTION
## Summary

Adds a `--check` mode to `scripts/sync-version.js` and runs it in CI right after `npm ci`. The check writes nothing and exits non-zero if any tracked target disagrees with `package.json`'s version:
- source `@version` JSDoc tags + the `SHARC_VERSION` constant
- README badge + CDN example URLs
- **`package-lock.json`** (root `.version` and `.packages[""].version`)

## Why

The 0.7.7 cut propagated the version via `sync-version.js` but skipped `npm version`, so `package-lock.json` was stranded at `0.7.6` while everything else read `0.7.7` (fixed reactively in #238). `sync-version.js` doesn't write the lockfile (that's `npm version`'s job), so nothing caught the drift — CI tolerated the mismatch and it rode to the release tag.

Had this guard existed, **#231 would have failed CI** instead of shipping the desync. It's the structural tripwire the #238 process-note asked for.

## Behavior

- On a synced tree: prints each target as matching, exits 0.
- On drift: prints the offending target(s) (e.g. `package-lock.json (root .version): 0.7.6 (expected 0.7.7)`) and exits 1 with a hint to use `npm version` rather than a manual edit.
- Normal `node scripts/sync-version.js` (no flag) is unchanged — still propagates and writes.

## Validation

- `node scripts/sync-version.js --check` on current main → exit 0 (all targets match 0.7.7)
- Negative test: temporarily desync the lockfile → exit 1, correct target named
- Normal sync mode (no `--check`) → unchanged, no writes on an already-synced tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)