### PR TITLE
docs: add unauthorized_protocol security event to api-reference

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1514,7 +1514,7 @@ type SHARCSecurityEvent = {
   type: 'wrapper_top_frame_inaccessible' | 'renderer_origin_mismatch'
       | 'renderer_protocol_error' | 'renderer_failed'
       | 'bridge_load_failed' | 'unauthorized_navigation'
-      | 'feature_load_failed';
+      | 'feature_load_failed' | 'unauthorized_protocol';
   severity: 'warning' | 'error';
   errorCode?: number;          // present on terminating variants only
   timestamp: number;           // Date.now() at emit
@@ -1524,9 +1524,9 @@ type SHARCSecurityEvent = {
 };
 ```
 
-`severity` is the discriminator between non-terminating warnings (`'warning'` — currently only the wrapper-cross-origin carve-out) and terminating errors (`'error'` — every other variant). Operator dashboards typically alert on `severity === 'error'` and log-only on `'warning'`. Note that `feature_load_failed` carries `severity: 'error'` despite being non-terminating — see the variant's row below for the distinction.
+`severity` is the discriminator between non-terminating warnings (`'warning'` — currently only the wrapper-cross-origin carve-out) and terminating errors (`'error'` — every other variant). Operator dashboards typically alert on `severity === 'error'` and log-only on `'warning'`. Note that `feature_load_failed` and `unauthorized_protocol` carry `severity: 'error'` despite being non-terminating — see each variant's row below for the distinction.
 
-The seven reserved `type` values and their `details` schemas:
+The eight reserved `type` values and their `details` schemas:
 
 | `type` | `severity` | `errorCode` | `details` |
 |---|---|---|---|
@@ -1537,6 +1537,7 @@ The seven reserved `type` values and their `details` schemas:
 | `bridge_load_failed` (0.7.1+) | `'error'` | `2115` | `{ reason, bridge, url }` — `bridge` is the failed identifier (`'mraid'`, `'safeframe'`, …), bounded to 200 chars; `url` is the resolved bridge-module URL (or substituted-but-unparseable template string on the unparseable-URL path), bounded to 500 chars, `''` when unavailable; `reason` is the literal `'bridge_load_failed'` for parity with `renderer_failed`. |
 | `unauthorized_navigation` | `'error'` | `2118` | `{ variant: 'markup' \| 'url', msSinceRender: number }` |
 | `feature_load_failed` (0.7.4+) | `'error'` | — (non-terminating; no code) | `{ featureName, reason, scriptUrl }` — `featureName` is the canonical `supportedFeatures` entry whose load failed (e.g. `'com.iabtechlab.sharc.omid'`); `reason` is a classified token — current in-tree bridges emit `'timeout'`, `'network'`, or `'evaluation_throw'` (script-tag loaders cannot distinguish a 404 from other transport failures; future fetch-based loaders may emit additional tokens like `'http_404'`); `scriptUrl` is the URL that failed to load, bounded to 500 chars (parity with `bridge_load_failed.details.url`). |
+| `unauthorized_protocol` (0.7.7+) | `'error'` | — (non-terminating; no code) | `{ type, phase, reason }` — payload is **deliberately minimized** to three enumerated, attacker-uncontrolled fields. `type` is a registered prefix (e.g. `'SHARC:Renderer:'`) or the literal `'unknown-prefix'` for prefix-unregistered envelopes. `phase` is one of the six router-tracked lifecycle phases: `'init' \| 'attaching-renderer' \| 'rendered' \| 'omid-active' \| 'creative-active' \| 'terminated'`. `reason` discriminates which router gate-step failed: `'out-of-phase' \| 'nonce-mismatch' \| 'prefix-unregistered'`. No attacker-controlled string (envelope payload, raw `event.data.type`, etc.) is included. Fires when an inbound envelope passes every trust-anchor check (source, origin, registered prefix, placementSessionId, protocol nonce, declared type) but arrives in a lifecycle phase outside the type's declared `phases` set. Defends against cross-protocol envelope-type impersonation by iframe-side extensions. Per [`docs/design/0.7.7-cross-frame-protocol-router.md`](design/0.7.7-cross-frame-protocol-router.md) § 8. |
 
 Note: timeout (`2114`), post-failed (`2119`), and integrity-failed (`2120`) all surface as `renderer_protocol_error` on the structured channel — the spec vocabulary does not include them as distinct event types. The `details.subtype` discriminates inside the variant.
 


### PR DESCRIPTION
## Summary

0.7.7 introduced the `unauthorized_protocol` `SHARCSecurityEvent` variant (non-terminating, `severity: 'error'`), but `docs/api-reference.md` was never updated. Operators implementing `onSecurityEvent` switch statements had no documented schema for the variant despite it being a public observability surface.

## Changes — `docs/api-reference.md` (+4/-3)

- Add `'unauthorized_protocol'` to the `SHARCSecurityEvent.type` union
- Update the carve-out note to flag both `feature_load_failed` AND `unauthorized_protocol` as non-terminating with `severity: 'error'`
- Update "The seven reserved `type` values" → "eight"
- Add a full variant row documenting the `{type, phase, reason}` payload, the enumerated values for each field, the rationale (cross-protocol envelope-type impersonation defense), and a link to `docs/design/0.7.7-cross-frame-protocol-router.md` § 8

## Explicitly out of scope

- `container.protocolRouter` (the extension-registration surface from the same release) is **not** documented here. CHANGELOG classifies it as "not part of the creative-facing public API" — exposing it in `api-reference.md` is a separate documentation decision worth its own conversation.
- `README.md` / `architecture-design.md` / `architecture-overview.md` were not touched. The router is mostly internal; an architectural diagram update is a bigger change that should go through design.

## How this was surfaced

A targeted docs-sweep against the known-debt memory note (which turned out to be stale — `restore→collapse`, `placementType`, dismiss-button all already reflected in current docs). Pivoting to "did 0.7.7's public surface drift?" caught this one gap.

## Test plan

- [x] `git diff --check` clean
- [x] Internal link to `docs/design/0.7.7-cross-frame-protocol-router.md` § 8 resolves
- [x] Markdown table renders (8 rows now, previously 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)