### PR TITLE
chore: 0.7.10 ergonomics and measurement-auditability

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+node scripts/sync-version.js --check
+npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,5 +76,8 @@ jobs:
       - name: Enforce size budgets
         run: npm run size
 
+      - name: Check size-history delta (#310)
+        run: npm run size-history:check
+
       - name: Verify publish tarball contents (#276)
         run: npm run pack:verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- Generalized source type-check coverage to all `src/**/*.js` files, expanded
+  lint coverage across tests and creative-validator tooling, and documented
+  `npm run check:ci` as the local pre-push gate.
+- Added an opt-in zero-dependency pre-commit hook for version-sync and lint
+  checks.
+- Added a size-history delta guard to flag release-over-release bundle growth
+  above 10% unless a raised size limit documents the budget decision.
+- Extended version-sync coverage to the README current-version marker and
+  refreshed release docs for the broader version-reference audit.
+- Documented creative-validator OMID attribution diagnostic buckets and
+  measurement-layer limitations, with focused regression coverage for mixed
+  subscriber attribution and vendor-host allowlist drift.
+
 ## [0.7.9] - 2026-06-03
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We'd love to accept your patches and contributions to SHARC. There are just a fe
 
 2. **Fork and branch.** Follow the normal [forking](https://help.github.com/articles/fork-a-repo) workflow. Keep each group of changes on a separate branch so that a pull request only includes commits related to that bug or feature.
 
-3. **Verify in the test harness.** There is no automated test runner. Run `node server.cjs` and drive the relevant harness page (`test/browser/index.html`, `test/browser/mraid-test.html`, `test/browser/safeframe-test.html`, or `test/browser/mraid-3-compliance-runner.html`) to exercise your change. Read the protocol trace in the log pane to confirm correct behavior. For bug fixes, add or extend a scenario in the relevant harness when feasible.
+3. **Verify locally.** For narrow changes, run the most specific `npm run test:*` script first. Before pushing release-sensitive changes, run `npm run check:ci`; it is the local mirror of the protected CI/release gate. Use `node server.cjs` and the browser harness pages (`test/browser/index.html`, `test/browser/mraid-test.html`, `test/browser/safeframe-test.html`, or `test/browser/mraid-3-compliance-runner.html`) when a change needs visual or protocol-trace inspection.
 
 4. **License header.** All contributions must be licensed under Apache 2.0. New source files under `src/`, `examples/`, or `test/` should carry an SPDX license identifier (`// SPDX-License-Identifier: Apache-2.0`) at the top.
 
@@ -25,6 +25,24 @@ We'd love to accept your patches and contributions to SHARC. There are just a fe
 7. **Update the changelog.** Add an entry under `## [Unreleased]` in `CHANGELOG.md` (Keep a Changelog format) describing the externally visible change. PRs that change behavior without a changelog entry will be asked to add one.
 
 8. **Push and open a pull request.** Link the PR to the originating issue.
+
+## Local pre-push gate
+
+`npm run check:ci` is the canonical local pre-push gate. It runs the same
+release-shaped path enforced by CI: version sync, production build, declaration
+build, `test:all:built`, published-surface type checks, bfcache coverage,
+creative-source performance coverage, size budgets, size-history delta checks,
+and publish-tarball validation. Expect roughly 3-5 minutes on a local machine.
+
+For a shorter commit-time loop, install the optional zero-dependency Git hook:
+
+```bash
+npm run install-hooks
+```
+
+That points Git at `.githooks/`, whose `pre-commit` hook runs
+`node scripts/sync-version.js --check` and `npm run lint`. The hook is opt-in;
+CI and branch protection remain the authoritative gate for every PR.
 
 ## Branch protection and required checks
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol reference implementation.
 
 > 📋 This repository is the current SHARC reference implementation and working specification set.
-> It is in active pre-1.0 development at package version `0.7.7` and is not yet published to npm.
+> It is in active pre-1.0 development at package version `0.7.9` and is not yet published to npm.
 > Start with the curated docs index at [docs/README.md](docs/README.md) and the current state summary at [docs/current-status.md](docs/current-status.md).
 
 ## Overview

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,6 +44,7 @@ This list is for verification after the bump; do not edit these entries manually
 | `src/sharc-navigation-bridge.js` | `@version` JSDoc |
 | `src/sharc-protocol-router.js` | `@version` JSDoc |
 | `README.md` | Version badge + CDN example URLs |
+| `README.md` | Current package version marker |
 | `SECURITY.md` | Current package version marker |
 | `docs/current-status.md` | Current package version marker |
 | `docs/api-reference.md` | Current package version marker |
@@ -65,7 +66,8 @@ missing. If you bump the wrong version before pushing, recover with
 ## What still needs manual attention
 
 - **`CHANGELOG.md`** — the `[Unreleased]` heading must be renamed to the new dated version heading before running `npm version`. The script does not touch the changelog, and the release workflow blocks before npm publish if the matching section is missing.
-- **Prose-embedded historical refs** — `sync-version.js` updates only the stable current-version markers. Before publishing, run `grep -nE "0\\.7\\.[0-9]" SECURITY.md docs/*.md` and verify any remaining older versions are historical release references, not stale current-status prose.
+- **Prose-embedded historical refs** — `sync-version.js` updates only the stable current-version markers. Before publishing, run `grep -nE "0\\.7\\.[0-9]" SECURITY.md docs/*.md README.md CONTRIBUTING.md` and verify any remaining older versions are historical release references, not stale current-status prose.
+- **Size-history snapshot** — after `npm run size:built` has measured the release candidate, commit a `docs/size-history/<version>.json` snapshot in the existing `{name,path,size,limit}` shape. `npm run size-history:check` compares the latest two snapshots and fails if a bundle grows more than 10% without a raised size limit documenting the decision.
 - **Release notes** — if publishing a GitHub release, copy the relevant changelog section into the release body.
 
 ## npm publishing

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,4 +20,22 @@ export default [
       }],
     },
   },
