### PR TITLE
test: expose OMID inline vendor source diagnostics

### DIFF
--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -270,6 +270,31 @@ rows mean OMID was used by some script but not by the expected inline vendor.
 Those rows are deliberate hard failures for inline-vendor validation; inspect
 the runtime-outcome facet before interpreting them as ordinary no-subscription
 failures.
+`inlineVendorRowsByDiagnosticOutcome` gives the runner's more specific per-row
+explanation:
+
+| Outcome | Meaning |
+| --- | --- |
+| `not-run` | The row did not run inline-vendor measurement. |
+| `omid3p-missing` | The expected inline vendor could not find `window.omid3p`. |
+| `no-subscription` | `window.omid3p` existed, but no subscription call was observed. |
+| `expected-vendor-lifecycle` | A subscription from an expected vendor source was observed and lifecycle callbacks fired. |
+| `expected-vendor-no-lifecycle` | A subscription from an expected vendor source was observed, but no lifecycle callback fired. |
+| `unattributed-lifecycle` | Subscription and callbacks were observed, but the subscription source did not match the expected vendor allowlist. |
+| `unattributed-no-lifecycle` | A subscription from a non-allowlisted or unknown source was observed, but no lifecycle callback fired. |
+
+Source facets such as
+`inlineVendorSubscriptionCallsBySourceOrigin` and
+`inlineVendorUnattributedCallsBySourceOrigin` aggregate the captured stack/script
+origins for subscription calls, so proxy-hosted vendor traffic can be separated
+from true no-subscription rows. These origin-keyed facets are private-tier.
+This is measurement, not policy: the validator's
+`expectedVendorSubscriptionObserved` gate is unchanged by these facets. Source
+attribution uses `document.currentScript` and Chrome/V8 stack frames where
+available; `unknown` can mean either no parseable source frame or an async
+subscription whose useful caller frame was unavailable. If a call exposes
+multiple source URLs, the first expected-vendor match is treated as attributed,
+so this source mapping is a diagnostic signal rather than attestation.
 `inlineVendorSubscriptionCap` measures the unit enforced by the 0.7.8 shim cap:
 cumulative `registerSessionObserver` plus `addEventListener` calls per session.
 It reports `rowsMeasured`, nearest-rank `median`/`p99`/`max`, and count buckets

--- a/tools/creative-validator/fixtures/omid-vendor-proxy-probe.js
+++ b/tools/creative-validator/fixtures/omid-vendor-proxy-probe.js
@@ -1,0 +1,13 @@
+(function () {
+  if (!window.omid3p || typeof window.omid3p.registerSessionObserver !== 'function') {
+    return;
+  }
+
+  // 455256 is DoubleVerify's IAB vendor ID; attribution intentionally keys off
+  // the script source URL, not this caller-supplied value.
+  window.omid3p.registerSessionObserver(function () {}, '455256', 'fixture-proxy');
+
+  if (typeof window.omid3p.addEventListener === 'function') {
+    window.omid3p.addEventListener('impression', function () {}, 'fixture-proxy');
+  }
+})();

