### PR TITLE
chore: 0.7.10 polish — #314 NIT cleanups + current-status.md 0.7.9 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ### Changed
 
+- Tightened size-history delta guard to detect suspicious shrinkage and
+  new-module appearance; documented pre-commit hook scope in CONTRIBUTING.md.
+- Updated docs/current-status.md with What Shipped in 0.7.9 section.
 - Generalized source type-check coverage to all `src/**/*.js` files, expanded
   lint coverage across tests and creative-validator tooling, and documented
   `npm run check:ci` as the local pre-push gate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,8 @@ npm run install-hooks
 That points Git at `.githooks/`, whose `pre-commit` hook runs
 `node scripts/sync-version.js --check` and `npm run lint`. The hook is opt-in;
 CI and branch protection remain the authoritative gate for every PR.
+The pre-commit hook runs `npm run lint` against the full repository, not staged
+files only; expect 1-3 seconds of linting time on a typical change.
 
 ## Branch protection and required checks
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -20,9 +20,26 @@ The following are the most reliable descriptions of the present implementation:
 - [proposals/creative-sources.md](./proposals/creative-sources.md) — design rationale, threat model, and decision log for the 0.7.0 Creative Sources work
 - bridge design docs under [`docs/design/`](./design)
 - the current source and generated `dist/` artifacts
-- [CHANGELOG.md](../CHANGELOG.md) — what shipped in `0.7.7` and earlier
+- [CHANGELOG.md](../CHANGELOG.md) — full release history and unreleased changes
 
 As of `0.6.0`, every public package subpath ships generated TypeScript declaration files (`.d.ts`) alongside its `.mjs` bundle. TypeScript consumers get full IntelliSense and compile-time argument validation when importing any subpath. 0.7.0 expands the typedef surface to cover the Creative Markup variant — `creativeUrl` is optional, `creativeHtml` / `creativeRendererUrl` / `onSecurityEvent` are added, and `SHARCSecurityEvent` is a discriminated union that now covers seven reserved variants (0.7.1 added `bridge_load_failed`; 0.7.4 added `feature_load_failed`).
