### PR TITLE
test: classify inline OMID vendor instrumentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@size-limit/preset-big-lib": "^12.1.0",
         "eslint": "^9.0.0",
         "globals": "^15.0.0",
+        "htmlparser2": "^9.1.0",
         "jsdom": "^26.1.0",
         "puppeteer-core": "^24.22.0",
         "rollup": "^4.12.0",
@@ -2038,6 +2039,78 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.339",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
@@ -2774,6 +2847,39 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-proxy-agent": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@size-limit/preset-big-lib": "^12.1.0",
     "eslint": "^9.0.0",
     "globals": "^15.0.0",
+    "htmlparser2": "^9.1.0",
     "jsdom": "^26.1.0",
     "puppeteer-core": "^24.22.0",
     "rollup": "^4.12.0",

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -111,6 +111,10 @@ causes subsequent bridge cases in the same run to fail the same way.
 
 When an executable case declares OMID capability via AdCOM API `7`, the runner
 records that capability signal separately from actual OMID measurement payloads.
+The normalizer also records inline OMID-aware vendor scripts in `adm` as a
+separate instrumentation signal. Known real-world script signals include
+DoubleVerify `dvtp_src.js`, IAS/Integral `adsafeprotected` or `integralads`
+scripts, Moat/Oracle `moatads` scripts, and direct `omid3p` observer probes.
 If the case also carries a sanitized
 `creativeMeta.measurement.omid.verificationScripts` sidecar, the runner enables
 the container's `omidAutoInstall` path with validator-owned HTTPS placeholder SDK
@@ -206,9 +210,13 @@ facets and are not expected to sum to `rowsWithDocumentSources`.
 
 OMID facets under `corpusDiagnostics.omid` aggregate the per-row OMID outcomes
 the runner records at `diagnostics.measurement.omid`. They separate OMID
