### PR TITLE
docs: document OMID regex scanner boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 - Documented creative-validator OMID attribution diagnostic buckets and
   measurement-layer limitations, with focused regression coverage for mixed
   subscriber attribution and vendor-host allowlist drift.
+- Documented the creative-validator inline OMID scanner's regex-literal
+  boundary (#261) and added a near-miss regression test for an adjacent
+  escaped-URL-regex shape; tokenizer-backed scanning remains tracked in #258.
 
 ## [0.7.9] - 2026-06-03
 

--- a/tools/creative-validator/src/normalizer.js
+++ b/tools/creative-validator/src/normalizer.js
@@ -254,6 +254,20 @@ function isExecutableInlineScriptTag(attrs) {
     || normalized === 'text/ecmascript';
 }
 
+/**
+ * Removes JavaScript comments for inline OMID signal scanning without treating
+ * comment-like text inside strings as comments.
+ *
+ * Known limitation (#261): this helper is not a JavaScript tokenizer and does
+ * not parse regex literals. A same-line regex literal that ends with an
+ * escaped slash before its closing delimiter, for example
+ * `/example\.com\//; window.omid3p...`, can be mistaken for a line comment and
+ * suppress a following inline OMID signal. The trailing `\//` is read as a
+ * backslash followed by `//`, which this stripper treats as a line comment. The
+ * private inline-vendor corpus did not show a live miss for this shape; #258
+ * tracks tokenizer-backed scanning if the corpus later needs full JavaScript
+ * lexical precision.
+ */
 function stripJsCommentsQuoteAware(source) {
   let out = '';
   let i = 0;

--- a/tools/creative-validator/test/test-normalizer.js
+++ b/tools/creative-validator/test/test-normalizer.js
@@ -192,6 +192,27 @@ test('inline OMID generic signal survives protocol-relative strings before the c
   assert.equal(scripts[0].vendor, 'generic-omid3p');
 });
 
+test('inline OMID generic signal survives escaped URL regex literals before the call', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script>
+      var urlPattern = /https?:\\/\\/[^\\s]+/; window.omid3p.registerSessionObserver(function(){});
+    </script>
+  `);
+  assert.equal(scripts.length, 1);
+  assert.equal(scripts[0].vendor, 'generic-omid3p');
+});
+
+test('inline OMID generic signal is suppressed by escaped-slash regex literal boundary', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script>
+      var host = /example\\.com\\//; window.omid3p.registerSessionObserver(function(){});
+    </script>
+  `);
+  // Known limitation #261: trailing \// is read as a line comment. When #258
+  // lands tokenizer-backed scanning, flip this to assert the signal is found.
+  assert.equal(scripts.length, 0);
+});
+
 test('inline OMID generic signal survives double-slash strings without counting comments', () => {
   const scripts = extractInlineOmidVendorScripts(`
     <script>


### PR DESCRIPTION
## Summary

- Documents the inline OMID scanner boundary from #261 at `stripJsCommentsQuoteAware`.
- Adds focused normalizer coverage for the corrected escaped-URL-regex case that should still detect inline `omid3p` calls.
- Adds an Unreleased changelog note.

## Corpus evidence

- Scanned the post-281 inline-vendor normalized corpus: 97 rows, 0 raw `omid3p.registerSessionObserver` / `omid3p.addEventListener` matches, 0 live misses.
- Scanned the 9 referenced cleaned source files: 0 raw matches, 0 live misses.
- Per the #261 comment gate, this keeps the regex-literal tokenizer work parked under #258 rather than changing scanner behavior now.

Closes #261.

## Validation

- `npm run test:creative-validator-normalizer`
- `npx eslint tools/creative-validator/src/normalizer.js tools/creative-validator/test/test-normalizer.js --max-warnings=0`
- `git diff --check`
