### PR TITLE
test: refine OMID vendor validator telemetry

### DIFF
--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -121,16 +121,28 @@ the container's `omidAutoInstall` path with validator-owned HTTPS placeholder SD
 URLs and an in-page mock OM SDK Session Client. Inline-vendor rows without a
 sidecar are also run through a validator-owned temporary sidecar synthesized
 from the normalized inline HTTPS vendor script URLs; this changes only the
-private run input, not the committed normalized corpus row. The real browser
-harness wraps `window.omid3p` inside the renderer frame before the creative
-runs and records whether inline vendor code found OMID, called
-`registerSessionObserver`, and received lifecycle callbacks under
-`diagnostics.measurement.omid.inlineVendor`. Report rows include
+private run input, not the committed normalized corpus row. The synthesized
+sidecar defaults to `accessMode: "limited"`; private sweeps can run with
+`--omid-inline-vendor-access-mode full` to compare vendor activation behavior
+without changing the normalized corpus. The validator shim does not enforce
+different JS capabilities for `limited` versus `full`; the flag changes the
+declared `VerificationScriptResource.accessMode` label so real vendor scripts
+can self-route on the mode they observe. The real browser harness wraps
+`window.omid3p` inside the renderer frame before the creative runs and records
+whether inline vendor code found OMID, subscribed through
+`registerSessionObserver` or `addEventListener`, and received lifecycle
+callbacks under `diagnostics.measurement.omid.inlineVendor`.
+
+For inline-vendor diagnostics, `passed` is intentionally a broad runtime
+observation flag: the vendor found OMID, subscribed, and received at least one
+callback. This is broader than the original strict check. The strict
+sessionStart/loaded/impression observation is exposed separately as
+`lifecycleComplete`, while `lifecycleNotObserved` separates
+subscribed-but-not-callbacked rows from true no-subscription failures. Report rows include
 `diagnostics.measurement.omid` so private corpus triage can distinguish
 "container can support OMID but the bid supplied no sidecar" from "OMID sidecar
-installed and the container-owned session started." Cap-value measurement is
-blocked on the #252 decision about whether the cap unit is cumulative
-register-calls or live observers.
+installed and the container-owned session started." Cap-value measurement uses
+#252's enforced unit: cumulative register-calls per session.
 
 Report rows also include `diagnostics.network`, a compact summary of
 transport-level failed requests, HTTP error responses, and CORS/CSP-like console
@@ -224,6 +236,11 @@ increment `rowsWithSidecar` and drive the extension/session progress counters.
 `byInstrumentationSignal` buckets each row as `declared-api7+inline-vendor`,
 `declared-api7-only`, `inline-vendor-only`, or `absent`; this is the primary
 declared-vs-instrumented-vs-absent corpus readout for the 0.7.8 OMID verifier.
