### PR TITLE
docs: add CSP embedded frame reduction

### DIFF
--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -273,6 +273,10 @@ pass while emitting document-source classes for private corpus triage.
 `006-blank-opaque-document-sources` captures delayed opaque child documents:
 post-load `about:blank`, URL-less, and `srcdoc` iframe creation should pass
 while separating row-level blank/opaque prevalence from repeated event counts.
+`007-csp-embedded-frame-diagnostics` captures Chromium CSP Embedded
+Enforcement diagnostics from child iframes that do not opt into the renderer
+iframe's CSP. These rows should pass while reporting CSP console and
+document-source diagnostics, without being conflated with script CSP failures.
 
 ### Security
 

--- a/tools/creative-validator/fixtures/csp-embedded-child.js
+++ b/tools/creative-validator/fixtures/csp-embedded-child.js
@@ -1,0 +1,7 @@
+window.addEventListener('load', function () {
+  setTimeout(function () {
+    var frame = document.createElement('iframe');
+    frame.src = '/tools/creative-validator/fixtures/csp-embedded-child.txt';
+    document.body.appendChild(frame);
+  }, 50);
+});

--- a/tools/creative-validator/fixtures/csp-embedded-child.txt
+++ b/tools/creative-validator/fixtures/csp-embedded-child.txt
@@ -1,0 +1,1 @@
+Synthetic child document without a Content-Security-Policy response header.

--- a/tools/creative-validator/fixtures/reductions/007-csp-embedded-frame-diagnostics/README.md
+++ b/tools/creative-validator/fixtures/reductions/007-csp-embedded-frame-diagnostics/README.md
@@ -1,0 +1,30 @@
+# 007 CSP Embedded Frame Diagnostics
+
+Synthetic reduction for private corpus rows where creatives create child
+iframes that trigger Chromium CSP Embedded Enforcement console messages while
+the top-level SHARC creative continues to run successfully.
+
+The May 30, 2026 post-#245 private corpus pass showed this pattern as common
+and non-fatal: CSP-like console diagnostics appeared in 458 passed rows, mostly
+from external child frames blocked by the renderer iframe's embedded CSP
+requirement. Only 5 of those rows also had script-load errors, so the dominant
+pattern is child-frame CSP diagnostics rather than broken creative scripts.
+
+The fixture pins these validator boundaries:
+
+- a child iframe whose response does not opt into the embedder's CSP should pass
+  the creative row and report CSP console diagnostics.
+- delayed child-frame creation should pass and classify as normal
+  document-source activity as well as CSP console diagnostics.
+- CSP console diagnostics without script-load errors should not be classified
+  as `script-csp-blocked`.
+
+The companion `tools/creative-validator/fixtures/csp-embedded-child.txt` file is
+load-bearing: the dev server returns it as a successful non-HTML response
+without a Content-Security-Policy header, which is what lets Chromium produce
+the embedded-enforcement console diagnostic for the child document load.
+
+This reduction does not weaken the renderer CSP requirement. It documents that
+Chromium's CSP Embedded Enforcement console output is expected diagnostic noise
+for child frames that do not opt in with compatible policy headers, and remains
+distinct from SHARC navigation-policy or bridge failures.

