### PR TITLE
test: measure OMID inline vendor subscription caps

### DIFF
--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -270,6 +270,22 @@ rows mean OMID was used by some script but not by the expected inline vendor.
 Those rows are deliberate hard failures for inline-vendor validation; inspect
 the runtime-outcome facet before interpreting them as ordinary no-subscription
 failures.
+`inlineVendorSubscriptionCap` measures the unit enforced by the 0.7.8 shim cap:
+cumulative `registerSessionObserver` plus `addEventListener` calls per session.
+It reports `rowsMeasured`, nearest-rank `median`/`p99`/`max`, and count buckets
+over all measured inline-vendor rows, including rows with zero subscription
+calls; p99 therefore reflects the upper tail of vendors that did subscribe.
+Triage emits the distribution only; the cap recommendation is a release decision
+derived from `ceil(p99 * 1.25)` and reviewed against the current shim default
+(`64`). In the initial 96-row inline-vendor corpus, nearest-rank p99 equals max,
+so a recommendation of `73` is effectively max plus 25% tail-uncertainty
+headroom. This sizes the legitimate-traffic false-positive floor, not the
+security/DoS ceiling; before copying a value into the shim, review replay-cost
+bounds, cap-hit telemetry, and corpus coverage because the initial sample is
+IAS/DV-dominant. `inlineVendorSessionProfile` reports row-run wallclock duration
+(`outcome.durationMs`, including the validator settle floor) and
+`geometryChange` callback volume, so corpus runs can inform emission-side cache
+and event-rate bounds without claiming true OMID session lifetime.
 `byOutcome` assigns each capability-declared row a single mutually-exclusive
 progress label (`capability-no-sidecar`, `sidecar-no-extension`,
 `extension-no-feature`, `feature-no-session`, `session-started`,

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -154,6 +154,29 @@ function emptySummary(files) {
         inlineVendorRowsByRuntimeOutcome: {},
         inlineVendorRowsByLifecycleObservation: {},
         inlineVendorRowsByExpectedAttribution: {},
+        inlineVendorSubscriptionCap: {
+          unit: 'cumulative-register-calls-per-session',
+          rowsMeasured: 0,
+          median: 0,
+          p99: 0,
+          max: 0,
+          byCumulativeRegisterCallCount: {},
+        },
+        inlineVendorSessionProfile: {
+          rowsMeasured: 0,
+          durationMs: {
+            median: 0,
+            p99: 0,
+            max: 0,
+            byCount: {},
+          },
+          geometryChangeCallbacks: {
+            median: 0,
+            p99: 0,
+            max: 0,
+            byCount: {},
+          },
+        },
         byOutcome: {},
         byVerificationScriptCount: {},
         capabilityRowsByBidder: {},
@@ -170,6 +193,26 @@ function emptySummary(files) {
 function increment(map, key, amount = 1) {
   const normalized = normalizeKey(key);
   map[normalized] = (map[normalized] || 0) + amount;
+}
+
+function percentile(values, p) {
+  if (!Array.isArray(values) || values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(sorted.length - 1, index))];
+}
+
+function finalizeDistribution(facet, byCountKey = 'byCount') {
+  const values = [];
+  for (const [rawCount, rows] of Object.entries(facet[byCountKey])) {
+    const count = Number(rawCount);
+    if (!Number.isFinite(count)) continue;
+    for (let i = 0; i < rows; i += 1) values.push(count);
+  }
+  facet.median = percentile(values, 50);
+  facet.p99 = percentile(values, 99);
+  facet.max = values.length > 0 ? Math.max(...values) : 0;
+  facet[byCountKey] = sortEntries(facet[byCountKey], { numericKeys: true });
 }
 
 function normalizeKey(value) {
@@ -736,6 +779,21 @@ function addOmidCorpusFacets(summary, row, fields) {
     const inlineVendor = omid.inlineVendor || {};
     increment(facet.inlineVendorRowsByAccessMode, inlineVendor.accessMode || 'not-run');
     if (inlineVendor.expected === true) {
+      const cumulativeRegisterCalls =
+        networkCount(inlineVendor.registerSessionObserverCalls)
+        + networkCount(inlineVendor.addEventListenerCalls);
+      const cap = facet.inlineVendorSubscriptionCap;
+      cap.rowsMeasured += 1;
+      increment(cap.byCumulativeRegisterCallCount, cumulativeRegisterCalls);
+      const profile = facet.inlineVendorSessionProfile;
+      const durationMs = networkCount(row.outcome && row.outcome.durationMs);
+      const geometryChangeCallbacks = networkCount(
+        inlineVendor.callbackEventsByType && inlineVendor.callbackEventsByType.geometryChange,
+      );
+      profile.rowsMeasured += 1;
+      increment(profile.durationMs.byCount, durationMs);
+      increment(profile.geometryChangeCallbacks.byCount, geometryChangeCallbacks);
+
       let runtimeOutcome = 'omid3p-missing';
       if (inlineVendor.omid3pFound === true
           && inlineVendor.expectedVendorSubscriptionObserved === true) {
@@ -1074,6 +1132,13 @@ function triageReports(files) {
     sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByLifecycleObservation);
   summary.corpusDiagnostics.omid.inlineVendorRowsByExpectedAttribution =
     sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByExpectedAttribution);
+  finalizeDistribution(
+    summary.corpusDiagnostics.omid.inlineVendorSubscriptionCap,
+    'byCumulativeRegisterCallCount',
+  );
+  const profile = summary.corpusDiagnostics.omid.inlineVendorSessionProfile;
+  finalizeDistribution(profile.durationMs);
+  finalizeDistribution(profile.geometryChangeCallbacks);
   summary.corpusDiagnostics.omid.byVerificationScriptCount =
     sortEntries(summary.corpusDiagnostics.omid.byVerificationScriptCount, { numericKeys: true });
   summary.corpusDiagnostics.omid.capabilityRowsByBidder =

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -807,6 +807,7 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
           expectedVendorRegisterSessionObserverCalls: 1,
           expectedVendorAddEventListenerCalls: 0,
           callbackEvents: 3,
+          callbackEventsByType: { geometryChange: 2 },
           lifecycleObserved: true,
           lifecycleComplete: true,
           lifecycleNotObserved: false,
@@ -829,7 +830,7 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
             },
           },
         },
-        outcome: { status: 'passed', bucket: 'passed' },
+        outcome: { status: 'passed', bucket: 'passed', durationMs: 3000 },
       }),
       // Capability-declared row that installs the extension but never starts a session.
       omidReport({
@@ -875,7 +876,7 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
             },
           },
         },