+  {
+    files: ["test/browser/**/*.js"],
+    languageOptions: {
+      globals: {
+        SHARC: "readonly",
+        mraid: "readonly",
+      },
+    },
+  },
+  {
+    files: ["test/**/*.js", "tools/creative-validator/**/*.js"],
+    rules: {
+      // Test fixtures intentionally assert parser handling of control ranges
+      // and fixed whitespace; production sources keep the recommended rules.
+      "no-control-regex": "off",
+      "no-regex-spaces": "off",
+    },
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "scripts": {
     "version": "node scripts/sync-version.js && git add src/sharc-protocol.js src/sharc-container.js src/sharc-protocol-router.js src/lifecycle-adapters/base-adapter.js src/lifecycle-adapters/html-adapter.js src/sharc-creative.js src/sharc-mraid-bridge.js src/sharc-safeframe-bridge.js src/sharc-omid-bridge.js src/sharc-omid-shim.js src/sharc-navigation-bridge.js README.md SECURITY.md docs/current-status.md docs/api-reference.md",
     "dev": "node server.cjs",
+    "install-hooks": "git config core.hooksPath .githooks",
     "build": "rollup -c && npm run build:types",
     "build:types": "tsc -p tsconfig.types.json",
     "build:watch": "rollup -c --watch",
@@ -98,9 +99,10 @@
     "test:all": "npm run build && npm run test:all:built && npm run test:types",
     "test:all:built": "npm run test:smoke && npm run test:ci-parity && npm run test:treeshake && npm run test:creative-protocol-placement-type && npm run test:placement && npm run test:placement-stamping && npm run test:creative-sources && npm run test:creative-sources-load && npm run test:protocol-router && npm run test:protocol-router-nonce-derivation && npm run test:renderer-protocol-retrofit && npm run test:renderer-out-of-phase && npm run test:browser && npm run test:navigation-bridge && npm run test:creative-sdk-autoinstall && npm run test:creative-sdk-injection && npm run test:bridges-detection && npm run test:non-sharc-loading && npm run test:html-lifecycle-adapter && npm run test:omid-container-lifecycle && npm run test:omid-shim && npm run test:omid-shim-transport && npm run test:omid-router-consumption && npm run test:omid-markup-delivery && npm run test:omid-renderer-prelude && npm run test:renderer-prelude-nonce-self-remove && npm run test:omid-bridge-geometry-throttle && npm run test:omid-bridge-edge-fixes && npm run test:renderer-fallback && npm run test:creative-validator-normalizer && npm run test:creative-validator-diagnose && npm run test:creative-validator-runner && npm run test:creative-validator-triage",
     "pack:verify": "node scripts/verify-package-tarball.js",
-    "check:ci": "node scripts/sync-version.js --check && npm run build:prod && npm run build:types && npm run test:all:built && npm run test:types && npm run test:bfcache:built && npm run test:perf && npm run size:built && npm run pack:verify",
+    "size-history:check": "node scripts/check-size-history-delta.js",
+    "check:ci": "node scripts/sync-version.js --check && npm run build:prod && npm run build:types && npm run test:all:built && npm run test:types && npm run test:bfcache:built && npm run test:perf && npm run size:built && npm run size-history:check && npm run pack:verify",
     "regen:baseline": "node scripts/regen-mraid3-baseline.js",
-    "lint": "eslint src/**/*.js --max-warnings=0",
+    "lint": "eslint 'src/**/*.js' 'test/**/*.js' 'tools/creative-validator/**/*.js' --max-warnings=0",
     "check": "npm run build && npm run test:all:built && npm run size && npm run build"
   },
   "devDependencies": {

--- a/scripts/check-size-history-delta.js
+++ b/scripts/check-size-history-delta.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Checks release-over-release size-history growth.
+ *
+ * The default threshold is >10% per minor/patch snapshot. That matches the
+ * scale of headroom SHARC keeps meaningful in ADR-0001: routine movement should
+ * pass, but sudden growth should require an explicit budget decision. A raised
+ * limit in the newer snapshot is treated as that decision.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const historyDir = resolve(root, 'docs/size-history');
+const threshold = Number(process.env.SHARC_SIZE_HISTORY_THRESHOLD || '0.10');
+
+if (!Number.isFinite(threshold) || threshold < 0) {
+  console.error('SHARC_SIZE_HISTORY_THRESHOLD must be a non-negative number.');
+  process.exit(1);
+}
+
+function parseVersion(filename) {
+  const match = /^(\d+)\.(\d+)\.(\d+)\.json$/.exec(filename);
+  if (!match) return null;
+  return match.slice(1).map(Number);
+}
+
+function compareVersionFiles(a, b) {
+  const av = parseVersion(a);
+  const bv = parseVersion(b);
+  for (let i = 0; i < av.length; i++) {
+    if (av[i] !== bv[i]) return av[i] - bv[i];
+  }
+  return 0;
+}
+
+function loadSnapshot(filename) {
+  const rows = JSON.parse(readFileSync(resolve(historyDir, filename), 'utf8'));
+  const byName = new Map();
+  for (const row of rows) {
+    if (!row?.name || !Number.isFinite(row.size) || !Number.isFinite(row.limit)) {
+      throw new Error(`${filename} has an invalid size-history row.`);
+    }
+    byName.set(row.name, row);
+  }
+  return byName;
+}
+
+const snapshots = readdirSync(historyDir)
+  .filter((file) => parseVersion(file))
+  .sort(compareVersionFiles);
+
+if (snapshots.length < 2) {
+  console.log('OK. Size-history delta check skipped: fewer than two snapshots.');
+  process.exit(0);
+}
+
+const previousFile = snapshots[snapshots.length - 2];
+const currentFile = snapshots[snapshots.length - 1];
+const previous = loadSnapshot(previousFile);
+const current = loadSnapshot(currentFile);
+const failures = [];
+
+for (const [name, currentRow] of current.entries()) {
+  const previousRow = previous.get(name);
+  if (!previousRow || previousRow.size <= 0) continue;
+
+  const growthBytes = currentRow.size - previousRow.size;
+  const growthRatio = growthBytes / previousRow.size;
+  const limitRaised = currentRow.limit > previousRow.limit;
+  if (growthRatio > threshold && !limitRaised) {
+    failures.push({
+      name,
+      previousSize: previousRow.size,
+      currentSize: currentRow.size,
+      growthBytes,
+      growthPercent: growthRatio * 100,
+    });
+  }
+}
+
+if (failures.length > 0) {
+  console.error(
+    `Size-history delta check failed: ${currentFile} grew more than `
+    + `${(threshold * 100).toFixed(1)}% over ${previousFile} without a raised limit.`,
+  );
+  for (const failure of failures) {
+    console.error(
+      `  - ${failure.name}: ${failure.previousSize} B -> ${failure.currentSize} B `
+      + `(+${failure.growthBytes} B, +${failure.growthPercent.toFixed(1)}%)`,
+    );
+  }
+  process.exit(1);
+}
+
+console.log(
+  `OK. Size-history deltas from ${previousFile} to ${currentFile} are within `
+  + `${(threshold * 100).toFixed(1)}% or have raised limits.`,
+);

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -101,6 +101,12 @@ const replacements = [
     pattern: /@iabtechlab\/sharc@[\d.]+/g,
     replacement: `@iabtechlab/sharc@${version}`,
   },
+  // README current package marker
+  {
+    file: 'README.md',
+    pattern: /(package version `)[\d.]+(`)/,
+    replacement: `$1${version}$2`,
+  },
   // Release-facing docs with stable single-line current-version markers.
   {
     file: 'SECURITY.md',

--- a/test/browser/test-placement-creative.js
+++ b/test/browser/test-placement-creative.js
@@ -310,7 +310,7 @@
         intent: 'resize',
         targetDimensions: { width: 320, height: 480 },
         closeRegion: { position: 'top-right', size: 50 }
-      }).then(function (result) {
+      }).then(function (_result) {
         logEntry('info', 'First resize resolved. Now resizing to 300x250...');
         return SHARC.requestPlacementChange({
           intent: 'resize',
@@ -333,7 +333,7 @@
         intent: 'resize',
         targetDimensions: { width: 320, height: 480 },
         closeRegion: { position: 'top-right', size: 50 }
-      }).then(function (result) {
+      }).then(function (_result) {
         logEntry('info', 'Resized. Now attempting expand without collapse...');
         return SHARC.requestPlacementChange({
           intent: 'expand'
@@ -387,10 +387,10 @@
       SHARC.getPlacementConstraints().then(function (constraints) {
         logEntry('info', 'Raw constraints: ' + JSON.stringify(constraints));
         // Verify flat fields exist (not nested under a 'constraints' key)
-        var hasFlat = constraints.hasOwnProperty('allowedIntents') ||
-                      constraints.hasOwnProperty('maxWidth') ||
-                      constraints.hasOwnProperty('allowOffscreen');
-        var hasNested = constraints.hasOwnProperty('constraints');
+        var hasFlat = Object.hasOwn(constraints, 'allowedIntents') ||
+                      Object.hasOwn(constraints, 'maxWidth') ||
+                      Object.hasOwn(constraints, 'allowOffscreen');
+        var hasNested = Object.hasOwn(constraints, 'constraints');
         if (hasFlat && !hasNested) {
           logEntry('ok', 'Payload uses flat fields (correct)');
           setResult('result-shape', true, 'Flat fields confirmed');

--- a/test/node/test-bridges-detection.js
+++ b/test/node/test-bridges-detection.js
@@ -337,19 +337,6 @@ function uninstallMockOmidSdk() {
   delete window.OmidSessionClient;
 }
 
-function createContainerStub() {
-  let state = 'loading';
-  return {
-    _iframe: document.createElement('iframe'),
-    getState() {
-      return state;
-    },
-    setState(next) {
-      state = next;
-    },
-  };
-}
-
 function createOmidTestContainer(omidBridge, extraOptions) {
   const c = new SHARCContainer(markupOptions({
     creativeMeta: { apis: [7] },
@@ -1002,14 +989,11 @@ function makeMarkupOpts(extra) {
 
   // G10: getter is non-writable. Direct overwrite has no effect.
   const c5 = new SHARCContainer(makeMarkupOpts({ creativeMeta: { apis: [6] } }));
-  let assignmentThrew = false;
   try {
     // In strict mode this throws; in sloppy mode it silently fails. Either way
     // the read-back must still return the original value.
     c5.apiFramework = 99;
-  } catch (e) {
-    assignmentThrew = true;
-  }
+  } catch (e) { /* strict mode throws */ }
   assert(c5.apiFramework === 6,
     'G10: container.apiFramework still returns original after direct assignment attempt (got ' + c5.apiFramework + ')');
 
@@ -1017,8 +1001,7 @@ function makeMarkupOpts(extra) {
   // (Object.defineProperty with writable:false + configurable:false). A
   // write attempt is a silent no-op in sloppy mode and throws in strict;
   // either way the public accessor still returns the construction value.
-  let mutationThrew = false;
-  try { c5._apiFramework = 12345; } catch (e) { mutationThrew = true; }
+  try { c5._apiFramework = 12345; } catch (e) { /* strict mode throws */ }
   assert(c5._apiFramework === 6,
     'G10: locked _apiFramework is non-writable; direct mutation has no effect on the backing field');
   assert(c5.apiFramework === 6,
@@ -1029,8 +1012,7 @@ function makeMarkupOpts(extra) {
   assert(c5._apiFramework === 6, 'G10: locked _apiFramework survives delete attempt');
 
   // G10: public accessor is non-configurable. delete fails.
-  let deleteThrew = false;
-  try { delete c5.apiFramework; } catch (e) { deleteThrew = true; }
+  try { delete c5.apiFramework; } catch (e) { /* strict mode throws */ }
   assert(c5.apiFramework === 6, 'G10: container.apiFramework survives delete attempt');
 
   // G10: both descriptors report configurable:false.

--- a/test/node/test-creative-sdk-autoinstall.js
+++ b/test/node/test-creative-sdk-autoinstall.js
@@ -89,7 +89,6 @@ if (!MODE) {
 // =========================================================================
 
 const { JSDOM } = await import('jsdom');
-const assert = (await import('node:assert/strict')).default;
 
 const PUBLISHER_ORIGIN = 'https://publisher.example';
 const dom = new JSDOM(

--- a/test/node/test-creative-sdk-injection.js
+++ b/test/node/test-creative-sdk-injection.js
@@ -1524,7 +1524,7 @@ const SDK_URL = 'https://op.example/sharc-creative.js';
     c._iframe = document.createElement('iframe');
 
     let threw = null;
-    const warns = captureWarn(async () => {
+    captureWarn(async () => {
       try {
         const injectors = c._extensions.filter((e) => typeof e.injectIntoMarkup === 'function');
         await c._fetchAndInjectCreative(injectors);

--- a/test/node/test-creative-sources-load.js
+++ b/test/node/test-creative-sources-load.js
@@ -69,7 +69,6 @@ global.MessageEvent = dom.window.MessageEvent;
 // crypto.randomUUID is required by Phase B's CSPRNG nonce. Node 19+ exposes
 // it as a global; fall back to webcrypto on Node 18.
 if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.randomUUID !== 'function') {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const nodeCrypto = await import('node:crypto');
   globalThis.crypto = nodeCrypto.webcrypto || nodeCrypto;
 }
@@ -2233,7 +2232,6 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
   //       and dispatch a second ack BOTH with and without the latch.
   {
     const { container } = await buildPostRender();
-    const iframe = container._iframe;
     await verifyFirstLoadProbe(container);
     assert(container._loadAckConsumed === true,
       '14i: latch set after first ack (precondition)');

--- a/test/node/test-creative-sources-perf.js
+++ b/test/node/test-creative-sources-perf.js
@@ -184,8 +184,7 @@ function timeUrlVariant() {
     // Hook initChannel — both variants converge here. Must hook BEFORE
     // load() because the URL variant attaches its load listener inside
     // _createIframe.
-    const origInit = container._protocol.initChannel.bind(container._protocol);
-    container._protocol.initChannel = function (...args) {
+    container._protocol.initChannel = function () {
       const elapsed = Number(process.hrtime.bigint() - started) / 1e6;
       // Don't actually run initChannel — jsdom MessageChannel works, but
       // we don't need the round-trip. Cleanly terminate the container.
@@ -223,8 +222,7 @@ async function timeMarkupVariant() {
   await container.protocolRouter.ready('SHARC:Renderer:');
   let started;
   const measurement = new Promise((resolve, reject) => {
-    const origInit = container._protocol.initChannel.bind(container._protocol);
-    container._protocol.initChannel = function (...args) {
+    container._protocol.initChannel = function () {
       const elapsed = Number(process.hrtime.bigint() - started) / 1e6;
       try { container._terminate(); } catch (_) { /* ignore */ }
       resolve(elapsed);

--- a/test/node/test-non-sharc-loading.js
+++ b/test/node/test-non-sharc-loading.js
@@ -457,15 +457,14 @@ flushContainers();
   // flow ran past the fail-closed point.
   let initFlowReached = false;
   const origAcceptSession = c._protocol.acceptSession.bind(c._protocol);
-  c._protocol.acceptSession = function (msg) {
+  c._protocol.acceptSession = function () {
     // Mimic SEC-006 reject: don't set sessionId.
     // (Calling original would also reject on the malformed UUID below,
     // but we bypass to be deterministic.)
     return;
   };
-  const origInitArgs = c._explicitSupportedFeatures;
   Object.defineProperty(c, '_mergedSupportedFeatures', {
-    set(val) { initFlowReached = true; },
+    set() { initFlowReached = true; },
     get() { return undefined; },
     configurable: true,
   });

--- a/test/node/test-omid-container-lifecycle.js
+++ b/test/node/test-omid-container-lifecycle.js
@@ -50,11 +50,8 @@ const { OmidCompatBridge } = await import('../../dist/sharc-omid-bridge.mjs');
 
 // ── Assertion harness ─────────────────────────────────────────────────────
 let failures = 0;
-let sectionFailures = 0;
-let currentSection = '';
 
 function section(name) {
-  currentSection = name;
   console.log(`\n${name}`);
 }
 
@@ -64,7 +61,6 @@ function assert(condition, message) {
   } else {
     console.error('  ✗', message);
     failures++;
-    sectionFailures++;
   }
 }
 function assertDevConsole(condition, message) {
@@ -83,7 +79,6 @@ function assertDeepEqual(actual, expected, message) {
   } else {
     console.error('  ✗', message, `\n      actual:   ${a}\n      expected: ${b}`);
     failures++;
-    sectionFailures++;
   }
 }
 
@@ -92,18 +87,15 @@ function assertThrows(fn, msgPattern, message, ErrorCtor) {
     fn();
     console.error('  ✗', message, '(no throw)');
     failures++;
-    sectionFailures++;
   } catch (e) {
     if (ErrorCtor && !(e instanceof ErrorCtor)) {
       console.error('  ✗', message, `(wrong type: ${e.constructor.name})`);
       failures++;
-      sectionFailures++;
       return;
     }
     if (msgPattern && !String(e.message).match(msgPattern)) {
       console.error('  ✗', message, `(wrong message: "${e.message}")`);
       failures++;
-      sectionFailures++;
       return;
     }
     console.log('  ✓', message);
@@ -634,7 +626,7 @@ section('C2. Timeout — resolve before timeout clears the timer');
   const realClearTimeout = global.clearTimeout;
 
   let clearTimeoutId = null;
-  global.setTimeout   = function(fn, ms) { return 99; };
+  global.setTimeout   = function() { return 99; };
   global.clearTimeout = function(id)     { clearTimeoutId = id; };
 
   const p = bridge._injectScriptWithTimeout('https://omid.example/ok.js', 5000);

--- a/test/node/test-protocol-router-nonce-derivation.js
+++ b/test/node/test-protocol-router-nonce-derivation.js
@@ -223,7 +223,6 @@ console.log('test-protocol-router-nonce-derivation.js — 0.7.7 HMAC derivation 
   assert(handlerCalls === 1, 'happy-path Q envelope still dispatches after re-derive');
 
   // P envelope with the OLD nonce is silent-dropped.
-  let pHandlerCalls = 0;
   // (P is already registered above; replace its handler is not API-supported,
   // so we re-create a router for the negative-control to keep things clean.)
   // The negative control above already shows old-nonce envelopes are dropped

--- a/test/node/test-protocol-router.js
+++ b/test/node/test-protocol-router.js
@@ -453,17 +453,6 @@ console.log('test-protocol-router.js — 0.7.7 router primitive coverage\n');
     'utf8'
   );
 
-  // The renderer protocol is registered in src/sharc-container.js with these
-  // phase strings. Extract them by inspecting the live registration.
-  // We can't easily reflect on src; instead, replay the container's
-  // registration pattern and reuse the phases.
-  const declaredPhases = new Set([
-    'attaching-renderer',
-    'rendered',
-    'creative-active',
-    'init',
-    'terminated',
-  ]);
   // Every phase declared by any registered protocol must appear somewhere
   // as `transitionTo('<phase>')` in src/sharc-container.js. `init` is the
   // router's default constructor phase, not a transition target; same for

--- a/test/node/test-renderer-domparser-fallback.js
+++ b/test/node/test-renderer-domparser-fallback.js
@@ -233,7 +233,7 @@ console.log('\n3. Runtime fallback on document.write failure (L1202)');
   const virtualConsole = new VirtualConsole();
   virtualConsole.on('jsdomError', () => { /* suppressed */ });
   ['log', 'info', 'warn', 'error', 'debug'].forEach((level) => {
-    virtualConsole.on(level, (...args) => { /* swallow renderer-side logs */ });
+    virtualConsole.on(level, () => { /* swallow renderer-side logs */ });
   });
 
   const containerOrigin = 'https://publisher.example';

--- a/tools/creative-validator/README.md
+++ b/tools/creative-validator/README.md
@@ -294,7 +294,10 @@ attribution uses `document.currentScript` and Chrome/V8 stack frames where
 available; `unknown` can mean either no parseable source frame or an async
 subscription whose useful caller frame was unavailable. If a call exposes
 multiple source URLs, the first expected-vendor match is treated as attributed,
-so this source mapping is a diagnostic signal rather than attestation.
+so this source mapping is a diagnostic signal rather than attestation. The
+runner and normalizer OMID vendor-host allowlists are pinned together by
+`tools/creative-validator/test/test-normalizer.js` so classifier drift does not
+silently inflate unattributed-subscription counts.
 `inlineVendorSubscriptionCap` measures the unit enforced by the 0.7.8 shim cap:
 cumulative `registerSessionObserver` plus `addEventListener` calls per session.
 It reports `rowsMeasured`, nearest-rank `median`/`p99`/`max`, and count buckets

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
       "sharc-omid-bridge": ["src/sharc-omid-bridge"]
     }
   },
-  "include": ["src/sharc-*.js", "src/lifecycle-adapters/*.js", "src/types/**/*.d.ts"],
+  "include": ["src/**/*.js", "src/types/**/*.d.ts"],
   "exclude": ["node_modules", "examples/compliance-ads"]
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -7,6 +7,6 @@
     "declarationDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/sharc-*.js", "src/lifecycle-adapters/*.js", "src/types/**/*.d.ts"],
+  "include": ["src/**/*.js", "src/types/**/*.d.ts"],
   "exclude": ["node_modules", "examples/compliance-ads", "test"]
 }


### PR DESCRIPTION
Closes #305.
Closes #306.
Closes #307.
Closes #309.
Closes #310.
Closes #311.
Closes #313.

## Summary
- Keep the recommended single-PR shape for the 0.7.10 ergonomics cycle because the changes are mechanical and share verification surface.
- Generalize source type-check includes to all src/**/*.js entries.
- Expand lint coverage to src, test, and tools/creative-validator with targeted test/harness overrides and cleanup of stale unused locals.
- Document npm run check:ci as the local pre-push gate and add an opt-in zero-dependency .githooks/pre-commit hook via npm run install-hooks.
- Add scripts/check-size-history-delta.js, wire it into check:ci and the protected CI job, and document release snapshot expectations.
- Extend sync-version coverage to the README current-version marker found during the markdown version audit.
- Make #313's validator auditability closure explicit by documenting the OMID vendor-host allowlist drift test in the creative-validator README.

## Verification
- npm run lint
- node scripts/sync-version.js --check
- npm run size-history:check
- npm run test:ci-parity
- .githooks/pre-commit
- npm run build
- npm run test:types
- npm run test:creative-validator-normalizer
- npm run test:creative-validator-runner
- npm run check:ci

Note: an initial sandboxed npm run check:ci failed when browser tests could not bind 127.0.0.1:18765. The rerun outside the sandbox passed end to end.
