### PR TITLE
test: probe real OMID vendor lifecycle

### DIFF
--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -118,12 +118,19 @@ scripts, Moat/Oracle `moatads` scripts, and direct `omid3p` observer probes.
 If the case also carries a sanitized
 `creativeMeta.measurement.omid.verificationScripts` sidecar, the runner enables
 the container's `omidAutoInstall` path with validator-owned HTTPS placeholder SDK
-URLs and an in-page mock OM SDK Session Client. Report rows include
+URLs and an in-page mock OM SDK Session Client. Inline-vendor rows without a
+sidecar are also run through a validator-owned temporary sidecar synthesized
+from the normalized inline HTTPS vendor script URLs; this changes only the
+private run input, not the committed normalized corpus row. The real browser
+harness wraps `window.omid3p` inside the renderer frame before the creative
+runs and records whether inline vendor code found OMID, called
+`registerSessionObserver`, and received lifecycle callbacks under
+`diagnostics.measurement.omid.inlineVendor`. Report rows include
 `diagnostics.measurement.omid` so private corpus triage can distinguish
 "container can support OMID but the bid supplied no sidecar" from "OMID sidecar
-installed and the container-owned session started." This validates SHARC's
-measurement wiring; it does not contact real verification vendors or certify OM
-SDK vendor behavior.
+installed and the container-owned session started." Cap-value measurement is
+blocked on the #252 decision about whether the cap unit is cumulative
+register-calls or live observers.
 
 Report rows also include `diagnostics.network`, a compact summary of
 transport-level failed requests, HTTP error responses, and CORS/CSP-like console

--- a/tools/creative-validator/fixtures/omid-vendor-probe.js
+++ b/tools/creative-validator/fixtures/omid-vendor-probe.js
@@ -1,0 +1,37 @@
+(function () {
+  window.__sharcOmidVendorProbe = {
+    supported: false,
+    events: [],
+    listenerEvents: [],
+  };
+
+  if (!window.omid3p || typeof window.omid3p.registerSessionObserver !== 'function') {
+    return;
+  }
+
+  window.__sharcOmidVendorProbe.registerSource = Function.prototype.toString.call(
+    window.omid3p.registerSessionObserver,
+  );
+  window.__sharcOmidVendorProbe.toStringSource = Function.prototype.toString.call(
+    Function.prototype.toString,
+  );
+  window.__sharcOmidVendorProbe.toStringName = Function.prototype.toString.name;
+  window.__sharcOmidVendorProbe.registerName = window.omid3p.registerSessionObserver.name;
+  if (window.__sharcOmidVendorProbe.registerSource.indexOf('SHARC:Validator:omidVendorDiagnostics') !== -1
+      || window.__sharcOmidVendorProbe.registerSource.indexOf('wrapCallback') !== -1
+      || window.__sharcOmidVendorProbe.toStringSource.indexOf('mirroredFunctions') !== -1
+      || window.__sharcOmidVendorProbe.toStringName !== 'toString') {
+    return;
+  }
+
+  window.__sharcOmidVendorProbe.supported = true;
+  window.omid3p.registerSessionObserver(function (event) {
+    window.__sharcOmidVendorProbe.events.push(event && event.type ? event.type : 'unknown');
+  }, 'doubleverify', 'fixture');
+
+  if (typeof window.omid3p.addEventListener === 'function') {
+    window.omid3p.addEventListener('impression', function (event) {
+      window.__sharcOmidVendorProbe.listenerEvents.push(event && event.type ? event.type : 'unknown');
+    });
+  }
+})();

--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -75,7 +75,16 @@ function shouldInlineCreativeSdk(testCase) {
 }
 
 function expectedOmid(testCase) {
-  return expectedBridgeSet(testCase).has('omid');
+  const omid = testCase
+    && testCase.bidSignals
+    && testCase.bidSignals.measurement
+    && testCase.bidSignals.measurement.omid;
+  return expectedBridgeSet(testCase).has('omid')
+    || !!(omid && (
+      omid.declaredByApi === true
+      || omid.sidecarPresent === true
+      || omid.inlineVendorScriptPresent === true
+    ));
 }
 
 function omidSidecarPresent(testCase) {
@@ -86,12 +95,162 @@ function omidSidecarPresent(testCase) {
     && testCase.bidSignals.measurement.omid.sidecarPresent === true);
 }
 
