### PR TITLE
docs: add blank opaque document reduction

### DIFF
--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -270,6 +270,9 @@ attempts that remain `navigation-policy` failures.
 `005-document-source-classification` captures normal nested document activity:
 static `srcdoc`/`about:blank` frames and external frame `src` assignments should
 pass while emitting document-source classes for private corpus triage.
+`006-blank-opaque-document-sources` captures delayed opaque child documents:
+post-load `about:blank`, URL-less, and `srcdoc` iframe creation should pass
+while separating row-level blank/opaque prevalence from repeated event counts.
 
 ### Security
 

--- a/tools/creative-validator/fixtures/reductions/006-blank-opaque-document-sources/README.md
+++ b/tools/creative-validator/fixtures/reductions/006-blank-opaque-document-sources/README.md
@@ -1,0 +1,24 @@
+# 006 Blank/Opaque Document Sources
+
+Synthetic reduction for private corpus rows where creatives create delayed
+opaque nested documents (`about:blank`, URL-less iframes, and `srcdoc`) after the
+main creative document is already running.
+
+The May 30, 2026 post-#232 private corpus pass showed this pattern as common
+and non-fatal: `blank-or-opaque-document` appeared in 217 passed rows,
+`srcdoc-frame` in 12 passed rows, and none of the blank/opaque rows had failed
+document requests. Most examples were delayed observed iframes rather than
+same-frame renderer navigation.
+
+The fixture pins these validator boundaries:
+
+- delayed `about:blank` iframe creation should pass and classify as
+  `blank-or-opaque-document` + `observed-frame`.
+- delayed URL-less `srcdoc` iframe creation should pass and classify as
+  `blank-or-opaque-document` + `observed-frame` + `srcdoc-frame`.
+- repeated opaque iframe creation should pass and increase event counts without
+  changing the row-level pass/fail bucket.
+
+This reduction does not make opaque child frames a SHARC failure. It documents
+that opaque nested documents are normal creative behavior and remain distinct
+from same-frame renderer navigation-policy failures.