+
+## What Shipped in 0.7.9
+
+0.7.9 is a release-governance and measurement-auditability release. It raises
+the documented bundle-size budgets, hardens release and CI parity checks, and
+records the branch-protection and size-history evidence needed to make future
+release decisions reviewable.
+
+**Bundle-size budget raise + ADR-0001** ([#296](https://github.com/jeffreycarlson/SHARC/issues/296) / [#304](https://github.com/jeffreycarlson/SHARC/pull/304)). Raised the `sharc-container` size budget to 30 KB and `sharc-creative` to 8 KB, recording the decision in `docs/adr/0001-sharc-container-size-budget.md` with 0.7.8/0.7.9 size-history snapshots.
+
+**Local and release test-script reorder** ([#297](https://github.com/jeffreycarlson/SHARC/issues/297) / [#299](https://github.com/jeffreycarlson/SHARC/issues/299)). Reordered the local and release test scripts so `check:ci` exercises the production bundle, `npm test` runs real tests, lifecycle adapters are covered by TypeScript includes, and missing CHANGELOG release notes block publishing.
+
+**Release-pipeline hardening** ([#298](https://github.com/jeffreycarlson/SHARC/issues/298)). Hardened release-pipeline guards by closing the publish tarball `dist/` allowlist and re-checking the validated tarball hash before npm publish.
+
+**YAML-structural CI parity guard** ([#300](https://github.com/jeffreycarlson/SHARC/issues/300)). Replaced the text-scan CI parity guard with a YAML-structural check covering accidental drift between `test:all:built` and ci.yml step lists. Intentional CI bypasses remain the responsibility of PR review and, in multi-maintainer governance, GitHub branch protection. The release gate now builds declarations before consumer type checks.
+
+**Branch protection and size-history audit trail** ([#304](https://github.com/jeffreycarlson/SHARC/pull/304)). Documented the `main` branch protection policy and added a 0.7.7 size-history snapshot to make the 0.7.9 size-budget ADR auditable.
 
 ## What Shipped in 0.7.8
 

--- a/scripts/check-size-history-delta.js
+++ b/scripts/check-size-history-delta.js
@@ -16,9 +16,25 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 const historyDir = resolve(root, 'docs/size-history');
 const threshold = Number(process.env.SHARC_SIZE_HISTORY_THRESHOLD || '0.10');
+const shrinkThreshold = Number(process.env.SHARC_SIZE_HISTORY_SHRINK_THRESHOLD || '0.25');
+const newModuleLimitRatio = Number(process.env.SHARC_SIZE_HISTORY_NEW_MODULE_LIMIT_RATIO || '0.90');
 
 if (!Number.isFinite(threshold) || threshold < 0) {
   console.error('SHARC_SIZE_HISTORY_THRESHOLD must be a non-negative number.');
+  process.exit(1);
+}
+
+if (!Number.isFinite(shrinkThreshold) || shrinkThreshold < 0) {
+  console.error('SHARC_SIZE_HISTORY_SHRINK_THRESHOLD must be a non-negative number.');
+  process.exit(1);
+}
+
+if (
+  !Number.isFinite(newModuleLimitRatio)
+  || newModuleLimitRatio < 0
+  || newModuleLimitRatio > 1
+) {
+  console.error('SHARC_SIZE_HISTORY_NEW_MODULE_LIMIT_RATIO must be between 0 and 1.');
   process.exit(1);
 }
 
@@ -66,13 +82,33 @@ const failures = [];
 
 for (const [name, currentRow] of current.entries()) {
   const previousRow = previous.get(name);
-  if (!previousRow || previousRow.size <= 0) continue;
+  if (!previousRow) {
+    console.info(
+      `INFO. New size-history module in ${currentFile}: ${name} `
+      + `(${currentRow.size} B of ${currentRow.limit} B limit).`,
+    );
+    if (currentRow.limit > 0 && currentRow.size / currentRow.limit > newModuleLimitRatio) {
+      failures.push({
+        kind: 'new-module-near-limit',
+        name,
+        currentSize: currentRow.size,
+        currentLimit: currentRow.limit,
+        limitPercent: (currentRow.size / currentRow.limit) * 100,
+      });
+    }
+    continue;
+  }
+  if (previousRow.size <= 0) continue;
 
   const growthBytes = currentRow.size - previousRow.size;
   const growthRatio = growthBytes / previousRow.size;
   const limitRaised = currentRow.limit > previousRow.limit;
+  const shrinkRatio = -growthRatio;
+  const limitLoweredEnough = currentRow.limit < previousRow.limit
+    && (previousRow.limit - currentRow.limit) / previousRow.limit > shrinkThreshold;
   if (growthRatio > threshold && !limitRaised) {
     failures.push({
+      kind: 'growth',
       name,
       previousSize: previousRow.size,
       currentSize: currentRow.size,
@@ -80,23 +116,48 @@ for (const [name, currentRow] of current.entries()) {
       growthPercent: growthRatio * 100,
     });
   }
+  if (shrinkRatio > shrinkThreshold && !limitLoweredEnough) {
+    failures.push({
+      kind: 'shrinkage',
+      name,
+      previousSize: previousRow.size,
+      currentSize: currentRow.size,
+      shrinkBytes: -growthBytes,
+      shrinkPercent: -growthRatio * 100,
+    });
+  }
 }
 
 if (failures.length > 0) {
   console.error(
-    `Size-history delta check failed: ${currentFile} grew more than `
-    + `${(threshold * 100).toFixed(1)}% over ${previousFile} without a raised limit.`,
+    `Size-history delta check failed for ${previousFile} -> ${currentFile}.`,
   );
   for (const failure of failures) {
-    console.error(
-      `  - ${failure.name}: ${failure.previousSize} B -> ${failure.currentSize} B `
-      + `(+${failure.growthBytes} B, +${failure.growthPercent.toFixed(1)}%)`,
-    );
+    if (failure.kind === 'growth') {
+      console.error(
+        `  - ${failure.name}: ${failure.previousSize} B -> ${failure.currentSize} B `
+        + `(+${failure.growthBytes} B, +${failure.growthPercent.toFixed(1)}%); `
+        + 'growth exceeded threshold without a raised limit.',
+      );
+    } else if (failure.kind === 'shrinkage') {
+      console.error(
+        `  - ${failure.name}: ${failure.previousSize} B -> ${failure.currentSize} B `
+        + `(-${failure.shrinkBytes} B, -${failure.shrinkPercent.toFixed(1)}%); `
+        + 'shrinkage exceeded threshold without a lowered limit.',
+      );
+    } else if (failure.kind === 'new-module-near-limit') {
+      console.error(
+        `  - ${failure.name}: new module starts at ${failure.currentSize} B `
+        + `of ${failure.currentLimit} B limit (${failure.limitPercent.toFixed(1)}%).`,
+      );
+    }
   }
   process.exit(1);
 }
 
 console.log(
   `OK. Size-history deltas from ${previousFile} to ${currentFile} are within `
-  + `${(threshold * 100).toFixed(1)}% or have raised limits.`,
+  + `${(threshold * 100).toFixed(1)}% growth / `
+  + `${(shrinkThreshold * 100).toFixed(1)}% shrinkage thresholds, have matching `
+  + 'limit decisions, or new modules are below the first-appearance budget guard.',
 );


### PR DESCRIPTION
## Summary

- tightens `scripts/check-size-history-delta.js` for #314 polish: suspicious shrinkage detection, new-module INFO logging, and first-appearance near-limit failure
- documents that the optional pre-commit hook runs full-repo `npm run lint`, not staged-file lint
- adds the `docs/current-status.md` "What Shipped in 0.7.9" section and removes a stale changelog pointer
- adds the requested `[Unreleased]` changelog entries

Closes #315.

## Validation

- `npm run size-history:check`
- `grep -nE "0\\.7\\.[0-9]" SECURITY.md docs/current-status.md docs/api-reference.md README.md`
- `git diff --check`
- `npm run lint`
- `npx eslint scripts/check-size-history-delta.js --max-warnings=0`
- `npm run check`