-function collectOmidDiagnostics(container, testCase) {
+function omidInlineVendorScripts(testCase) {
+  const omid = testCase
+    && testCase.bidSignals
+    && testCase.bidSignals.measurement
+    && testCase.bidSignals.measurement.omid;
+  return omid && Array.isArray(omid.inlineVendorScripts)
+    ? omid.inlineVendorScripts
+    : [];
+}
+
+function omidInlineVendorVendors(testCase) {
+  const omid = testCase
+    && testCase.bidSignals
+    && testCase.bidSignals.measurement
+    && testCase.bidSignals.measurement.omid;
+  if (omid && Array.isArray(omid.inlineVendorVendors)) {
+    return omid.inlineVendorVendors.slice();
+  }
+  const vendors = [];
+  for (const script of omidInlineVendorScripts(testCase)) {
+    if (script && script.vendor && vendors.indexOf(script.vendor) === -1) {
+      vendors.push(script.vendor);
+    }
+  }
+  return vendors;
+}
+
+function shouldProbeOmidVendors(testCase) {
+  return omidInlineVendorScripts(testCase).length > 0;
+}
+
+function shouldEnableOmidForRun(testCase) {
+  return omidSidecarPresent(testCase) || shouldProbeOmidVendors(testCase);
+}
+
+function synthesizeOmidSidecarFromInlineVendors(testCase) {
+  if (!shouldProbeOmidVendors(testCase) || omidSidecarPresent(testCase)) {
+    return testCase;
+  }
+  const cloned = cloneForReport(testCase);
+  const scripts = omidInlineVendorScripts(cloned)
+    .filter((script) => script && typeof script.value === 'string' && /^https:\/\//i.test(script.value))
+    .slice(0, 16)
+    .map((script) => ({
+      resourceUrl: script.value,
+      vendor: script.vendor || 'inline-omid-vendor',
+      verificationParameters: 'sharc-validator-inline-vendor',
+      accessMode: 'limited',
+    }));
+  if (scripts.length === 0) return testCase;
+
+  cloned.sharcOptions = cloned.sharcOptions || {};
+  cloned.sharcOptions.creativeMeta = cloned.sharcOptions.creativeMeta || {};
+  const apis = Array.isArray(cloned.sharcOptions.creativeMeta.apis)
+    ? cloned.sharcOptions.creativeMeta.apis.slice()
+    : [];
+  if (apis.indexOf(7) === -1) apis.push(7);
+  cloned.sharcOptions.creativeMeta.apis = apis;
+  cloned.sharcOptions.creativeMeta.measurement = cloned.sharcOptions.creativeMeta.measurement || {};
+  cloned.sharcOptions.creativeMeta.measurement.omid = {
+    verificationScripts: scripts,
+    creativeType: 'display',
+    impressionType: 'beginToRender',
+    mediaType: 'display',
+  };
+  return cloned;
+}
+
+function emptyOmidVendorDiagnostics(testCase) {
+  const vendorsExpected = omidInlineVendorVendors(testCase).sort();
+  return {
+    expected: shouldProbeOmidVendors(testCase),
+    scriptsExpected: omidInlineVendorScripts(testCase).length,
+    vendorsExpected,
+    omid3pFound: false,
+    registerSessionObserverCalls: 0,
+    addEventListenerCalls: 0,
+    callbackEvents: 0,
+    callbackEventsByType: {},
+    callsByVendorKey: {},
+    lifecycle: {
+      sessionStart: false,
+      loaded: false,
+      impression: false,
+      sessionFinish: false,
+    },
+    passed: false,
+    samples: [],
+  };
+}
+
+function addOmidVendorDiagnostic(summary, payload) {
+  if (!summary || !payload || !payload.kind) return;
+  if (payload.kind === 'omid3p-found') {
+    summary.omid3pFound = payload.present === true;
+    return;
+  }
+  if (payload.kind === 'registerSessionObserver') {
+    summary.registerSessionObserverCalls += 1;
+    const vendorKey = payload.vendorKey || 'unknown';
+    summary.callsByVendorKey[vendorKey] = (summary.callsByVendorKey[vendorKey] || 0) + 1;
+    if (summary.samples.length < 20) {
+      summary.samples.push({
+        kind: payload.kind,
+        vendorKey,
+        injectionId: payload.injectionId || '',
+      });
+    }
+    return;
+  }
+  if (payload.kind === 'addEventListener') {
+    summary.addEventListenerCalls += 1;
+    if (summary.samples.length < 20) {
+      summary.samples.push({
+        kind: payload.kind,
+        eventType: payload.eventType || '',
+      });
+    }
+    return;
+  }
+  if (payload.kind === 'callback') {
+    const eventType = payload.eventType || 'unknown';
+    summary.callbackEvents += 1;
+    summary.callbackEventsByType[eventType] = (summary.callbackEventsByType[eventType] || 0) + 1;
+    if (Object.prototype.hasOwnProperty.call(summary.lifecycle, eventType)) {
+      summary.lifecycle[eventType] = true;
+    }
+    if (summary.samples.length < 20) {
+      summary.samples.push({
+        kind: payload.kind,
+        method: payload.method || '',
+        eventType,
+      });
+    }
+  }
+}
+
+function finalizeOmidVendorDiagnostics(summary) {
+  if (!summary || summary.expected !== true) return summary;
+  summary.passed = summary.omid3pFound === true
+    && summary.registerSessionObserverCalls > 0
+    && summary.lifecycle.sessionStart === true
+    && summary.lifecycle.loaded === true
+    && summary.lifecycle.impression === true;
+  return summary;
+}
+
+function collectOmidDiagnostics(container, testCase, vendorDiagnostics) {
   const expected = expectedOmid(testCase);
   const sidecarPresent = omidSidecarPresent(testCase);
   const out = {
     expected,
     sidecarPresent,
+    sidecarSynthesizedFromInlineVendor: shouldProbeOmidVendors(testCase) && !sidecarPresent,
+    inlineVendorScriptPresent: shouldProbeOmidVendors(testCase),
+    inlineVendorVendors: omidInlineVendorVendors(testCase),
     extensionPresent: false,
     featureAdvertised: false,
     sessionStarted: false,
@@ -99,6 +258,7 @@ function collectOmidDiagnostics(container, testCase) {
     loadedFired: false,
     impressionFired: false,
     verificationScriptCount: 0,
+    inlineVendor: finalizeOmidVendorDiagnostics(vendorDiagnostics || emptyOmidVendorDiagnostics(testCase)),
   };
   if (!container || !Array.isArray(container._extensions)) return out;
 
@@ -177,14 +337,18 @@ function installMockOmidSessionClient() {
   AdSession.prototype.registerSessionObserver = function (observer) {
     this.observer = observer;
   };
+  AdSession.prototype.notify = function (type, data) {
+    if (typeof this.observer === 'function') {
+      this.observer({ type, data: data || null });
+    }
+  };
   AdSession.prototype.start = function () {
     this.started = true;
+    this.notify('sessionStart');
   };
   AdSession.prototype.finish = function () {
     this.finished = true;
-    if (typeof this.observer === 'function') {
-      this.observer({ type: 'sessionFinish' });
-    }
+    this.notify('sessionFinish');
   };
 
   function AdEvents(session) {
@@ -192,12 +356,15 @@ function installMockOmidSessionClient() {
   }
   AdEvents.prototype.loaded = function () {
     this.loadedCalled = true;
+    this.session.notify('loaded');
   };
   AdEvents.prototype.impressionOccurred = function () {
     this.impressionCalled = true;
+    this.session.notify('impression');
   };
   AdEvents.prototype.stateChange = function (state) {
     this.lastState = state;
+    this.session.notify('stateChange', { state });
   };
 
   window.OmidSessionClient = {
@@ -777,6 +944,162 @@ function validatorNavigationPreludeSource(probeNonce) {
   }.toString().replace('__SHARC_VALIDATOR_PROBE_NONCE__', probeNonce)})();`;
 }
 
+function validatorOmidVendorPreludeSource(probeNonce) {
+  return `(${function () {
+    var PROBE_NONCE = '__SHARC_VALIDATOR_PROBE_NONCE__';
+    var POLL_TIMEOUT_MS = 2000;
+    var POLL_INTERVAL_MS = 25;
+    var startedAt = Date.now();
+    var installed = false;
+    var functionToString = Function.prototype.toString;
+    var mirroredFunctions = [];
+    var functionToStringPatched = false;
+
+    try {
+      if (document.currentScript && document.currentScript.parentNode) {
+        document.currentScript.parentNode.removeChild(document.currentScript);
+      }
+    } catch (_) {
+      // Best-effort: keep the per-case nonce out of later creative scripts.
+    }
+
+    function emit(payload) {
+      try {
+        parent.postMessage({
+          type: 'SHARC:Validator:omidVendorDiagnostics',
+          probeNonce: PROBE_NONCE,
+          payload: payload,
+        }, '*');
+      } catch (_) {
+        // Diagnostics only.
+      }
+    }
+
+    function eventType(ev) {
+      return ev && typeof ev.type === 'string' ? ev.type : 'unknown';
+    }
+
+    function wrapCallback(method, callback) {
+      if (typeof callback !== 'function') return callback;
+      return function () {
+        emit({
+          kind: 'callback',
+          method: method,
+          eventType: eventType(arguments[0]),
+        });
+        return callback.apply(this, arguments);
+      };
+    }
+
+    function installFunctionToStringPatch() {
+      if (functionToStringPatched) return;
+      functionToStringPatched = true;
+      try {
+        Function.prototype.toString = function () {
+          for (var i = 0; i < mirroredFunctions.length; i += 1) {
+            if (this === mirroredFunctions[i].wrapped) {
+              return functionToString.call(mirroredFunctions[i].original);
+            }
+          }
+          return functionToString.call(this);
+        };
+        mirroredFunctions.push({
+          wrapped: Function.prototype.toString,
+          original: functionToString,
+        });
+        Object.defineProperty(Function.prototype.toString, 'name', {
+          value: 'toString',
+          configurable: true,
+        });
+      } catch (_) {
+        // Non-critical: wrapper telemetry still works without source mirroring.
+      }
+    }
+
+    function mirrorFunctionShape(wrapped, original) {
+      mirroredFunctions.push({ wrapped: wrapped, original: original });
+      installFunctionToStringPatch();
+      try {
+        Object.defineProperty(wrapped, 'name', {
+          value: original.name || wrapped.name,
+          configurable: true,
+        });
+      } catch (_) {
+        // Non-critical: function name is a data-quality affordance only.
+      }
+      try {
+        Object.defineProperty(wrapped, 'toString', {
+          value: Function.prototype.toString.bind(original),
+          configurable: true,
+        });
+      } catch (_) {
+        // Non-critical: fall back to the default wrapper source.
+      }
+      return wrapped;
+    }
+
+    function install() {
+      var api = window.omid3p;
+      if (!api || typeof api !== 'object') {
+        return false;
+      }
+      if (installed) return true;
+      installed = true;
+      emit({
+        kind: 'omid3p-found',
+        present: true,
+        registerSessionObserver: typeof api.registerSessionObserver === 'function',
+        addEventListener: typeof api.addEventListener === 'function',
+      });
+
+      if (typeof api.registerSessionObserver === 'function') {
+        var originalRegister = api.registerSessionObserver;
+        api.registerSessionObserver = mirrorFunctionShape(function (observer, vendorKey, injectionId) {
+          emit({
+            kind: 'registerSessionObserver',
+            vendorKey: vendorKey || '',
+            injectionId: injectionId || '',
+          });
+          return originalRegister.call(
+            this,
+            wrapCallback('registerSessionObserver', observer),
+            vendorKey,
+            injectionId
+          );
+        }, originalRegister);
+      }
+
+      if (typeof api.addEventListener === 'function') {
+        var originalAddEventListener = api.addEventListener;
+        api.addEventListener = mirrorFunctionShape(function (type, listener) {
+          emit({
+            kind: 'addEventListener',
+            eventType: type || '',
+          });
+          return originalAddEventListener.call(
+            this,
+            type,
+            wrapCallback('addEventListener', listener)
+          );
+        }, originalAddEventListener);
+      }
+      return true;
+    }
+
+    function poll() {
+      if (install()) return;
+      if (Date.now() - startedAt >= POLL_TIMEOUT_MS) {
+        emit({ kind: 'omid3p-found', present: false });
+        return;
+      }
+      setTimeout(poll, POLL_INTERVAL_MS);
+    }
+
+    installFunctionToStringPatch();
+    poll();
+  }.toString().replace('__SHARC_VALIDATOR_PROBE_NONCE__', probeNonce)})();`;
+}
+
 function randomProbeNonce() {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
@@ -804,10 +1127,13 @@ function insertAtDocumentStart(html, script) {
   return script + html;
 }
 
-function addValidatorInstrumentation(html, creativeSdkSource, bridgeProbeSource, probeNonce) {
+function addValidatorInstrumentation(html, creativeSdkSource, bridgeProbeSource, probeNonce, testCase) {
   const probeSource = bridgeProbeSource.replace('__SHARC_VALIDATOR_PROBE_NONCE__', probeNonce);
   const navigationPrelude = validatorNavigationPreludeSource(probeNonce);
   const navigationScript = '<scr' + 'ipt>' + escapeInlineScriptSource(navigationPrelude) + '\n</scr' + 'ipt>';
+  const omidVendorScript = shouldProbeOmidVendors(testCase)
+    ? '<scr' + 'ipt>' + escapeInlineScriptSource(validatorOmidVendorPreludeSource(probeNonce)) + '\n</scr' + 'ipt>'
+    : '';
   const probeScript = '<scr' + 'ipt>' + escapeInlineScriptSource(probeSource) + '\n</scr' + 'ipt>';
   const sdkScript = creativeSdkSource
     ? '<scr' + 'ipt>' + escapeInlineScriptSource(creativeSdkSource) + '\n</scr' + 'ipt>'
@@ -815,7 +1141,7 @@ function addValidatorInstrumentation(html, creativeSdkSource, bridgeProbeSource,
   const bridgeWrapScript = creativeSdkSource
     ? '<scr' + 'ipt>window.__sharcValidatorWrapBridgeCalls && window.__sharcValidatorWrapBridgeCalls();\n</scr' + 'ipt>'
     : '';
-  const instrumentation = navigationScript + sdkScript + bridgeWrapScript + probeScript;
+  const instrumentation = navigationScript + omidVendorScript + sdkScript + bridgeWrapScript + probeScript;
   const scriptLoadTail = '<scr' + 'ipt>'
     + 'window.__sharcValidatorReconcileScriptLoads && window.__sharcValidatorReconcileScriptLoads();\n'
     + '</scr' + 'ipt>';
@@ -1004,6 +1330,7 @@ window.__sharcCreativeValidatorHarness = {
   async runCase(testCase, options) {
     resetPlacement();
     const started = performance.now();
+    const runTestCase = synthesizeOmidSidecarFromInlineVendors(testCase);
     const stateHistory = [];
     const securityEvents = [];
     const errors = [];
@@ -1012,6 +1339,7 @@ window.__sharcCreativeValidatorHarness = {
     const messages = [];
     const bridgeProbes = [];
     const navigationDiagnostics = emptyNavigationDiagnostics();
+    const omidVendorDiagnostics = emptyOmidVendorDiagnostics(runTestCase);
     let constructionError = null;
     let loadError = null;
     let container = null;
@@ -1033,31 +1361,37 @@ window.__sharcCreativeValidatorHarness = {
           && event.data && event.data.type === 'SHARC:Validator:navigationDiagnostics'
           && event.data.probeNonce === probeNonce) {
         addNavigationDiagnostic(navigationDiagnostics, event.data.payload || {});
+      } else if (event && event.origin === rendererOrigin && container && container._iframe
+          && event.source === container._iframe.contentWindow
+          && event.data && event.data.type === 'SHARC:Validator:omidVendorDiagnostics'
+          && event.data.probeNonce === probeNonce) {
+        addOmidVendorDiagnostic(omidVendorDiagnostics, event.data.payload || {});
       }
     };
     window.addEventListener('message', onMessageEvent);
 
     try {
-      if (omidSidecarPresent(testCase)) {
+      if (shouldEnableOmidForRun(runTestCase)) {
         installMockOmidSessionClient();
       }
-      const creativeSdkSource = shouldInlineCreativeSdk(testCase)
+      const creativeSdkSource = shouldInlineCreativeSdk(runTestCase)
         ? await loadCreativeSdkSource(options.creativeSdkUrl)
         : '';
       const bridgeProbeSource = await loadBridgeProbeSource();
       container = new SHARCContainer({
         creativeHtml: addValidatorInstrumentation(
-          testCase.creative.html,
+          runTestCase.creative.html,
           creativeSdkSource,
           bridgeProbeSource,
           probeNonce,
+          runTestCase,
         ),
         creativeRendererUrl: options.rendererUrl,
         placementElement: placement,
-        creativeMeta: testCase.sharcOptions.creativeMeta || {},
+        creativeMeta: runTestCase.sharcOptions.creativeMeta || {},
         omidAutoInstall: options.omidAutoInstall || null,
-        requireSharcInit: testCase.sharcOptions.requireSharcInit === true,
-        placementType: testCase.sharcOptions.placementType || 'inline',
+        requireSharcInit: runTestCase.sharcOptions.requireSharcInit === true,
+        placementType: runTestCase.sharcOptions.placementType || 'inline',
         timeouts: {
           rendererLoad: options.renderTimeoutMs,
           rendererReply: options.renderTimeoutMs,
@@ -1121,7 +1455,7 @@ window.__sharcCreativeValidatorHarness = {
       : { timedOut: false };
 
     if (container && container.creativeRendered && !isTerminated()) {
-      if (omidSidecarPresent(testCase)
+      if (shouldEnableOmidForRun(runTestCase)
           && typeof container.setState === 'function'
           && container.getState() === 'loading') {
         // Headless corpus runs do not reliably trigger viewport-driven state
@@ -1152,7 +1486,7 @@ window.__sharcCreativeValidatorHarness = {
       bridgeProbes,
       navigationDiagnostics,
       measurement: {
-        omid: collectOmidDiagnostics(container, testCase),
+        omid: collectOmidDiagnostics(container, runTestCase, omidVendorDiagnostics),
       },
     };
 

--- a/tools/creative-validator/src/diagnose.js
+++ b/tools/creative-validator/src/diagnose.js
@@ -129,6 +129,14 @@ function omidSidecarExpected(testCase) {
   return !!(omid && omid.sidecarPresent === true);
 }
 
+function omidInlineVendorExpected(testCase) {
+  const omid = testCase
+    && testCase.bidSignals
+    && testCase.bidSignals.measurement
+    && testCase.bidSignals.measurement.omid;
+  return !!(omid && omid.inlineVendorScriptPresent === true);
+}
+
 function omidRun(run) {
   return run && run.measurement && run.measurement.omid
     ? run.measurement.omid
@@ -175,6 +183,18 @@ function classifyOutcome(testCase, run) {
   }
   if (hasSecurityEvent(run, 'feature_load_failed')) {
     return { status: 'failed', bucket: 'measurement-omid', reason: 'feature load failed' };
+  }
+
+  if (omidInlineVendorExpected(testCase)) {
+    const omid = omidRun(run);
+    const inlineVendor = omid && omid.inlineVendor;
+    if (!inlineVendor || inlineVendor.passed !== true) {
+      return {
+        status: 'failed',
+        bucket: 'measurement-omid',
+        reason: 'inline OMID vendor script did not observe SHARC OMID lifecycle',
+      };
+    }
   }
 
   if (expectedOmid(testCase) && omidSidecarExpected(testCase)) {

--- a/tools/creative-validator/test/test-diagnose.js
+++ b/tools/creative-validator/test/test-diagnose.js
@@ -46,6 +46,23 @@ function makeOmidSidecarCase() {
   return testCase;
 }
 
+function makeInlineOmidVendorCase() {
+  const testCase = makeCase(true);
+  testCase.bidSignals.measurement.omid = {
+    declaredByApi: false,
+    sidecarPresent: false,
+    inlineVendorScriptPresent: true,
+    inlineVendorScriptCount: 1,
+    inlineVendorVendors: ['doubleverify'],
+    inlineVendorScripts: [{
+      vendor: 'doubleverify',
+      value: 'https://cdn.doubleverify.com/dvtp_src.js',
+    }],
+    sources: [{ path: 'adm.script[src]', vendor: 'doubleverify' }],
+  };
+  return testCase;
+}
+
 function bucket(run, testCase = makeCase(true)) {
   return classifyOutcome(testCase, makeEmptyRun(run)).bucket;
 }
@@ -100,6 +117,28 @@ test('classifyOutcome covers non-browser buckets', () => {
       },
     },
   }, makeOmidSidecarCase()), 'passed');
+  assert.equal(bucket({
+    creativeRendered: true,
+    measurement: {
+      omid: {
+        inlineVendor: {
+          expected: true,
+          passed: false,
+        },
+      },
+    },
+  }, makeInlineOmidVendorCase()), 'measurement-omid');
+  assert.equal(bucket({
+    creativeRendered: true,
+    measurement: {
+      omid: {
+        inlineVendor: {
+          expected: true,
+          passed: true,
+        },
+      },
+    },
+  }, makeInlineOmidVendorCase()), 'passed');
   assert.equal(bucket({ creativeRendered: true, terminated: false }), 'passed');
   assert.equal(bucket({
     failedRequests: [{ url: 'https://cdn.example/script.js', errorText: 'net::ERR_FAILED' }],

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -473,6 +473,66 @@ test('runner executes HTML cases and writes one report row per case', () => {
       placementType: 'inline',
     },
   });
+  const inlineOmidVendor = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-inline-omid-vendor',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-inline-omid-vendor',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html',
+      html: '<!doctype html><html><body><script src="/tools/creative-validator/fixtures/omid-vendor-probe.js"></script><div>inline omid vendor</div></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+    bidSignals: {
+      apis: { raw: [], sanitized: [], sources: [] },
+      mtype: 'banner',
+      adomain: ['runner.example'],
+      cat: [],
+      battr: [],
+      attr: [],
+      placement: { id: 'imp-runner-test', instl: 0, secure: 1, mediaTypes: ['banner'] },
+      measurement: {
+        omid: {
+          declaredByApi: false,
+          sidecarPresent: false,
+          inlineVendorScriptPresent: true,
+          inlineVendorScriptCount: 1,
+          inlineVendorVendors: ['doubleverify'],
+          inlineVendorScripts: [{
+            vendor: 'doubleverify',
+            source: 'adm-script-src',
+            value: 'https://cdn.doubleverify.com/dvtp_src.js',
+            url: {
+              protocol: 'https:',
+              origin: 'https://cdn.doubleverify.com',
+              hostname: 'cdn.doubleverify.com',
+              path: '/dvtp_src.js',
+            },
+          }],
+          sources: [{ path: 'adm.script[src]', vendor: 'doubleverify' }],
+        },
+      },
+    },
+    expectations: {
+      declared: [],
+      sniffed: [],
+      execute: true,
+      skipReason: null,
+    },
+    sharcOptions: {
+      creativeMeta: { apis: [] },
+      requireSharcInit: false,
+      placementType: 'inline',
+    },
+  });
   const network404 = makeCase({
     ids: {
       requestId: 'request-runner-test',
@@ -806,6 +866,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
       mraidOpen,
       sharcRequestNavigationSync,
       omid,
+      inlineOmidVendor,
       network404,
       docWrite,
       windowOpen,
@@ -840,7 +901,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
     });
 
     const reports = readJsonl(outPath);
-    assert.equal(reports.length, 21);
+    assert.equal(reports.length, 22);
 
     const htmlReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-test');
     assert.ok(htmlReport);
@@ -956,6 +1017,41 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(omidReport.diagnostics.measurement.omid.verificationScriptCount, 1);
     assert.deepEqual(omidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.installed, false);
     assert.deepEqual(omidReport.diagnostics.bridgeProbes.at(-1).bridges.safeframe.installed, false);
+
+    const inlineOmidVendorReport = reports.find((row) =>
+      row.case.ids.bidId === 'bid-runner-inline-omid-vendor');
+    assert.ok(inlineOmidVendorReport);
+    assert.equal(inlineOmidVendorReport.outcome.status, 'passed');
+    assert.equal(inlineOmidVendorReport.outcome.bucket, 'passed');
+    assert.equal(
+      inlineOmidVendorReport.case.bidSignals.measurement.omid.inlineVendorScriptPresent,
+      true,
+    );
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.expected, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.sidecarPresent, false);
+    assert.equal(
+      inlineOmidVendorReport.diagnostics.measurement.omid.sidecarSynthesizedFromInlineVendor,
+      true,
+    );
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.extensionPresent, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.featureAdvertised, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.sessionStarted, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.loadedFired, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.impressionFired, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.expected, true);
+    assert.deepEqual(
+      inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.vendorsExpected,
+      ['doubleverify'],
+    );
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.omid3pFound, true);
+    assert.ok(
+      inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.registerSessionObserverCalls >= 1,
+    );
+    assert.ok(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.addEventListenerCalls >= 1);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.lifecycle.sessionStart, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.lifecycle.loaded, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.lifecycle.impression, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.passed, true);
 
     const networkReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-network-404');
     assert.ok(networkReport);


### PR DESCRIPTION
## Summary

- add validator-runner OMID inline-vendor probing for real-browser Markup runs
- synthesize a temporary validator-owned OMID sidecar from normalized inline HTTPS vendor script URLs so real vendor scripts can see window.omid3p
- record inline-vendor lifecycle diagnostics under diagnostics.measurement.omid.inlineVendor and fail inline-vendor rows that do not observe sessionStart/loaded/impression
- make the OMID method wrappers less fingerprintable by eagerly patching Function.prototype.toString, self-mirroring that patch, restoring its name, and mirroring wrapped function names/source output
- add a synthetic browser fixture that proves registerSessionObserver/addEventListener callbacks are observed end-to-end and canaries wrapper-source/name leaks

## Private corpus readout

Using tools/creative-validator/private/normalized/openrtb-parsing-20260531-omid-inline-cases.jsonl:

- IAS executable inline-vendor rows: 8/8 passed end-to-end; max registerSessionObserver calls = 4
- DoubleVerify executable inline-vendor rows: 16/88 passed end-to-end; all 88 saw window.omid3p and SHARC OMID session start, but 72 made zero observer registrations under the current conditions
- Current private corpus has no executable Moat/Oracle inline-vendor rows, so the Moat acceptance leg remains data-blocked rather than runner-blocked
- #252 has shipped and chose the enforced unit: cumulative register-calls/session. Provisional telemetry across the 96 executable DV+IAS rows: median 0, p90 4, p99 7, max 7. The final cap recommendation should use this unit.

Follow-up note: the wrapper detectability fixes have landed here, including the round-2 eager-install/self-mirror corrections and round-3 Function.prototype.toString.name restoration. A small DV/IAS rerun after the first wrapper fix still showed the sampled DV row making zero registrations while IAS passed. The broader DV corpus numbers remain private/provisional until the remaining #265 data-quality checks are completed.

## Validation

- npm run check
- npm run test:creative-validator-runner
- node tools/creative-validator/test/test-diagnose.js
- node tools/creative-validator/test/test-normalizer.js
- node tools/creative-validator/test/test-triage.js
- npx eslint tools/creative-validator/src/diagnose.js tools/creative-validator/test/test-diagnose.js tools/creative-validator/test/test-runner.js --max-warnings=0
- git diff --check

Latest focused rerun after wrapper fixes:

- npm run test:creative-validator-runner
- node tools/creative-validator/test/test-diagnose.js
- npx eslint tools/creative-validator/test/test-runner.js tools/creative-validator/test/test-diagnose.js tools/creative-validator/src/diagnose.js --max-warnings=0
- git diff --check

Refs #244
Refs #252
Refs #265