### PR TITLE
test: cache validator script responses

### DIFF
--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -149,6 +149,14 @@ transport-level failed requests, HTTP error responses, and CORS/CSP-like console
 messages grouped by origin, status, and resource type. These facets are
 diagnostic by default: a creative that renders successfully can still pass while
 showing broken pixels or third-party resource failures for later triage.
+During one `run` invocation, the runner also keeps an in-process LRU cache for
+successful `http:`/`https:` script responses and serves later matching script
+URLs from that cache across fresh browser contexts. This reduces repeated vendor
+CDN fetches without persisting private creative traffic to disk. `no-store`
+responses, failed responses, non-GET requests, and the special MRAID `mraid.js`
+alias are not cached. Cache counters and approximate decoded body bytes appear
+under `diagnostics.network.scriptCache` and aggregate under
+`corpusDiagnostics.network.scriptCache`.
 
 Report rows include `diagnostics.navigationDiagnostics` for bounded navigation
 source signals captured before creative markup runs. The harness records
@@ -196,6 +204,9 @@ clusters after the fatal failure count is already zero. These facets are
 aggregate-only and still avoid raw creative markup. They are still private-tier:
 the facets key by real bidder names and script origins, so summaries must not
 be shared with bidders.
+`corpusDiagnostics.network.scriptCache` aggregates the per-row script cache
+counters so corpus runs can report approximate decoded external script bytes
+fetched from network versus replayed from the in-process cache.
 
 Script-load corpus facets split error rows into diagnostic classes:
 `legacy-mraid-loader`, `external-script-aborted`, `external-script-dns`,

--- a/tools/creative-validator/src/runner.js
+++ b/tools/creative-validator/src/runner.js
@@ -20,6 +20,8 @@ const DEFAULT_RENDERER_PORT = 18866;
 const DEFAULT_RENDER_TIMEOUT_MS = 10_000;
 const DEFAULT_SETTLE_MS = 2_000;
 const DEFAULT_OMID_INLINE_VENDOR_ACCESS_MODE = 'limited';
+const SCRIPT_RESPONSE_CACHE_MAX_ENTRIES = 256;
+const SCRIPT_RESPONSE_CACHE_MAX_BYTES = 50 * 1024 * 1024;
 
 function parsePort(raw, fallback) {
   if (raw === undefined || raw === null || raw === '') return fallback;
@@ -311,6 +313,7 @@ function summarizeNetwork(run) {
     byStatus,
     corsConsole,
     cspConsole,
+    scriptCache: run.scriptCache || null,
   };
 }
 
@@ -401,16 +404,172 @@ function shouldAliasLegacyMraidLoader(testCase) {
   return expectedBridges(testCase).includes('mraid');
 }
 