--- a/tools/creative-validator/fixtures/reductions/007-csp-embedded-frame-diagnostics/cleaned-corpus.fixture.json
+++ b/tools/creative-validator/fixtures/reductions/007-csp-embedded-frame-diagnostics/cleaned-corpus.fixture.json
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "auction-row-csp-embedded-frame-diagnostics",
+    "auction": [
+      {
+        "bidder": "synthetic-csp-embedded-static-frame",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-csp-embedded-static-frame",
+          "imp": [
+            {
+              "id": "imp-csp-embedded-static-frame",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-csp-embedded-static-frame",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-csp-embedded-static-frame",
+                  "impid": "imp-csp-embedded-static-frame",
+                  "crid": "creative-csp-embedded-static-frame",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><div>synthetic CSP embedded static frame</div><iframe src=\"/tools/creative-validator/fixtures/csp-embedded-child.txt\"></iframe></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "bidder": "synthetic-csp-embedded-delayed-frame",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "request-csp-embedded-delayed-frame",
+          "imp": [
+            {
+              "id": "imp-csp-embedded-delayed-frame",
+              "instl": 0,
+              "secure": 1,
+              "banner": {
+                "w": 320,
+                "h": 50
+              }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "response-csp-embedded-delayed-frame",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "bid-csp-embedded-delayed-frame",
+                  "impid": "imp-csp-embedded-delayed-frame",
+                  "crid": "creative-csp-embedded-delayed-frame",
+                  "adomain": ["advertiser.example"],
+                  "w": 320,
+                  "h": 50,
+                  "adm": "<!doctype html><html><body><div>synthetic CSP embedded delayed frame</div><script src=\"/tools/creative-validator/fixtures/csp-embedded-child.js\"></script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -27,11 +27,15 @@ const documentSourceReductionPath = resolve(
 const opaqueDocumentReductionPath = resolve(
   'tools/creative-validator/fixtures/reductions/006-blank-opaque-document-sources/cleaned-corpus.fixture.json',
 );
+const cspEmbeddedFrameReductionPath = resolve(
+  'tools/creative-validator/fixtures/reductions/007-csp-embedded-frame-diagnostics/cleaned-corpus.fixture.json',
+);
 const reductionPorts = {
   externalScript: { runner: '18879', renderer: '18880' },
   navigation: { runner: '18869', renderer: '18870' },
   documentSource: { runner: '18877', renderer: '18878' },
   opaqueDocument: { runner: '18881', renderer: '18882' },
+  cspEmbeddedFrame: { runner: '18885', renderer: '18886' },
 };
 
 function makeCase(overrides) {
@@ -1509,5 +1513,69 @@ test('runner documents delayed opaque document-source reduction as passing diagn
       'srcdoc-frame|synthetic-opaque-delayed-srcdoc': 1,
       'srcdoc-frame|synthetic-opaque-repeated-frames': 1,
     });
+  });
+});
+
+test('runner documents CSP embedded-frame diagnostics as passing diagnostics', () => {
+  withReductionFixture({
+    fixturePath: cspEmbeddedFrameReductionPath,
+    workDirPrefix: 'test-runner-csp-embedded-frames-',
+    ports: reductionPorts.cspEmbeddedFrame,
+    runOptions: [
+      '--settle-ms',
+      '1500',
+    ],
+    includeTriage: true,
+  }, ({ reports, summary }) => {
+    assert.equal(reports.length, 2);
+    assert.equal(reports.filter((row) => row.outcome.status === 'passed').length, 2);
+    assert.equal(reports.filter((row) => row.outcome.bucket === 'passed').length, 2);
+
+    const byBid = (bidId) => reports.find((row) => row.case.ids.bidId === bidId);
+    const staticFrame = byBid('bid-csp-embedded-static-frame');
+    assert.ok(staticFrame);
+    assert.equal(staticFrame.diagnostics.network.cspConsoleCount, 1);
+    assert.equal(staticFrame.diagnostics.network.failedRequestCount, 1);
+    assert.equal(staticFrame.diagnostics.network.byResourceType.document, 1);
+    assert.match(
+      staticFrame.diagnostics.network.cspConsole[0].text,
+      /Content Security Policy/,
+    );
+    assert.equal(staticFrame.diagnostics.navigationDiagnostics.documentSources.count, 1);
+    assert.equal(staticFrame.diagnostics.navigationDiagnostics.documentSources.byKind.frame, 1);
+    assert.equal(staticFrame.diagnostics.navigationDiagnostics.scriptLoads.errorCount, 0);
+
+    const delayedFrame = byBid('bid-csp-embedded-delayed-frame');
+    assert.ok(delayedFrame);
+    assert.equal(delayedFrame.diagnostics.network.cspConsoleCount, 1);
+    assert.equal(delayedFrame.diagnostics.network.failedRequestCount, 1);
+    assert.equal(delayedFrame.diagnostics.network.byResourceType.document, 1);
+    assert.equal(delayedFrame.diagnostics.navigationDiagnostics.documentSources.count, 2);
+    assert.equal(delayedFrame.diagnostics.navigationDiagnostics.documentSources.byKind.frame, 1);
+    assert.equal(delayedFrame.diagnostics.navigationDiagnostics.documentSources.byKind['frame-src'], 1);
+    assert.equal(delayedFrame.diagnostics.navigationDiagnostics.scriptLoads.loadedCount, 1);
+    assert.equal(delayedFrame.diagnostics.navigationDiagnostics.scriptLoads.errorCount, 0);
+
+    const network = summary.corpusDiagnostics.network;
+    assert.equal(summary.totals.passed, 2);
+    assert.equal(summary.totals.failed, 0);
+    assert.equal(network.rowsWithCspConsole, 2);
+    assert.equal(network.rowsWithFailedDocuments, 2);
+    assert.equal(network.byShape['request:1 response:0 cors:0 csp:1'], 2);
+    assert.deepEqual(network.cspRowsByBidder, {
+      'synthetic-csp-embedded-delayed-frame': 1,
+      'synthetic-csp-embedded-static-frame': 1,
+    });
+    assert.deepEqual(network.documentSourceRowsByClass, {
+      'external-frame': 2,
+      'insecure-frame': 2,
+      'observed-frame': 2,
+      'frame-src-assignment': 1,
+    });
+
+    const scripts = summary.corpusDiagnostics.scriptLoads;
+    assert.equal(scripts.rowsWithErrors, 0);
+    assert.equal(scripts.rowsWithErrorsByClass['script-csp-blocked'], undefined);
+    assert.deepEqual(scripts.rowsWithErrorsByClass, {});
   });
 });


### PR DESCRIPTION
## Summary
- add reduction 007 for Chromium CSP Embedded Enforcement diagnostics from child iframes
- pin that CSP child-frame console diagnostics remain pass-only network/document-source diagnostics
- assert these rows are not classified as script CSP failures when script loads are clean

## Corpus signal
The May 30, 2026 post-#245 private corpus pass had 458 passed rows with CSP-like console diagnostics. Only 5 also had script-load errors; the dominant pattern is child-frame CSP diagnostic noise, not broken scripts.

## Validation
- npm run test:creative-validator-runner
- npx eslint tools/creative-validator/test/test-runner.js --max-warnings=0
- node -e JSON parse check for the new fixture
- git diff --check