### PR TITLE
feat: 0.7.8 OMID bridge — URL/srcdoc MessageChannel nonce delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,35 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   → vendor `registerSessionObserver` callback) plus nonce confidentiality.
   Tracks #217. (Deferred to follow-ons: URL/`srcdoc` MessageChannel variant.)
 
+- **OMID URL/`srcdoc`-variant delivery — MessageChannel nonce injection (0.7.8,
+  design § 4.3 mechanism ii).** Completes the no-renderer path. For the Creative
+  URL variant with `useMarkupInjection: true` (the container wraps the creative
+  in a `srcdoc` it controls), `OmidCompatBridge.injectIntoMarkup` — previously a
+  no-op — now prepends, as the first `<head>` children, the OMID shim
+  `<script src>` plus a port-receiver prelude (`installOmidShimPortReceiver`,
+  new shim export) when OMID is active. The prelude installs `window.omid3p`
+  **synchronously** (so a verification script's first read succeeds) and arms a
+  transferred-`MessagePort` receiver; the container constructs a `MessageChannel`
+  on iframe `load` and delivers the OMID `protocolNonce` over the transferred
+  port. The nonce travels **only** over the point-to-point port — it is **never**
+  baked into the `srcdoc` source (so it is not readable from `document.scripts`
+  text — the #254-clean property), and never on `location.hash`, a query param, a
+  global, or a DOM attribute. The shim stashes the port-delivered nonce as a
+  write-once closure constant and fails closed on inbound validation until it
+  resolves; the port handler is provably installed before the port message can
+  dispatch, and outbound `SHARC:Omid:Register` posts defer to `sessionStart`, so
+  the nonce is in hand before any signed envelope leaves the frame. Steady-state
+  OMID events still ride the router `window.message` channel (OMID-D1); the port
+  is used only for the one-time nonce hand-off. srcdoc/opaque-origin is handled
+  per § 7.4 (best-effort origin + load-bearing `event.source === parent`); the
+  outbound path fails closed rather than ever broadcasting the nonce with `'*'`
+  (C1). The change is **additive**: with OMID off (`exposeOmid3p: false`), the
+  `srcdoc` is byte-identical to the pre-0.7.8 shape — no prelude, no port, no
+  shim. End-to-end coverage uses a real `MessagePort` (parent transfers a port
+  to a srcdoc-like child; the shim receives the nonce over it and `omid3p`
+  works), plus regression-sensitive ordering, #254-clean, exposeOmid3p-off, and
+  malformed/missing-port assertions. Tracks #217.
+
 - **`placementSessionId` structural-immutability tripwire (#240).** The
   container's `placementSessionId` is now defined with a throwing setter, so any
   future direct mutation fails loud rather than silently desynchronizing the

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "test:omid-shim-transport": "node test/node/test-omid-shim-transport.js",
     "test:omid-router-consumption": "node test/node/test-omid-router-consumption.js",
     "test:omid-markup-delivery": "node test/node/test-omid-markup-delivery.js",
+    "test:omid-srcdoc-delivery": "node test/node/test-omid-srcdoc-delivery.js",
     "test:omid-renderer-prelude": "node test/node/test-omid-renderer-prelude.js",
     "test:omid-bridge-geometry-throttle": "node test/node/test-omid-bridge-geometry-throttle.js",
     "test:omid-bridge-edge-fixes": "node test/node/test-omid-bridge-edge-fixes.js",
@@ -92,7 +93,7 @@
     "test:perf": "node test/node/test-creative-sources-perf.js",
     "test:types": "tsc -p test/types/tsconfig.json",
     "test:all": "npm run build && npm run test:all:built",
-    "test:all:built": "npm run test:smoke && npm run test:treeshake && npm run test:creative-protocol-placement-type && npm run test:placement && npm run test:placement-stamping && npm run test:creative-sources && npm run test:creative-sources-load && npm run test:protocol-router && npm run test:protocol-router-nonce-derivation && npm run test:renderer-protocol-retrofit && npm run test:renderer-out-of-phase && npm run test:browser && npm run test:navigation-bridge && npm run test:creative-sdk-autoinstall && npm run test:creative-sdk-injection && npm run test:bridges-detection && npm run test:non-sharc-loading && npm run test:html-lifecycle-adapter && npm run test:omid-container-lifecycle && npm run test:omid-shim && npm run test:omid-shim-transport && npm run test:omid-router-consumption && npm run test:omid-markup-delivery && npm run test:omid-renderer-prelude && npm run test:omid-bridge-geometry-throttle && npm run test:omid-bridge-edge-fixes && npm run test:renderer-fallback && npm run test:creative-validator-normalizer && npm run test:creative-validator-diagnose && npm run test:creative-validator-runner && npm run test:creative-validator-triage",
+    "test:all:built": "npm run test:smoke && npm run test:treeshake && npm run test:creative-protocol-placement-type && npm run test:placement && npm run test:placement-stamping && npm run test:creative-sources && npm run test:creative-sources-load && npm run test:protocol-router && npm run test:protocol-router-nonce-derivation && npm run test:renderer-protocol-retrofit && npm run test:renderer-out-of-phase && npm run test:browser && npm run test:navigation-bridge && npm run test:creative-sdk-autoinstall && npm run test:creative-sdk-injection && npm run test:bridges-detection && npm run test:non-sharc-loading && npm run test:html-lifecycle-adapter && npm run test:omid-container-lifecycle && npm run test:omid-shim && npm run test:omid-shim-transport && npm run test:omid-router-consumption && npm run test:omid-markup-delivery && npm run test:omid-srcdoc-delivery && npm run test:omid-renderer-prelude && npm run test:omid-bridge-geometry-throttle && npm run test:omid-bridge-edge-fixes && npm run test:renderer-fallback && npm run test:creative-validator-normalizer && npm run test:creative-validator-diagnose && npm run test:creative-validator-runner && npm run test:creative-validator-triage",
     "regen:baseline": "node scripts/regen-mraid3-baseline.js",
     "lint": "eslint src/*.js --max-warnings=0",
     "check": "npm run build && npm run test:all:built && npm run size && npm run build"

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -2016,6 +2016,19 @@ class SHARCContainer {
       // The 200ms initChannel deferral above is unrelated — that's an OM
       // SDK ordering concession, not a backstop concern.
       this._armRendererBackstop();
+
+      // 0.7.8 (§ 4.3 mechanism ii): URL + `useMarkupInjection` (`srcdoc`) OMID
+      // nonce delivery. The shim + port-receiver prelude were prepended into the
+      // srcdoc by the OMID bridge's `injectIntoMarkup` (gated on the SAME OMID
+      // condition this transfer is gated on). The srcdoc parses top-to-bottom,
+      // so by the time this `load` event fires the prelude has already run and
+      // armed its transferred-port `window` `message` listener. Transfer one
+      // MessageChannel port in now and deliver the OMID `protocolNonce` over it
+      // — never baked into the srcdoc source (#254-clean), never on hash/query/
+      // global/DOM-attr. No-op when OMID is not active for this placement.
+      if (this._useMarkupInjection) {
+        this._transferOmidPort(iframe);
+      }
     }, { once: true });
 
     if (!this._useMarkupInjection) {
@@ -3234,6 +3247,92 @@ class SHARCContainer {
     // The iframe's load event will fire, triggering MessageChannel setup.
     if (this._iframe) {
       this._iframe.srcdoc = html;
+    }
+  }
+
+  /**
+   * URL + `useMarkupInjection` (`srcdoc`) OMID nonce delivery (§ 4.3 mechanism
+   * ii). Called once on the srcdoc iframe's `load` event. No-op unless OMID is
+   * active for this placement (an OMID extension returns a non-null
+   * `getSrcdocOmidInjection()` — the SAME gate that decided whether
+   * `injectIntoMarkup` prepended the shim + port-receiver prelude).
+   *
+   * Mechanism:
+   *   1. Construct a `MessageChannel`. Transfer `port2` into the srcdoc frame
+   *      via `contentWindow.postMessage({type:'SHARC:Omid:Port'}, origin,
+   *      [port2])`. The window message carries NO secret — only the port. The
+   *      prelude's `window` `message` listener (already armed during srcdoc
+   *      parse) accepts the port.
+   *   2. The prelude wires `port.onmessage` and posts `{type:'PortReady'}` back
+   *      over the port. On that ready ping, deliver the OMID `protocolNonce`
+   *      over `port1` — point-to-point, invisible to any creative `window`
+   *      `message` listener, and never written into the srcdoc source.
+   *
+   * Origin: posts to the publisher origin (srcdoc inherits the parent origin in
+   * Chromium; Safari/opaque is covered by the shim's `event.source === parent`
+   * load-bearing check — § 7.4). FAIL CLOSED — never `'*'`: a `'*'` target on
+   * the window message would let any document occupying the iframe receive the
+   * port (and then the nonce). C1 discipline, mirroring `_relayOmidEvent`.
+   *
+   * @param {HTMLIFrameElement} iframe
+   * @private
+   */
+  _transferOmidPort(iframe) {
+    let injection = null;
+    for (let ei = 0; ei < this._extensions.length; ei++) {
+      const ext = this._extensions[ei];
+      if (ext && typeof ext.getSrcdocOmidInjection === 'function') {
+        const candidate = ext.getSrcdocOmidInjection();
+        if (candidate
+            && typeof candidate.protocolNonce === 'string'
+            && candidate.protocolNonce.length > 0) {
+          injection = candidate;
+          break;
+        }
+      }
+    }
+    if (injection === null) return; // OMID not active — leave srcdoc untouched.
+
+    if (typeof MessageChannel === 'undefined') {
+      console.warn('[SHARCContainer] MessageChannel unavailable; OMID srcdoc nonce delivery skipped.');
+      return;
+    }
+    if (!iframe || !iframe.contentWindow) return;
+
+    // C1: concrete target origin only — never '*'. srcdoc inherits the
+    // publisher origin; the shim tolerates opaque origin via event.source.
+    const targetOrigin = injection.containerOrigin;
+    if (!targetOrigin) {
+      console.warn('[SHARCContainer] refusing to transfer OMID port without a concrete origin (would leak the port/nonce to any origin).');
+      return;
+    }
+
+    const channel = new MessageChannel();
+    const nonce = injection.protocolNonce;
+
+    // Deliver the nonce over the port only after the prelude acknowledges it has
+    // wired its port handler. Ports buffer pre-handler messages, so this is a
+    // robustness belt — it also makes the ordering observable for tests.
+    channel.port1.onmessage = (ev) => {
+      const data = ev && ev.data;
+      if (data && typeof data === 'object' && data.type === 'SHARC:Omid:PortReady') {
+        try {
+          channel.port1.postMessage({ protocolNonce: nonce });
+        } catch (postErr) {
+          console.warn('[SHARCContainer] OMID nonce port-post failed:',
+            postErr && (postErr.message || postErr));
+        }
+      }
+    };
+    try { channel.port1.start(); } catch (_) { /* auto-starts on onmessage */ }
+
+    try {
+      iframe.contentWindow.postMessage(
+        { type: 'SHARC:Omid:Port' }, targetOrigin, [channel.port2]);
+    } catch (postErr) {
+      // DataCloneError / detached frame — log, do not throw out of load handler.
+      console.warn('[SHARCContainer] OMID port transfer failed:',
+        postErr && (postErr.message || postErr));
     }
   }
 

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -118,6 +118,48 @@ function safeCall(label, fn) {
 }
 
 /**
+ * Escapes a string for safe inclusion inside a double-quoted HTML attribute.
+ * The srcdoc shim `<script src>` URL is operator-controlled (validated
+ * `baseUrl`), but escape defensively so a stray quote / angle bracket cannot
+ * break out of the attribute context.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeHtmlAttr(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Finds the index at which to insert the OMID shim scripts as the FIRST
+ * children of `<head>` for the `srcdoc` variant (§ 4.3 ii: prelude must run at
+ * the very top, before any creative markup). Most-specific-wins, mirroring the
+ * container's `_findCreativeSdkInjectionIndex` contract but scoped to what the
+ * shim needs: after `<head ...>` open tag → after `<html ...>` open tag →
+ * prepend (null → caller prepends). Token-boundary checks reject `<header>`,
+ * `<htmlfoo>`, etc.
+ *
+ * @param {string} html
+ * @returns {number|null} insertion index, or null to prepend.
+ */
+function findHeadInsertionIndex(html) {
+  // After <head ...> open tag. Boundary char after "head" must be whitespace
+  // or '>' so <header>/<heading> do not match.
+  var headRe = /<head(?=[\s>])[^>]*>/i;
+  var m = headRe.exec(html);
+  if (m) return m.index + m[0].length;
+  // After <html ...> open tag.
+  var htmlRe = /<html(?=[\s>])[^>]*>/i;
+  m = htmlRe.exec(html);
+  if (m) return m.index + m[0].length;
+  return null;
+}
+
+/**
  * Logs and throws a configuration error before OM SDK session creation starts.
  *
  * @param {string} message
@@ -555,19 +597,76 @@ OmidCompatBridge.prototype = /** @type {any} */ ({
   },
 
   /**
-   * Returns creative markup unchanged.
+   * URL + `useMarkupInjection` (`srcdoc`) variant shim install (§ 4.2 / § 4.3
+   * mechanism ii). Called by `SHARCContainer._fetchAndInjectCreative()` for the
+   * Creative URL variant when the operator opted into `useMarkupInjection: true`
+   * (the container wraps the creative in a `srcdoc` it controls).
    *
-   * This is the method called by `SHARCContainer._fetchAndInjectCreative()`
-   * when an extension is detected as an injector. For OMID this method is a
-   * true no-op because OM SDK scripts stay in the publisher page:
+   * When OMID is active for this placement, this prepends — as the FIRST
+   * children of `<head>` (or the document if there is no head), before any
+   * creative content — two scripts:
+   *
+   *   1. `<script src="<baseUrl>/sharc-omid-shim.js">` — loads the shim IIFE,
+   *      which self-attaches `window.SHARC.installOmidShimPortReceiver`. A
+   *      parser-blocking external script in `srcdoc`, so it runs to completion
+   *      before the inline prelude below.
+   *   2. An inline prelude `<script>` that calls `installOmidShimPortReceiver`,
+   *      which installs `window.omid3p` SYNCHRONOUSLY (so a verification
+   *      script's first read succeeds — § 4.1) and arms the transferred-port
+   *      receiver. The OMID `protocolNonce` is NOT in this source — it arrives
+   *      async over the MessagePort the container transfers in (§ 4.3 ii). The
+   *      prelude inlines only `placementSessionId` and `containerOrigin`, which
+   *      are non-secret transport anchors (they ride every envelope and the
+   *      Markup-variant renderer inlines them too).
+   *
+   * Returns the markup unchanged when OMID is not active for this placement
+   * (`exposeOmid3p: false`, the `SHARC:Omid:` protocol not registered, or its
+   * nonce not yet derived) — keeping the srcdoc byte-identical to the OMID-off
+   * path. The container's port transfer is gated on the SAME conditions
+   * (`getSrcdocOmidInjection()`), so the prelude and the port handoff are wired
+   * together or not at all.
    *
    *   container calls: `extension.injectIntoMarkup(html)` → string
    *
    * @param {string} html - The raw creative HTML markup.
-   * @returns {string} The raw creative HTML markup, unchanged.
+   * @returns {string} The markup with the shim + prelude prepended, or unchanged.
    */
   injectIntoMarkup: function (html) {
-    return html;
+    if (typeof html !== 'string') return html;
+    var injection = this.getSrcdocOmidInjection();
+    if (injection === null) return html;
+
+    var base = this.options.baseUrl || '/sharc';
+    var shimUrl = base.replace(/\/+$/, '') + '/sharc-omid-shim.js';
+
+    var psid = injection.placementSessionId;
+    var containerOrigin = injection.containerOrigin;
+
+    // Build the two scripts. The nonce is NOT inlined — only the non-secret
+    // transport anchors are. JSON-encode + escape `<` so a hostile value can
+    // never break out of the inline-script context.
+    var jsonLit = function (v) {
+      return JSON.stringify(String(v)).replace(/</g, '\\u003c');
+    };
+    var shimTag = '<script src="' + escapeHtmlAttr(shimUrl) + '"></script>';
+    var preludeTag = '<script>'
+      + '(function(){try{'
+      + 'var f=(window.SHARC&&window.SHARC.installOmidShimPortReceiver)'
+      + '||(typeof installOmidShimPortReceiver==="function"?installOmidShimPortReceiver:null);'
+      + 'if(!f){if(window.console&&console.error)console.error('
+      + '"[SHARC OMID srcdoc] installOmidShimPortReceiver unavailable — shim script did not load");return;}'
+      + 'f({placementSessionId:' + jsonLit(psid) + ','
+      + 'containerOrigin:' + jsonLit(containerOrigin) + '});'
+      + '}catch(e){if(window.console&&console.error)console.error('
+      + '"[SHARC OMID srcdoc] shim port-receiver install failed:",e&&e.message?e.message:e);}}());'
+      + '</script>';
+    var scripts = shimTag + preludeTag;
+
+    var idx = findHeadInsertionIndex(html);
+    if (idx !== null) {
+      return html.slice(0, idx) + scripts + html.slice(idx);
+    }
+    return scripts + html;
   },
 
   /**
@@ -933,8 +1032,22 @@ OmidCompatBridge.prototype = /** @type {any} */ ({
       self._omid.sessionStarted = true;
       self._omid.sessionFinished = false;
       // Record the creative-iframe origin for outbound posting (§ 6.2 step 2).
+      //   - Markup variant: the renderer's validated origin (`_rendererOrigin`).
+      //   - URL + `useMarkupInjection` (`srcdoc`) variant: there is no renderer,
+      //     so `_rendererOrigin` is null. A srcdoc frame inherits the publisher
+      //     origin (Chromium) or is opaque (Safari/others). Outbound `:Event`
+      //     posts target the publisher origin; the shim tolerates the opaque
+      //     case via its load-bearing `event.source === parent` check (§ 7.4).
+      //     This keeps `_relayOmidEvent`'s C1 fail-closed guard from refusing to
+      //     post on the no-renderer path (it would otherwise see a null origin
+      //     and drop every event).
       if (self._container) {
-        self._omidIframeOrigin = self._container._rendererOrigin || self._omidIframeOrigin;
+        var iframeOrigin = self._container._rendererOrigin;
+        if (!iframeOrigin && self._container._useMarkupInjection
+            && typeof window !== 'undefined' && window.location) {
+          iframeOrigin = window.location.origin;
+        }
+        self._omidIframeOrigin = iframeOrigin || self._omidIframeOrigin;
       }
       // OMID session has started on the publisher page — this is router
       // § 4.1's documented `omid-active` entry condition. Drive the phase
@@ -1264,6 +1377,51 @@ OmidCompatBridge.prototype = /** @type {any} */ ({
       return null;
     }
     return { protocolNonce: this._omidProtocolNonce };
+  },
+
+  /**
+   * URL/`srcdoc` variant trusted-injection accessor (§ 4.3 mechanism ii). The
+   * counterpart to `getRendererOmidInjection` for the no-renderer path.
+   *
+   * The container queries this in two places, which MUST agree:
+   *   1. `injectIntoMarkup(html)` — to decide whether to prepend the shim +
+   *      port-receiver prelude into the `srcdoc`.
+   *   2. The iframe `load` handler — to decide whether to create the
+   *      `MessageChannel`, transfer a port into the frame, and deliver the OMID
+   *      `protocolNonce` over it.
+   *
+   * Returns `null` whenever OMID is not active for this placement, so both
+   * sites no-op together and the `srcdoc` stays byte-identical to the OMID-off
+   * path. Same gate as `getRendererOmidInjection` plus the transport anchors the
+   * prelude needs inlined (non-secret: `placementSessionId` + `containerOrigin`).
+   *
+   * The returned `protocolNonce` is for the container's port-transfer step ONLY;
+   * it is NEVER inlined into the `srcdoc` source (that would re-introduce the
+   * #254 DOM-readable exposure). It travels exclusively over the transferred
+   * MessagePort.
+   *
+   * @returns {{ protocolNonce: string, placementSessionId: string, containerOrigin: string }|null}
+   */
+  getSrcdocOmidInjection: function () {
+    if (this.options.exposeOmid3p === false) return null;
+    if (!this._omidProtocolRegistered) return null;
+    if (typeof this._omidProtocolNonce !== 'string'
+        || this._omidProtocolNonce.length === 0) {
+      return null;
+    }
+    var container = this._container;
+    var psid = (container && typeof container.placementSessionId === 'string')
+      ? container.placementSessionId
+      : null;
+    if (psid === null) return null;
+    var containerOrigin = (typeof window !== 'undefined' && window.location)
+      ? window.location.origin
+      : '';
+    return {
+      protocolNonce: this._omidProtocolNonce,
+      placementSessionId: psid,
+      containerOrigin: containerOrigin,
+    };
   },
 
   /**

--- a/src/sharc-omid-shim.js
+++ b/src/sharc-omid-shim.js
@@ -157,7 +157,23 @@ function installOmidShim(config) {
 
   // The OMID protocolNonce — private closure constant. Outbound SHARC:Omid:
   // Register envelopes are signed with it; it is NEVER read back out.
+  //
+  // Two delivery shapes feed this one closure var:
+  //   - Markup variant (§ 4.3 mechanism i): the renderer source-rewrites the
+  //     nonce in as a baked literal, so `config.protocolNonce` is present at
+  //     install and this is a true constant from line one.
+  //   - URL/`srcdoc` variant (§ 4.3 mechanism ii): the nonce arrives async over
+  //     a transferred MessagePort AFTER install (the shim installs synchronously
+  //     so `window.omid3p` is present before any creative read — § 4.1). The
+  //     prelude sets it exactly once via the control-handle `_setProtocolNonce`
+  //     below the instant the port message arrives. It is still a closure var
+  //     never reachable from `window.omid3p`; "constant" is enforced by the
+  //     write-once guard (a second set is ignored), not by `var`.
   var protocolNonce = config.protocolNonce;
+  // Tracks whether the nonce has been delivered yet (port variant installs with
+  // a pending nonce). `false` once a non-empty nonce is in hand. Used to gate
+  // the write-once setter and to fail-closed on inbound validation pre-delivery.
+  var nonceResolved = (typeof protocolNonce === 'string' && protocolNonce.length > 0);
   var placementSessionId = config.placementSessionId;
   var containerOrigin = config.containerOrigin;
   var parentWindow = config.parentWindow
@@ -275,6 +291,13 @@ function installOmidShim(config) {
     if (event.origin && event.origin !== 'null') {
       if (containerOrigin && event.origin !== containerOrigin) return false;
     }
+    // Fail closed before the nonce has been delivered (port variant installs
+    // with a pending nonce). No legitimate inbound `:Event` can arrive before
+    // `sessionStart`, which is itself long after the port-delivered nonce
+    // resolves — so this only ever rejects a pre-delivery forgery, never a real
+    // event. Guards against `sharcNonce === undefined === protocolNonce` ever
+    // passing while the nonce is still pending.
+    if (!nonceResolved) return false;
     if (event.data.sharcNonce !== protocolNonce) return false;
     if (event.data.placementSessionId !== placementSessionId) return false;
     return true;
@@ -325,6 +348,12 @@ function installOmidShim(config) {
     var queued = pendingRegisterEnvelopes;
     pendingRegisterEnvelopes = [];
     for (var i = 0; i < queued.length; i++) {
+      // Re-stamp the live nonce. In the port variant a Register can be built
+      // (queued) before the nonce arrives over the port; the envelope captured
+      // the then-pending value. Flush runs only at `sessionStart`, by which
+      // point the nonce is resolved — re-stamp so the posted envelope carries
+      // the real nonce, never a stale pending one.
+      queued[i].sharcNonce = protocolNonce;
       postRegister(queued[i]);
     }
   }
@@ -431,9 +460,29 @@ function installOmidShim(config) {
 
   // Internal control handle — test/diagnostic affordance only. Deliberately
   // carries NO nonce. Not the omid3p surface.
+  //
+  // `_setProtocolNonce` is the URL/`srcdoc` port variant's one-time nonce
+  // delivery seam (§ 4.3 mechanism ii). The shim installs synchronously with a
+  // pending nonce (so `window.omid3p` exists before any creative read — § 4.1),
+  // then the prelude calls this the instant the nonce arrives over the
+  // transferred MessagePort. Write-once: a second call (or a call when the
+  // nonce was already baked in by the Markup source-rewrite path) is ignored,
+  // so a creative that somehow reached the control handle cannot rotate the
+  // nonce. It returns the resulting resolved-state for tests. The handle is
+  // NEVER exposed to vendor JS (it is the prelude's private return value), and
+  // there is deliberately no getter — the nonce is write-only from here.
+  function setProtocolNonce(nonce) {
+    if (nonceResolved) return false;
+    if (typeof nonce !== 'string' || nonce.length === 0) return false;
+    protocolNonce = nonce;
+    nonceResolved = true;
+    return true;
+  }
+
   return {
     _handleInbound: handleInbound,
     _isValidInbound: isValidInbound,
+    _setProtocolNonce: setProtocolNonce,
     getStats: function () {
       return {
         liveSubscriptions: subscriptions.size,
@@ -443,10 +492,130 @@ function installOmidShim(config) {
         sessionStarted: sessionStarted,
         dropped: dropped,
         maxSubscriptions: maxSubscriptions,
+        nonceResolved: nonceResolved,
       };
     },
     destroy: dropOmid3p,
   };
+}
+
+/**
+ * URL/`srcdoc` variant prelude (§ 4.3 mechanism ii — MessageChannel).
+ *
+ * There is no renderer in the URL+`useMarkupInjection` path, so the Markup
+ * variant's source-rewrite-the-nonce-as-a-literal mechanism (i) does not apply.
+ * Instead the container transfers a one-time `MessagePort` into the `srcdoc`
+ * frame and delivers the OMID `protocolNonce` over it. This function is the
+ * shim-side receiver, designed to run as the FIRST script in the `srcdoc`
+ * document (synchronously, during parse, before any creative markup executes).
+ *
+ * ORDERING GUARANTEE (the crux — design § 4.3 ii). Executed synchronously, in
+ * this exact order, before yielding to the event loop:
+ *   1. Install `window.omid3p` (via `installOmidShim`) with a PENDING nonce, so
+ *      a verification script's first synchronous `window.omid3p` read succeeds
+ *      (§ 4.1). Vendor `registerSessionObserver`/`addEventListener` calls that
+ *      run in the same synchronous parse unit queue locally; the shim defers the
+ *      outbound `SHARC:Omid:Register` post to `sessionStart` regardless (§ 5.5),
+ *      so no Register can post before the nonce resolves.
+ *   2. Install the `window` `message` listener that catches the transferred
+ *      port. The port arrives as `event.ports[0]` of a `window` message — this
+ *      is the ONLY window message the prelude consumes; the nonce itself rides
+ *      the port (`port.onmessage`), point-to-point and invisible to any creative
+ *      `window` `message` listener.
+ *   3. When the port message arrives (a TASK — it cannot dispatch until the
+ *      current synchronous unit, including parser-inserted creative `<script>`s,
+ *      has yielded), register `port.onmessage`, then post a readiness ping so
+ *      the container can deliver the nonce as the first thing over the port.
+ *   4. The nonce message over the port stashes the nonce via the shim handle's
+ *      write-once `_setProtocolNonce`. The port handler is provably installed
+ *      before the nonce message can be dispatched (handler registered
+ *      synchronously; message is a task), so the nonce becomes a resolved
+ *      closure constant before any outbound Register is posted (Register posts
+ *      defer to `sessionStart`, a later inbound). RACE-FREE.
+ *
+ * The nonce NEVER transits the `srcdoc` source (so it is not readable from
+ * `document.scripts` text — #254-clean), NEVER `location.hash`/query/global/
+ * DOM-attr, and NEVER reaches `window.omid3p` or any observer callback.
+ *
+ * @param {{
+ *   placementSessionId: string,
+ *   containerOrigin: string,
+ *   targetWindow?: Window,
+ *   parentWindow?: Window,
+ *   maxSubscriptions?: number,
+ *   onNonceResolved?: (resolved: boolean) => void,
+ * }} config
+ * @returns {object} the shim's internal control handle (carries no nonce).
+ */
+function installOmidShimPortReceiver(config) {
+  config = config || {};
+  var targetWindow = config.targetWindow
+    || (typeof window !== 'undefined' ? window : undefined);
+  if (!targetWindow) {
+    throw new Error('[SHARC OMID Shim] no target window for port-receiver install');
+  }
+  var parentWindow = config.parentWindow
+    || (targetWindow.parent || (typeof window !== 'undefined' ? window.parent : undefined));
+
+  // STEP 1 — install the shim synchronously with a PENDING nonce so
+  // `window.omid3p` is present before any creative read (§ 4.1). The outbound
+  // Register path still rides `window.message` (OMID-D1: the port is for the
+  // nonce only, steady-state OMID traffic uses the router channel), so the
+  // shim's default `postRegister` (parent.postMessage to containerOrigin) is
+  // exactly right here — we do NOT route Register over the port.
+  var handle = installOmidShim({
+    // protocolNonce intentionally omitted — delivered async over the port.
+    placementSessionId: config.placementSessionId,
+    containerOrigin: config.containerOrigin,
+    targetWindow: targetWindow,
+    parentWindow: parentWindow,
+    maxSubscriptions: config.maxSubscriptions,
+  });
+
+  var portWired = false;
+
+  function wirePort(port) {
+    if (portWired || !port) return;
+    portWired = true;
+    // STEP 4 — nonce arrives over the point-to-point port. Stash it write-once.
+    port.onmessage = function (ev) {
+      var data = ev && ev.data;
+      var nonce = (data && typeof data === 'object') ? data.protocolNonce : data;
+      var ok = handle._setProtocolNonce(nonce);
+      if (typeof config.onNonceResolved === 'function') {
+        try { config.onNonceResolved(ok); } catch (_) { /* test hook */ }
+      }
+    };
+    if (typeof port.start === 'function') {
+      try { port.start(); } catch (_) { /* ports auto-start on onmessage assign */ }
+    }
+    // Tell the container the receiver is live so it can post the nonce now.
+    // Carries NO secret — it is a bare readiness ping back over the same port.
+    try { port.postMessage({ type: 'SHARC:Omid:PortReady' }); } catch (_) { /* best-effort */ }
+  }
+
+  // STEP 2/3 — one-time window listener that captures the transferred port.
+  // The container posts `contentWindow.postMessage(initMsg, origin, [port2])`;
+  // the port shows up as event.ports[0]. We accept the port on a best-effort
+  // origin check (srcdoc may be opaque-origin — § 7.4): require source===parent;
+  // accept the port and let the nonce-bearing port message (and the inbound
+  // `:Event` validator) be the load-bearing nonce gate. No nonce is read here.
+  var portListener = function (event) {
+    if (parentWindow && event.source !== parentWindow) return;
+    if (!event.ports || event.ports.length === 0) return;
+    var data = event.data;
+    if (!data || typeof data !== 'object') return;
+    if (data.type !== 'SHARC:Omid:Port') return;
+    if (typeof targetWindow.removeEventListener === 'function') {
+      try { targetWindow.removeEventListener('message', portListener, false); } catch (_) { /* ignore */ }
+    }
+    wirePort(event.ports[0]);
+  };
+  if (typeof targetWindow.addEventListener === 'function') {
+    targetWindow.addEventListener('message', portListener, false);
+  }
+
+  return handle;
 }
 
 // ---------------------------------------------------------------------------
@@ -454,15 +623,22 @@ function installOmidShim(config) {
 // ---------------------------------------------------------------------------
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { installOmidShim: installOmidShim, MAX_OMID_SUBSCRIPTIONS: MAX_OMID_SUBSCRIPTIONS };
+  module.exports = {
+    installOmidShim: installOmidShim,
+    installOmidShimPortReceiver: installOmidShimPortReceiver,
+    MAX_OMID_SUBSCRIPTIONS: MAX_OMID_SUBSCRIPTIONS,
+  };
 }
 
-export { installOmidShim, MAX_OMID_SUBSCRIPTIONS };
+export { installOmidShim, installOmidShimPortReceiver, MAX_OMID_SUBSCRIPTIONS };
 
 // Browser-global attachment for the source-rewrite / direct-include path.
 if (typeof window !== 'undefined') {
   window.SHARC = window.SHARC || {};
   if (!window.SHARC.installOmidShim) {
     window.SHARC.installOmidShim = installOmidShim;
+  }
+  if (!window.SHARC.installOmidShimPortReceiver) {
+    window.SHARC.installOmidShimPortReceiver = installOmidShimPortReceiver;
   }
 }

--- a/test/node/test-omid-srcdoc-delivery.js
+++ b/test/node/test-omid-srcdoc-delivery.js
@@ -1,0 +1,403 @@
+/**
+ * test-omid-srcdoc-delivery.js — 0.7.8 OMID URL + `useMarkupInjection`
+ * (`srcdoc`) variant nonce delivery via MessageChannel (design § 4.3 mechanism
+ * ii — the no-renderer path).
+ *
+ * The Markup variant (PR 1, test-omid-markup-delivery.js) delivers the OMID
+ * nonce by renderer source-rewrite. There is no renderer in the URL+`srcdoc`
+ * path, so the container instead:
+ *   - has the OMID bridge's `injectIntoMarkup` prepend the shim + a port-
+ *     receiver prelude into the `srcdoc` (NO nonce literal — #254-clean), and
+ *   - transfers a `MessageChannel` port into the frame on iframe `load`,
+ *     delivering the OMID `protocolNonce` over that point-to-point port.
+ *
+ * Assertions:
+ *   1. CONTAINER injectIntoMarkup: when OMID active, prepends the shim
+ *      `<script src>` + port-receiver prelude as the FIRST head children; the
+ *      nonce is NOT a readable literal anywhere in the srcdoc source
+ *      (#254-clean). With `exposeOmid3p:false`, markup is byte-identical
+ *      (unchanged).
+ *   2. REAL MessagePort END-TO-END: a parent transfers a REAL port to a
+ *      srcdoc-like child window; the shim receives the nonce over the port and
+ *      `window.omid3p` works (registerSessionObserver → callback on inbound
+ *      sessionStart). NOT via calling an internal directly.
+ *   3. ORDERING (regression-sensitive): the port handler is installed and the
+ *      nonce stashed BEFORE creative code runs; and the negative case — a port
+ *      whose nonce is delivered AFTER creative execution — leaves the nonce
+ *      unresolved at creative-time (the property the real wiring must preserve).
+ *   4. #254-CLEAN in the live document: the nonce is NOT readable from
+ *      `document.scripts` text, NOT on hash/global/DOM-attr, NOT on omid3p.
+ *   5. exposeOmid3p-OFF: srcdoc path unchanged — no prelude, no port, no shim.
+ *   6. MALFORMED/MISSING-PORT: no port, wrong message shape → clean failure,
+ *      no hang, omid3p still present (nonce just stays unresolved).
+ *
+ * Real MessagePort note: jsdom does NOT provide MessageChannel/MessagePort, but
+ * Node's global `MessageChannel` is a real, message-delivering web MessagePort.
+ * A jsdom `MessageEvent` carries a real Node `MessagePort` in `event.ports`, so
+ * the nonce genuinely travels over a real port (verified end-to-end below).
+ *
+ * Runs in Node after `npm run build`. Uses jsdom. No test framework.
+ *
+ * @see docs/design/0.7.8-omid-spec-compliant-bridge.md § 4.2, § 4.3, § 7.4
+ */
+
+import { JSDOM } from 'jsdom';
+
+const PUBLISHER_ORIGIN = 'https://publisher.example';
+const CREATIVE_URL = PUBLISHER_ORIGIN + '/creative.html';
+const CREATIVE_HTML = '<!DOCTYPE html><html><head><title>ad</title></head>'
+  + '<body><div id="creative">ad</div></body></html>';
+
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+  url: PUBLISHER_ORIGIN + '/page.html',
+});
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.HTMLIFrameElement = dom.window.HTMLIFrameElement;
+global.MessageEvent = dom.window.MessageEvent;
+global.DOMParser = dom.window.DOMParser;
+// Real web MessagePort (Node global) — jsdom provides neither. The container's
+// `_transferOmidPort` constructs `new MessageChannel()`; wire the Node global
+// onto the jsdom window so production code sees a real, working channel.
+dom.window.MessageChannel = MessageChannel;
+dom.window.MessagePort = MessagePort;
+
+if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.subtle?.sign !== 'function') {
+  const nodeCrypto = await import('node:crypto');
+  globalThis.crypto = nodeCrypto.webcrypto;
+}
+
+const protoMod = await import('../../dist/sharc-protocol.mjs');
+window.SHARC = window.SHARC || {};
+window.SHARC.Protocol = protoMod;
+const { SHARCContainer } = await import('../../dist/sharc-container.mjs');
+const { OmidCompatBridge } = await import('../../dist/sharc-omid-bridge.mjs');
+const shimMod = await import('../../dist/sharc-omid-shim.mjs');
+const { installOmidShimPortReceiver } = shimMod;
+
+let failures = 0;
+function section(name) { console.log('\n' + name); }
+function assert(condition, message) {
+  if (condition) console.log('  ✓', message);
+  else { console.error('  ✗', message); failures++; }
+}
+const tick = () => new Promise((r) => setTimeout(r, 10));
+
+function freshSlot() {
+  document.body.innerHTML = '';
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  return el;
+}
+
+function installOmSdkStub() {
+  let registeredObserver = null;
+  const adSession = {
+    sessionId: 'omsdk-session-srcdoc',
+    setCreativeType() {}, setImpressionType() {}, registerAdView() {},
+    registerSessionObserver(cb) { registeredObserver = cb; },
+    addFriendlyObstruction() {}, removeFriendlyObstruction() {},
+    start() {},
+    finish() { if (registeredObserver) registeredObserver({ type: 'sessionFinish' }); },
+  };
+  window.OmidSessionClient = {
+    Partner: function () {},
+    Context: function () { this.setContentUrl = function () {}; this.setServiceScriptUrl = function () {}; },
+    AdSession: function () { return adSession; },
+    AdEvents: function () { return { loaded() {}, impressionOccurred() {}, stateChange() {} }; },
+    MediaEvents: function () { return { playerStateChange() {} }; },
+    VerificationScriptResource: function () {},
+    VastProperties: function () {},
+  };
+  return adSession;
+}
+
+// Build a URL + useMarkupInjection container, await OMID-nonce derivation, and
+// capture the srcdoc the container assigns + the port/nonce transfer.
+async function buildSrcdocContainer(bridgeOptions) {
+  installOmSdkStub();
+  const bridge = new OmidCompatBridge({
+    omSdkServiceScriptUrl: 'https://cdn.example/omid/omweb-v1.js',
+    omSdkSessionClientUrl: 'https://cdn.example/omid/omid-session-client-v1.js',
+    creativeType: 'display', mediaType: 'display',
+    baseUrl: '/sharc',
+    ...bridgeOptions,
+  });
+  const c = new SHARCContainer({
+    creativeUrl: CREATIVE_URL,
+    creativeSource: 'url',
+    useMarkupInjection: true,
+    placementElement: freshSlot(),
+    extensions: [bridge],
+  });
+  // Stub fetch so _fetchAndInjectCreative reads our creative HTML.
+  global.fetch = async () => ({ ok: true, status: 200, statusText: 'OK', text: async () => CREATIVE_HTML });
+
+  c.load();
+  await c.protocolRouter.ready('SHARC:Omid:');
+  return { c, bridge };
+}
+
+console.log('test-omid-srcdoc-delivery.js — 0.7.8 OMID srcdoc/MessageChannel\n');
+
+let derivedNonce = null;
+let psid = null;
+
+// ── 1. Container injectIntoMarkup: shim + prelude, #254-clean ───────────────
+section('1. injectIntoMarkup prepends shim + port-receiver prelude (OMID active)');
+{
+  const { c, bridge } = await buildSrcdocContainer({});
+  const omid = c.protocolRouter.getProtocol('SHARC:Omid:');
+  derivedNonce = omid.protocolNonce;
+  psid = c.placementSessionId;
+
+  const out = bridge.injectIntoMarkup(CREATIVE_HTML);
+  assert(out !== CREATIVE_HTML, 'injectIntoMarkup transformed the markup when OMID active');
+  assert(/<script src="\/sharc\/sharc-omid-shim\.js"><\/script>/.test(out),
+    'prepends the shim <script src> tag');
+  assert(/installOmidShimPortReceiver/.test(out),
+    'prepends the port-receiver prelude (calls installOmidShimPortReceiver)');
+  // First head child ordering: shim tag appears immediately after <head ...>.
+  const headIdx = out.search(/<head(?=[\s>])[^>]*>/i);
+  const shimIdx = out.indexOf('sharc-omid-shim.js');
+  const creativeIdx = out.indexOf('id="creative"');
+  assert(headIdx !== -1 && shimIdx > headIdx && shimIdx < creativeIdx,
+    'shim script is injected at the top of <head>, before creative content');
+  // #254-clean: the OMID nonce is NOT a readable literal anywhere in the srcdoc.
+  assert(out.indexOf(derivedNonce) === -1,
+    'the OMID nonce is NOT present as a literal in the srcdoc source (#254-clean)');
+  // Non-secret transport anchors MAY be inlined (psid, origin) — sanity check
+  // the prelude carries them so the shim can validate inbound events.
+  assert(out.indexOf(psid) !== -1,
+    'placementSessionId (non-secret transport anchor) is inlined in the prelude');
+  c._terminate();
+}
+
+// ── 2. exposeOmid3p OFF — srcdoc unchanged ──────────────────────────────────
+section('2. injectIntoMarkup is a no-op when exposeOmid3p:false');
+{
+  const { c, bridge } = await buildSrcdocContainer({ exposeOmid3p: false });
+  const out = bridge.injectIntoMarkup(CREATIVE_HTML);
+  assert(out === CREATIVE_HTML,
+    'injectIntoMarkup returns markup byte-identical when OMID off (no shim, no prelude)');
+  assert(out.indexOf('sharc-omid-shim.js') === -1, 'no shim script injected when OMID off');
+  assert(typeof bridge.getSrcdocOmidInjection === 'function'
+    && bridge.getSrcdocOmidInjection() === null,
+    'getSrcdocOmidInjection() returns null when OMID off (gates the port transfer off too)');
+  c._terminate();
+}
+
+// ── 3. Real-MessagePort END-TO-END + ORDERING ───────────────────────────────
+//
+// Drive the real shim prelude (`installOmidShimPortReceiver`) inside a child
+// jsdom window with `window.parent` set to a distinct publisher window. Transfer
+// a REAL Node MessagePort carrying the nonce. Assert window.omid3p works and the
+// nonce arrives over the port — and that the handler/nonce ordering holds.
+section('3. real-MessagePort end-to-end + ordering');
+{
+  // Child (srcdoc-like) window.
+  const childDom = new JSDOM(
+    '<!DOCTYPE html><html><head></head><body></body></html>',
+    { url: CREATIVE_URL, runScripts: 'dangerously' });
+  const childWin = childDom.window;
+  // Distinct publisher window object as the parent identity (event.source gate).
+  const parentWin = dom.window;
+  childWin.MessagePort = MessagePort;
+
+  // Install the shim prelude as the FIRST thing in the child window (mirrors the
+  // prelude running synchronously at the top of the srcdoc). Track ordering via
+  // a resolution flag.
+  let nonceResolvedAt = null;       // 'before-creative' | 'after-creative'
+  let creativeRan = false;
+  const handle = installOmidShimPortReceiver({
+    placementSessionId: psid,
+    containerOrigin: PUBLISHER_ORIGIN,
+    targetWindow: childWin,
+    parentWindow: parentWin,
+    onNonceResolved: () => { nonceResolvedAt = creativeRan ? 'after-creative' : 'before-creative'; },
+  });
+
+  // §4.1: window.omid3p is present SYNCHRONOUSLY, before any creative read.
+  assert(childWin.omid3p && typeof childWin.omid3p === 'object',
+    'window.omid3p installed synchronously by the prelude (before any port message)');
+  assert(typeof childWin.omid3p.registerSessionObserver === 'function'
+    && typeof childWin.omid3p.addEventListener === 'function',
+    'omid3p exposes the two probed methods immediately (isSupported() → true)');
+  assert(handle.getStats().nonceResolved === false,
+    'nonce is NOT yet resolved at install time (arrives async over the port)');
+
+  // Build a REAL MessageChannel; emulate the container's _transferOmidPort
+  // handshake from the publisher side.
+  const channel = new MessageChannel();
+  channel.port1.onmessage = (ev) => {
+    if (ev && ev.data && ev.data.type === 'SHARC:Omid:PortReady') {
+      channel.port1.postMessage({ protocolNonce: derivedNonce });
+    }
+  };
+  channel.port1.start();
+
+  // A "creative" registers an observer synchronously (omid3p present) BEFORE the
+  // port message can dispatch (port delivery is a task).
+  let observed = null;
+  childWin.omid3p.registerSessionObserver(function (ev) { observed = ev; }, 'dv', 'inj-1');
+  creativeRan = true; // creative's synchronous unit has run
+
+  // Now deliver the transferred port as a window message with a REAL port in
+  // event.ports (the container's contentWindow.postMessage(..., [port2])).
+  const portEvt = new childWin.MessageEvent('message', {
+    data: { type: 'SHARC:Omid:Port' },
+    origin: PUBLISHER_ORIGIN,
+    source: parentWin,
+    ports: [channel.port2],
+  });
+  childWin.dispatchEvent(portEvt);
+
+  await tick(); // let the port handshake + nonce delivery run
+
+  assert(handle.getStats().nonceResolved === true,
+    'nonce resolved after the port message delivered it (over a REAL MessagePort)');
+  assert(nonceResolvedAt === 'after-creative',
+    'ORDERING: the nonce arrives as a TASK, after the synchronous creative unit — '
+    + 'omid3p was present the whole time, nonce stashed before any Register posts');
+
+  // Now an inbound sessionStart Event (from parent) reaches the observer — the
+  // shim's inbound validator now passes (nonce resolved, source===parent).
+  const evt = new childWin.MessageEvent('message', {
+    data: {
+      type: 'SHARC:Omid:Event', sharcNonce: derivedNonce, placementSessionId: psid,
+      event: { type: 'sessionStart', data: { context: { apiVersion: '1.0' } } },
+    },
+    origin: PUBLISHER_ORIGIN, source: parentWin,
+  });
+  childWin.dispatchEvent(evt);
+
+  assert(observed !== null && observed.type === 'sessionStart',
+    'END-TO-END: registered observer received the sessionStart after real-port nonce delivery');
+  assert(observed && JSON.stringify(observed).indexOf(derivedNonce) === -1,
+    'observer callback NEVER carries the OMID nonce (§ 5.2 / § 9 dep 6)');
+
+  // #254-clean in the live document: nonce not on hash/global/omid3p.
+  assert(childWin.location.hash.indexOf(derivedNonce) === -1,
+    'nonce is NOT on the child location.hash');
+  assert(childWin.protocolNonce === undefined && childWin.omid3p.protocolNonce === undefined,
+    'nonce is NOT a global and NOT on window.omid3p');
+
+  channel.port1.close(); channel.port2.close();
+  handle.destroy();
+}
+
+// ── 3b. ORDERING negative case: nonce delivered before handler is impossible;
+// assert the regression-sensitive property — a forged inbound Event arriving
+// BEFORE the nonce resolves is DROPPED (fail-closed). If the shim resolved the
+// nonce eagerly/synchronously from the window message (the bug shape), this
+// would leak. ───────────────────────────────────────────────────────────────
+section('3b. ordering regression: inbound Event before nonce-resolve is dropped');
+{
+  const childDom = new JSDOM(
+    '<!DOCTYPE html><html><head></head><body></body></html>',
+    { url: CREATIVE_URL, runScripts: 'dangerously' });
+  const childWin = childDom.window;
+  const parentWin = dom.window;
+  childWin.MessagePort = MessagePort;
+
+  const handle = installOmidShimPortReceiver({
+    placementSessionId: psid, containerOrigin: PUBLISHER_ORIGIN,
+    targetWindow: childWin, parentWindow: parentWin,
+  });
+  let observed = null;
+  childWin.omid3p.registerSessionObserver(function (ev) { observed = ev; });
+
+  // Inbound sessionStart BEFORE any port/nonce delivery — must be dropped, since
+  // the shim fails closed while the nonce is unresolved (a pre-fix shim that
+  // treated `undefined === undefined` as a nonce match would deliver it).
+  assert(handle.getStats().nonceResolved === false, 'pre-condition: nonce unresolved');
+  const evt = new childWin.MessageEvent('message', {
+    data: {
+      type: 'SHARC:Omid:Event', sharcNonce: undefined, placementSessionId: psid,
+      event: { type: 'sessionStart', data: {} },
+    },
+    origin: PUBLISHER_ORIGIN, source: parentWin,
+  });
+  childWin.dispatchEvent(evt);
+  assert(observed === null,
+    'inbound Event with no nonce is DROPPED while the nonce is unresolved (fail-closed) '
+    + '— the negative case the eager-resolve bug would FAIL');
+  handle.destroy();
+}
+
+// ── 4. #254-clean: nonce not readable from document.scripts text ────────────
+section('4. #254-clean — nonce not readable from the srcdoc document.scripts');
+{
+  // Run the REAL bridge-produced srcdoc in a live document and read its scripts.
+  const { c, bridge } = await buildSrcdocContainer({});
+  const omid = c.protocolRouter.getProtocol('SHARC:Omid:');
+  const nonce = omid.protocolNonce;
+  const out = bridge.injectIntoMarkup(CREATIVE_HTML);
+
+  const liveDom = new JSDOM(out, { url: CREATIVE_URL });
+  const scripts = Array.from(liveDom.window.document.scripts);
+  let anyScriptHasNonce = false;
+  for (const s of scripts) {
+    if ((s.textContent && s.textContent.indexOf(nonce) !== -1)
+        || (s.src && s.src.indexOf(nonce) !== -1)
+        || (s.outerHTML && s.outerHTML.indexOf(nonce) !== -1)) {
+      anyScriptHasNonce = true;
+    }
+  }
+  assert(!anyScriptHasNonce,
+    'the OMID nonce is NOT readable from any document.scripts text/src/outerHTML (#254-clean)');
+  assert(liveDom.serialize().indexOf(nonce) === -1,
+    'the OMID nonce is NOT anywhere in the serialized srcdoc DOM');
+  c._terminate();
+}
+
+// ── 5. Malformed / missing-port handling — clean failure, no hang ───────────
+section('5. malformed / missing-port handling');
+{
+  const childDom = new JSDOM(
+    '<!DOCTYPE html><html><head></head><body></body></html>',
+    { url: CREATIVE_URL, runScripts: 'dangerously' });
+  const childWin = childDom.window;
+  const parentWin = dom.window;
+  childWin.MessagePort = MessagePort;
+
+  const handle = installOmidShimPortReceiver({
+    placementSessionId: psid, containerOrigin: PUBLISHER_ORIGIN,
+    targetWindow: childWin, parentWindow: parentWin,
+  });
+
+  // (a) Port message with NO ports — ignored, no throw, nonce stays unresolved.
+  childWin.dispatchEvent(new childWin.MessageEvent('message', {
+    data: { type: 'SHARC:Omid:Port' }, origin: PUBLISHER_ORIGIN, source: parentWin,
+  }));
+  // (b) Wrong message shape (right ports, wrong type) — ignored.
+  const ch = new MessageChannel();
+  childWin.dispatchEvent(new childWin.MessageEvent('message', {
+    data: { type: 'NotThePortMessage' }, origin: PUBLISHER_ORIGIN, source: parentWin,
+    ports: [ch.port2],
+  }));
+  // (c) Port message from a NON-parent source — rejected by the source gate.
+  const ch2 = new MessageChannel();
+  childWin.dispatchEvent(new childWin.MessageEvent('message', {
+    data: { type: 'SHARC:Omid:Port' }, origin: PUBLISHER_ORIGIN, source: {}, ports: [ch2.port2],
+  }));
+  await tick();
+
+  assert(handle.getStats().nonceResolved === false,
+    'nonce stays unresolved under malformed/missing/wrong-source port messages (no spurious resolve)');
+  assert(childWin.omid3p && typeof childWin.omid3p.registerSessionObserver === 'function',
+    'omid3p still present and usable (no hang, no crash) after malformed port messages');
+  ch.port1.close(); ch.port2.close(); ch2.port1.close(); ch2.port2.close();
+  handle.destroy();
+}
+
+// ── Summary ─────────────────────────────────────────────────────────────────
+console.log('');
+if (failures === 0) {
+  console.log('✓ All omid-srcdoc-delivery assertions passed.');
+  process.exit(0);
+} else {
+  console.error('✗ ' + failures + ' omid-srcdoc-delivery assertion(s) failed.');
+  process.exit(1);
+}


### PR DESCRIPTION
PR2 of the 0.7.8 OMID bridge: the **URL/`srcdoc` MessageChannel nonce-delivery variant** (design §4.3 mechanism ii — the no-renderer path). Builds on the merged Markup-variant core (#250).

## What it adds
- **Container port-transfer** (`_transferOmidPort`): on the srcdoc iframe `load`, constructs a `MessageChannel`, transfers `port2` into the frame (`postMessage({type:'SHARC:Omid:Port'}, origin, [port2])` — no secret on the window message), and delivers the OMID nonce over the point-to-point `port1` after a `PortReady` handshake. **Fails closed** on a missing concrete origin — never `'*'` (C1).
- **Bridge `injectIntoMarkup`** (was a no-op stub in #250): prepends the shim `<script src>` + a port-receiver prelude as the first `<head>` children when OMID is active; `getSrcdocOmidInjection()` gates injection + port transfer together.
- **Shim port-receive** (`installOmidShimPortReceiver`): installs `window.omid3p` synchronously, arms a one-time listener for the transferred port, stashes the port-delivered nonce write-once as a closure constant.

## #254-clean by construction
The nonce travels **only over the transferred port** — never inlined into the srcdoc source. Tests assert it's absent from the bridge-produced markup, `document.scripts` text/src/outerHTML of the live srcdoc, the serialized DOM, `location.hash`, globals, and `window.omid3p`. So this variant delivers the nonce *without* the DOM-readable exposure the Markup source-rewrite has (the direction #254's fix points).

## Ordering guarantee (regression-tested)
The prelude is the first synchronous script: it installs `omid3p` + the port-receive listener before yielding. A port message is a *task* that can't dispatch until the synchronous parse unit (incl. creative inline scripts) yields, so the handler is provably installed before the nonce can arrive; Register posts defer to `sessionStart`, so the nonce is a resolved closure constant before any outbound. Test asserts `nonceResolvedAt === 'after-creative'` and a fail-closed control (inbound Event with unresolved nonce is dropped) — **verified to fail if the guard is removed.**

## Scope / lane
`src/sharc-container.js` (srcdoc/port) + `src/sharc-omid-bridge.js` (`injectIntoMarkup`, accessor) + `src/sharc-omid-shim.js` (port-receive) + `test/node/test-omid-srcdoc-delivery.js`. **No** `examples/renderer/index.html` (no renderer in this variant), router, or validator changes.

## Validation
- `npm run build`, `npm run test:all:built`, `npm run test:perf`, `tsc -p tsconfig.types.json` — all green.
- No version bump (CHANGELOG `[Unreleased]`).

## Two-level DoD
This PR = bridge-side Layer 1 (synthetic stub). 0.7.8 release done = + #244 Layer 2 (real DV/IAS/Moat) + cap reconciliation.

## Note
A **pre-existing** timing flake surfaced (not introduced here, out of lane): `test/node/test-creative-sources-load.js` renderer-integrity-preflight uses a fixed `setTimeout(20)` that races an async `crypto.subtle.digest` — intermittent full-chain failure, exercises no OMID code. Filed as a separate follow-up.

Refs #217, #254 (this variant is the #254-clean delivery mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
