### PR TITLE
test: add OMID validator debug selection facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 - Documented the creative-validator inline OMID scanner's regex-literal
   boundary (#261) and added a near-miss regression test for an adjacent
   escaped-URL-regex shape; tokenizer-backed scanning remains tracked in #258.
+- Added creative-validator OMID triage facets for expected vendor script-cache
+  observations and a `select` CLI command for rebuilding executable rerun
+  subsets from original normalized cases.
 
 ## [0.7.9] - 2026-06-03
 

--- a/tools/creative-validator/src/cli.js
+++ b/tools/creative-validator/src/cli.js
@@ -24,11 +24,13 @@ Usage:
   creative-validator normalize <corpus-file-or-glob> [more-files...] --out <private/cases.jsonl>
   creative-validator run <normalized-cases.jsonl> --out <private/reports/report.jsonl>
   creative-validator triage <report-jsonl-or-glob> [more-files...] --out <private/triage/summary.json>
+  creative-validator select <normalized-cases.jsonl> --report <report-jsonl-or-glob> [--diagnostic-outcome <name>] [--status <name>] [--bucket <name>] [--limit <n>] --out <private/cases.jsonl>
 
 Examples:
   node tools/creative-validator/src/cli.js normalize "tools/creative-validator/private/*.cleaned.json" --out tools/creative-validator/private/normalized/cases.jsonl
   node tools/creative-validator/src/cli.js run tools/creative-validator/private/normalized/cases.jsonl --out tools/creative-validator/private/reports/report.jsonl
   node tools/creative-validator/src/cli.js triage "tools/creative-validator/private/reports/*.jsonl" --out tools/creative-validator/private/triage/summary.json
+  node tools/creative-validator/src/cli.js select tools/creative-validator/private/normalized/cases.jsonl --report tools/creative-validator/private/reports/report.jsonl --diagnostic-outcome no-subscription --limit 5 --out tools/creative-validator/private/debug/no-subscription.jsonl
 
 Run options:
   --port <n>
@@ -106,12 +108,17 @@ function parseArgs(argv) {
     console.log(usage());
     process.exit(0);
   }
-  if (command !== 'normalize' && command !== 'run' && command !== 'triage') {
-    throw new Error('Expected command: normalize, run, or triage\n\n' + usage());
+  if (command !== 'normalize' && command !== 'run' && command !== 'triage' && command !== 'select') {
+    throw new Error('Expected command: normalize, run, triage, or select\n\n' + usage());
   }
 
   const inputs = [];
   let out = null;
+  let report = null;
+  let diagnosticOutcome = null;
+  let status = null;
+  let bucket = null;
+  let limit = null;
   let allowPublicOut = false;
   let port = null;
   let rendererPort = null;
@@ -125,6 +132,16 @@ function parseArgs(argv) {
     const arg = rest[i];
     if (arg === '--out') {
       out = rest[++i];
+    } else if (arg === '--report') {
+      report = rest[++i];
+    } else if (arg === '--diagnostic-outcome') {
+      diagnosticOutcome = rest[++i];
+    } else if (arg === '--status') {
+      status = rest[++i];
+    } else if (arg === '--bucket') {
+      bucket = rest[++i];
+    } else if (arg === '--limit') {
+      limit = parsePositiveInt(rest[++i], '--limit');
     } else if (arg === '--allow-public-out') {
       allowPublicOut = true;
     } else if (arg === '--port') {
@@ -155,17 +172,28 @@ function parseArgs(argv) {
   if (command === 'run' && inputs.length !== 1) {
     throw new Error('run expects exactly one normalized JSONL input file.');
   }
+  if (command === 'select' && inputs.length !== 1) {
+    throw new Error('select expects exactly one normalized JSONL input file.');
+  }
+  if (command === 'select' && !report) {
+    throw new Error('select requires --report <report-jsonl-or-glob>.');
+  }
   return {
     allowPublicOut,
+    bucket,
     command,
+    diagnosticOutcome,
     inputs,
+    limit,
     out,
     port,
+    report,
     rendererPort,
     rendererUrl,
     repoRoot,
     renderTimeoutMs,
     settleMs,
+    status,
     omidInlineVendorAccessMode,
     verbose,
   };
@@ -199,6 +227,69 @@ function readJsonCorpus(file) {
   }
 }
 
+function readJsonl(file) {
+  const text = readFileSync(file, 'utf8').trim();
+  if (!text) return [];
+  return text.split('\n').map((line, index) => {
+    try {
+      return JSON.parse(line);
+    } catch (err) {
+      throw new Error(`Failed to parse ${basename(file)} line ${index + 1}: ${err.message}`);
+    }
+  });
+}
+
+function selectionCaseKey(testCase) {
+  return JSON.stringify({
+    source: testCase && testCase.source ? testCase.source : {},
+    ids: testCase && testCase.ids ? testCase.ids : {},
+  });
+}
+
+function reportDiagnosticOutcome(row) {
+  return row
+    && row.diagnostics
+    && row.diagnostics.measurement
+    && row.diagnostics.measurement.omid
+    && row.diagnostics.measurement.omid.inlineVendor
+    ? row.diagnostics.measurement.omid.inlineVendor.diagnosticOutcome
+    : undefined;
+}
+
+function reportMatchesSelection(row, filters) {
+  if (filters.diagnosticOutcome && reportDiagnosticOutcome(row) !== filters.diagnosticOutcome) return false;
+  if (filters.status && (!row.outcome || row.outcome.status !== filters.status)) return false;
+  if (filters.bucket && (!row.outcome || row.outcome.bucket !== filters.bucket)) return false;
+  return true;
+}
+
+function selectCasesJsonl(outPath, normalizedFile, reportFiles, filters) {
+  const cases = readJsonl(normalizedFile);
+  const casesByKey = new Map(cases.map((testCase) => [selectionCaseKey(testCase), testCase]));
+  const selected = [];
+  const seen = new Set();
+  const max = filters.limit || Number.POSITIVE_INFINITY;
+
+  for (const file of reportFiles) {
+    for (const row of readJsonl(file)) {
+      if (selected.length >= max) break;
+      if (!reportMatchesSelection(row, filters)) continue;
+      const key = selectionCaseKey(row.case);
+      if (seen.has(key)) continue;
+      const original = casesByKey.get(key);
+      if (!original) {
+        throw new Error(`Report row from ${basename(file)} does not match any normalized case.`);
+      }
+      seen.add(key);
+      selected.push(original);
+    }
+    if (selected.length >= max) break;
+  }
+
+  writeFileSync(outPath, selected.map((item) => JSON.stringify(item)).join('\n') + (selected.length ? '\n' : ''));
+  return selected.length;
+}
+
 function writeCasesJsonl(outPath, files) {
   return new Promise((resolvePromise, reject) => {
     const stream = createWriteStream(outPath, { encoding: 'utf8' });
@@ -227,15 +318,20 @@ function writeCasesJsonl(outPath, files) {
 async function main() {
   const {
     allowPublicOut,
+    bucket,
     command,
+    diagnosticOutcome,
     inputs,
+    limit,
     out,
     port,
+    report,
     rendererPort,
     rendererUrl,
     repoRoot,
     renderTimeoutMs,
     settleMs,
+    status,
     omidInlineVendorAccessMode,
     verbose,
   } = parseArgs(process.argv.slice(2));
@@ -264,6 +360,25 @@ async function main() {
     const summary = triageReports(files);
     writeFileSync(outPath, JSON.stringify(summary, null, 2) + '\n');
     console.log(`Triaged ${summary.totals.reports} report row(s) from ${files.length} file(s) to ${outPath}`);
+    return;
+  }
+
+  if (command === 'select') {
+    const inputPath = resolve(inputs[0]);
+    if (!existsSync(inputPath)) throw new Error(`Input file not found: ${inputs[0]}`);
+    const reportFiles = expandInput(report);
+    if (reportFiles.length === 0) {
+      throw new Error('No report files matched.');
+    }
+
+    mkdirSync(dirname(outPath), { recursive: true });
+    const count = selectCasesJsonl(outPath, inputPath, reportFiles, {
+      bucket,
+      diagnosticOutcome,
+      limit,
+      status,
+    });
+    console.log(`Selected ${count} normalized case(s) from ${reportFiles.length} report file(s) to ${outPath}`);
     return;
   }
 

--- a/tools/creative-validator/src/cli.js
+++ b/tools/creative-validator/src/cli.js
@@ -292,7 +292,7 @@ function selectCasesJsonl(outPath, normalizedFile, reportFiles, filters) {
     throw new Error('Selection matched zero report rows; refusing to write empty rerun input.');
   }
 
-  writeFileSync(outPath, selected.map((item) => JSON.stringify(item)).join('\n') + (selected.length ? '\n' : ''));
+  writeFileSync(outPath, selected.map((item) => JSON.stringify(item)).join('\n') + '\n');
   return selected.length;
 }
 

--- a/tools/creative-validator/src/cli.js
+++ b/tools/creative-validator/src/cli.js
@@ -278,12 +278,18 @@ function selectCasesJsonl(outPath, normalizedFile, reportFiles, filters) {
       if (seen.has(key)) continue;
       const original = casesByKey.get(key);
       if (!original) {
-        throw new Error(`Report row from ${basename(file)} does not match any normalized case.`);
+        throw new Error(
+          `Report row from ${basename(file)} does not match any normalized case: ${key.slice(0, 500)}`,
+        );
       }
       seen.add(key);
       selected.push(original);
     }
     if (selected.length >= max) break;
+  }
+
+  if (selected.length === 0) {
+    throw new Error('Selection matched zero report rows; refusing to write empty rerun input.');
   }
 
   writeFileSync(outPath, selected.map((item) => JSON.stringify(item)).join('\n') + (selected.length ? '\n' : ''));

--- a/tools/creative-validator/src/normalizer.js
+++ b/tools/creative-validator/src/normalizer.js
@@ -198,11 +198,21 @@ function hostMatchesSuffix(hostname, suffix) {
   return hostname === suffix || hostname.endsWith(`.${suffix}`);
 }
 
+function omidVendorMatchesHostname(vendor, hostname) {
+  if (typeof vendor !== 'string' || !vendor || typeof hostname !== 'string' || !hostname) {
+    return false;
+  }
+  const normalizedVendor = vendor.toLowerCase();
+  const normalizedHostname = hostname.toLowerCase().replace(/\.$/, '');
+  const pattern = OMID_VENDOR_SCRIPT_HOSTS.find((item) => item.vendor === normalizedVendor);
+  if (!pattern) return false;
+  return pattern.hosts.some((host) => hostMatchesSuffix(normalizedHostname, host));
+}
+
 function classifyOmidVendorScript(url) {
   if (!url || typeof url.hostname !== 'string' || !url.hostname) return null;
-  const hostname = url.hostname;
   for (const pattern of OMID_VENDOR_SCRIPT_HOSTS) {
-    if (pattern.hosts.some((host) => hostMatchesSuffix(hostname, host))) {
+    if (omidVendorMatchesHostname(pattern.vendor, url.hostname)) {
       return pattern.vendor;
     }
   }
@@ -910,6 +920,7 @@ export {
   classifyAdmKind,
   extractInlineOmidVendorScripts,
   normalizeCleanedCorpus,
+  omidVendorMatchesHostname,
   sanitizeApiDeclarations,
   toJsonl,
   unwrapAdm,

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -8,6 +8,7 @@
 
 import { readFileSync } from 'fs';
 import { basename } from 'path';
+import { omidVendorMatchesHostname } from './normalizer.js';
 
 const SAMPLE_LIMIT = 5;
 
@@ -321,25 +322,6 @@ function omidInstrumentationSignalKey(declaredByApi, inlineInstrumented) {
   return 'absent';
 }
 
-function originMatchesInlineVendor(vendor, origin) {
-  const normalizedVendor = String(vendor || '').toLowerCase();
-  const normalizedOrigin = String(origin || '').toLowerCase();
-  if (!normalizedVendor || !normalizedOrigin) return false;
-  if (normalizedVendor === 'doubleverify') {
-    return normalizedOrigin.includes('doubleverify')
-      || /(^|[.-])dv([.-]|$)/.test(normalizedOrigin);
-  }
-  if (normalizedVendor === 'ias') {
-    return normalizedOrigin.includes('imrworldwide')
-      || normalizedOrigin.includes('adsafeprotected')
-      || normalizedOrigin.includes('ias');
-  }
-  if (normalizedVendor === 'moat') {
-    return normalizedOrigin.includes('moat');
-  }
-  return normalizedOrigin.includes(normalizedVendor);
-}
-
 function scriptCacheOriginHasLoadedBytes(values) {
   return networkCount(values && values.hits) > 0
     || networkCount(values && values.stores) > 0
@@ -355,7 +337,13 @@ function expectedInlineVendorScriptCacheObserved(row, bidOmid) {
   const byOrigin = scriptCacheDiagnostics(row).byOrigin || {};
   for (const [origin, values] of Object.entries(byOrigin)) {
     if (!scriptCacheOriginHasLoadedBytes(values)) continue;
-    if (vendors.some((vendor) => originMatchesInlineVendor(vendor, origin))) {
+    let hostname = null;
+    try {
+      hostname = new URL(origin).hostname;
+    } catch (_) {
+      hostname = null;
+    }
+    if (vendors.some((vendor) => omidVendorMatchesHostname(vendor, hostname))) {
       return true;
     }
   }

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -155,6 +155,8 @@ function emptySummary(files) {
         inlineVendorRowsByDiagnosticOutcome: {},
         inlineVendorRowsByLifecycleObservation: {},
         inlineVendorRowsByExpectedAttribution: {},
+        inlineVendorRowsByExpectedScriptCache: {},
+        inlineVendorExpectedScriptCacheNoSubscriptionRows: 0,
         inlineVendorSubscriptionCallsBySourceVendor: {},
         inlineVendorSubscriptionCallsBySourceOrigin: {},
         inlineVendorUnattributedCallsBySourceVendor: {},
@@ -317,6 +319,47 @@ function omidInstrumentationSignalKey(declaredByApi, inlineInstrumented) {
   if (declaredByApi) return 'declared-api7-only';
   if (inlineInstrumented) return 'inline-vendor-only';
   return 'absent';
+}
+
+function originMatchesInlineVendor(vendor, origin) {
+  const normalizedVendor = String(vendor || '').toLowerCase();
+  const normalizedOrigin = String(origin || '').toLowerCase();
+  if (!normalizedVendor || !normalizedOrigin) return false;
+  if (normalizedVendor === 'doubleverify') {
+    return normalizedOrigin.includes('doubleverify')
+      || /(^|[.-])dv([.-]|$)/.test(normalizedOrigin);
+  }
+  if (normalizedVendor === 'ias') {
+    return normalizedOrigin.includes('imrworldwide')
+      || normalizedOrigin.includes('adsafeprotected')
+      || normalizedOrigin.includes('ias');
+  }
+  if (normalizedVendor === 'moat') {
+    return normalizedOrigin.includes('moat');
+  }
+  return normalizedOrigin.includes(normalizedVendor);
+}
+
+function scriptCacheOriginHasLoadedBytes(values) {
+  return networkCount(values && values.hits) > 0
+    || networkCount(values && values.stores) > 0
+    || networkCount(values && values.bytesFromNetwork) > 0
+    || networkCount(values && values.bytesFromCache) > 0;
+}
+
+function expectedInlineVendorScriptCacheObserved(row, bidOmid) {
+  const vendors = Array.isArray(bidOmid.inlineVendorVendors)
+    ? bidOmid.inlineVendorVendors
+    : [];
+  if (vendors.length === 0) return false;
+  const byOrigin = scriptCacheDiagnostics(row).byOrigin || {};
+  for (const [origin, values] of Object.entries(byOrigin)) {
+    if (!scriptCacheOriginHasLoadedBytes(values)) continue;
+    if (vendors.some((vendor) => originMatchesInlineVendor(vendor, origin))) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function msSinceRenderBin(value) {
@@ -816,6 +859,14 @@ function addOmidCorpusFacets(summary, row, fields) {
         facet.inlineVendorRowsByExpectedAttribution,
         inlineVendor.expectedVendorSubscriptionObserved === true ? 'expected-vendor' : 'none',
       );
+      const expectedScriptCacheObserved = expectedInlineVendorScriptCacheObserved(row, bidOmid);
+      const scriptCacheKey = expectedScriptCacheObserved
+        ? (inlineVendor.subscriptionObserved === true ? 'expected-script-cache-subscribed' : 'expected-script-cache-no-subscription')
+        : 'expected-script-cache-not-observed';
+      increment(facet.inlineVendorRowsByExpectedScriptCache, scriptCacheKey);
+      if (scriptCacheKey === 'expected-script-cache-no-subscription') {
+        facet.inlineVendorExpectedScriptCacheNoSubscriptionRows += 1;
+      }
       for (const [vendor, count] of Object.entries(inlineVendor.callsBySourceVendor || {})) {
         increment(facet.inlineVendorSubscriptionCallsBySourceVendor, vendor, networkCount(count));
       }
@@ -843,6 +894,7 @@ function addOmidCorpusFacets(summary, row, fields) {
       increment(facet.inlineVendorRowsByDiagnosticOutcome, 'not-run');
       increment(facet.inlineVendorRowsByLifecycleObservation, 'not-run');
       increment(facet.inlineVendorRowsByExpectedAttribution, 'not-run');
+      increment(facet.inlineVendorRowsByExpectedScriptCache, 'not-run');
     }
   }
   if (omid.sidecarPresent === true) facet.rowsWithSidecar += 1;
@@ -1159,6 +1211,8 @@ function triageReports(files) {
     sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByLifecycleObservation);
   summary.corpusDiagnostics.omid.inlineVendorRowsByExpectedAttribution =
     sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByExpectedAttribution);
+  summary.corpusDiagnostics.omid.inlineVendorRowsByExpectedScriptCache =
+    sortEntries(summary.corpusDiagnostics.omid.inlineVendorRowsByExpectedScriptCache);
   summary.corpusDiagnostics.omid.inlineVendorSubscriptionCallsBySourceVendor =
     sortEntries(summary.corpusDiagnostics.omid.inlineVendorSubscriptionCallsBySourceVendor);
   summary.corpusDiagnostics.omid.inlineVendorSubscriptionCallsBySourceOrigin =

--- a/tools/creative-validator/test/test-normalizer.js
+++ b/tools/creative-validator/test/test-normalizer.js
@@ -14,6 +14,7 @@ import {
   classifyAdmKind,
   extractInlineOmidVendorScripts,
   normalizeCleanedCorpus,
+  omidVendorMatchesHostname,
   sanitizeApiDeclarations,
   toJsonl,
   unwrapAdm,
@@ -121,6 +122,16 @@ test('runner OMID attribution allowlist stays aligned with normalizer host class
   assert.ok(runnerHosts.length > 0, 'runner OMID vendor host extraction is non-empty');
   assert.ok(normalizerHosts.length > 0, 'normalizer OMID vendor host extraction is non-empty');
   assert.deepEqual(runnerHosts, normalizerHosts);
+});
+
+test('canonical OMID vendor host matcher uses suffix registry entries only', () => {
+  assert.equal(omidVendorMatchesHostname('ias', 'cdn.integralads.com'), true);
+  assert.equal(omidVendorMatchesHostname('ias', 'iasds01.com'), true);
+  assert.equal(omidVendorMatchesHostname('ias', 'imrworldwide.com'), false);
+  assert.equal(omidVendorMatchesHostname('doubleverify', 'cdn.doubleverify.com'), true);
+  assert.equal(omidVendorMatchesHostname('doubleverify', 'dv.tv'), false);
+  assert.equal(omidVendorMatchesHostname('oracle', 'tags.grapeshot.co.uk'), true);
+  assert.equal(omidVendorMatchesHostname('generic-omid3p', 'cdn.doubleverify.com'), false);
 });
 
 test('inline OMID vendor script detection requires vendor script hosts', () => {

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -836,6 +836,51 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
           },
         },
         outcome: { status: 'passed', bucket: 'passed', durationMs: 3000 },
+        diagnostics: {
+          measurement: {
+            omid: {
+              expected: true,
+              sidecarPresent: true,
+              extensionPresent: true,
+              featureAdvertised: true,
+              sessionStarted: true,
+              sessionFinished: true,
+              loadedFired: true,
+              impressionFired: true,
+              verificationScriptCount: 2,
+              inlineVendor: {
+                expected: true,
+                accessMode: 'limited',
+                omid3pFound: true,
+                subscriptionObserved: true,
+                expectedVendorSubscriptionObserved: true,
+                registerSessionObserverCalls: 1,
+                addEventListenerCalls: 0,
+                expectedVendorRegisterSessionObserverCalls: 1,
+                expectedVendorAddEventListenerCalls: 0,
+                callbackEvents: 3,
+                callbackEventsByType: { geometryChange: 2 },
+                callsBySourceVendor: { doubleverify: 1 },
+                callsBySourceOrigin: { 'https://cdn.doubleverify.com': 1 },
+                unattributedCallsBySourceVendor: {},
+                unattributedCallsBySourceOrigin: {},
+                lifecycleObserved: true,
+                lifecycleComplete: true,
+                lifecycleNotObserved: false,
+                passed: true,
+                diagnosticOutcome: 'expected-vendor-lifecycle',
+              },
+            },
+          },
+          network: {
+            scriptCache: {
+              enabled: true,
+              byOrigin: {
+                'https://cdn.doubleverify.com': { stores: 1, bytesFromNetwork: 1000 },
+              },
+            },
+          },
+        },
       }),
       // Capability-declared row that installs the extension but never starts a session.
       omidReport({
@@ -887,6 +932,50 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
           },
         },
         outcome: { status: 'failed', bucket: 'measurement-omid', durationMs: 4000 },
+        diagnostics: {
+          measurement: {
+            omid: {
+              expected: true,
+              sidecarPresent: true,
+              extensionPresent: true,
+              featureAdvertised: true,
+              sessionStarted: false,
+              sessionFinished: false,
+              loadedFired: false,
+              impressionFired: false,
+              verificationScriptCount: 1,
+              inlineVendor: {
+                expected: true,
+                accessMode: 'limited',
+                omid3pFound: true,
+                subscriptionObserved: false,
+                expectedVendorSubscriptionObserved: false,
+                registerSessionObserverCalls: 0,
+                addEventListenerCalls: 0,
+                expectedVendorRegisterSessionObserverCalls: 0,
+                expectedVendorAddEventListenerCalls: 0,
+                callbackEvents: 0,
+                callsBySourceVendor: {},
+                callsBySourceOrigin: {},
+                unattributedCallsBySourceVendor: {},
+                unattributedCallsBySourceOrigin: {},
+                lifecycleObserved: false,
+                lifecycleComplete: false,
+                lifecycleNotObserved: false,
+                passed: false,
+                diagnosticOutcome: 'no-subscription',
+              },
+            },
+          },
+          network: {
+            scriptCache: {
+              enabled: true,
+              byOrigin: {
+                'https://cdn.doubleverify.com': { hits: 1, bytesFromCache: 1000 },
+              },
+            },
+          },
+        },
       }),
       // Capability-declared row whose extension installs but never advertises the OMID feature.
       omidReport({
@@ -1062,6 +1151,12 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
       'expected-vendor': 2,
       none: 1,
     });
+    assert.deepEqual(omid.inlineVendorRowsByExpectedScriptCache, {
+      'expected-script-cache-no-subscription': 1,
+      'expected-script-cache-not-observed': 1,
+      'expected-script-cache-subscribed': 1,
+    });
+    assert.equal(omid.inlineVendorExpectedScriptCacheNoSubscriptionRows, 1);
     assert.deepEqual(omid.inlineVendorSubscriptionCallsBySourceVendor, {
       doubleverify: 1,
       unknown: 4,
@@ -1249,6 +1344,8 @@ test('triageReports emits a stable empty OMID facet for a zero-row corpus', () =
       inlineVendorRowsByDiagnosticOutcome: {},
       inlineVendorRowsByLifecycleObservation: {},
       inlineVendorRowsByExpectedAttribution: {},
+      inlineVendorRowsByExpectedScriptCache: {},
+      inlineVendorExpectedScriptCacheNoSubscriptionRows: 0,
       inlineVendorSubscriptionCallsBySourceVendor: {},
       inlineVendorSubscriptionCallsBySourceOrigin: {},
       inlineVendorUnattributedCallsBySourceVendor: {},
@@ -1316,6 +1413,98 @@ test('triage CLI writes private summary and rejects public output by default', (
       /Refusing to write private creative validator output outside/,
     );
     assert.equal(existsSync(publicOut), false);
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});
+
+test('select CLI rebuilds targeted rerun inputs from original normalized cases', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-select-cli-'));
+  const casesPath = resolve(workDir, 'cases.jsonl');
+  const reportPath = resolve(workDir, 'report.jsonl');
+  const outPath = resolve(workDir, 'selected.jsonl');
+
+  const firstCase = {
+    ...report().case,
+    source: { ...report().case.source, rowIndex: 0 },
+    ids: { bidId: 'bid-select-1', crid: 'creative-select-1' },
+    creative: {
+      mode: 'markup',
+      admKind: 'html',
+      html: '<script src="https://cdn.doubleverify.com/dvtp_src.js"></script>',
+    },
+  };
+  const secondCase = {
+    ...report().case,
+    source: { ...report().case.source, rowIndex: 1 },
+    ids: { bidId: 'bid-select-2', crid: 'creative-select-2' },
+    creative: {
+      mode: 'markup',
+      admKind: 'html',
+      html: '<script src="https://cdn.example.test/other.js"></script>',
+    },
+  };
+
+  try {
+    writeJsonl(casesPath, [firstCase, secondCase]);
+    writeJsonl(reportPath, [
+      report({
+        case: {
+          ...firstCase,
+          creative: {
+            mode: firstCase.creative.mode,
+            admKind: firstCase.creative.admKind,
+          },
+        },
+        outcome: { status: 'failed', bucket: 'measurement-omid' },
+        diagnostics: {
+          measurement: {
+            omid: {
+              inlineVendor: { diagnosticOutcome: 'no-subscription' },
+            },
+          },
+        },
+      }),
+      report({
+        case: {
+          ...secondCase,
+          creative: {
+            mode: secondCase.creative.mode,
+            admKind: secondCase.creative.admKind,
+          },
+        },
+        outcome: { status: 'passed', bucket: 'passed' },
+        diagnostics: {
+          measurement: {
+            omid: {
+              inlineVendor: { diagnosticOutcome: 'expected-vendor-lifecycle' },
+            },
+          },
+        },
+      }),
+    ]);
+
+    execFileSync('node', [
+      cliPath,
+      'select',
+      casesPath,
+      '--report',
+      reportPath,
+      '--diagnostic-outcome',
+      'no-subscription',
+      '--out',
+      outPath,
+    ], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const selected = readFileSync(outPath, 'utf8').trim().split('\n').map(JSON.parse);
+    assert.equal(selected.length, 1);
+    assert.equal(selected[0].ids.bidId, 'bid-select-1');
+    assert.equal(selected[0].creative.html, firstCase.creative.html);
   } finally {
     rmSync(workDir, { force: true, recursive: true });
   }

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -1053,6 +1053,50 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
           },
         },
         outcome: { status: 'passed', bucket: 'passed', durationMs: 6000 },
+        diagnostics: {
+          measurement: {
+            omid: {
+              expected: false,
+              sidecarPresent: false,
+              extensionPresent: false,
+              featureAdvertised: false,
+              sessionStarted: false,
+              sessionFinished: false,
+              loadedFired: false,
+              impressionFired: false,
+              verificationScriptCount: 0,
+              inlineVendor: {
+                expected: true,
+                accessMode: 'full',
+                omid3pFound: true,
+                subscriptionObserved: true,
+                expectedVendorSubscriptionObserved: true,
+                registerSessionObserverCalls: 0,
+                addEventListenerCalls: 4,
+                expectedVendorRegisterSessionObserverCalls: 0,
+                expectedVendorAddEventListenerCalls: 1,
+                callbackEvents: 0,
+                lifecycleObserved: false,
+                lifecycleComplete: false,
+                lifecycleNotObserved: true,
+                callsBySourceVendor: { unknown: 4 },
+                callsBySourceOrigin: { 'https://cadmus2.script.ac': 4 },
+                unattributedCallsBySourceVendor: { unknown: 4 },
+                unattributedCallsBySourceOrigin: { 'https://cadmus2.script.ac': 4 },
+                passed: false,
+                diagnosticOutcome: 'unattributed-no-lifecycle',
+              },
+            },
+          },
+          network: {
+            scriptCache: {
+              enabled: true,
+              byOrigin: {
+                'https://cdn.integralads.com': { stores: 1, bytesFromNetwork: 1000 },
+              },
+            },
+          },
+        },
       }),
       // Row with no measurement diagnostics at all.
       report({
@@ -1153,8 +1197,7 @@ test('triageReports aggregates OMID capability and sidecar outcomes', () => {
     });
     assert.deepEqual(omid.inlineVendorRowsByExpectedScriptCache, {
       'expected-script-cache-no-subscription': 1,
-      'expected-script-cache-not-observed': 1,
-      'expected-script-cache-subscribed': 1,
+      'expected-script-cache-subscribed': 2,
     });
     assert.equal(omid.inlineVendorExpectedScriptCacheNoSubscriptionRows, 1);
     assert.deepEqual(omid.inlineVendorSubscriptionCallsBySourceVendor, {
@@ -1505,6 +1548,210 @@ test('select CLI rebuilds targeted rerun inputs from original normalized cases',
     assert.equal(selected.length, 1);
     assert.equal(selected[0].ids.bidId, 'bid-select-1');
     assert.equal(selected[0].creative.html, firstCase.creative.html);
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});
+
+test('select CLI enforces private output boundary', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-select-boundary-'));
+  const casesPath = resolve(workDir, 'cases.jsonl');
+  const reportPath = resolve(workDir, 'report.jsonl');
+  const publicOut = resolve('tools/creative-validator/fixtures/select-leak.jsonl');
+
+  try {
+    const testCase = {
+      ...report().case,
+      creative: { mode: 'markup', admKind: 'html', html: '<div>selected</div>' },
+    };
+    writeJsonl(casesPath, [testCase]);
+    writeJsonl(reportPath, [
+      report({
+        case: testCase,
+        diagnostics: {
+          measurement: { omid: { inlineVendor: { diagnosticOutcome: 'no-subscription' } } },
+        },
+      }),
+    ]);
+
+    assert.throws(
+      () => execFileSync('node', [
+        cliPath,
+        'select',
+        casesPath,
+        '--report',
+        reportPath,
+        '--diagnostic-outcome',
+        'no-subscription',
+        '--out',
+        publicOut,
+      ], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }),
+      /Refusing to write private creative validator output outside/,
+    );
+    assert.equal(existsSync(publicOut), false);
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});
+
+test('select CLI fails zero-match selections before writing output', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-select-empty-'));
+  const casesPath = resolve(workDir, 'cases.jsonl');
+  const reportPath = resolve(workDir, 'report.jsonl');
+  const outPath = resolve(workDir, 'selected.jsonl');
+
+  try {
+    const testCase = {
+      ...report().case,
+      creative: { mode: 'markup', admKind: 'html', html: '<div>not selected</div>' },
+    };
+    writeJsonl(casesPath, [testCase]);
+    writeJsonl(reportPath, [
+      report({
+        case: testCase,
+        diagnostics: {
+          measurement: { omid: { inlineVendor: { diagnosticOutcome: 'expected-vendor-lifecycle' } } },
+        },
+      }),
+    ]);
+
+    assert.throws(
+      () => execFileSync('node', [
+        cliPath,
+        'select',
+        casesPath,
+        '--report',
+        reportPath,
+        '--diagnostic-outcome',
+        'no-subscription',
+        '--out',
+        outPath,
+      ], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }),
+      /Selection matched zero report rows/,
+    );
+    assert.equal(existsSync(outPath), false);
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});
+
+test('select CLI fails unmatched report rows before writing output', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-select-unmatched-'));
+  const casesPath = resolve(workDir, 'cases.jsonl');
+  const reportPath = resolve(workDir, 'report.jsonl');
+  const outPath = resolve(workDir, 'selected.jsonl');
+
+  try {
+    const testCase = {
+      ...report().case,
+      ids: { bidId: 'bid-present', crid: 'creative-present' },
+      creative: { mode: 'markup', admKind: 'html', html: '<div>present</div>' },
+    };
+    const unmatchedReportCase = {
+      ...testCase,
+      ids: { bidId: 'bid-missing', crid: 'creative-missing' },
+    };
+    writeJsonl(casesPath, [testCase]);
+    writeJsonl(reportPath, [
+      report({
+        case: unmatchedReportCase,
+        diagnostics: {
+          measurement: { omid: { inlineVendor: { diagnosticOutcome: 'no-subscription' } } },
+        },
+      }),
+    ]);
+
+    assert.throws(
+      () => execFileSync('node', [
+        cliPath,
+        'select',
+        casesPath,
+        '--report',
+        reportPath,
+        '--diagnostic-outcome',
+        'no-subscription',
+        '--out',
+        outPath,
+      ], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }),
+      /does not match any normalized case: .*bid-missing/,
+    );
+    assert.equal(existsSync(outPath), false);
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});
+
+test('select CLI deduplicates report rows and honors limit', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-select-limit-'));
+  const casesPath = resolve(workDir, 'cases.jsonl');
+  const reportPath = resolve(workDir, 'report.jsonl');
+  const outPath = resolve(workDir, 'selected.jsonl');
+
+  const makeCase = (index) => ({
+    ...report().case,
+    source: { ...report().case.source, rowIndex: index },
+    ids: { bidId: `bid-limit-${index}`, crid: `creative-limit-${index}` },
+    creative: { mode: 'markup', admKind: 'html', html: `<div>${index}</div>` },
+  });
+
+  try {
+    const cases = [makeCase(0), makeCase(1), makeCase(2)];
+    writeJsonl(casesPath, cases);
+    writeJsonl(reportPath, [
+      cases[0],
+      cases[0],
+      cases[1],
+      cases[2],
+    ].map((testCase) => report({
+      case: {
+        ...testCase,
+        creative: {
+          mode: testCase.creative.mode,
+          admKind: testCase.creative.admKind,
+        },
+      },
+      diagnostics: {
+        measurement: { omid: { inlineVendor: { diagnosticOutcome: 'no-subscription' } } },
+      },
+    })));
+
+    execFileSync('node', [
+      cliPath,
+      'select',
+      casesPath,
+      '--report',
+      reportPath,
+      '--diagnostic-outcome',
+      'no-subscription',
+      '--limit',
+      '2',
+      '--out',
+      outPath,
+    ], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const selected = readFileSync(outPath, 'utf8').trim().split('\n').map(JSON.parse);
+    assert.deepEqual(selected.map((item) => item.ids.bidId), ['bid-limit-0', 'bid-limit-1']);
+    assert.deepEqual(selected.map((item) => item.creative.html), ['<div>0</div>', '<div>1</div>']);
   } finally {
     rmSync(workDir, { force: true, recursive: true });
   }


### PR DESCRIPTION
## Summary
- add creative-validator OMID triage facets for expected vendor script-cache observation vs subscription outcome
- add a `select` CLI command to rebuild targeted rerun JSONL files from original normalized cases instead of summarized report rows
- cover the new triage facet and selector behavior in `test-triage.js`

## Verification
- `npm run test:creative-validator-triage`
- `npm run lint`
- `npm run check` (passed before rebasing this focused commit onto `origin/main`)
- private corpus smoke: regenerated post-314 OMID triage and selected 3 executable no-subscription cases from the original normalized corpus