### PR TITLE
test: harden inline OMID vendor URL normalization

### DIFF
--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -141,6 +141,8 @@ function synthesizeOmidSidecarFromInlineVendors(testCase, accessMode) {
     return testCase;
   }
   const cloned = cloneForReport(testCase);
+  // The normalizer enforces explicit HTTPS + known vendor hosts upstream; keep
+  // this HTTPS check as defense-in-depth before synthesized sidecar execution.
   // The validator shim exposes the same OMID JS surface for limited/full; this
   // label lets real vendor scripts self-route on the declared access mode.
   const scripts = omidInlineVendorScripts(cloned)

--- a/tools/creative-validator/src/normalizer.js
+++ b/tools/creative-validator/src/normalizer.js
@@ -209,10 +209,13 @@ function classifyOmidVendorScript(url) {
   return null;
 }
 
-function sanitizeScriptUrl(value) {
+function sanitizeInlineVendorScriptUrl(value) {
   if (typeof value !== 'string' || !value.trim()) return null;
+  const trimmed = value.trim();
+  if (!/^https:\/\//i.test(trimmed)) return null;
   try {
-    const parsed = new URL(value.trim(), 'https://creative.invalid/');
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'https:') return null;
     const hostname = parsed.hostname
       ? parsed.hostname.toLowerCase().replace(/\.$/, '')
       : '';
@@ -221,6 +224,7 @@ function sanitizeScriptUrl(value) {
       origin: parsed.origin === 'null' ? 'opaque' : parsed.origin,
       hostname,
       path: parsed.pathname.slice(0, 200),
+      href: parsed.href,
     };
   } catch (_) {
     return null;
@@ -386,7 +390,7 @@ function extractInlineOmidVendorScriptScan(adm) {
   let vendorScriptMatches = 0;
   let vendorMatchLimitReached = false;
   for (const src of scan.sources) {
-    const url = sanitizeScriptUrl(src);
+    const url = sanitizeInlineVendorScriptUrl(src);
     const vendor = classifyOmidVendorScript(url);
     if (!vendor) continue;
     if (vendorScriptMatches >= MAX_OMID_VENDOR_SCRIPT_MATCHES) {
@@ -394,12 +398,13 @@ function extractInlineOmidVendorScriptScan(adm) {
       continue;
     }
     vendorScriptMatches += 1;
-    const value = src.slice(0, 500);
+    const value = url.href.slice(0, 500);
     scripts.push({
       vendor,
       source: 'adm-script-src',
+      // Use parsed URL fields for comparisons; value is canonical report text.
       value,
-      truncated: src.length > value.length,
+      truncated: url.href.length > value.length,
       url,
     });
   }

--- a/tools/creative-validator/test/test-normalizer.js
+++ b/tools/creative-validator/test/test-normalizer.js
@@ -95,10 +95,35 @@ test('inline OMID vendor script detection requires vendor script hosts', () => {
   const scripts = extractInlineOmidVendorScripts(`
     <script src="https://example.com/blog/about-moatads.html"></script>
     <script src="https://cdn.example.com/integralads-tracker.js"></script>
+    <script src="https://attacker.com/dvtp_src.js"></script>
+    <script src="https://cdn.doubleverify.com@attacker.com/dvtp_src.js"></script>
     <script src="/dvtp_src.js"></script>
     <script>function registerSessionObserver() { return false; }</script>
   `);
   assert.deepEqual(scripts, []);
+});
+
+test('inline OMID vendor script detection requires explicit HTTPS URLs', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script src="http://cdn.doubleverify.com/dvtp_src.js"></script>
+    <script src="data:text/javascript,window.omid3p"></script>
+    <script src="javascript:void(0)"></script>
+    <script src="//cdn.doubleverify.com/dvtp_src.js"></script>
+    <script src="/dvtp_src.js"></script>
+    <script src="   https://cdn.doubleverify.com/padded.js   "></script>
+    <script src="HTTPS://cdn.doubleverify.com/upper.js"></script>
+    <script src="https://cdn.doubleverify.com/dvtp_src.js"></script>
+  `);
+  assert.deepEqual(scripts.map((script) => script.vendor), [
+    'doubleverify',
+    'doubleverify',
+    'doubleverify',
+  ]);
+  assert.deepEqual(scripts.map((script) => script.value), [
+    'https://cdn.doubleverify.com/padded.js',
+    'https://cdn.doubleverify.com/upper.js',
+    'https://cdn.doubleverify.com/dvtp_src.js',
+  ]);
 });
 
 test('inline OMID generic signal ignores inert text and data-type does not shadow type', () => {


### PR DESCRIPTION
## Summary
- Require inline OMID vendor script URLs to be explicit `https://` before they can enter `inlineVendorScripts[]`.
- Keep the existing known-vendor host gate in the normalizer and add an attacker-host regression case.
- Document the harness-side HTTPS filter as defense-in-depth before synthesized sidecar execution.

Closes #266.

## Notes
The normalizer now rejects protocol-relative, relative, `http:`, `data:`, and `javascript:` script URLs before vendor classification. The existing vendor-host allowlist remains the second upstream gate, so `https://attacker.com/dvtp_src.js` is still excluded even though it is HTTPS.

## Validation
- `node tools/creative-validator/test/test-normalizer.js`
- `npx eslint tools/creative-validator/src/normalizer.js tools/creative-validator/test/test-normalizer.js --max-warnings=0`
- `git diff --check`
- `npm run test:creative-validator-runner`