--- a/tools/creative-validator/fixtures/reductions/006-blank-opaque-document-sources/cleaned-corpus.fixture.json
+++ b/tools/creative-validator/fixtures/reductions/006-blank-opaque-document-sources/cleaned-corpus.fixture.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "auction-row-blank-opaque-document-sources",
+    "auction": [
+      {
+        "bidder": "synthetic-opaque-delayed-about",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-opaque-delayed-about",
+          "imp": [
+            {
+              "id": "imp-opaque-delayed-about",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-opaque-delayed-about",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-opaque-delayed-about",
+                  "impid": "imp-opaque-delayed-about",
+                  "crid": "creative-opaque-delayed-about",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><div>synthetic delayed about frame</div><script>window.addEventListener('load',function(){setTimeout(function(){var frame=document.createElement('iframe');frame.src='about:blank';document.body.appendChild(frame);},50);});</script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "bidder": "synthetic-opaque-delayed-srcdoc",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-opaque-delayed-srcdoc",
+          "imp": [
+            {
+              "id": "imp-opaque-delayed-srcdoc",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-opaque-delayed-srcdoc",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-opaque-delayed-srcdoc",
+                  "impid": "imp-opaque-delayed-srcdoc",
+                  "crid": "creative-opaque-delayed-srcdoc",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><div>synthetic delayed srcdoc frame</div><script>window.addEventListener('load',function(){setTimeout(function(){var frame=document.createElement('iframe');frame.srcdoc='<!doctype html><html><body>delayed srcdoc frame</body></html>';document.body.appendChild(frame);},50);});</script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "bidder": "synthetic-opaque-repeated-frames",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-opaque-repeated-frames",
+          "imp": [
+            {
+              "id": "imp-opaque-repeated-frames",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-opaque-repeated-frames",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-opaque-repeated-frames",
+                  "impid": "imp-opaque-repeated-frames",
+                  "crid": "creative-opaque-repeated-frames",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><div>synthetic repeated opaque frames</div><script>window.addEventListener('load',function(){setTimeout(function(){var a=document.createElement('iframe');a.src='about:blank';document.body.appendChild(a);var b=document.createElement('iframe');document.body.appendChild(b);var c=document.createElement('iframe');c.srcdoc='<!doctype html><html><body>second delayed srcdoc frame</body></html>';document.body.appendChild(c);},50);});</script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -24,10 +24,14 @@ const navigationReductionPath = resolve(
 const documentSourceReductionPath = resolve(
   'tools/creative-validator/fixtures/reductions/005-document-source-classification/cleaned-corpus.fixture.json',
 );
+const opaqueDocumentReductionPath = resolve(
+  'tools/creative-validator/fixtures/reductions/006-blank-opaque-document-sources/cleaned-corpus.fixture.json',
+);
 const reductionPorts = {
   externalScript: { runner: '18879', renderer: '18880' },
   navigation: { runner: '18869', renderer: '18870' },
   documentSource: { runner: '18877', renderer: '18878' },
+  opaqueDocument: { runner: '18881', renderer: '18882' },
 };
 
 function makeCase(overrides) {
@@ -1432,6 +1436,78 @@ test('runner documents nested document-source reduction as passing diagnostics',
       'observed-frame|synthetic-document-source-frame-src-property': 1,
       'observed-frame|synthetic-document-source-srcdoc': 1,
       'srcdoc-frame|synthetic-document-source-srcdoc': 1,
+    });
+  });
+});
+
+test('runner documents delayed opaque document-source reduction as passing diagnostics', () => {
+  withReductionFixture({
+    fixturePath: opaqueDocumentReductionPath,
+    workDirPrefix: 'test-runner-opaque-documents-',
+    ports: reductionPorts.opaqueDocument,
+    runOptions: [
+      '--settle-ms',
+      '1500',
+    ],
+    includeTriage: true,
+  }, ({ reports, summary }) => {
+    assert.equal(reports.length, 3);
+    assert.equal(reports.filter((row) => row.outcome.status === 'passed').length, 3);
+    assert.equal(reports.filter((row) => row.outcome.bucket === 'passed').length, 3);
+
+    const byBid = (bidId) => reports.find((row) => row.case.ids.bidId === bidId);
+    const about = byBid('bid-opaque-delayed-about');
+    assert.ok(about);
+    assert.equal(about.diagnostics.navigationDiagnostics.documentSources.count, 1);
+    assert.deepEqual(about.diagnostics.navigationDiagnostics.documentSources.byKind, { frame: 1 });
+    assert.deepEqual(about.diagnostics.navigationDiagnostics.documentSources.byProtocol, { 'about:': 1 });
+
+    const srcdoc = byBid('bid-opaque-delayed-srcdoc');
+    assert.ok(srcdoc);
+    assert.equal(srcdoc.diagnostics.navigationDiagnostics.documentSources.count, 1);
+    assert.deepEqual(srcdoc.diagnostics.navigationDiagnostics.documentSources.byKind, { frame: 1 });
+    assert.deepEqual(srcdoc.diagnostics.navigationDiagnostics.documentSources.byProtocol, { unknown: 1 });
+    assert.ok(srcdoc.diagnostics.navigationDiagnostics.documentSources.calls.some((call) =>
+      call.kind === 'frame' && call.srcdoc === true));
+
+    const repeated = byBid('bid-opaque-repeated-frames');
+    assert.ok(repeated);
+    assert.equal(repeated.diagnostics.navigationDiagnostics.documentSources.count, 3);
+    assert.deepEqual(repeated.diagnostics.navigationDiagnostics.documentSources.byKind, { frame: 3 });
+    assert.deepEqual(repeated.diagnostics.navigationDiagnostics.documentSources.byProtocol, {
+      'about:': 1,
+      unknown: 2,
+    });
+    assert.equal(
+      repeated.diagnostics.navigationDiagnostics.documentSources.calls.filter((call) => call.srcdoc === true).length,
+      1,
+    );
+
+    const network = summary.corpusDiagnostics.network;
+    assert.equal(summary.totals.passed, 3);
+    assert.equal(summary.totals.failed, 0);
+    assert.equal(network.rowsWithFailedRequests, 0);
+    assert.equal(network.rowsWithFailedDocuments, 0);
+    assert.equal(network.rowsWithDocumentSources, 3);
+    assert.deepEqual(network.documentSourceRowsByClass, {
+      'blank-or-opaque-document': 3,
+      'observed-frame': 3,
+      'srcdoc-frame': 2,
+    });
+    assert.deepEqual(network.documentSourceEventsByClass, {
+      'blank-or-opaque-document': 5,
+      'observed-frame': 5,
+      'srcdoc-frame': 2,
+    });
+    assert.deepEqual(network.documentSourceRowsByClassAndBidder, {
+      'blank-or-opaque-document|synthetic-opaque-delayed-about': 1,
+      'blank-or-opaque-document|synthetic-opaque-delayed-srcdoc': 1,
+      'blank-or-opaque-document|synthetic-opaque-repeated-frames': 1,
+      'observed-frame|synthetic-opaque-delayed-about': 1,
+      'observed-frame|synthetic-opaque-delayed-srcdoc': 1,
+      'observed-frame|synthetic-opaque-repeated-frames': 1,
+      'srcdoc-frame|synthetic-opaque-delayed-srcdoc': 1,
+      'srcdoc-frame|synthetic-opaque-repeated-frames': 1,
     });
   });
 });


### PR DESCRIPTION
## Summary
- add reduction 006 for delayed blank/opaque child-document creation
- document that post-load about:blank, URL-less, and srcdoc iframe creation remains a passing diagnostic boundary
- add runner coverage that checks row-level and event-level document-source triage counts

## Validation
- npm run test:creative-validator-runner
- npx eslint tools/creative-validator/test/test-runner.js --max-warnings=0
- node -e JSON parse check for the new fixture
- git diff --check