### PR TITLE
docs: harden governance and size ADR audit trail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   CI bypasses remain the responsibility of PR review and, in multi-maintainer
   governance, GitHub branch protection. The release gate now builds
   declarations before consumer type checks.
+- Documented the `main` branch protection policy and added a 0.7.7 size-history
+  snapshot to make the 0.7.9 size-budget ADR auditable.
 
 ## [0.7.8] - 2026-06-01
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,18 +28,20 @@ We'd love to accept your patches and contributions to SHARC. There are just a fe
 
 ## Branch protection and required checks
 
-The `main` branch is protected. GitHub must report the `Build, Size, and Pack
-Test` check as passing before a PR can merge, and branches must be up to date
-with `main` before merge. The repository also requires linear history, matching
-the project's squash/rebase merge style.
+The `main` branch is protected:
+
+- Required check: `Build, Size, and Pack Test`
+- Required status checks must be up to date before merge
+- Required linear history, matching the project's squash/rebase merge style
 
 Required checks shall not be disabled or renamed without an explicit governance
 decision. The local CI parity guard is an accidental-drift defense: it catches
 cases where `test:all:built` and the workflow step list diverge unintentionally.
 Intentional workflow bypasses are handled by PR review today and by GitHub
-branch protection as SHARC moves toward multi-maintainer governance. See
-[PR #300](https://github.com/jeffreycarlson/SHARC/pull/300) for the empirical
-review context and the parity-guard threat-model boundary.
+branch protection as SHARC moves toward multi-maintainer governance. See the
+[parity-guard threat-model comment](./scripts/check-ci-test-all-built-parity.js#L2-L24)
+and [PR #300](https://github.com/jeffreycarlson/SHARC/pull/300) for the
+empirical review context.
 
 ## Releasing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,21 @@ We'd love to accept your patches and contributions to SHARC. There are just a fe
 
 8. **Push and open a pull request.** Link the PR to the originating issue.
 
+## Branch protection and required checks
+
+The `main` branch is protected. GitHub must report the `Build, Size, and Pack
+Test` check as passing before a PR can merge, and branches must be up to date
+with `main` before merge. The repository also requires linear history, matching
+the project's squash/rebase merge style.
+
+Required checks shall not be disabled or renamed without an explicit governance
+decision. The local CI parity guard is an accidental-drift defense: it catches
+cases where `test:all:built` and the workflow step list diverge unintentionally.
+Intentional workflow bypasses are handled by PR review today and by GitHub
+branch protection as SHARC moves toward multi-maintainer governance. See
+[PR #300](https://github.com/jeffreycarlson/SHARC/pull/300) for the empirical
+review context and the parity-guard threat-model boundary.
+
 ## Releasing
 
 Maintainers: see [`RELEASING.md`](./RELEASING.md) for the version bump and publish workflow.

--- a/docs/adr/0001-sharc-container-size-budget.md
+++ b/docs/adr/0001-sharc-container-size-budget.md
@@ -24,9 +24,13 @@ headroom under their existing limits:
 | sharc-omid-shim | `dist/sharc-omid-shim.js` | 1,400 B | 4,000 B | 2,600 B / 65.0% |
 | sharc-navigation-bridge | `dist/sharc-navigation-bridge.js` | 1,132 B | 10,000 B | 8,868 B / 88.7% |
 
-The recent growth is concentrated in the OMID path. Between `v0.7.7` and
-`v0.7.8`, the container, OMID bridge, and OMID shim gained roughly 1,100 net
-source lines across the core OMID bridge and geometry work, including:
+The recent growth is concentrated in the OMID path. The committed
+`docs/size-history/0.7.7.json` and `docs/size-history/0.7.8.json` snapshots show
+the container moving from 23,339 B to 24,697 B (+1,358 B) and the OMID bridge
+from 3,401 B to 4,742 B (+1,341 B). Between `v0.7.7` and `v0.7.8`,
+`src/sharc-container.js`, `src/sharc-omid-bridge.js`, and the new
+`src/sharc-omid-shim.js` gained 1,125 net source lines across the core OMID
+bridge and geometry work, including:
 
 - `feat: 0.7.8 OMID bridge -- core + Markup variant (producer) (#250)`
 - `fix: emit OMID geometry viewability data (#289)`
@@ -67,8 +71,10 @@ This is the selected option.
 ### Option B: Refactor for headroom now
 
 Refactor `sharc-container.js` to move more OMID geometry or adapter-selection
-work out of the container bundle. This could recover measurable bytes, but it is
-a product-code change with API-adjacent risk and should not be bundled into the
+work out of the container bundle. For example, moving the geometry-translation
+table and associated normalization helpers behind an OMID-specific entry point
+could plausibly recover roughly 2-4 KB based on file inspection. That is a
+product-code change with API-adjacent risk and should not be bundled into the
 release-engineering hardening cycle without a dedicated design pass.
 
 ### Option C: Hold the line

--- a/docs/size-history/0.7.7.json
+++ b/docs/size-history/0.7.7.json
@@ -1,0 +1,44 @@
+[
+  {
+    "name": "sharc-protocol",
+    "path": "dist/sharc-protocol.js",
+    "size": 3266,
+    "limit": 15000
+  },
+  {
+    "name": "sharc-container",
+    "path": "dist/sharc-container.js",
+    "size": 23339,
+    "limit": 25000
+  },
+  {
+    "name": "sharc-creative",
+    "path": "dist/sharc-creative.js",
+    "size": 5640,
+    "limit": 6000
+  },
+  {
+    "name": "sharc-mraid-bridge",
+    "path": "dist/sharc-mraid-bridge.js",
+    "size": 3135,
+    "limit": 30000
+  },
+  {
+    "name": "sharc-safeframe-bridge",
+    "path": "dist/sharc-safeframe-bridge.js",
+    "size": 2140,
+    "limit": 30000
+  },
+  {
+    "name": "sharc-omid-bridge",
+    "path": "dist/sharc-omid-bridge.js",
+    "size": 3401,
+    "limit": 25000
+  },
+  {
+    "name": "sharc-navigation-bridge",
+    "path": "dist/sharc-navigation-bridge.js",
+    "size": 1132,
+    "limit": 10000
+  }
+]


### PR DESCRIPTION
Closes #302.
Closes #303.

## Summary
- Add the measured v0.7.7 size-history snapshot and cite it from ADR-0001.
- Reconcile ADR-0001 source-line growth against git diff v0.7.7..v0.7.8 for the named OMID files.
- Expand ADR-0001 Option B with a concrete container refactor candidate and rough 2-4 KB recovery range.
- Document the main branch protection policy and required Build, Size, and Pack Test check in CONTRIBUTING.md.
- Add a changelog note for the governance/ADR auditability work.

## GitHub settings verification
- main branch protection is enabled.
- Required status checks are strict/up-to-date.
- Required check: Build, Size, and Pack Test.
- Required linear history is enabled.
- Admin enforcement remains disabled, preserving emergency maintainer override.

## Verification
- Generated docs/size-history/0.7.7.json from a scratch v0.7.7 worktree using npm run size:analyze.
- Validated docs/size-history/0.7.7.json parses as JSON.
- npm run test:ci-parity