-capability signals from actual measurement sidecars: AdCOM API `7` increments
-`rowsCapabilityDeclared`, while sanitized verification scripts increment
-`rowsWithSidecar` and drive the extension/session progress counters.
+capability signals from actual instrumentation and measurement sidecars: AdCOM
+API `7` increments `rowsCapabilityDeclared`, inline OMID-aware vendor scripts in
+`adm` increment `rowsInlineInstrumented`, and sanitized verification scripts
+increment `rowsWithSidecar` and drive the extension/session progress counters.
+`byInstrumentationSignal` buckets each row as `declared-api7+inline-vendor`,
+`declared-api7-only`, `inline-vendor-only`, or `absent`; this is the primary
+declared-vs-instrumented-vs-absent corpus readout for the 0.7.8 OMID verifier.
 `byOutcome` assigns each capability-declared row a single mutually-exclusive
 progress label (`capability-no-sidecar`, `sidecar-no-extension`,
 `extension-no-feature`, `feature-no-session`, `session-started`,

--- a/tools/creative-validator/src/normalizer.js
+++ b/tools/creative-validator/src/normalizer.js
@@ -2,9 +2,11 @@
  * @file Creative validator normalizer.
  *
  * Converts cleaned OpenRTB export rows into stable SHARC creative validator
- * test cases. This module is intentionally dependency-free so the private
- * hardening harness can iterate without changing the package surface.
+ * test cases for the private hardening harness without changing the package
+ * surface.
  */
+
+import { Parser } from 'htmlparser2';
 
 const SHARC_API_CODES = new Set([10, 11, 12]);
 const MRAID_API_CODES = new Set([3, 5, 6]);
@@ -41,6 +43,30 @@ const MRAID_METHODS = [
   'useCustomClose',
 ].join('|');
 const MRAID_METHOD_RE = new RegExp(`\\bmraid\\s*\\.\\s*(${MRAID_METHODS})\\b`);
+const OMID_VENDOR_SCRIPT_HOSTS = [
+  {
+    vendor: 'doubleverify',
+    hosts: ['doubleverify.com'],
+  },
+  {
+    vendor: 'ias',
+    hosts: ['adsafeprotected.com', 'integralads.com', 'iasds01.com'],
+  },
+  {
+    vendor: 'moat',
+    hosts: ['moatads.com', 'moat.com'],
+  },
+  {
+    vendor: 'oracle',
+    hosts: ['oracle.com', 'oraclecloud.com', 'grapeshot.co.uk'],
+  },
+];
+const INLINE_OMID_SIGNALS = [
+  /\bomid3p\s*\.\s*(?:registerSessionObserver|addEventListener)\s*\(/i,
+];
+const INLINE_OMID_TOKEN_RE = /\bomid3p\b/i;
+const MAX_OMID_ADM_SCAN_CHARS = 1_000_000;
+const MAX_OMID_VENDOR_SCRIPT_MATCHES = 256;
 
 function isPlainObject(value) {
   return value !== null
@@ -166,6 +192,236 @@ function extractOmidSidecar(bid) {
     }
   }
   return { sidecar: null, sources };
+}
+
+function hostMatchesSuffix(hostname, suffix) {
+  return hostname === suffix || hostname.endsWith(`.${suffix}`);
+}
+
+function classifyOmidVendorScript(url) {
+  if (!url || typeof url.hostname !== 'string' || !url.hostname) return null;
+  const hostname = url.hostname;
+  for (const pattern of OMID_VENDOR_SCRIPT_HOSTS) {
+    if (pattern.hosts.some((host) => hostMatchesSuffix(hostname, host))) {
+      return pattern.vendor;
+    }
+  }
+  return null;
+}
+
+function sanitizeScriptUrl(value) {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  try {
+    const parsed = new URL(value.trim(), 'https://creative.invalid/');
+    const hostname = parsed.hostname
+      ? parsed.hostname.toLowerCase().replace(/\.$/, '')
+      : '';
+    return {
+      protocol: parsed.protocol,
+      origin: parsed.origin === 'null' ? 'opaque' : parsed.origin,
+      hostname,
+      path: parsed.pathname.slice(0, 200),
+    };
+  } catch (_) {
+    return null;
+  }
+}
+
+function uniqueOmidVendorScripts(scripts) {
+  const seen = new Set();
+  const out = [];
+  for (const script of scripts) {
+    const key = `${script.vendor}\u001f${script.source}\u001f${script.value}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(script);
+  }
+  return out;
+}
+
+function isExecutableInlineScriptTag(attrs) {
+  const type = attrs.type;
+  if (!type) return true;
+  const normalized = type.split(';')[0].trim().toLowerCase();
+  return normalized === 'module'
+    || normalized === 'text/javascript'
+    || normalized === 'application/javascript'
+    || normalized === 'application/ecmascript'
+    || normalized === 'text/ecmascript';
+}
+
+function stripJsCommentsQuoteAware(source) {
+  let out = '';
+  let i = 0;
+  let inString = '';
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  while (i < source.length) {
+    const c = source[i];
+    const next = source[i + 1];
+
+    if (inLineComment) {
+      if (c === '\n') {
+        inLineComment = false;
+        out += c;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (c === '*' && next === '/') {
+        inBlockComment = false;
+        i += 2;
+      } else {
+        i += 1;
+      }
+      continue;
+    }
+
+    if (inString) {
+      if (c === '\\' && next !== undefined) {
+        out += c + next;
+        i += 2;
+        continue;
+      }
+      if (c === inString) inString = '';
+      out += c;
+      i += 1;
+      continue;
+    }
+
+    if (c === '/' && next === '/') {
+      inLineComment = true;
+      i += 2;
+      continue;
+    }
+
+    if (c === '/' && next === '*') {
+      inBlockComment = true;
+      i += 2;
+      continue;
+    }
+
+    if (c === '"' || c === "'" || c === '`') {
+      inString = c;
+      out += c;
+      i += 1;
+      continue;
+    }
+
+    out += c;
+    i += 1;
+  }
+
+  return out;
+}
+
+function extractScriptTagSources(adm) {
+  const sources = [];
+  let inlineOmidSignalFound = false;
+  const scanAdm = adm.length > MAX_OMID_ADM_SCAN_CHARS
+    ? adm.slice(0, MAX_OMID_ADM_SCAN_CHARS)
+    : adm;
+
+  let inExecutableInlineScript = false;
+  let currentInlineBuffer = '';
+  function finishInlineScript() {
+    if (!inExecutableInlineScript) return;
+    const signalBody = INLINE_OMID_TOKEN_RE.test(currentInlineBuffer)
+      ? stripJsCommentsQuoteAware(currentInlineBuffer)
+      : '';
+    if (!inlineOmidSignalFound
+        && signalBody
+        && INLINE_OMID_SIGNALS.some((re) => re.test(signalBody))) {
+      inlineOmidSignalFound = true;
+    }
+    inExecutableInlineScript = false;
+    currentInlineBuffer = '';
+  }
+
+  const parser = new Parser({
+    onopentag(name, attrs) {
+      if (!/^(?:[a-z][a-z0-9]*:)?script$/i.test(name)) return;
+      finishInlineScript();
+      if (attrs.src) {
+        sources.push(attrs.src);
+      } else if (isExecutableInlineScriptTag(attrs)) {
+        inExecutableInlineScript = true;
+        currentInlineBuffer = '';
+      }
+    },
+    ontext(text) {
+      if (inExecutableInlineScript) currentInlineBuffer += text;
+    },
+    onclosetag(name) {
+      if (!/^(?:[a-z][a-z0-9]*:)?script$/i.test(name)) return;
+      finishInlineScript();
+    },
+    onend() {
+      finishInlineScript();
+    },
+  });
+  parser.write(scanAdm);
+  parser.end();
+
+  return {
+    sources,
+    inlineOmidSignalFound,
+    admTruncatedForScan: scanAdm.length < adm.length,
+  };
+}
+
+function extractInlineOmidVendorScriptScan(adm) {
+  if (typeof adm !== 'string' || !adm) {
+    return {
+      scripts: [],
+      admTruncatedForScan: false,
+      scriptTagLimitReached: false,
+    };
+  }
+  const scan = extractScriptTagSources(adm);
+  const scripts = [];
+  let vendorScriptMatches = 0;
+  let vendorMatchLimitReached = false;
+  for (const src of scan.sources) {
+    const url = sanitizeScriptUrl(src);
+    const vendor = classifyOmidVendorScript(url);
+    if (!vendor) continue;
+    if (vendorScriptMatches >= MAX_OMID_VENDOR_SCRIPT_MATCHES) {
+      vendorMatchLimitReached = true;
+      continue;
+    }
+    vendorScriptMatches += 1;
+    const value = src.slice(0, 500);
+    scripts.push({
+      vendor,
+      source: 'adm-script-src',
+      value,
+      truncated: src.length > value.length,
+      url,
+    });
+  }
+
+  if (scan.inlineOmidSignalFound) {
+    scripts.push({
+      vendor: 'generic-omid3p',
+      source: 'adm-inline-script',
+      value: 'omid3p observer probe',
+      url: null,
+    });
+  }
+
+  return {
+    scripts: uniqueOmidVendorScripts(scripts),
+    admTruncatedForScan: scan.admTruncatedForScan,
+    scriptTagLimitReached: vendorMatchLimitReached,
+  };
+}
+
+function extractInlineOmidVendorScripts(adm) {
+  return extractInlineOmidVendorScriptScan(adm).scripts;
 }
 
 /**
@@ -506,6 +762,30 @@ function normalizeBid(row, rowIndex, auction, auctionIndex, bid, options) {
   const creativeMeta = { apis: apis.sanitized.slice() };
   const omidDeclared = hasAny(apis.sanitized, OMID_API_CODES);
   const omidSidecar = extractOmidSidecar(bid);
+  const inlineOmidVendorScan = mode === 'adm-html'
+    ? extractInlineOmidVendorScriptScan(unwrapped.adm)
+    : { scripts: [], admTruncatedForScan: false, scriptTagLimitReached: false };
+  const inlineOmidVendorScripts = inlineOmidVendorScan.scripts;
+  const omidMeasurement = {
+    declaredByApi: omidDeclared,
+    sidecarPresent: !!omidSidecar.sidecar,
+    inlineVendorScriptPresent: inlineOmidVendorScripts.length > 0,
+    inlineVendorScriptCount: inlineOmidVendorScripts.length,
+    verificationScriptCount: omidSidecar.sidecar
+      ? omidSidecar.sidecar.verificationScripts.length
+      : 0,
+    sources: omidSidecar.sources,
+  };
+  if (inlineOmidVendorScripts.length > 0) {
+    omidMeasurement.inlineVendorVendors = [...new Set(inlineOmidVendorScripts.map((script) => script.vendor))].sort();
+    omidMeasurement.inlineVendorScripts = inlineOmidVendorScripts;
+  }
+  if (inlineOmidVendorScan.admTruncatedForScan) {
+    omidMeasurement.inlineVendorScanTruncated = true;
+  }
+  if (inlineOmidVendorScan.scriptTagLimitReached) {
+    omidMeasurement.inlineVendorScriptTagLimitReached = true;
+  }
   if (omidSidecar.sidecar) {
     creativeMeta.measurement = { omid: omidSidecar.sidecar };
   }
@@ -545,14 +825,7 @@ function normalizeBid(row, rowIndex, auction, auctionIndex, bid, options) {
       attr: Array.isArray(bid.attr) ? bid.attr.slice() : [],
       placement: sanitizePlacement(placement),
       measurement: {
-        omid: {
-          declaredByApi: omidDeclared,
-          sidecarPresent: !!omidSidecar.sidecar,
-          verificationScriptCount: omidSidecar.sidecar
-            ? omidSidecar.sidecar.verificationScripts.length
-            : 0,
-          sources: omidSidecar.sources,
-        },
+        omid: omidMeasurement,
       },
     },
     expectations: {
@@ -616,6 +889,7 @@ function toJsonl(cases) {
 
 export {
   classifyAdmKind,
+  extractInlineOmidVendorScripts,
   normalizeCleanedCorpus,
   sanitizeApiDeclarations,
   toJsonl,

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -119,6 +119,12 @@ function emptySummary(files) {
       omid: {
         rows: 0,
         rowsCapabilityDeclared: 0,
+        rowsInlineInstrumented: 0,
+        rowsCapabilityDeclaredInlineInstrumented: 0,
+        rowsInlineInstrumentedWithoutCapability: 0,
+        rowsAbsent: 0,
+        rowsScanTruncated: 0,
+        rowsTagLimitReached: 0,
         rowsWithSidecar: 0,
         rowsWithExtension: 0,
         rowsFeatureAdvertised: 0,
@@ -126,6 +132,10 @@ function emptySummary(files) {
         rowsSessionFinished: 0,
         rowsLoadedFired: 0,
         rowsImpressionFired: 0,
+        byInstrumentationSignal: {},
+        byInlineVendorScriptCount: {},
+        inlineVendorRowsByVendor: {},
+        inlineVendorRowsByBidder: {},
         byOutcome: {},
         byVerificationScriptCount: {},
         capabilityRowsByBidder: {},
@@ -210,6 +220,16 @@ function omidDiagnostics(row) {
     : {};
 }
 
+function omidBidSignals(row) {
+  return row
+    && row.case
+    && row.case.bidSignals
+    && row.case.bidSignals.measurement
+    && row.case.bidSignals.measurement.omid
+    ? row.case.bidSignals.measurement.omid
+    : {};
+}
+
 function omidOutcomeKey(omid) {
   if (omid.sidecarPresent !== true) return 'capability-no-sidecar';
   if (omid.extensionPresent !== true) return 'sidecar-no-extension';
@@ -217,6 +237,13 @@ function omidOutcomeKey(omid) {
   if (omid.sessionStarted !== true) return 'feature-no-session';
   if (omid.sessionFinished !== true) return 'session-started';
   return 'session-finished';
+}
+
+function omidInstrumentationSignalKey(declaredByApi, inlineInstrumented) {
+  if (declaredByApi && inlineInstrumented) return 'declared-api7+inline-vendor';
+  if (declaredByApi) return 'declared-api7-only';
+  if (inlineInstrumented) return 'inline-vendor-only';
+  return 'absent';
 }
 
 function msSinceRenderBin(value) {
@@ -620,8 +647,28 @@ function addRuntimeCorpusFacets(summary, row, fields) {
 
 function addOmidCorpusFacets(summary, row, fields) {
   const omid = omidDiagnostics(row);
+  const bidOmid = omidBidSignals(row);
   const facet = summary.corpusDiagnostics.omid;
+  const declaredByApi = omid.expected === true || bidOmid.declaredByApi === true;
+  const inlineInstrumented = bidOmid.inlineVendorScriptPresent === true
+    || networkCount(bidOmid.inlineVendorScriptCount) > 0;
+  const inlineScriptCount = networkCount(bidOmid.inlineVendorScriptCount);
   facet.rows += 1;
+  if (bidOmid.inlineVendorScanTruncated === true) facet.rowsScanTruncated += 1;
+  if (bidOmid.inlineVendorScriptTagLimitReached === true) facet.rowsTagLimitReached += 1;
+  increment(facet.byInstrumentationSignal, omidInstrumentationSignalKey(declaredByApi, inlineInstrumented));
+  if (!declaredByApi && !inlineInstrumented) facet.rowsAbsent += 1;
+  if (inlineInstrumented) {
+    facet.rowsInlineInstrumented += 1;
+    increment(facet.byInlineVendorScriptCount, inlineScriptCount);
+    increment(facet.inlineVendorRowsByBidder, fields.bidder);
+    const vendors = Array.isArray(bidOmid.inlineVendorVendors)
+      ? bidOmid.inlineVendorVendors
+      : [];
+    for (const vendor of vendors) increment(facet.inlineVendorRowsByVendor, vendor);
+    if (declaredByApi) facet.rowsCapabilityDeclaredInlineInstrumented += 1;
+    else facet.rowsInlineInstrumentedWithoutCapability += 1;
+  }
   if (omid.sidecarPresent === true) facet.rowsWithSidecar += 1;
   if (omid.extensionPresent === true) facet.rowsWithExtension += 1;
   if (omid.featureAdvertised === true) facet.rowsFeatureAdvertised += 1;
@@ -630,9 +677,15 @@ function addOmidCorpusFacets(summary, row, fields) {
   if (omid.loadedFired === true) facet.rowsLoadedFired += 1;
   if (omid.impressionFired === true) facet.rowsImpressionFired += 1;
 
-  if (omid.expected !== true) return;
+  if (!declaredByApi) return;
 
   facet.rowsCapabilityDeclared += 1;
+
+  // Runtime outcome buckets are based on diagnostics emitted by a runner pass.
+  // Bidstream API 7 still counts as declared capability above, but rows without
+  // OMID runtime diagnostics should not inflate "capability-no-sidecar".
+  if (omid.expected !== true) return;
+
   increment(facet.byOutcome, omidOutcomeKey(omid));
   increment(facet.byVerificationScriptCount, networkCount(omid.verificationScriptCount));
   increment(facet.capabilityRowsByBidder, fields.bidder);
@@ -906,6 +959,14 @@ function triageReports(files) {
     sortEntries(summary.corpusDiagnostics.network.failedResponseStatus, { numericKeys: true });
   summary.corpusDiagnostics.omid.byOutcome =
     sortEntries(summary.corpusDiagnostics.omid.byOutcome);
+  summary.corpusDiagnostics.omid.byInstrumentationSignal =
+    sortEntries(summary.corpusDiagnostics.omid.byInstrumentationSignal);
+  summary.corpusDiagnostics.omid.byInlineVendorScriptCount =
+    sortEntries(summary.corpusDiagnostics.omid.byInlineVendorScriptCount, { numericKeys: true });
+  summary.corpusDiagnostics.omid.inlineVendorRowsByVendor =
+    sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByVendor);
+  summary.corpusDiagnostics.omid.inlineVendorRowsByBidder =
+    sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByBidder);
   summary.corpusDiagnostics.omid.byVerificationScriptCount =
     sortEntries(summary.corpusDiagnostics.omid.byVerificationScriptCount, { numericKeys: true });
   summary.corpusDiagnostics.omid.capabilityRowsByBidder =

--- a/tools/creative-validator/test/test-normalizer.js
+++ b/tools/creative-validator/test/test-normalizer.js
@@ -12,6 +12,7 @@ import { tmpdir } from 'node:os';
 import test from 'node:test';
 import {
   classifyAdmKind,
+  extractInlineOmidVendorScripts,
   normalizeCleanedCorpus,
   sanitizeApiDeclarations,
   toJsonl,
@@ -70,6 +71,303 @@ test('adm unwrap does not tag long printable non-base64 payloads as base64', () 
   assert.deepEqual(unwrapped.transformations, []);
 });
 
+test('inline OMID vendor script detection separates instrumentation from declaration', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script src="https://cdn.doubleverify.com/dvtp_src.js"></script>
+    <script src="https://static.adsafeprotected.com/ias.js"></script>
+    <script src="https://z.moatads.com/example/moatad.js"></script>
+    <script>window.omid3p && window.omid3p.registerSessionObserver(observer, 'vendor')</script>
+  `);
+  assert.deepEqual(scripts.map((script) => script.vendor), [
+    'doubleverify',
+    'ias',
+    'moat',
+    'generic-omid3p',
+  ]);
+  assert.equal(scripts[0].source, 'adm-script-src');
+  assert.equal(scripts[0].url.origin, 'https://cdn.doubleverify.com');
+  assert.equal(scripts[0].url.hostname, 'cdn.doubleverify.com');
+  assert.equal(scripts[3].source, 'adm-inline-script');
+  assert.equal(extractInlineOmidVendorScripts('<script src="mraid.js"></script>').length, 0);
+});
+
+test('inline OMID vendor script detection requires vendor script hosts', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script src="https://example.com/blog/about-moatads.html"></script>
+    <script src="https://cdn.example.com/integralads-tracker.js"></script>
+    <script src="/dvtp_src.js"></script>
+    <script>function registerSessionObserver() { return false; }</script>
+  `);
+  assert.deepEqual(scripts, []);
+});
+
+test('inline OMID generic signal ignores inert text and data-type does not shadow type', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <div>window.omid3p.registerSessionObserver(function(){})</div>
+    <script type="application/json">{"probe":"window.omid3p.addEventListener(function(){})"}</script>
+    <script>/* window.omid3p.registerSessionObserver(function(){}) */</script>
+    <script>// window.omid3p.addEventListener("impression", function(){})</script>
+    <script>/** Use window.omid3p.addEventListener() for OMID observers. */</script>
+    <script data-type="application/json">window.omid3p.registerSessionObserver(function(){})</script>
+  `);
+  assert.equal(scripts.length, 1);
+  assert.equal(scripts[0].vendor, 'generic-omid3p');
+});
+
+test('inline OMID generic signal handles executable MIME parameters', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script type="text/javascript;charset=utf-8">
+      window.omid3p.registerSessionObserver(function(){});
+    </script>
+  `);
+  assert.equal(scripts.length, 1);
+  assert.equal(scripts[0].vendor, 'generic-omid3p');
+});
+
+test('inline OMID generic signal survives protocol-relative strings before the call', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script>
+      var u = "//cdn.example.com/verification.js"; window.omid3p.addEventListener("geometryChange", function(){});
+      window.omid3p.addEventListener("impression", function(){});
+    </script>
+  `);
+  assert.equal(scripts.length, 1);
+  assert.equal(scripts[0].vendor, 'generic-omid3p');
+});
+
+test('inline OMID generic signal survives double-slash strings without counting comments', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script>
+      var path = "path//thing";
+      /* window.omid3p.registerSessionObserver(function(){}) */
+      // window.omid3p.addEventListener("impression", function(){})
+    </script>
+  `);
+  assert.deepEqual(scripts, []);
+});
+
+test('inline OMID generic signal is not hidden by non-matching inline body stuffing', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    ${'<script>noop()</script>'.repeat(64)}
+    <script>window.omid3p.registerSessionObserver(function(){});</script>
+  `);
+  assert.equal(scripts.length, 1);
+  assert.equal(scripts[0].vendor, 'generic-omid3p');
+});
+
+test('inline OMID generic signal is not hidden by token-only inline body stuffing', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    ${'<script>var x = "omid3p";</script>'.repeat(64)}
+    <script>window.omid3p.registerSessionObserver(function(){});</script>
+  `);
+  assert.equal(scripts.length, 1);
+  assert.equal(scripts[0].vendor, 'generic-omid3p');
+});
+
+test('inline OMID vendor script detection ignores data-src lazy-load attributes', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script data-src="https://moatads.com/x.js"></script>
+  `);
+  assert.deepEqual(scripts, []);
+});
+
+test('inline OMID vendor script detection ignores attributes embedded in other attribute values', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script foo="abc src='https://moatads.com/x.js' def"></script>
+    <script foo='type="application/json"'>window.omid3p.registerSessionObserver(function(){});</script>
+  `);
+  assert.equal(scripts.length, 1);
+  assert.equal(scripts[0].vendor, 'generic-omid3p');
+});
+
+test('inline OMID vendor script detection handles quote-adjacent attributes', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script async=""src="https://cdn.doubleverify.com/dvtp_src.js"></script>
+    <script foo="x"type="text/javascript;charset=utf-8">
+      window.omid3p.addEventListener('impression', function(){});
+    </script>
+  `);
+  assert.deepEqual(scripts.map((script) => script.vendor), ['doubleverify', 'generic-omid3p']);
+});
+
+test('inline OMID vendor script detection handles greater-than characters inside attributes', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script foo="a>" src="https://cdn.doubleverify.com/dvtp_src.js"></script>
+    <script foo='b>' type="text/javascript">
+      window.omid3p.registerSessionObserver(function(){});
+    </script>
+  `);
+  assert.deepEqual(scripts.map((script) => script.vendor), ['doubleverify', 'generic-omid3p']);
+});
+
+test('inline OMID vendor script detection follows first duplicate attribute semantics', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script src="https://cdn.doubleverify.com/dvtp_src.js" src="https://example.com/benign.js"></script>
+    <script type="text/javascript" type="application/json">
+      window.omid3p.registerSessionObserver(function(){});
+    </script>
+  `);
+  assert.deepEqual(scripts.map((script) => script.vendor), ['doubleverify', 'generic-omid3p']);
+});
+
+test('inline OMID vendor script detection recovers after malformed script closer', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script src="https://example.com/oops>
+    <script src="https://z.moatads.com/swallowed.js"></script>
+    <script src="https://cdn.doubleverify.com/dvtp_src.js"></script>
+  `);
+  assert.deepEqual(scripts.map((script) => script.vendor), ['doubleverify']);
+});
+
+test('inline OMID vendor script detection uses decoded script src attributes', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script src="https://cdn.doubleverify.com/dvtp_src.js?x=1&amp;y=2"></script>
+  `);
+  assert.equal(scripts.length, 1);
+  assert.equal(scripts[0].vendor, 'doubleverify');
+  assert.equal(scripts[0].value, 'https://cdn.doubleverify.com/dvtp_src.js?x=1&y=2');
+});
+
+test('inline OMID vendor script detection handles namespaced tags and trailing-dot hosts', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <svg:script src="https://doubleverify.com./dvtp_src.js"></svg:script>
+  `);
+  assert.equal(scripts.length, 1);
+  assert.equal(scripts[0].vendor, 'doubleverify');
+  assert.equal(scripts[0].url.hostname, 'doubleverify.com');
+});
+
+test('normalization bounds inline OMID vendor scans', () => {
+  const longAdm = `${Array.from({ length: 300 }, (_, index) =>
+    `<script src="https://cdn.doubleverify.com/${index}.js"></script>`).join('')}${'x'.repeat(1_000_001)}`;
+  const [bounded] = normalizeCleanedCorpus([{
+    id: 'auction-row-omid-bounded',
+    auction: [{
+      bidder: 'synthetic-omid-bounded',
+      mtype: 'banner',
+      bid_request: {
+        id: 'request-omid-bounded',
+        imp: [{ id: 'imp-omid-bounded', banner: { w: 300, h: 250 } }],
+      },
+      bid_response: {
+        id: 'response-omid-bounded',
+        seatbid: [{
+          bid: [{
+            id: 'bid-omid-bounded',
+            impid: 'imp-omid-bounded',
+            crid: 'creative-omid-bounded',
+            adm: longAdm,
+          }],
+        }],
+      },
+    }],
+  }]);
+
+  const omid = bounded.bidSignals.measurement.omid;
+  assert.equal(omid.inlineVendorScriptCount, 256);
+  assert.equal(omid.inlineVendorScanTruncated, true);
+  assert.equal(omid.inlineVendorScriptTagLimitReached, true);
+});
+
+test('normalization does not let inline script tag stuffing hide later vendor src tags', () => {
+  const stuffedAdm = `${'<script>noop()</script>'.repeat(256)}`
+    + '<script src="https://cdn.doubleverify.com/dvtp_src.js"></script>';
+  const [stuffed] = normalizeCleanedCorpus([{
+    id: 'auction-row-omid-stuffed',
+    auction: [{
+      bidder: 'synthetic-omid-stuffed',
+      mtype: 'banner',
+      bid_request: {
+        id: 'request-omid-stuffed',
+        imp: [{ id: 'imp-omid-stuffed', banner: { w: 300, h: 250 } }],
+      },
+      bid_response: {
+        id: 'response-omid-stuffed',
+        seatbid: [{
+          bid: [{
+            id: 'bid-omid-stuffed',
+            impid: 'imp-omid-stuffed',
+            crid: 'creative-omid-stuffed',
+            adm: stuffedAdm,
+          }],
+        }],
+      },
+    }],
+  }]);
+
+  const omid = stuffed.bidSignals.measurement.omid;
+  assert.equal(omid.inlineVendorScriptCount, 1);
+  assert.equal(omid.inlineVendorScriptTagLimitReached, undefined);
+  assert.equal(omid.inlineVendorScripts[0].vendor, 'doubleverify');
+});
+
+test('normalization does not let non-vendor src stuffing hide later vendor src tags', () => {
+  const stuffedAdm = `${Array.from({ length: 256 }, (_, index) =>
+    `<script src="https://example.com/${index}.js"></script>`).join('')}`
+    + '<script src="https://cdn.doubleverify.com/dvtp_src.js"></script>';
+  const [stuffed] = normalizeCleanedCorpus([{
+    id: 'auction-row-omid-src-stuffed',
+    auction: [{
+      bidder: 'synthetic-omid-src-stuffed',
+      mtype: 'banner',
+      bid_request: {
+        id: 'request-omid-src-stuffed',
+        imp: [{ id: 'imp-omid-src-stuffed', banner: { w: 300, h: 250 } }],
+      },
+      bid_response: {
+        id: 'response-omid-src-stuffed',
+        seatbid: [{
+          bid: [{
+            id: 'bid-omid-src-stuffed',
+            impid: 'imp-omid-src-stuffed',
+            crid: 'creative-omid-src-stuffed',
+            adm: stuffedAdm,
+          }],
+        }],
+      },
+    }],
+  }]);
+
+  const omid = stuffed.bidSignals.measurement.omid;
+  assert.equal(omid.inlineVendorScriptCount, 1);
+  assert.equal(omid.inlineVendorScriptTagLimitReached, undefined);
+  assert.equal(omid.inlineVendorScripts[0].vendor, 'doubleverify');
+});
+
+test('normalization preserves inline OMID vendor instrumentation without API declaration', () => {
+  const [inlineOmid] = normalizeCleanedCorpus([{
+    id: 'auction-row-omid-inline',
+    auction: [{
+      bidder: 'synthetic-omid-inline',
+      mtype: 'banner',
+      bid_request: {
+        id: 'request-omid-inline',
+        imp: [{ id: 'imp-omid-inline', banner: { w: 300, h: 250 } }],
+      },
+      bid_response: {
+        id: 'response-omid-inline',
+        seatbid: [{
+          bid: [{
+            id: 'bid-omid-inline',
+            impid: 'imp-omid-inline',
+            crid: 'creative-omid-inline',
+            adm: '<script src="https://cdn.doubleverify.com/dvtp_src.js"></script>',
+          }],
+        }],
+      },
+    }],
+  }]);
+
+  assert.equal(inlineOmid.bidSignals.measurement.omid.declaredByApi, false);
+  assert.equal(inlineOmid.bidSignals.measurement.omid.sidecarPresent, false);
+  assert.equal(inlineOmid.bidSignals.measurement.omid.inlineVendorScriptPresent, true);
+  assert.equal(inlineOmid.bidSignals.measurement.omid.inlineVendorScriptCount, 1);
+  assert.equal(inlineOmid.bidSignals.measurement.omid.inlineVendorScanTruncated, undefined);
+  assert.equal(inlineOmid.bidSignals.measurement.omid.inlineVendorScriptTagLimitReached, undefined);
+  assert.deepEqual(inlineOmid.bidSignals.measurement.omid.inlineVendorVendors, ['doubleverify']);
+  assert.equal(inlineOmid.bidSignals.measurement.omid.inlineVendorScripts[0].url.path, '/dvtp_src.js');
+});
+
 test('cleaned corpus normalization emits one stable case per bid', () => {
   assert.equal(cases.length, 5);
 
@@ -84,6 +382,10 @@ test('cleaned corpus normalization emits one stable case per bid', () => {
   assert.deepEqual(mraid.sharcOptions.creativeMeta.apis, [3, 5, 7]);
   assert.equal(mraid.bidSignals.measurement.omid.declaredByApi, true);
   assert.equal(mraid.bidSignals.measurement.omid.sidecarPresent, true);
+  assert.equal(mraid.bidSignals.measurement.omid.inlineVendorScriptPresent, false);
+  assert.equal(mraid.bidSignals.measurement.omid.inlineVendorScriptCount, 0);
+  assert.equal(mraid.bidSignals.measurement.omid.inlineVendorVendors, undefined);
+  assert.equal(mraid.bidSignals.measurement.omid.inlineVendorScripts, undefined);
   assert.equal(mraid.bidSignals.measurement.omid.verificationScriptCount, 1);
   assert.deepEqual(mraid.bidSignals.measurement.omid.sources, [{
     path: 'bid.ext.measurement.omid',

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -738,6 +738,18 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
         case: {
           ...report().case,
           source: { ...report().case.source, bidder: 'bidder-omid-a', rowIndex: 0 },
+          bidSignals: {
+            ...report().case.bidSignals,
+            measurement: {
+              omid: {
+                declaredByApi: true,
+                sidecarPresent: true,
+                inlineVendorScriptPresent: true,
+                inlineVendorScriptCount: 1,
+                inlineVendorVendors: ['doubleverify'],
+              },
+            },
+          },
         },
         outcome: { status: 'passed', bucket: 'passed' },
       }),
@@ -800,6 +812,18 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
         case: {
           ...report().case,
           source: { ...report().case.source, bidder: 'bidder-omid-c', rowIndex: 2 },
+          bidSignals: {
+            ...report().case.bidSignals,
+            measurement: {
+              omid: {
+                declaredByApi: false,
+                sidecarPresent: false,
+                inlineVendorScriptPresent: true,
+                inlineVendorScriptCount: 2,
+                inlineVendorVendors: ['ias', 'moat'],
+              },
+            },
+          },
         },
         outcome: { status: 'passed', bucket: 'passed' },
       }),
@@ -812,12 +836,41 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
         outcome: { status: 'passed', bucket: 'passed' },
         diagnostics: {},
       }),
+      // Bidstream-declared OMID row without runtime OMID diagnostics: counts as
+      // declared capability, but does not enter runtime outcome buckets.
+      report({
+        case: {
+          ...report().case,
+          source: { ...report().case.source, bidder: 'bidder-omid-g', rowIndex: 6 },
+          bidSignals: {
+            ...report().case.bidSignals,
+            measurement: {
+              omid: {
+                declaredByApi: true,
+                sidecarPresent: false,
+                inlineVendorScriptPresent: false,
+                inlineVendorScriptCount: 0,
+                inlineVendorScanTruncated: true,
+                inlineVendorScriptTagLimitReached: true,
+              },
+            },
+          },
+        },
+        outcome: { status: 'skipped', bucket: 'unsupported-input' },
+        diagnostics: {},
+      }),
     ]);
 
     const summary = triageReports([reportPath]);
     const omid = summary.corpusDiagnostics.omid;