+Inline-vendor runtime facets additionally bucket synthesized access mode,
+subscription/runtime outcome, and lifecycle observation completeness. Lifecycle
+observation uses `complete`, `partial`, `subscribed-none`, or `not-applicable`;
+`not-applicable` means the vendor did not subscribe, so lifecycle callbacks
+could not be expected.
 `byOutcome` assigns each capability-declared row a single mutually-exclusive
 progress label (`capability-no-sidecar`, `sidecar-no-extension`,
 `extension-no-feature`, `feature-no-session`, `session-started`,

--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -130,11 +130,19 @@ function shouldEnableOmidForRun(testCase) {
   return omidSidecarPresent(testCase) || shouldProbeOmidVendors(testCase);
 }
 
-function synthesizeOmidSidecarFromInlineVendors(testCase) {
+function omidInlineVendorAccessMode(options) {
+  return options && options.omidInlineVendorAccessMode === 'full'
+    ? 'full'
+    : 'limited';
+}
+
+function synthesizeOmidSidecarFromInlineVendors(testCase, accessMode) {
   if (!shouldProbeOmidVendors(testCase) || omidSidecarPresent(testCase)) {
     return testCase;
   }
   const cloned = cloneForReport(testCase);
+  // The validator shim exposes the same OMID JS surface for limited/full; this
+  // label lets real vendor scripts self-route on the declared access mode.
   const scripts = omidInlineVendorScripts(cloned)
     .filter((script) => script && typeof script.value === 'string' && /^https:\/\//i.test(script.value))
     .slice(0, 16)
@@ -142,7 +150,7 @@ function synthesizeOmidSidecarFromInlineVendors(testCase) {
       resourceUrl: script.value,
       vendor: script.vendor || 'inline-omid-vendor',
       verificationParameters: 'sharc-validator-inline-vendor',
-      accessMode: 'limited',
+      accessMode,
     }));
   if (scripts.length === 0) return testCase;
 
@@ -163,13 +171,15 @@ function synthesizeOmidSidecarFromInlineVendors(testCase) {
   return cloned;
 }
 
-function emptyOmidVendorDiagnostics(testCase) {
+function emptyOmidVendorDiagnostics(testCase, accessMode) {
   const vendorsExpected = omidInlineVendorVendors(testCase).sort();
   return {
     expected: shouldProbeOmidVendors(testCase),
+    accessMode,
     scriptsExpected: omidInlineVendorScripts(testCase).length,
     vendorsExpected,
     omid3pFound: false,
+    subscriptionObserved: false,
     registerSessionObserverCalls: 0,
     addEventListenerCalls: 0,
     callbackEvents: 0,
@@ -182,6 +192,9 @@ function emptyOmidVendorDiagnostics(testCase) {
       sessionFinish: false,
     },
     passed: false,
+    lifecycleObserved: false,
+    lifecycleComplete: false,
+    lifecycleNotObserved: false,
     samples: [],
   };
 }
@@ -234,15 +247,23 @@ function addOmidVendorDiagnostic(summary, payload) {
 
 function finalizeOmidVendorDiagnostics(summary) {
   if (!summary || summary.expected !== true) return summary;
-  summary.passed = summary.omid3pFound === true
-    && summary.registerSessionObserverCalls > 0
-    && summary.lifecycle.sessionStart === true
+  summary.subscriptionObserved = summary.registerSessionObserverCalls > 0
+    || summary.addEventListenerCalls > 0;
+  summary.lifecycleObserved = summary.callbackEvents > 0;
+  summary.lifecycleComplete = summary.lifecycle.sessionStart === true
     && summary.lifecycle.loaded === true
     && summary.lifecycle.impression === true;
+  summary.lifecycleNotObserved = summary.subscriptionObserved === true
+    && summary.lifecycleObserved !== true;
+  // "passed" is the broad runtime-observation gate; lifecycleComplete preserves
+  // the stricter sessionStart/loaded/impression shape for publication.
+  summary.passed = summary.omid3pFound === true
+    && summary.subscriptionObserved === true
+    && summary.lifecycleObserved === true;
   return summary;
 }
 
-function collectOmidDiagnostics(container, testCase, vendorDiagnostics) {
+function collectOmidDiagnostics(container, testCase, vendorDiagnostics, accessMode) {
   const expected = expectedOmid(testCase);
   const sidecarPresent = omidSidecarPresent(testCase);
   const out = {
@@ -258,7 +279,9 @@ function collectOmidDiagnostics(container, testCase, vendorDiagnostics) {
     loadedFired: false,
     impressionFired: false,
     verificationScriptCount: 0,
-    inlineVendor: finalizeOmidVendorDiagnostics(vendorDiagnostics || emptyOmidVendorDiagnostics(testCase)),
+    inlineVendor: finalizeOmidVendorDiagnostics(
+      vendorDiagnostics || emptyOmidVendorDiagnostics(testCase, accessMode),
+    ),
   };
   if (!container || !Array.isArray(container._extensions)) return out;
 
@@ -1330,7 +1353,8 @@ window.__sharcCreativeValidatorHarness = {
   async runCase(testCase, options) {
     resetPlacement();
     const started = performance.now();
-    const runTestCase = synthesizeOmidSidecarFromInlineVendors(testCase);
+    const inlineVendorAccessMode = omidInlineVendorAccessMode(options);
+    const runTestCase = synthesizeOmidSidecarFromInlineVendors(testCase, inlineVendorAccessMode);
     const stateHistory = [];
     const securityEvents = [];
     const errors = [];
@@ -1339,7 +1363,7 @@ window.__sharcCreativeValidatorHarness = {
     const messages = [];
     const bridgeProbes = [];
     const navigationDiagnostics = emptyNavigationDiagnostics();
-    const omidVendorDiagnostics = emptyOmidVendorDiagnostics(runTestCase);
+    const omidVendorDiagnostics = emptyOmidVendorDiagnostics(runTestCase, inlineVendorAccessMode);
     let constructionError = null;
     let loadError = null;
     let container = null;
@@ -1486,7 +1510,7 @@ window.__sharcCreativeValidatorHarness = {
       bridgeProbes,
       navigationDiagnostics,
       measurement: {
-        omid: collectOmidDiagnostics(container, runTestCase, omidVendorDiagnostics),
+        omid: collectOmidDiagnostics(container, runTestCase, omidVendorDiagnostics, inlineVendorAccessMode),
       },
     };
 

--- a/tools/creative-validator/src/cli.js
+++ b/tools/creative-validator/src/cli.js
@@ -30,10 +30,19 @@ Examples:
   node tools/creative-validator/src/cli.js run tools/creative-validator/private/normalized/cases.jsonl --out tools/creative-validator/private/reports/report.jsonl
   node tools/creative-validator/src/cli.js triage "tools/creative-validator/private/reports/*.jsonl" --out tools/creative-validator/private/triage/summary.json
 
+Run options:
+  --port <n>
+  --renderer-port <n>
+  --renderer-url <url>
+  --repo-root <path>
+  --render-timeout-ms <n>
+  --settle-ms <n>
+  --omid-inline-vendor-access-mode <limited|full>
+  --verbose
+
 Notes:
   - Globs are supported only in the final path segment, e.g. private/*.cleaned.json.
   - Output must stay under tools/creative-validator/private/ unless --allow-public-out is passed.
-  - Run options: --port, --renderer-port, --renderer-url, --repo-root, --render-timeout-ms, --settle-ms, --verbose.
 `;
 }
 
@@ -110,6 +119,7 @@ function parseArgs(argv) {
   let repoRoot = null;
   let renderTimeoutMs = null;
   let settleMs = null;
+  let omidInlineVendorAccessMode = null;
   let verbose = false;
   for (let i = 0; i < rest.length; i++) {
     const arg = rest[i];
@@ -129,6 +139,8 @@ function parseArgs(argv) {
       renderTimeoutMs = parsePositiveInt(rest[++i], '--render-timeout-ms');
     } else if (arg === '--settle-ms') {
       settleMs = parsePositiveInt(rest[++i], '--settle-ms');
+    } else if (arg === '--omid-inline-vendor-access-mode') {
+      omidInlineVendorAccessMode = parseOmidInlineVendorAccessMode(rest[++i]);
     } else if (arg === '--verbose') {
       verbose = true;
     } else if (arg === '--help' || arg === '-h') {
@@ -154,6 +166,7 @@ function parseArgs(argv) {
     repoRoot,
     renderTimeoutMs,
     settleMs,
+    omidInlineVendorAccessMode,
     verbose,
   };
 }
@@ -164,6 +177,13 @@ function parsePositiveInt(value, flag) {
     throw new Error(`${flag} must be a positive integer.`);
   }
   return n;
+}
+
+function parseOmidInlineVendorAccessMode(value) {
+  if (value !== 'limited' && value !== 'full') {
+    throw new Error('--omid-inline-vendor-access-mode must be "limited" or "full".');
+  }
+  return value;
 }
 
 function readJsonCorpus(file) {
@@ -216,6 +236,7 @@ async function main() {
     repoRoot,
     renderTimeoutMs,
     settleMs,
+    omidInlineVendorAccessMode,
     verbose,
   } = parseArgs(process.argv.slice(2));
   const outPath = resolve(out);
@@ -255,6 +276,7 @@ async function main() {
     repoRoot,
     renderTimeoutMs,
     settleMs,
+    omidInlineVendorAccessMode,
     verbose,
   });
   console.log(`Ran ${result.count} normalized case(s) to ${result.outFile}`);

--- a/tools/creative-validator/src/diagnose.js
+++ b/tools/creative-validator/src/diagnose.js
@@ -188,11 +188,18 @@ function classifyOutcome(testCase, run) {
   if (omidInlineVendorExpected(testCase)) {
     const omid = omidRun(run);
     const inlineVendor = omid && omid.inlineVendor;
-    if (!inlineVendor || inlineVendor.passed !== true) {
+    if (!inlineVendor || inlineVendor.omid3pFound !== true) {
       return {
         status: 'failed',
         bucket: 'measurement-omid',
-        reason: 'inline OMID vendor script did not observe SHARC OMID lifecycle',
+        reason: 'inline OMID vendor script did not find window.omid3p',
+      };
+    }
+    if (inlineVendor.subscriptionObserved !== true) {
+      return {
+        status: 'failed',
+        bucket: 'measurement-omid',
+        reason: 'inline OMID vendor script did not subscribe to OMID',
       };
     }
   }

--- a/tools/creative-validator/src/runner.js
+++ b/tools/creative-validator/src/runner.js
@@ -19,6 +19,7 @@ const DEFAULT_PORT = 18865;
 const DEFAULT_RENDERER_PORT = 18866;
 const DEFAULT_RENDER_TIMEOUT_MS = 10_000;
 const DEFAULT_SETTLE_MS = 2_000;
+const DEFAULT_OMID_INLINE_VENDOR_ACCESS_MODE = 'limited';
 
 function parsePort(raw, fallback) {
   if (raw === undefined || raw === null || raw === '') return fallback;
@@ -634,6 +635,7 @@ async function runExecutableCase(browser, testCase, options) {
         rendererUrl: options.rendererUrl,
         renderTimeoutMs: options.renderTimeoutMs,
         settleMs: options.settleMs,
+        omidInlineVendorAccessMode: options.omidInlineVendorAccessMode,
       },
     );
     backfillScriptLoadDiagnostics(run.navigationDiagnostics, scriptOutcomes);
@@ -733,6 +735,8 @@ async function runNormalizedCases(inputFile, outFile, options = {}) {
     harnessUrl,
     renderTimeoutMs: options.renderTimeoutMs || DEFAULT_RENDER_TIMEOUT_MS,
     settleMs: options.settleMs || DEFAULT_SETTLE_MS,
+    omidInlineVendorAccessMode: options.omidInlineVendorAccessMode
+      || DEFAULT_OMID_INLINE_VENDOR_ACCESS_MODE,
     verbose: options.verbose === true,
   };
 

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -136,6 +136,9 @@ function emptySummary(files) {
         byInlineVendorScriptCount: {},
         inlineVendorRowsByVendor: {},
         inlineVendorRowsByBidder: {},
+        inlineVendorRowsByAccessMode: {},
+        inlineVendorRowsByRuntimeOutcome: {},
+        inlineVendorRowsByLifecycleObservation: {},
         byOutcome: {},
         byVerificationScriptCount: {},
         capabilityRowsByBidder: {},
@@ -668,6 +671,27 @@ function addOmidCorpusFacets(summary, row, fields) {
     for (const vendor of vendors) increment(facet.inlineVendorRowsByVendor, vendor);
     if (declaredByApi) facet.rowsCapabilityDeclaredInlineInstrumented += 1;
     else facet.rowsInlineInstrumentedWithoutCapability += 1;
+
+    const inlineVendor = omid.inlineVendor || {};
+    increment(facet.inlineVendorRowsByAccessMode, inlineVendor.accessMode || 'not-run');
+    if (inlineVendor.expected === true) {
+      let runtimeOutcome = 'omid3p-missing';
+      if (inlineVendor.omid3pFound === true && inlineVendor.subscriptionObserved === true) {
+        runtimeOutcome = inlineVendor.passed === true ? 'observed-lifecycle' : 'subscribed-no-lifecycle';
+      } else if (inlineVendor.omid3pFound === true) {
+        runtimeOutcome = 'omid3p-no-subscription';
+      }
+      increment(facet.inlineVendorRowsByRuntimeOutcome, runtimeOutcome);
+
+      let lifecycleOutcome = 'not-applicable';
+      if (inlineVendor.lifecycleComplete === true) lifecycleOutcome = 'complete';
+      else if (inlineVendor.lifecycleObserved === true) lifecycleOutcome = 'partial';
+      else if (inlineVendor.lifecycleNotObserved === true) lifecycleOutcome = 'subscribed-none';
+      increment(facet.inlineVendorRowsByLifecycleObservation, lifecycleOutcome);
+    } else {
+      increment(facet.inlineVendorRowsByRuntimeOutcome, 'not-run');
+      increment(facet.inlineVendorRowsByLifecycleObservation, 'not-run');
+    }
   }
   if (omid.sidecarPresent === true) facet.rowsWithSidecar += 1;
   if (omid.extensionPresent === true) facet.rowsWithExtension += 1;
@@ -967,6 +991,12 @@ function triageReports(files) {
     sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByVendor);
   summary.corpusDiagnostics.omid.inlineVendorRowsByBidder =
     sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByBidder);
+  summary.corpusDiagnostics.omid.inlineVendorRowsByAccessMode =
+    sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByAccessMode);
+  summary.corpusDiagnostics.omid.inlineVendorRowsByRuntimeOutcome =
+    sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByRuntimeOutcome);
+  summary.corpusDiagnostics.omid.inlineVendorRowsByLifecycleObservation =
+    sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByLifecycleObservation);
   summary.corpusDiagnostics.omid.byVerificationScriptCount =
     sortEntries(summary.corpusDiagnostics.omid.byVerificationScriptCount, { numericKeys: true });
   summary.corpusDiagnostics.omid.capabilityRowsByBidder =

--- a/tools/creative-validator/test/test-diagnose.js
+++ b/tools/creative-validator/test/test-diagnose.js
@@ -123,6 +123,8 @@ test('classifyOutcome covers non-browser buckets', () => {
       omid: {
         inlineVendor: {
           expected: true,
+          omid3pFound: true,
+          subscriptionObserved: false,
           passed: false,
         },
       },
@@ -134,6 +136,22 @@ test('classifyOutcome covers non-browser buckets', () => {
       omid: {
         inlineVendor: {
           expected: true,
+          omid3pFound: true,
+          subscriptionObserved: true,
+          lifecycleNotObserved: true,
+          passed: false,
+        },
+      },
+    },
+  }, makeInlineOmidVendorCase()), 'passed');
+  assert.equal(bucket({
+    creativeRendered: true,
+    measurement: {
+      omid: {
+        inlineVendor: {
+          expected: true,
+          omid3pFound: true,
+          subscriptionObserved: true,
           passed: true,
         },
       },

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -32,6 +32,7 @@ const cspEmbeddedFrameReductionPath = resolve(
 );
 const reductionPorts = {
   externalScript: { runner: '18879', renderer: '18880' },
+  omidFullAccess: { runner: '18887', renderer: '18888' },
   navigation: { runner: '18869', renderer: '18870' },
   documentSource: { runner: '18877', renderer: '18878' },
   opaqueDocument: { runner: '18881', renderer: '18882' },
@@ -1039,11 +1040,13 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.loadedFired, true);
     assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.impressionFired, true);
     assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.expected, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.accessMode, 'limited');
     assert.deepEqual(
       inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.vendorsExpected,
       ['doubleverify'],
     );
     assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.omid3pFound, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.subscriptionObserved, true);
     assert.ok(
       inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.registerSessionObserverCalls >= 1,
     );
@@ -1051,6 +1054,9 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.lifecycle.sessionStart, true);
     assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.lifecycle.loaded, true);
     assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.lifecycle.impression, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.lifecycleObserved, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.lifecycleComplete, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.lifecycleNotObserved, false);
     assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.passed, true);
 
     const networkReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-network-404');
@@ -1195,6 +1201,92 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(nativeReport.outcome.bucket, 'unsupported-input');
     assert.equal(nativeReport.outcome.reason, 'unsupported-adm-kind:native-json');
     assert.equal(nativeReport.outcome.creativeRendered, false);
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});
+
+test('runner passes inline OMID vendor access mode to the browser harness', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-runner-omid-full-access-'));
+  const inputPath = resolve(workDir, 'cases.jsonl');
+  const outPath = resolve(workDir, 'reports.jsonl');
+
+  const inlineOmidVendor = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-inline-omid-vendor-full-access',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-inline-omid-vendor-full-access',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html',
+      html: '<!doctype html><html><body><script src="/tools/creative-validator/fixtures/omid-vendor-probe.js"></script><div>inline omid vendor</div></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+    bidSignals: {
+      apis: { raw: [], sanitized: [], sources: [] },
+      mtype: 'banner',
+      adomain: ['runner.example'],
+      cat: [],
+      battr: [],
+      attr: [],
+      placement: { id: 'imp-runner-test', instl: 0, secure: 1, mediaTypes: ['banner'] },
+      measurement: {
+        omid: {
+          declaredByApi: false,
+          sidecarPresent: false,
+          inlineVendorScriptPresent: true,
+          inlineVendorScriptCount: 1,
+          inlineVendorVendors: ['doubleverify'],
+          inlineVendorScripts: [{
+            vendor: 'doubleverify',
+            source: 'adm-script-src',
+            value: 'https://cdn.doubleverify.com/dvtp_src.js',
+            url: {
+              protocol: 'https:',
+              origin: 'https://cdn.doubleverify.com',
+              hostname: 'cdn.doubleverify.com',
+              path: '/dvtp_src.js',
+            },
+          }],
+          sources: [{ path: 'adm.script[src]', vendor: 'doubleverify' }],
+        },
+      },
+    },
+  });
+
+  try {
+    writeFileSync(inputPath, `${JSON.stringify(inlineOmidVendor)}\n`);
+    runCli([
+      'run',
+      inputPath,
+      '--out',
+      outPath,
+      '--port',
+      reductionPorts.omidFullAccess.runner,
+      '--renderer-port',
+      reductionPorts.omidFullAccess.renderer,
+      '--render-timeout-ms',
+      '4000',
+      '--settle-ms',
+      '500',
+      '--omid-inline-vendor-access-mode',
+      'full',
+    ]);
+
+    const [report] = readJsonl(outPath);
+    assert.equal(report.diagnostics.measurement.omid.inlineVendor.expected, true);
+    assert.equal(report.diagnostics.measurement.omid.inlineVendor.accessMode, 'full');
+    assert.equal(report.diagnostics.measurement.omid.inlineVendor.omid3pFound, true);
+    assert.equal(report.diagnostics.measurement.omid.inlineVendor.subscriptionObserved, true);
   } finally {
     rmSync(workDir, { force: true, recursive: true });
   }

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -734,6 +734,19 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
         loadedFired: true,
         impressionFired: true,
         verificationScriptCount: 2,
+        inlineVendor: {
+          expected: true,
+          accessMode: 'limited',
+          omid3pFound: true,
+          subscriptionObserved: true,
+          registerSessionObserverCalls: 1,
+          addEventListenerCalls: 0,
+          callbackEvents: 3,
+          lifecycleObserved: true,
+          lifecycleComplete: true,
+          lifecycleNotObserved: false,
+          passed: true,
+        },
       }, {
         case: {
           ...report().case,
@@ -764,10 +777,35 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
         loadedFired: false,
         impressionFired: false,
         verificationScriptCount: 1,
+        inlineVendor: {
+          expected: true,
+          accessMode: 'limited',
+          omid3pFound: true,
+          subscriptionObserved: false,
+          registerSessionObserverCalls: 0,
+          addEventListenerCalls: 0,
+          callbackEvents: 0,
+          lifecycleObserved: false,
+          lifecycleComplete: false,
+          lifecycleNotObserved: false,
+          passed: false,
+        },
       }, {
         case: {
           ...report().case,
           source: { ...report().case.source, bidder: 'bidder-omid-b', rowIndex: 1 },
+          bidSignals: {
+            ...report().case.bidSignals,
+            measurement: {
+              omid: {
+                declaredByApi: true,
+                sidecarPresent: true,
+                inlineVendorScriptPresent: true,
+                inlineVendorScriptCount: 1,
+                inlineVendorVendors: ['doubleverify'],
+              },
+            },
+          },
         },
         outcome: { status: 'failed', bucket: 'measurement-omid' },
       }),
@@ -808,6 +846,19 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
         loadedFired: false,
         impressionFired: false,
         verificationScriptCount: 0,
+        inlineVendor: {
+          expected: true,
+          accessMode: 'full',
+          omid3pFound: true,
+          subscriptionObserved: true,
+          registerSessionObserverCalls: 0,
+          addEventListenerCalls: 1,
+          callbackEvents: 0,
+          lifecycleObserved: false,
+          lifecycleComplete: false,
+          lifecycleNotObserved: true,
+          passed: false,
+        },
       }, {
         case: {
           ...report().case,
@@ -865,8 +916,8 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
     const omid = summary.corpusDiagnostics.omid;
     assert.equal(omid.rows, 7);
     assert.equal(omid.rowsCapabilityDeclared, 5);
-    assert.equal(omid.rowsInlineInstrumented, 2);
-    assert.equal(omid.rowsCapabilityDeclaredInlineInstrumented, 1);
+    assert.equal(omid.rowsInlineInstrumented, 3);
+    assert.equal(omid.rowsCapabilityDeclaredInlineInstrumented, 2);
     assert.equal(omid.rowsInlineInstrumentedWithoutCapability, 1);
     assert.equal(omid.rowsAbsent, 1);
     assert.equal(omid.rowsScanTruncated, 1);
@@ -886,19 +937,34 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
     });
     assert.deepEqual(omid.byInstrumentationSignal, {
       absent: 1,
-      'declared-api7+inline-vendor': 1,
-      'declared-api7-only': 4,
+      'declared-api7+inline-vendor': 2,
+      'declared-api7-only': 3,
       'inline-vendor-only': 1,
     });
-    assert.deepEqual(omid.byInlineVendorScriptCount, { 1: 1, 2: 1 });
+    assert.deepEqual(omid.byInlineVendorScriptCount, { 1: 2, 2: 1 });
     assert.deepEqual(omid.inlineVendorRowsByVendor, {
-      doubleverify: 1,
+      doubleverify: 2,
       ias: 1,
       moat: 1,
     });
     assert.deepEqual(omid.inlineVendorRowsByBidder, {
       'bidder-omid-a': 1,
+      'bidder-omid-b': 1,
       'bidder-omid-c': 1,
+    });
+    assert.deepEqual(omid.inlineVendorRowsByAccessMode, {
+      full: 1,
+      limited: 2,
+    });
+    assert.deepEqual(omid.inlineVendorRowsByRuntimeOutcome, {
+      'omid3p-no-subscription': 1,
+      'observed-lifecycle': 1,
+      'subscribed-no-lifecycle': 1,
+    });
+    assert.deepEqual(omid.inlineVendorRowsByLifecycleObservation, {
+      complete: 1,
+      'not-applicable': 1,
+      'subscribed-none': 1,
     });
     assert.deepEqual(omid.byVerificationScriptCount, { 0: 1, 1: 2, 2: 1 });
     assert.deepEqual(omid.capabilityRowsByBidder, {
@@ -953,6 +1019,9 @@ test('triageReports emits a stable empty OMID facet for a zero-row corpus', () =
       byInlineVendorScriptCount: {},
       inlineVendorRowsByVendor: {},
       inlineVendorRowsByBidder: {},
+      inlineVendorRowsByAccessMode: {},
+      inlineVendorRowsByRuntimeOutcome: {},
+      inlineVendorRowsByLifecycleObservation: {},
       byOutcome: {},
       byVerificationScriptCount: {},
       capabilityRowsByBidder: {},


### PR DESCRIPTION
## Summary
- Add auditable inline OMID vendor access-mode diagnostics and a CLI sweep option for synthesized sidecars (`limited` default, `full` opt-in).
- Split inline-vendor runtime telemetry into subscription vs lifecycle-observation facets so subscribed-but-no-callback rows are not treated as hard container failures.
- Update validator triage/README/tests to report access mode, runtime outcome, and lifecycle completeness separately.

Closes #265.

## Private corpus sweep
Input: `tools/creative-validator/private/debug-omid-vendor-e2e/cases-inline-vendor-executable-post264.jsonl` (96 executable inline-vendor rows: 88 DoubleVerify, 8 IAS).

Limited sweep:
- accessMode: limited 96/96
- passed: 26/96 (DoubleVerify 18/88, IAS 8/8)
- failed: 70/96, all `inline OMID vendor script did not subscribe to OMID`
- runtime facets: observed-lifecycle 26, omid3p-no-subscription 70
- lifecycle facets: complete 26, not-observed 70
- registerSessionObserverCalls: median 0, p90 4, p99 7, max 7
- geometryChange callbacks: median 0, p90 7, p99 12, max 12

Full sweep:
- accessMode: full 96/96
- passed: 24/96 (DoubleVerify 16/88, IAS 8/8)
- failed: 72/96, all `inline OMID vendor script did not subscribe to OMID`
- runtime facets: observed-lifecycle 24, omid3p-no-subscription 72
- lifecycle facets: complete 24, not-observed 72
- registerSessionObserverCalls: median 0, p90 4, p99 7, max 7
- geometryChange callbacks: median 0, p90 7, p99 12, max 12

Conclusion: `accessMode: full` does not improve DV activation in this corpus. The remaining DV zero-subscription rows now read as validator/vendor activation data, not a lifecycle-callback classification artifact.

## Validation
- `node tools/creative-validator/test/test-diagnose.js`
- `node tools/creative-validator/test/test-triage.js`
- `npx eslint tools/creative-validator/src/cli.js tools/creative-validator/src/runner.js tools/creative-validator/src/diagnose.js tools/creative-validator/src/triage.js tools/creative-validator/test/test-diagnose.js tools/creative-validator/test/test-triage.js tools/creative-validator/test/test-runner.js --max-warnings=0`
- `git diff --check`
- `npm run test:creative-validator-runner`
- `npm run check`
- Private corpus limited/full sweeps listed above
