### PR TITLE
ci: harden release publish guards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,23 @@ jobs:
       - name: Validate publish tarball artifact (#276)
         run: npm run pack:verify -- --keep --metadata package-tarball.json
 
+      - name: Re-verify publish tarball hash (#287)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Tamper detection inside the trusted runner; provenance attestation
+          # remains the cryptographic anchor for what npm publishes.
+          TARBALL="$(node -p "JSON.parse(require('fs').readFileSync('package-tarball.json', 'utf8')).path")"
+          EXPECTED_SHA="$(node -p "JSON.parse(require('fs').readFileSync('package-tarball.json', 'utf8')).sha256")"
+          ACTUAL_SHA="$(node -e "const fs = require('fs'); const crypto = require('crypto'); process.stdout.write(crypto.createHash('sha256').update(fs.readFileSync(process.argv[1])).digest('hex'));" "$TARBALL")"
+
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error title=Publish tarball hash mismatch::Validated tarball hash changed before publish."
+            echo "expected=$EXPECTED_SHA"
+            echo "actual=$ACTUAL_SHA"
+            exit 1
+          fi
+
       - name: Publish to npm with provenance attestation
         if: env.NPM_TOKEN_PRESENT == 'true'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 - Reordered the local and release test scripts so `check:ci` exercises the
   production bundle, `npm test` runs real tests, lifecycle adapters are covered
   by TypeScript includes, and missing CHANGELOG release notes block publishing.
+- Hardened release-pipeline guards by closing the publish tarball `dist/`
+  allowlist and re-checking the validated tarball hash before npm publish.
 
 ## [0.7.8] - 2026-06-01
 

--- a/scripts/verify-package-tarball.js
+++ b/scripts/verify-package-tarball.js
@@ -120,6 +120,11 @@ try {
     fail('Publish tarball contains files outside dist/ + package metadata:', stray.sort());
   }
 
+  const unexpectedDist = [...files].filter((path) => path.startsWith('dist/') && !expected.has(path));
+  if (unexpectedDist.length > 0) {
+    fail('Publish tarball contains unexpected dist/ files:', unexpectedDist.sort());
+  }
+
   const sourceMaps = [...files].filter((path) => path.endsWith('.map'));
   if (sourceMaps.length > 0) {
     fail('Publish tarball must not contain sourcemaps:', sourceMaps.sort());


### PR DESCRIPTION
## Summary
- close the publish tarball `dist/` allowlist by rejecting any packed `dist/` file outside the expected manifest
- re-compute the validated tarball SHA immediately before npm publish
- document the hash step trust model: tamper detection inside the trusted runner, paired with npm provenance attestation

This PR intentionally ships #286 and #287 only. The #285 parity-guard change was split out after review found that it needs a structural YAML-aware rewrite rather than another tactical regex guard.

The `dist/` check is intentionally stricter than the issue text: it rejects any unexpected `dist/` member, not only unexpected file extensions. That keeps the package manifest closed until a future intentional artifact is added to the expected set.

Closes #286.
Closes #287.

## Verification
- `node scripts/check-ci-test-all-built-parity.js`
- `npm run pack:verify`