--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -192,7 +192,11 @@ function emptyOmidVendorDiagnostics(testCase, accessMode) {
     callbackEventsByType: {},
     callsByVendorKey: {},
     callsByExpectedVendor: {},
+    callsBySourceVendor: {},
+    callsBySourceOrigin: {},
     unattributedSubscriptionCalls: 0,
+    unattributedCallsBySourceVendor: {},
+    unattributedCallsBySourceOrigin: {},
     lifecycle: {
       sessionStart: false,
       loaded: false,
@@ -200,6 +204,7 @@ function emptyOmidVendorDiagnostics(testCase, accessMode) {
       sessionFinish: false,
     },
     passed: false,
+    diagnosticOutcome: 'not-run',
     lifecycleObserved: false,
     lifecycleComplete: false,
     lifecycleNotObserved: false,
@@ -237,6 +242,41 @@ function classifyOmidVendorSourceUrl(value) {
   return '';
 }
 
+function sourceOriginForUrl(value) {
+  try {
+    return new URL(String(value || '')).origin || 'unknown';
+  } catch (_) {
+    return 'unknown';
+  }
+}
+
+function uniqueNonEmpty(values) {
+  const out = [];
+  for (const value of values) {
+    if (!value || out.indexOf(value) !== -1) continue;
+    out.push(value);
+  }
+  return out;
+}
+
+function sourceUrlsForPayload(payload) {
+  return Array.isArray(payload.sourceUrls) ? payload.sourceUrls : [];
+}
+
+function sourceVendorsForPayload(payload) {
+  const vendors = uniqueNonEmpty(sourceUrlsForPayload(payload).map(classifyOmidVendorSourceUrl));
+  return vendors.length > 0 ? vendors : ['unknown'];
+}
+
+function sourceOriginsForPayload(payload) {
+  const origins = uniqueNonEmpty(sourceUrlsForPayload(payload).map(sourceOriginForUrl));
+  return origins.length > 0 ? origins : ['unknown'];
+}
+
+function incrementMap(map, key) {
+  map[key || 'unknown'] = (map[key || 'unknown'] || 0) + 1;
+}
+
 function expectedOmidVendorForCall(summary, payload) {
   const expected = Array.isArray(summary.vendorsExpected)
     ? summary.vendorsExpected
@@ -251,8 +291,20 @@ function expectedOmidVendorForCall(summary, payload) {
   return '';
 }
 
+function recordOmidVendorSubscriptionSources(summary, payload, expectedVendor) {
+  const sourceVendors = sourceVendorsForPayload(payload);
+  const sourceOrigins = sourceOriginsForPayload(payload);
+  for (const vendor of sourceVendors) incrementMap(summary.callsBySourceVendor, vendor);
+  for (const origin of sourceOrigins) incrementMap(summary.callsBySourceOrigin, origin);
+  if (!expectedVendor) {
+    for (const vendor of sourceVendors) incrementMap(summary.unattributedCallsBySourceVendor, vendor);
+    for (const origin of sourceOrigins) incrementMap(summary.unattributedCallsBySourceOrigin, origin);
+  }
+}
+
 function recordOmidVendorSubscription(summary, payload, method) {
   const expectedVendor = expectedOmidVendorForCall(summary, payload);
+  recordOmidVendorSubscriptionSources(summary, payload, expectedVendor);
   if (expectedVendor) {
     summary.callsByExpectedVendor[expectedVendor] =
       (summary.callsByExpectedVendor[expectedVendor] || 0) + 1;
@@ -340,6 +392,19 @@ function finalizeOmidVendorDiagnostics(summary) {
   summary.passed = summary.omid3pFound === true
     && summary.expectedVendorSubscriptionObserved === true
     && summary.lifecycleObserved === true;
+  if (summary.omid3pFound !== true) {
+    summary.diagnosticOutcome = 'omid3p-missing';
+  } else if (summary.subscriptionObserved !== true) {
+    summary.diagnosticOutcome = 'no-subscription';
+  } else if (summary.expectedVendorSubscriptionObserved === true) {
+    summary.diagnosticOutcome = summary.lifecycleObserved === true
+      ? 'expected-vendor-lifecycle'
+      : 'expected-vendor-no-lifecycle';
+  } else {
+    summary.diagnosticOutcome = summary.lifecycleObserved === true
+      ? 'unattributed-lifecycle'
+      : 'unattributed-no-lifecycle';
+  }
   return summary;
 }
 

--- a/tools/creative-validator/src/runner.js
+++ b/tools/creative-validator/src/runner.js
@@ -27,6 +27,8 @@ const SYNTHETIC_OMID_FIXTURE_SCRIPTS = {
     'tools/creative-validator/fixtures/omid-vendor-probe.js',
   'cdn.doubleverify.com/__sharc-validator-fixtures/omid-vendor-async-probe.js':
     'tools/creative-validator/fixtures/omid-vendor-async-probe.js',
+  'cadmus2.script.ac/__sharc-validator-fixtures/omid-vendor-proxy-probe.js':
+    'tools/creative-validator/fixtures/omid-vendor-proxy-probe.js',
 };
 
 function parsePort(raw, fallback) {

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -152,8 +152,15 @@ function emptySummary(files) {
         inlineVendorRowsByBidder: {},
         inlineVendorRowsByAccessMode: {},
         inlineVendorRowsByRuntimeOutcome: {},
+        inlineVendorRowsByDiagnosticOutcome: {},
         inlineVendorRowsByLifecycleObservation: {},
         inlineVendorRowsByExpectedAttribution: {},
+        inlineVendorSubscriptionCallsBySourceVendor: {},
+        inlineVendorSubscriptionCallsBySourceOrigin: {},
+        inlineVendorUnattributedCallsBySourceVendor: {},
+        inlineVendorUnattributedCallsBySourceOrigin: {},
+        inlineVendorUnattributedRowsBySourceVendor: {},
+        inlineVendorUnattributedRowsBySourceOrigin: {},
         inlineVendorSubscriptionCap: {
           unit: 'cumulative-register-calls-per-session',
           rowsMeasured: 0,
@@ -804,10 +811,27 @@ function addOmidCorpusFacets(summary, row, fields) {
         runtimeOutcome = 'omid3p-no-subscription';
       }
       increment(facet.inlineVendorRowsByRuntimeOutcome, runtimeOutcome);
+      increment(facet.inlineVendorRowsByDiagnosticOutcome, inlineVendor.diagnosticOutcome || runtimeOutcome);
       increment(
         facet.inlineVendorRowsByExpectedAttribution,
         inlineVendor.expectedVendorSubscriptionObserved === true ? 'expected-vendor' : 'none',
       );
+      for (const [vendor, count] of Object.entries(inlineVendor.callsBySourceVendor || {})) {
+        increment(facet.inlineVendorSubscriptionCallsBySourceVendor, vendor, networkCount(count));
+      }
+      for (const [origin, count] of Object.entries(inlineVendor.callsBySourceOrigin || {})) {
+        increment(facet.inlineVendorSubscriptionCallsBySourceOrigin, origin, networkCount(count));
+      }
+      for (const [vendor, count] of Object.entries(inlineVendor.unattributedCallsBySourceVendor || {})) {
+        const n = networkCount(count);
+        increment(facet.inlineVendorUnattributedCallsBySourceVendor, vendor, n);
+        if (n > 0) increment(facet.inlineVendorUnattributedRowsBySourceVendor, vendor);
+      }
+      for (const [origin, count] of Object.entries(inlineVendor.unattributedCallsBySourceOrigin || {})) {
+        const n = networkCount(count);
+        increment(facet.inlineVendorUnattributedCallsBySourceOrigin, origin, n);
+        if (n > 0) increment(facet.inlineVendorUnattributedRowsBySourceOrigin, origin);
+      }
 
       let lifecycleOutcome = 'not-applicable';
       if (inlineVendor.lifecycleComplete === true) lifecycleOutcome = 'complete';
@@ -816,6 +840,7 @@ function addOmidCorpusFacets(summary, row, fields) {
       increment(facet.inlineVendorRowsByLifecycleObservation, lifecycleOutcome);
     } else {
       increment(facet.inlineVendorRowsByRuntimeOutcome, 'not-run');
+      increment(facet.inlineVendorRowsByDiagnosticOutcome, 'not-run');
       increment(facet.inlineVendorRowsByLifecycleObservation, 'not-run');
       increment(facet.inlineVendorRowsByExpectedAttribution, 'not-run');
     }
@@ -1128,10 +1153,24 @@ function triageReports(files) {
     sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByAccessMode);
   summary.corpusDiagnostics.omid.inlineVendorRowsByRuntimeOutcome =
     sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByRuntimeOutcome);
+  summary.corpusDiagnostics.omid.inlineVendorRowsByDiagnosticOutcome =
+    sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByDiagnosticOutcome);
   summary.corpusDiagnostics.omid.inlineVendorRowsByLifecycleObservation =
     sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByLifecycleObservation);
   summary.corpusDiagnostics.omid.inlineVendorRowsByExpectedAttribution =
     sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByExpectedAttribution);
+  summary.corpusDiagnostics.omid.inlineVendorSubscriptionCallsBySourceVendor =
+    sortEntries(summary.corpusDiagnostics.omid.inlineVendorSubscriptionCallsBySourceVendor);
+  summary.corpusDiagnostics.omid.inlineVendorSubscriptionCallsBySourceOrigin =
+    sortEntries(summary.corpusDiagnostics.omid.inlineVendorSubscriptionCallsBySourceOrigin);
+  summary.corpusDiagnostics.omid.inlineVendorUnattributedCallsBySourceVendor =
+    sortEntries(summary.corpusDiagnostics.omid.inlineVendorUnattributedCallsBySourceVendor);
+  summary.corpusDiagnostics.omid.inlineVendorUnattributedCallsBySourceOrigin =
+    sortEntries(summary.corpusDiagnostics.omid.inlineVendorUnattributedCallsBySourceOrigin);
+  summary.corpusDiagnostics.omid.inlineVendorUnattributedRowsBySourceVendor =
+    sortEntries(summary.corpusDiagnostics.omid.inlineVendorUnattributedRowsBySourceVendor);
+  summary.corpusDiagnostics.omid.inlineVendorUnattributedRowsBySourceOrigin =
+    sortEntries(summary.corpusDiagnostics.omid.inlineVendorUnattributedRowsBySourceOrigin);
   finalizeDistribution(
     summary.corpusDiagnostics.omid.inlineVendorSubscriptionCap,
     'byCumulativeRegisterCallCount',

--- a/tools/creative-validator/test/test-normalizer.js
+++ b/tools/creative-validator/test/test-normalizer.js
@@ -26,6 +26,30 @@ const cliPath = resolve('tools/creative-validator/src/cli.js');
 const fixture = JSON.parse(readFileSync(fixturePath, 'utf8'));
 const cases = normalizeCleanedCorpus(fixture, { sourceFile: fixturePath });
 
+function stringLiterals(source) {
+  return [...source.matchAll(/'([^']+)'/g)].map((match) => match[1]);
+}
+
+function normalizerOmidVendorHosts() {
+  const source = readFileSync(resolve('tools/creative-validator/src/normalizer.js'), 'utf8');
+  const block = source.match(/const OMID_VENDOR_SCRIPT_HOSTS = \[(.*?)\];/s);
+  assert.ok(block, 'normalizer OMID vendor host block exists');
+  const hosts = [];
+  for (const match of block[1].matchAll(/hosts:\s*\[([^\]]*)\]/g)) {
+    hosts.push(...stringLiterals(match[1]));
+  }
+  return hosts.sort();
+}
+
+function runnerOmidVendorHosts() {
+  const source = readFileSync(resolve('tools/creative-validator/harness/markup-runner.html'), 'utf8');
+  const block = source.match(/function classifyOmidVendorSourceUrl\(value\) \{(.*?)\n\}/s);
+  assert.ok(block, 'runner OMID vendor source classifier exists');
+  return [...block[1].matchAll(/\[([\s\S]*?)\]\s*\.some/g)]
+    .flatMap((match) => stringLiterals(match[1]))
+    .sort();
+}
+
 test('API sanitization filters, deduplicates, and sorts known integer codes', () => {
   assert.deepEqual(sanitizeApiDeclarations([7, 3, 999, 3, 'x', 10, 5]), [3, 5, 7, 10]);
 });
@@ -89,6 +113,14 @@ test('inline OMID vendor script detection separates instrumentation from declara
   assert.equal(scripts[0].url.hostname, 'cdn.doubleverify.com');
   assert.equal(scripts[3].source, 'adm-inline-script');
   assert.equal(extractInlineOmidVendorScripts('<script src="mraid.js"></script>').length, 0);
+});
+
+test('runner OMID attribution allowlist stays aligned with normalizer host classifier', () => {
+  const runnerHosts = runnerOmidVendorHosts();
+  const normalizerHosts = normalizerOmidVendorHosts();
+  assert.ok(runnerHosts.length > 0, 'runner OMID vendor host extraction is non-empty');
+  assert.ok(normalizerHosts.length > 0, 'normalizer OMID vendor host extraction is non-empty');
+  assert.deepEqual(runnerHosts, normalizerHosts);
 });
 
 test('inline OMID vendor script detection requires vendor script hosts', () => {

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -674,6 +674,28 @@ test('runner executes HTML cases and writes one report row per case', () => {
       placementType: 'inline',
     },
   });
+  const inlineOmidProxySubscriber = makeCase({
+    ids: {
+      requestId: 'request-runner-test',
+      responseId: 'response-runner-test',
+      bidId: 'bid-runner-inline-omid-proxy-subscriber',
+      impId: 'imp-runner-test',
+      crid: 'creative-runner-inline-omid-proxy-subscriber',
+    },
+    creative: {
+      mode: 'adm-html',
+      admKind: 'html',
+      html: '<!doctype html><html><body><script src="https://cadmus2.script.ac/__sharc-validator-fixtures/omid-vendor-proxy-probe.js"></script><div>inline omid proxy subscriber</div></body></html>',
+      url: null,
+      width: 320,
+      height: 50,
+      placementType: 'inline',
+      transformations: [],
+    },
+    bidSignals: inlineOmidUnrelatedSubscriber.bidSignals,
+    expectations: inlineOmidUnrelatedSubscriber.expectations,
+    sharcOptions: inlineOmidUnrelatedSubscriber.sharcOptions,
+  });
   const inlineOmidMixedSubscriber = makeCase({
     ids: {
       requestId: 'request-runner-test',
@@ -1035,6 +1057,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
       inlineOmidVendor,
       inlineOmidVendorAsync,
       inlineOmidUnrelatedSubscriber,
+      inlineOmidProxySubscriber,
       inlineOmidMixedSubscriber,
       network404,
       docWrite,
@@ -1070,7 +1093,7 @@ test('runner executes HTML cases and writes one report row per case', () => {
     });
 
     const reports = readJsonl(outPath);
-    assert.equal(reports.length, 25);
+    assert.equal(reports.length, 26);
 
     const htmlReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-test');
     assert.ok(htmlReport);
@@ -1302,6 +1325,60 @@ test('runner executes HTML cases and writes one report row per case', () => {
     );
     assert.equal(unrelatedSubscriberReport.diagnostics.measurement.omid.inlineVendor.lifecycleObserved, true);
     assert.equal(unrelatedSubscriberReport.diagnostics.measurement.omid.inlineVendor.passed, false);
+    assert.equal(
+      unrelatedSubscriberReport.diagnostics.measurement.omid.inlineVendor.diagnosticOutcome,
+      'unattributed-lifecycle',
+    );
+    assert.equal(
+      unrelatedSubscriberReport.diagnostics.measurement.omid.inlineVendor.callsBySourceOrigin[
+        `http://localhost:${reductionPorts.runnerSmoke.renderer}`
+      ],
+      2,
+    );
+    assert.equal(
+      unrelatedSubscriberReport.diagnostics.measurement.omid.inlineVendor
+        .unattributedCallsBySourceOrigin[`http://localhost:${reductionPorts.runnerSmoke.renderer}`],
+      2,
+    );
+
+    const proxySubscriberReport = reports.find((row) =>
+      row.case.ids.bidId === 'bid-runner-inline-omid-proxy-subscriber');
+    assert.ok(proxySubscriberReport);
+    assert.equal(proxySubscriberReport.outcome.status, 'failed');
+    assert.equal(proxySubscriberReport.outcome.bucket, 'measurement-omid');
+    assert.equal(
+      proxySubscriberReport.diagnostics.measurement.omid.inlineVendor.diagnosticOutcome,
+      'unattributed-lifecycle',
+    );
+    assert.equal(proxySubscriberReport.diagnostics.measurement.omid.inlineVendor.subscriptionObserved, true);
+    assert.equal(
+      proxySubscriberReport.diagnostics.measurement.omid.inlineVendor.expectedVendorSubscriptionObserved,
+      false,
+    );
+    assert.equal(
+      proxySubscriberReport.diagnostics.measurement.omid.inlineVendor.callsByVendorKey['455256'],
+      1,
+    );
+    assert.equal(
+      proxySubscriberReport.diagnostics.measurement.omid.inlineVendor.callsBySourceOrigin[
+        'https://cadmus2.script.ac'
+      ],
+      2,
+    );
+    assert.equal(
+      proxySubscriberReport.diagnostics.measurement.omid.inlineVendor.callsBySourceVendor.unknown,
+      2,
+    );
+    assert.equal(
+      proxySubscriberReport.diagnostics.measurement.omid.inlineVendor
+        .unattributedCallsBySourceOrigin['https://cadmus2.script.ac'],
+      2,
+    );
+    assert.equal(
+      proxySubscriberReport.diagnostics.measurement.omid.inlineVendor
+        .unattributedCallsBySourceVendor.unknown,
+      2,
+    );
 
     const mixedSubscriberReport = reports.find((row) =>
       row.case.ids.bidId === 'bid-runner-inline-omid-mixed-subscriber');
@@ -1330,6 +1407,25 @@ test('runner executes HTML cases and writes one report row per case', () => {
     );
     assert.ok(
       mixedSubscriberReport.diagnostics.measurement.omid.inlineVendor.addEventListenerCalls >= 2,
+    );
+    assert.equal(
+      mixedSubscriberReport.diagnostics.measurement.omid.inlineVendor.diagnosticOutcome,
+      'expected-vendor-lifecycle',
+    );
+    assert.ok(
+      mixedSubscriberReport.diagnostics.measurement.omid.inlineVendor.callsBySourceVendor.doubleverify >= 1,
+    );
+    assert.ok(
+      mixedSubscriberReport.diagnostics.measurement.omid.inlineVendor.callsBySourceVendor.unknown >= 1,
+    );
+    assert.equal(
+      mixedSubscriberReport.diagnostics.measurement.omid.inlineVendor
+        .unattributedCallsBySourceVendor.doubleverify,
+      undefined,
+    );
+    assert.ok(
+      mixedSubscriberReport.diagnostics.measurement.omid.inlineVendor
+        .unattributedCallsBySourceVendor.unknown >= 1,
     );
 
     const networkReport = reports.find((row) => row.case.ids.bidId === 'bid-runner-network-404');

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -808,10 +808,15 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
           expectedVendorAddEventListenerCalls: 0,
           callbackEvents: 3,
           callbackEventsByType: { geometryChange: 2 },
+          callsBySourceVendor: { doubleverify: 1 },
+          callsBySourceOrigin: { 'https://cdn.doubleverify.com': 1 },
+          unattributedCallsBySourceVendor: {},
+          unattributedCallsBySourceOrigin: {},
           lifecycleObserved: true,
           lifecycleComplete: true,
           lifecycleNotObserved: false,
           passed: true,
+          diagnosticOutcome: 'expected-vendor-lifecycle',
         },
       }, {
         case: {
@@ -854,10 +859,15 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
           expectedVendorRegisterSessionObserverCalls: 0,
           expectedVendorAddEventListenerCalls: 0,
           callbackEvents: 0,
+          callsBySourceVendor: {},
+          callsBySourceOrigin: {},
+          unattributedCallsBySourceVendor: {},
+          unattributedCallsBySourceOrigin: {},
           lifecycleObserved: false,
           lifecycleComplete: false,
           lifecycleNotObserved: false,
           passed: false,
+          diagnosticOutcome: 'no-subscription',
         },
       }, {
         case: {
@@ -929,7 +939,12 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
           lifecycleObserved: false,
           lifecycleComplete: false,
           lifecycleNotObserved: true,
+          callsBySourceVendor: { unknown: 4 },
+          callsBySourceOrigin: { 'https://cadmus2.script.ac': 4 },
+          unattributedCallsBySourceVendor: { unknown: 4 },
+          unattributedCallsBySourceOrigin: { 'https://cadmus2.script.ac': 4 },
           passed: false,
+          diagnosticOutcome: 'unattributed-no-lifecycle',
         },
       }, {
         case: {
@@ -1033,6 +1048,11 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
       'observed-lifecycle': 1,
       'subscribed-no-lifecycle': 1,
     });
+    assert.deepEqual(omid.inlineVendorRowsByDiagnosticOutcome, {
+      'expected-vendor-lifecycle': 1,
+      'no-subscription': 1,
+      'unattributed-no-lifecycle': 1,
+    });
     assert.deepEqual(omid.inlineVendorRowsByLifecycleObservation, {
       complete: 1,
       'not-applicable': 1,
@@ -1041,6 +1061,26 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
     assert.deepEqual(omid.inlineVendorRowsByExpectedAttribution, {
       'expected-vendor': 2,
       none: 1,
+    });
+    assert.deepEqual(omid.inlineVendorSubscriptionCallsBySourceVendor, {
+      doubleverify: 1,
+      unknown: 4,
+    });
+    assert.deepEqual(omid.inlineVendorSubscriptionCallsBySourceOrigin, {
+      'https://cadmus2.script.ac': 4,
+      'https://cdn.doubleverify.com': 1,
+    });
+    assert.deepEqual(omid.inlineVendorUnattributedCallsBySourceVendor, {
+      unknown: 4,
+    });
+    assert.deepEqual(omid.inlineVendorUnattributedCallsBySourceOrigin, {
+      'https://cadmus2.script.ac': 4,
+    });
+    assert.deepEqual(omid.inlineVendorUnattributedRowsBySourceVendor, {
+      unknown: 1,
+    });
+    assert.deepEqual(omid.inlineVendorUnattributedRowsBySourceOrigin, {
+      'https://cadmus2.script.ac': 1,
     });
     assert.deepEqual(omid.inlineVendorSubscriptionCap, {
       unit: 'cumulative-register-calls-per-session',
@@ -1206,8 +1246,15 @@ test('triageReports emits a stable empty OMID facet for a zero-row corpus', () =
       inlineVendorRowsByBidder: {},
       inlineVendorRowsByAccessMode: {},
       inlineVendorRowsByRuntimeOutcome: {},
+      inlineVendorRowsByDiagnosticOutcome: {},
       inlineVendorRowsByLifecycleObservation: {},
       inlineVendorRowsByExpectedAttribution: {},
+      inlineVendorSubscriptionCallsBySourceVendor: {},
+      inlineVendorSubscriptionCallsBySourceOrigin: {},
+      inlineVendorUnattributedCallsBySourceVendor: {},
+      inlineVendorUnattributedCallsBySourceOrigin: {},
+      inlineVendorUnattributedRowsBySourceVendor: {},
+      inlineVendorUnattributedRowsBySourceOrigin: {},
       inlineVendorSubscriptionCap: {
         unit: 'cumulative-register-calls-per-session',
         rowsMeasured: 0,


### PR DESCRIPTION
## Summary
- add runner diagnostics for inline OMID subscription source vendors/origins and a per-row diagnostic outcome
- add triage facets for attributed vs unattributed subscription source origins/vendors
- add a synthetic proxy-host OMID fixture that reproduces expected-DV metadata with non-DV subscription source URLs

## Corpus readout
Ran the 97-row inline-OMID corpus with the new diagnostics:

- status unchanged: 10 passed / 86 failed / 1 skipped
- failure bucket unchanged: 86 measurement-omid
- diagnostic outcome split: 76 no-subscription, 10 unattributed-lifecycle, 10 expected-vendor-lifecycle, 1 not-run
- unattributed source origins: googletagservices/pagead/doubleclick clusters plus cadmus2.script.ac
- cap measurement unchanged: rowsMeasured 96, median 0, p99 58, max 58

Artifacts are private-tier under tools/creative-validator/private/:
- reports/openrtb-parsing-20260602-dvdiag-omid-inline-limited-report.jsonl
- triage/openrtb-parsing-20260602-dvdiag-omid-inline-limited-summary.json

## Validation
- npm run test:creative-validator-runner
- npm run test:creative-validator-triage
- targeted ESLint for validator runner/triage files
- git diff --check origin/main..HEAD
- npm run check (passed before final rebase; focused validator checks reran after rebase)

Refs #244