-async function installLegacyMraidLoaderAlias(page, testCase) {
-  if (!shouldAliasLegacyMraidLoader(testCase)) return;
+function createScriptCacheStats(enabled, cache) {
+  const snapshot = cache && typeof cache.snapshot === 'function'
+    ? cache.snapshot()
+    : { entries: 0, totalBytes: 0 };
+  const stats = {
+    enabled,
+    lookups: 0,
+    hits: 0,
+    misses: 0,
+    stores: 0,
+    skipped: 0,
+    errors: 0,
+    bytesFromNetwork: 0,
+    bytesFromCache: 0,
+    byOrigin: {},
+    entriesAtStart: snapshot.entries,
+    totalBytesAtStart: snapshot.totalBytes,
+    entriesAtEnd: snapshot.entries,
+    totalBytesAtEnd: snapshot.totalBytes,
+  };
+  return stats;
+}
+
+function updateScriptCacheStatsSnapshot(stats, cache) {
+  if (!stats || !cache || typeof cache.snapshot !== 'function') return;
+  const snapshot = cache.snapshot();
+  stats.entriesAtEnd = snapshot.entries;
+  stats.totalBytesAtEnd = snapshot.totalBytes;
+}
+
+function scriptCacheOrigin(url) {
+  try {
+    return new URL(url).origin;
+  } catch (_) {
+    return 'unknown';
+  }
+}
+
+function recordScriptCacheOrigin(stats, url, field, amount = 1) {
+  const origin = scriptCacheOrigin(url);
+  if (!stats.byOrigin[origin]) {
+    stats.byOrigin[origin] = {
+      lookups: 0,
+      hits: 0,
+      misses: 0,
+      stores: 0,
+      bytesFromNetwork: 0,
+      bytesFromCache: 0,
+    };
+  }
+  stats.byOrigin[origin][field] = (stats.byOrigin[origin][field] || 0) + amount;
+}
+
+function isCacheableScriptRequest(request) {
+  if (!request || request.resourceType() !== 'script' || request.method() !== 'GET') return false;
+  if (isLegacyMraidLoaderUrl(request.url())) return false;
+  try {
+    const parsed = new URL(request.url());
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch (_) {
+    return false;
+  }
+}
+
+function sanitizeCachedResponseHeaders(headers, bodyLength) {
+  const sanitized = {};
+  for (const [name, value] of Object.entries(headers || {})) {
+    const normalized = name.toLowerCase();
+    if (
+      normalized === 'content-encoding'
+      || normalized === 'content-length'
+      || normalized === 'set-cookie'
+      || normalized === 'set-cookie2'
+      || normalized === 'clear-site-data'
+      || normalized === 'transfer-encoding'
+      || normalized === 'connection'
+      || normalized === 'keep-alive'
+      || normalized === 'proxy-authenticate'
+      || normalized === 'proxy-authorization'
+      || normalized === 'te'
+      || normalized === 'trailer'
+      || normalized === 'upgrade'
+    ) {
+      continue;
+    }
+    sanitized[name] = value;
+  }
+  if (!Object.keys(sanitized).some((name) => name.toLowerCase() === 'content-type')) {
+    sanitized['content-type'] = 'application/javascript; charset=utf-8';
+  }
+  sanitized['content-length'] = String(bodyLength);
+  return sanitized;
+}
+
+function responseAllowsScriptCache(response) {
+  if (!response) return false;
+  const status = response.status();
+  if (status < 200 || status >= 300) return false;
+  const headers = response.headers ? response.headers() : {};
+  const cacheControl = String(headers['cache-control'] || '').toLowerCase();
+  return !cacheControl.includes('no-store');
+}
+
+function createScriptResponseCache({
+  maxEntries = SCRIPT_RESPONSE_CACHE_MAX_ENTRIES,
+  maxBytes = SCRIPT_RESPONSE_CACHE_MAX_BYTES,
+} = {}) {
+  const entries = new Map();
+  let totalBytes = 0;
+
+  function evict() {
+    while (entries.size > maxEntries || totalBytes > maxBytes) {
+      const oldestKey = entries.keys().next().value;
+      if (oldestKey === undefined) break;
+      const oldest = entries.get(oldestKey);
+      totalBytes -= oldest ? oldest.bytes : 0;
+      entries.delete(oldestKey);
+    }
+  }
+
+  return {
+    get(url) {
+      const entry = entries.get(url);
+      if (!entry) return null;
+      entries.delete(url);
+      entries.set(url, entry);
+      return entry;
+    },
+    set(url, entry) {
+      if (!url || !entry || !Buffer.isBuffer(entry.body)) return false;
+      if (entry.body.length > maxBytes) return false;
+      const existing = entries.get(url);
+      if (existing) totalBytes -= existing.bytes;
+      const stored = {
+        status: entry.status,
+        headers: sanitizeCachedResponseHeaders(entry.headers, entry.body.length),
+        body: entry.body,
+        bytes: entry.body.length,
+      };
+      entries.set(url, stored);
+      totalBytes += stored.bytes;
+      evict();
+      return true;
+    },
+    snapshot() {
+      return {
+        entries: entries.size,
+        totalBytes,
+      };
+    },
+  };
+}
+
+async function installRequestInterceptors(page, testCase, options, stats, pendingCacheWrites) {
+  const aliasLegacyMraid = shouldAliasLegacyMraidLoader(testCase);
+  const scriptResponseCache = options.scriptResponseCache || null;
+  const servedFromScriptCache = new WeakSet();
   await page.setRequestInterception(true);
   page.on('request', async (request) => {
+    let fulfillingFromScriptCache = false;
     try {
       if (typeof request.isInterceptResolutionHandled === 'function'
           && request.isInterceptResolutionHandled()) {
         return;
       }
-      if (request.resourceType() === 'script' && isLegacyMraidLoaderUrl(request.url())) {
+      if (aliasLegacyMraid && request.resourceType() === 'script' && isLegacyMraidLoaderUrl(request.url())) {
         await request.respond({
           status: 200,
           contentType: 'application/javascript; charset=utf-8',
@@ -418,8 +577,30 @@ async function installLegacyMraidLoaderAlias(page, testCase) {
         });
         return;
       }
+      if (scriptResponseCache && isCacheableScriptRequest(request)) {
+        stats.lookups += 1;
+        recordScriptCacheOrigin(stats, request.url(), 'lookups');
+        const cached = scriptResponseCache.get(request.url());
+        if (cached) {
+          fulfillingFromScriptCache = true;
+          servedFromScriptCache.add(request);
+          await request.respond({
+            status: cached.status,
+            headers: cached.headers,
+            body: cached.body,
+          });
+          stats.hits += 1;
+          stats.bytesFromCache += cached.bytes;
+          recordScriptCacheOrigin(stats, request.url(), 'hits');
+          recordScriptCacheOrigin(stats, request.url(), 'bytesFromCache', cached.bytes);
+          return;
+        }
+        stats.misses += 1;
+        recordScriptCacheOrigin(stats, request.url(), 'misses');
+      }
       await request.continue();
     } catch (_) {
+      if (fulfillingFromScriptCache) stats.errors += 1;
       try {
         await request.continue();
       } catch (_) {
@@ -427,6 +608,43 @@ async function installLegacyMraidLoaderAlias(page, testCase) {
         // diagnostics are already collected from completed/failed requests.
       }
     }
+  });
+  page.on('requestfinished', (request) => {
+    if (!scriptResponseCache || servedFromScriptCache.has(request) || !isCacheableScriptRequest(request)) return;
+    const response = request.response();
+    if (!responseAllowsScriptCache(response)) {
+      stats.skipped += 1;
+      return;
+    }
+    const declaredLength = Number(response.headers()['content-length']);
+    if (Number.isFinite(declaredLength) && declaredLength > SCRIPT_RESPONSE_CACHE_MAX_BYTES) {
+      stats.skipped += 1;
+      return;
+    }
+    const write = response.buffer()
+      .then((body) => {
+        if (!Buffer.isBuffer(body) || body.length === 0) {
+          stats.skipped += 1;
+          return;
+        }
+        const stored = scriptResponseCache.set(request.url(), {
+          status: response.status(),
+          headers: response.headers(),
+          body,
+        });
+        if (!stored) {
+          stats.skipped += 1;
+          return;
+        }
+        stats.stores += 1;
+        stats.bytesFromNetwork += body.length;
+        recordScriptCacheOrigin(stats, request.url(), 'stores');
+        recordScriptCacheOrigin(stats, request.url(), 'bytesFromNetwork', body.length);
+      })
+      .catch(() => {
+        stats.errors += 1;
+      });
+    pendingCacheWrites.push(write);
   });
 }
 
@@ -537,8 +755,10 @@ async function runExecutableCase(browser, testCase, options) {
   const failedRequests = [];
   const failedResponses = [];
   const scriptOutcomes = [];
+  const pendingCacheWrites = [];
+  const scriptCacheStats = createScriptCacheStats(Boolean(options.scriptResponseCache), options.scriptResponseCache);
 
-  await installLegacyMraidLoaderAlias(page, testCase);
+  await installRequestInterceptors(page, testCase, options, scriptCacheStats, pendingCacheWrites);
 
   page.on('console', (msg) => {
     const summarized = summarizeConsoleMessage(msg);
@@ -623,6 +843,7 @@ async function runExecutableCase(browser, testCase, options) {
         failedRequests,
         failedResponses,
         scriptOutcomes,
+        scriptCache: scriptCacheStats,
       };
     }
 
@@ -646,6 +867,7 @@ async function runExecutableCase(browser, testCase, options) {
       failedRequests,
       failedResponses,
       scriptOutcomes,
+      scriptCache: scriptCacheStats,
     };
   } catch (err) {
     return makeEmptyRun({
@@ -655,8 +877,11 @@ async function runExecutableCase(browser, testCase, options) {
       failedRequests,
       failedResponses,
       scriptOutcomes,
+      scriptCache: scriptCacheStats,
     });
   } finally {
+    await Promise.allSettled(pendingCacheWrites);
+    updateScriptCacheStatsSnapshot(scriptCacheStats, options.scriptResponseCache);
     await context.close();
   }
 }
@@ -737,6 +962,7 @@ async function runNormalizedCases(inputFile, outFile, options = {}) {
     settleMs: options.settleMs || DEFAULT_SETTLE_MS,
     omidInlineVendorAccessMode: options.omidInlineVendorAccessMode
       || DEFAULT_OMID_INLINE_VENDOR_ACCESS_MODE,
+    scriptResponseCache: createScriptResponseCache(),
     verbose: options.verbose === true,
   };
 
@@ -792,6 +1018,8 @@ export {
   DEFAULT_RENDER_TIMEOUT_MS,
   DEFAULT_SETTLE_MS,
   classifyOutcome,
+  isCacheableScriptRequest,
   readJsonl,
   runNormalizedCases,
+  sanitizeCachedResponseHeaders,
 };

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -115,6 +115,20 @@ function emptySummary(files) {
         failedDocumentRowsByBidder: {},
         failedResourceType: {},
         failedResponseStatus: {},
+        scriptCache: {
+          rowsEnabled: 0,
+          rowsWithHits: 0,
+          rowsWithStores: 0,
+          lookups: 0,
+          hits: 0,
+          misses: 0,
+          stores: 0,
+          skipped: 0,
+          errors: 0,
+          bytesFromNetwork: 0,
+          bytesFromCache: 0,
+          byOrigin: {},
+        },
       },
       omid: {
         rows: 0,
@@ -188,6 +202,11 @@ function networkDiagnostics(row) {
   return row && row.diagnostics && row.diagnostics.network
     ? row.diagnostics.network
     : {};
+}
+
+function scriptCacheDiagnostics(row) {
+  const network = networkDiagnostics(row);
+  return network && network.scriptCache ? network.scriptCache : {};
 }
 
 function failedRequests(row) {
@@ -514,6 +533,47 @@ function addRuntimeCorpusFacets(summary, row, fields) {
   const navigation = navigationDiagnostics(row);
   const scriptLoads = navigation.scriptLoads || {};
   const legacy = legacyMraidLoaderDiagnostics(row);
+  const scriptCache = scriptCacheDiagnostics(row);
+  if (scriptCache.enabled === true) {
+    const cacheFacet = summary.corpusDiagnostics.network.scriptCache;
+    const lookups = networkCount(scriptCache.lookups);
+    const hits = networkCount(scriptCache.hits);
+    const misses = networkCount(scriptCache.misses);
+    const stores = networkCount(scriptCache.stores);
+    const skipped = networkCount(scriptCache.skipped);
+    const errors = networkCount(scriptCache.errors);
+    const bytesFromNetwork = networkCount(scriptCache.bytesFromNetwork);
+    const bytesFromCache = networkCount(scriptCache.bytesFromCache);
+    cacheFacet.rowsEnabled += 1;
+    if (hits > 0) cacheFacet.rowsWithHits += 1;
+    if (stores > 0) cacheFacet.rowsWithStores += 1;
+    cacheFacet.lookups += lookups;
+    cacheFacet.hits += hits;
+    cacheFacet.misses += misses;
+    cacheFacet.stores += stores;
+    cacheFacet.skipped += skipped;
+    cacheFacet.errors += errors;
+    cacheFacet.bytesFromNetwork += bytesFromNetwork;
+    cacheFacet.bytesFromCache += bytesFromCache;
+    for (const [origin, values] of Object.entries(scriptCache.byOrigin || {})) {
+      if (!cacheFacet.byOrigin[origin]) {
+        cacheFacet.byOrigin[origin] = {
+          lookups: 0,
+          hits: 0,
+          misses: 0,
+          stores: 0,
+          bytesFromNetwork: 0,
+          bytesFromCache: 0,
+        };
+      }
+      cacheFacet.byOrigin[origin].lookups += networkCount(values && values.lookups);
+      cacheFacet.byOrigin[origin].hits += networkCount(values && values.hits);
+      cacheFacet.byOrigin[origin].misses += networkCount(values && values.misses);
+      cacheFacet.byOrigin[origin].stores += networkCount(values && values.stores);
+      cacheFacet.byOrigin[origin].bytesFromNetwork += networkCount(values && values.bytesFromNetwork);
+      cacheFacet.byOrigin[origin].bytesFromCache += networkCount(values && values.bytesFromCache);
+    }
+  }
   const scriptCount = networkCount(scriptLoads.count);
   const scriptErrorCount = networkCount(scriptLoads.errorCount);
   const scriptLoadedCount = networkCount(scriptLoads.loadedCount);
@@ -790,6 +850,10 @@ function sortEntries(map, options = {}) {
         : a[0].localeCompare(b[0]))));
 }
 
+function sortObjectKeys(map) {
+  return Object.fromEntries(Object.entries(map || {}).sort(([a], [b]) => a.localeCompare(b)));
+}
+
 function sortedGroups(groups) {
   return [...groups.values()].sort((a, b) =>
     b.count - a.count
@@ -981,6 +1045,8 @@ function triageReports(files) {
     sortEntries(summary.corpusDiagnostics.network.failedResourceType);
   summary.corpusDiagnostics.network.failedResponseStatus =
     sortEntries(summary.corpusDiagnostics.network.failedResponseStatus, { numericKeys: true });
+  summary.corpusDiagnostics.network.scriptCache.byOrigin =
+    sortObjectKeys(summary.corpusDiagnostics.network.scriptCache.byOrigin);
   summary.corpusDiagnostics.omid.byOutcome =
     sortEntries(summary.corpusDiagnostics.omid.byOutcome);
   summary.corpusDiagnostics.omid.byInstrumentationSignal =

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -16,6 +16,10 @@ import {
 } from 'node:fs';
 import { resolve } from 'node:path';
 import test from 'node:test';
+import {
+  isCacheableScriptRequest,
+  sanitizeCachedResponseHeaders,
+} from '../src/runner.js';
 
 const cliPath = resolve('tools/creative-validator/src/cli.js');
 const navigationReductionPath = resolve(
@@ -30,13 +34,22 @@ const opaqueDocumentReductionPath = resolve(
 const cspEmbeddedFrameReductionPath = resolve(
   'tools/creative-validator/fixtures/reductions/007-csp-embedded-frame-diagnostics/cleaned-corpus.fixture.json',
 );
+
+let nextTestPort = 12000 + (process.pid % 900) * 20;
+function testPortPair() {
+  const ports = { runner: String(nextTestPort), renderer: String(nextTestPort + 1) };
+  nextTestPort += 2;
+  return ports;
+}
+
 const reductionPorts = {
-  externalScript: { runner: '18879', renderer: '18880' },
-  omidFullAccess: { runner: '18887', renderer: '18888' },
-  navigation: { runner: '18869', renderer: '18870' },
-  documentSource: { runner: '18877', renderer: '18878' },
-  opaqueDocument: { runner: '18881', renderer: '18882' },
-  cspEmbeddedFrame: { runner: '18885', renderer: '18886' },
+  runnerSmoke: testPortPair(),
+  externalScript: testPortPair(),
+  omidFullAccess: testPortPair(),
+  navigation: testPortPair(),
+  documentSource: testPortPair(),
+  opaqueDocument: testPortPair(),
+  cspEmbeddedFrame: testPortPair(),
 };
 
 function makeCase(overrides) {
@@ -111,6 +124,51 @@ function runCli(args) {
   assert.equal(result.stderr, '', `CLI wrote unexpected stderr: ${result.stderr}`);
   return result.stdout;
 }
+
+function fakeRequest({ url, method = 'GET', resourceType = 'script' }) {
+  return {
+    method: () => method,
+    resourceType: () => resourceType,
+    url: () => url,
+  };
+}
+
+test('script response cache excludes mraid.js and cross-row state headers', () => {
+  assert.equal(
+    isCacheableScriptRequest(fakeRequest({ url: 'https://cdn.example/foo/mraid.js?cb=1#frag' })),
+    false,
+  );
+  assert.equal(
+    isCacheableScriptRequest(fakeRequest({ url: 'https://cdn.example/foo/MRAID.JS' })),
+    false,
+  );
+  assert.equal(
+    isCacheableScriptRequest(fakeRequest({ url: 'https://cdn.example/tag.js' })),
+    true,
+  );
+  assert.equal(
+    isCacheableScriptRequest(fakeRequest({ url: 'https://cdn.example/tag.js', method: 'POST' })),
+    false,
+  );
+  assert.equal(
+    isCacheableScriptRequest(fakeRequest({ url: 'https://cdn.example/pixel.png', resourceType: 'image' })),
+    false,
+  );
+
+  const headers = sanitizeCachedResponseHeaders({
+    'content-type': 'application/javascript',
+    'content-encoding': 'gzip',
+    'set-cookie': 'vendor_session=abc; HttpOnly',
+    'set-cookie2': 'legacy=abc',
+    'clear-site-data': '"cookies"',
+  }, 12);
+  assert.equal(headers['content-type'], 'application/javascript');
+  assert.equal(headers['content-length'], '12');
+  assert.equal(headers['content-encoding'], undefined);
+  assert.equal(headers['set-cookie'], undefined);
+  assert.equal(headers['set-cookie2'], undefined);
+  assert.equal(headers['clear-site-data'], undefined);
+});
 
 function withReductionFixture({ fixturePath, workDirPrefix, ports, runOptions = [], includeTriage = false }, assertions) {
   const privateRoot = resolve('tools/creative-validator/private');
@@ -889,9 +947,9 @@ test('runner executes HTML cases and writes one report row per case', () => {
       '--out',
       outPath,
       '--port',
-      '18867',
+      reductionPorts.runnerSmoke.runner,
       '--renderer-port',
-      '18868',
+      reductionPorts.runnerSmoke.renderer,
       '--render-timeout-ms',
       '4000',
       '--settle-ms',
@@ -1097,9 +1155,19 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(scriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.errorCount, 0);
     assert.equal(scriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.byProtocol['http:'], 1);
     assert.equal(scriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.calls[0].url.present, true);
+    assert.equal(scriptLoadOkReport.diagnostics.network.scriptCache.enabled, true);
+    assert.ok(scriptLoadOkReport.diagnostics.network.scriptCache.lookups >= 1);
+    assert.ok(scriptLoadOkReport.diagnostics.network.scriptCache.stores >= 1);
+    assert.ok(scriptLoadOkReport.diagnostics.network.scriptCache.bytesFromNetwork > 0);
+    assert.equal('entries' in scriptLoadOkReport.diagnostics.network.scriptCache, false);
+    assert.equal('totalBytes' in scriptLoadOkReport.diagnostics.network.scriptCache, false);
+    assert.ok(Number.isInteger(scriptLoadOkReport.diagnostics.network.scriptCache.entriesAtStart));
+    assert.ok(Number.isInteger(scriptLoadOkReport.diagnostics.network.scriptCache.entriesAtEnd));
+    assert.ok(scriptLoadOkReport.diagnostics.network.scriptCache.entriesAtEnd
+      >= scriptLoadOkReport.diagnostics.network.scriptCache.entriesAtStart);
     assert.match(
       scriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.calls[0].url.origin,
-      /^http:\/\/(?:127\.0\.0\.1|localhost):18868$/,
+      new RegExp(`^http://(?:127\\.0\\.0\\.1|localhost):${reductionPorts.runnerSmoke.renderer}$`),
     );
 
     const scriptLoadMissingReport = reports.find((row) =>
@@ -1130,6 +1198,8 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(staticScriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.loadedCount, 1);
     assert.equal(staticScriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.errorCount, 0);
     assert.equal(staticScriptLoadOkReport.diagnostics.navigationDiagnostics.scriptLoads.byStatus.loaded, 1);
+    assert.ok(staticScriptLoadOkReport.diagnostics.network.scriptCache.hits >= 1);
+    assert.ok(staticScriptLoadOkReport.diagnostics.network.scriptCache.bytesFromCache > 0);
 
     const staticScriptLoadMissingReport = reports.find((row) =>
       row.case.ids.bidId === 'bid-runner-static-script-load-missing');

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -104,6 +104,27 @@ test('triageReports groups private report rows by failure dimensions', () => {
             failedResponseCount: 0,
             corsConsoleCount: 0,
             cspConsoleCount: 1,
+            scriptCache: {
+              enabled: true,
+              lookups: 2,
+              hits: 1,
+              misses: 1,
+              stores: 1,
+              skipped: 0,
+              errors: 0,
+              bytesFromNetwork: 1200,
+              bytesFromCache: 1200,
+              byOrigin: {
+                'https://cdn.example': {
+                  lookups: 2,
+                  hits: 1,
+                  misses: 1,
+                  stores: 1,
+                  bytesFromNetwork: 1200,
+                  bytesFromCache: 1200,
+                },
+              },
+            },
           },
           failedRequests: [{
             url: 'https://cdn.example/tag.js',
@@ -235,6 +256,27 @@ test('triageReports groups private report rows by failure dimensions', () => {
             failedResponseCount: 1,
             corsConsoleCount: 1,
             cspConsoleCount: 0,
+            scriptCache: {
+              enabled: true,
+              lookups: 1,
+              hits: 0,
+              misses: 1,
+              stores: 1,
+              skipped: 1,
+              errors: 0,
+              bytesFromNetwork: 800,
+              bytesFromCache: 0,
+              byOrigin: {
+                'https://cdn.example': {
+                  lookups: 1,
+                  hits: 0,
+                  misses: 1,
+                  stores: 1,
+                  bytesFromNetwork: 800,
+                  bytesFromCache: 0,
+                },
+              },
+            },
             byResourceType: {
               document: 1,
               script: 2,
@@ -572,6 +614,26 @@ test('triageReports groups private report rows by failure dimensions', () => {
     });
     assert.deepEqual(summary.corpusDiagnostics.network.failedResponseStatus, {
       404: 1,
+    });
+    assert.equal(summary.corpusDiagnostics.network.scriptCache.rowsEnabled, 2);
+    assert.equal(summary.corpusDiagnostics.network.scriptCache.rowsWithHits, 1);
+    assert.equal(summary.corpusDiagnostics.network.scriptCache.rowsWithStores, 2);
+    assert.equal(summary.corpusDiagnostics.network.scriptCache.lookups, 3);
+    assert.equal(summary.corpusDiagnostics.network.scriptCache.hits, 1);
+    assert.equal(summary.corpusDiagnostics.network.scriptCache.misses, 2);
+    assert.equal(summary.corpusDiagnostics.network.scriptCache.stores, 2);
+    assert.equal(summary.corpusDiagnostics.network.scriptCache.skipped, 1);
+    assert.equal(summary.corpusDiagnostics.network.scriptCache.bytesFromNetwork, 2000);
+    assert.equal(summary.corpusDiagnostics.network.scriptCache.bytesFromCache, 1200);
+    assert.deepEqual(summary.corpusDiagnostics.network.scriptCache.byOrigin, {
+      'https://cdn.example': {
+        lookups: 3,
+        hits: 1,
+        misses: 2,
+        stores: 2,
+        bytesFromNetwork: 2000,
+        bytesFromCache: 1200,
+      },
     });
     assert.equal(summary.failureGroups.length, 1);
     assert.equal(summary.failureGroups[0].bucket, 'bridge-missing');


### PR DESCRIPTION
## Summary

- add a run-scoped in-memory LRU for successful script responses in the creative validator runner
- reuse the existing request-interception lane while preserving the legacy MRAID mraid.js alias boundary
- expose per-row and triage-level script cache diagnostics for hit/miss counts and approximate network-vs-cache decoded body bytes
- document the cache policy in the validator README

Closes #267.

## Validation

- npm run test:creative-validator-runner
- npm run test:creative-validator-triage
- npx eslint tools/creative-validator/src/runner.js tools/creative-validator/src/triage.js tools/creative-validator/test/test-runner.js tools/creative-validator/test/test-triage.js --max-warnings=0
- npm run build
- npm run check
- git diff --check

## Corpus Measurement

Inline OMID vendor slice, 96 executable rows, limited access:

- default settle 2s: 28 passed / 68 failed; cache 903 lookups, 650 hits, 253 misses, ~6.99 MB decoded body bytes fetched, ~106.39 MB decoded body bytes served from cache
- comparable 3s settle window: 25 passed / 71 failed; cache 896 lookups, 647 hits, 249 misses, ~6.96 MB decoded body bytes fetched, ~105.77 MB decoded body bytes served from cache

Compared to the post-#266 limited baseline of 26 passed / 70 failed, the comparable 3s run moved by one net row with DV rows flipping both directions. That is consistent with the existing DoubleVerify runtime variance rather than a material cache-induced pass-rate change.