-        outcome: { status: 'failed', bucket: 'measurement-omid' },
+        outcome: { status: 'failed', bucket: 'measurement-omid', durationMs: 4000 },
       }),
       // Capability-declared row whose extension installs but never advertises the OMID feature.
       omidReport({
@@ -921,7 +922,7 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
           subscriptionObserved: true,
           expectedVendorSubscriptionObserved: true,
           registerSessionObserverCalls: 0,
-          addEventListenerCalls: 1,
+          addEventListenerCalls: 4,
           expectedVendorRegisterSessionObserverCalls: 0,
           expectedVendorAddEventListenerCalls: 1,
           callbackEvents: 0,
@@ -947,7 +948,7 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
             },
           },
         },
-        outcome: { status: 'passed', bucket: 'passed' },
+        outcome: { status: 'passed', bucket: 'passed', durationMs: 6000 },
       }),
       // Row with no measurement diagnostics at all.
       report({
@@ -1041,6 +1042,40 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
       'expected-vendor': 2,
       none: 1,
     });
+    assert.deepEqual(omid.inlineVendorSubscriptionCap, {
+      unit: 'cumulative-register-calls-per-session',
+      rowsMeasured: 3,
+      median: 1,
+      p99: 4,
+      max: 4,
+      byCumulativeRegisterCallCount: {
+        0: 1,
+        1: 1,
+        4: 1,
+      },
+    });
+    assert.deepEqual(omid.inlineVendorSessionProfile, {
+      rowsMeasured: 3,
+      durationMs: {
+        median: 4000,
+        p99: 6000,
+        max: 6000,
+        byCount: {
+          3000: 1,
+          4000: 1,
+          6000: 1,
+        },
+      },
+      geometryChangeCallbacks: {
+        median: 0,
+        p99: 2,
+        max: 2,
+        byCount: {
+          0: 2,
+          2: 1,
+        },
+      },
+    });
     assert.deepEqual(omid.byVerificationScriptCount, { 0: 1, 1: 2, 2: 1 });
     assert.deepEqual(omid.capabilityRowsByBidder, {
       'bidder-omid-a': 1,
@@ -1059,6 +1094,81 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
     assert.deepEqual(omid.sessionNotStartedRowsByBidder, {
       'bidder-omid-b': 1,
       'bidder-omid-e': 1,
+    });
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});
+
+test('triageReports computes OMID cap p99 independently from max at n >= 100', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-triage-omid-cap-p99-'));
+  const reportPath = resolve(workDir, 'report.jsonl');
+
+  function inlineVendorReport(rowIndex, registerSessionObserverCalls) {
+    return omidReport({
+      expected: false,
+      inlineVendor: {
+        expected: true,
+        accessMode: 'limited',
+        omid3pFound: true,
+        subscriptionObserved: registerSessionObserverCalls > 0,
+        expectedVendorSubscriptionObserved: registerSessionObserverCalls > 0,
+        registerSessionObserverCalls,
+        addEventListenerCalls: 0,
+        expectedVendorRegisterSessionObserverCalls: registerSessionObserverCalls,
+        expectedVendorAddEventListenerCalls: 0,
+        callbackEvents: 0,
+        callbackEventsByType: {},
+        lifecycleObserved: false,
+        lifecycleComplete: false,
+        lifecycleNotObserved: registerSessionObserverCalls > 0,
+        passed: false,
+      },
+    }, {
+      case: {
+        ...report().case,
+        source: {
+          ...report().case.source,
+          bidder: 'bidder-omid-percentile',
+          rowIndex,
+        },
+        bidSignals: {
+          ...report().case.bidSignals,
+          measurement: {
+            omid: {
+              declaredByApi: false,
+              sidecarPresent: false,
+              inlineVendorScriptPresent: true,
+              inlineVendorScriptCount: 1,
+              inlineVendorVendors: ['doubleverify'],
+            },
+          },
+        },
+      },
+      outcome: { status: 'failed', bucket: 'measurement-omid', durationMs: 3000 },
+    });
+  }
+
+  try {
+    writeJsonl(reportPath, [
+      ...Array.from({ length: 99 }, (_, index) => inlineVendorReport(index, 1)),
+      inlineVendorReport(99, 1000),
+    ]);
+
+    const cap = triageReports([reportPath])
+      .corpusDiagnostics.omid.inlineVendorSubscriptionCap;
+    assert.deepEqual(cap, {
+      unit: 'cumulative-register-calls-per-session',
+      rowsMeasured: 100,
+      median: 1,
+      p99: 1,
+      max: 1000,
+      byCumulativeRegisterCallCount: {
+        1: 99,
+        1000: 1,
+      },
     });
   } finally {
     rmSync(workDir, { force: true, recursive: true });
@@ -1098,6 +1208,29 @@ test('triageReports emits a stable empty OMID facet for a zero-row corpus', () =
       inlineVendorRowsByRuntimeOutcome: {},
       inlineVendorRowsByLifecycleObservation: {},
       inlineVendorRowsByExpectedAttribution: {},
+      inlineVendorSubscriptionCap: {
+        unit: 'cumulative-register-calls-per-session',
+        rowsMeasured: 0,
+        median: 0,
+        p99: 0,
+        max: 0,
+        byCumulativeRegisterCallCount: {},
+      },
+      inlineVendorSessionProfile: {
+        rowsMeasured: 0,
+        durationMs: {
+          median: 0,
+          p99: 0,
+          max: 0,
+          byCount: {},
+        },
+        geometryChangeCallbacks: {
+          median: 0,
+          p99: 0,
+          max: 0,
+          byCount: {},
+        },
+      },
       byOutcome: {},
       byVerificationScriptCount: {},
       capabilityRowsByBidder: {},


### PR DESCRIPTION
## Summary
- add `corpusDiagnostics.omid.inlineVendorSubscriptionCap` to triage summaries, measuring the #252-settled unit: cumulative `registerSessionObserver` + `addEventListener` calls per session
- add `inlineVendorSessionProfile` with duration and `geometryChange` callback distributions for #244 / #228 emission-bound sizing
- document the new cap/session-profile facets and pin them in triage tests

## Post-#290 corpus run
Ran the merged #290 behavior against the private 97-row inline-vendor corpus:

- Overall: 10 passed, 86 failed, 1 skipped
- IAS: 8 passed, 1 skipped
- DoubleVerify: 2 passed, 86 failed
- Runtime split: 76 `omid3p-no-subscription`, 10 `unattributed-subscription`, 10 `observed-lifecycle`, 1 `not-run`
- Expected attribution: 10 `expected-vendor`, 86 `none`, 1 `not-run`

## Cap measurement from that run
`inlineVendorSubscriptionCap`:

- unit: `cumulative-register-calls-per-session`
- rows measured: 96
- median: 0
- p99: 58
- max: 58
- buckets: 0×76, 3×1, 17×4, 37×6, 38×7, 45×1, 58×1

Recommendation: `MAX_OMID_SUBSCRIPTIONS = 73` using p99 + 25% headroom (15).

Session profile:

- duration median/p99/max: 3062 / 3066 / 3066 ms
- geometryChange callback median/p99/max: 0 / 12 / 12

## Validation
- post-#290 private corpus run + triage under `tools/creative-validator/private/`
- npm run test:creative-validator-triage
- npx eslint tools/creative-validator/src/triage.js tools/creative-validator/test/test-triage.js --max-warnings=0
- git diff --check

Refs #244.