-    assert.equal(omid.rows, 6);
-    assert.equal(omid.rowsCapabilityDeclared, 4);
+    assert.equal(omid.rows, 7);
+    assert.equal(omid.rowsCapabilityDeclared, 5);
+    assert.equal(omid.rowsInlineInstrumented, 2);
+    assert.equal(omid.rowsCapabilityDeclaredInlineInstrumented, 1);
+    assert.equal(omid.rowsInlineInstrumentedWithoutCapability, 1);
+    assert.equal(omid.rowsAbsent, 1);
+    assert.equal(omid.rowsScanTruncated, 1);
+    assert.equal(omid.rowsTagLimitReached, 1);
     assert.equal(omid.rowsWithSidecar, 3);
     assert.equal(omid.rowsWithExtension, 3);
     assert.equal(omid.rowsFeatureAdvertised, 2);
@@ -830,6 +883,22 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
       'extension-no-feature': 1,
       'feature-no-session': 1,
       'session-finished': 1,
+    });
+    assert.deepEqual(omid.byInstrumentationSignal, {
+      absent: 1,
+      'declared-api7+inline-vendor': 1,
+      'declared-api7-only': 4,
+      'inline-vendor-only': 1,
+    });
+    assert.deepEqual(omid.byInlineVendorScriptCount, { 1: 1, 2: 1 });
+    assert.deepEqual(omid.inlineVendorRowsByVendor, {
+      doubleverify: 1,
+      ias: 1,
+      moat: 1,
+    });
+    assert.deepEqual(omid.inlineVendorRowsByBidder, {
+      'bidder-omid-a': 1,
+      'bidder-omid-c': 1,
     });
     assert.deepEqual(omid.byVerificationScriptCount, { 0: 1, 1: 2, 2: 1 });
     assert.deepEqual(omid.capabilityRowsByBidder, {
@@ -867,6 +936,12 @@ test('triageReports emits a stable empty OMID facet for a zero-row corpus', () =
     assert.deepEqual(summary.corpusDiagnostics.omid, {
       rows: 0,
       rowsCapabilityDeclared: 0,
+      rowsInlineInstrumented: 0,
+      rowsCapabilityDeclaredInlineInstrumented: 0,
+      rowsInlineInstrumentedWithoutCapability: 0,
+      rowsAbsent: 0,
+      rowsScanTruncated: 0,
+      rowsTagLimitReached: 0,
       rowsWithSidecar: 0,
       rowsWithExtension: 0,
       rowsFeatureAdvertised: 0,
@@ -874,6 +949,10 @@ test('triageReports emits a stable empty OMID facet for a zero-row corpus', () =
       rowsSessionFinished: 0,
       rowsLoadedFired: 0,
       rowsImpressionFired: 0,
+      byInstrumentationSignal: {},
+      byInlineVendorScriptCount: {},
+      inlineVendorRowsByVendor: {},
+      inlineVendorRowsByBidder: {},
       byOutcome: {},
       byVerificationScriptCount: {},
       capabilityRowsByBidder: {},


### PR DESCRIPTION
## Summary

- add a validator normalizer signal for inline OMID-aware vendor scripts in adm markup, separate from AdCOM API 7 declaration and OMID sidecars
- add corpus triage facets for declared-api7+inline-vendor, declared-api7-only, inline-vendor-only, and absent OMID rows
- document the private-tier OMID instrumentation readout and cover the new fields in normalizer/triage tests

## Private corpus spot check

Normalized 1,745 private cleaned cases with this branch. The new classifier found 97 inline OMID-vendor rows: 96 also declared API 7, 1 was inline-only, and detected vendors were DoubleVerify (88 rows) and IAS/Integral (9 rows). The generated private output remains under tools/creative-validator/private/ and is untracked.

## Validation

- node tools/creative-validator/test/test-normalizer.js
- node tools/creative-validator/test/test-triage.js
- npx eslint tools/creative-validator/src/normalizer.js tools/creative-validator/src/triage.js tools/creative-validator/test/test-normalizer.js tools/creative-validator/test/test-triage.js --max-warnings=0
- npm run check

Refs #244
