### PR TITLE
fix: keep renderer load-probe channel in-phase under OMID (#321)

### DIFF
--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -1264,9 +1264,9 @@ class SHARCContainer {
         types: {
           'rendered':  { phases: ['attaching-renderer'], direction: 'inbound' },
           'failed':    { phases: ['attaching-renderer'], direction: 'inbound' },
-          'loadAck':   { phases: ['attaching-renderer', 'rendered', 'creative-active'], direction: 'inbound' },
+          'loadAck':   { phases: ['attaching-renderer', 'rendered', 'creative-active', 'omid-active', 'omid-finishing'], direction: 'inbound' },
           'render':    { phases: ['attaching-renderer'], direction: 'outbound' },
-          'loadProbe': { phases: ['attaching-renderer', 'rendered', 'creative-active'], direction: 'outbound' },
+          'loadProbe': { phases: ['attaching-renderer', 'rendered', 'creative-active', 'omid-active', 'omid-finishing'], direction: 'outbound' },
         },
         handler: this._handleRendererEnvelope.bind(this),
         onReady: ({ protocolNonce }) => {

--- a/test/node/test-renderer-out-of-phase.js
+++ b/test/node/test-renderer-out-of-phase.js
@@ -13,6 +13,8 @@
 
 import { JSDOM } from 'jsdom';
 
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
 const PUBLISHER_ORIGIN = 'https://publisher.example';
 const RENDERER_URL = 'https://renderer.operator.example/0.7.0/';
 const RENDERER_ORIGIN = 'https://renderer.operator.example';
@@ -243,24 +245,35 @@ console.log('test-renderer-out-of-phase.js — 0.7.7 phase-enforcement coverage\
 // `['attaching-renderer']` (anti-forgery), so a replay under OMID is still
 // rejected out-of-phase.
 // ────────────────────────────────────────────────────────────────────────────
-{
-  console.log('\n4. #321: :loadAck inbound during omid-active is ACCEPTED (recovery enabler)');
-  const errors = [];
-  const securityEvents = [];
+// ────────────────────────────────────────────────────────────────────────────
+// Shared driver: render the markup variant, then arm a post-render first-load
+// probe by firing a second iframe `load`. Returns the container with
+// `_pendingLoadProbe` installed (a function) and `_loadAckConsumed === false`,
+// parked in `phase`. The backstop is armed with `verifyFirstLoad: true` inside
+// `_onRendererRendered` (src/sharc-container.js:3173); the subsequent `load`
+// event posts the `:loadProbe` and installs `onAck` as `_pendingLoadProbe`
+// (src ~:4512). A real inbound `:loadAck` routed in-phase then drives
+// `_dispatchRendererLoadAck` (src:2757) which latches `_loadAckConsumed` and
+// nulls `_pendingLoadProbe`. This is the observable consumption seam — a
+// loadAck that is merely "not rejected" but never routed to the handler would
+// leave `_loadAckConsumed === false` and let the 100ms backstop deadline fire
+// 2118. `rendererReply: 150` keeps that deadline within the test's wait window.
+// ────────────────────────────────────────────────────────────────────────────
+async function armedProbeInPhase(phase, sink) {
   const slot = freshSlot();
   const c = new SHARCContainer({
     creativeHtml: CREATIVE_HTML,
     creativeRendererUrl: RENDERER_URL,
     placementElement: slot,
-    timeouts: { rendererLoad: 5000, rendererReply: 5000 },
-    onError: (code, msg) => errors.push({ code, msg }),
-    onSecurityEvent: (ev) => securityEvents.push(ev),
+    timeouts: { rendererLoad: 5000, rendererReply: 150 },
+    onError: (code, msg) => sink.errors.push({ code, msg }),
+    onSecurityEvent: (ev) => sink.securityEvents.push(ev),
   });
   c.load();
   await c.protocolRouter.ready('SHARC:Renderer:');
   c._iframe.contentWindow.postMessage = () => {};
   c._iframe.dispatchEvent(new dom.window.Event('load'));
-  // Valid handshake → phase: rendered.
+  // Valid handshake → phase: rendered; arms the first-load backstop.
   window.dispatchEvent(new dom.window.MessageEvent('message', {
     data: {
       type: 'SHARC:Renderer:rendered',
@@ -271,11 +284,24 @@ console.log('test-renderer-out-of-phase.js — 0.7.7 phase-enforcement coverage\
     origin: RENDERER_ORIGIN,
     source: c._iframe.contentWindow,
   }));
-  // Park the router in `omid-active`, mirroring the OMID AdSession-start
-  // transition (`_onOmidLifecycleSignal('omid-active')`).
-  c.protocolRouter.transitionTo('omid-active');
-  assert(c.protocolRouter.getPhase() === 'omid-active',
-    'router parked in omid-active (OMID AdSession active)');
+  // Park the router in the OMID phase under test, mirroring the bridge's
+  // AdSession lifecycle transition (`_onOmidLifecycleSignal`).
+  c.protocolRouter.transitionTo(phase);
+  // Post-render iframe load → posts `:loadProbe`, installs `_pendingLoadProbe`.
+  c._iframe.dispatchEvent(new dom.window.Event('load'));
+  return c;
+}
+
+async function loadAckConsumedInPhase(label, phase) {
+  console.log('\n' + label);
+  const sink = { errors: [], securityEvents: [] };
+  const c = await armedProbeInPhase(phase, sink);
+  assert(c.protocolRouter.getPhase() === phase,
+    `router parked in ${phase}`);
+  assert(typeof c._pendingLoadProbe === 'function',
+    'precondition: a first-load probe is armed (callback installed)');
+  assert(c._loadAckConsumed === false,
+    'precondition: loadAck not yet consumed');
 
   // Inbound :loadAck — the backstop's control-channel reply.
   window.dispatchEvent(new dom.window.MessageEvent('message', {
@@ -287,20 +313,49 @@ console.log('test-renderer-out-of-phase.js — 0.7.7 phase-enforcement coverage\
     origin: RENDERER_ORIGIN,
     source: c._iframe.contentWindow,
   }));
-  const loadAckRejection = securityEvents.find(
-    (e) => e.type === 'unauthorized_protocol' && e.details.phase === 'omid-active'
+
+  const loadAckRejection = sink.securityEvents.find(
+    (e) => e.type === 'unauthorized_protocol' && e.details.phase === phase
   );
   assert(loadAckRejection == null,
-    ':loadAck in omid-active is NOT rejected as unauthorized_protocol (#321)');
-  assert(errors.length === 0,
-    'accepting the :loadAck does not surface an error');
+    `:loadAck in ${phase} is NOT rejected as unauthorized_protocol (#321)`);
+  // The decisive consumption assertions: the router actually routed the ack to
+  // `_dispatchRendererLoadAck`, which latched the single-use flag and resolved
+  // the pending probe. A non-rejected-but-undelivered ack would fail these.
+  assert(c._loadAckConsumed === true,
+    `:loadAck in ${phase} is CONSUMED (_loadAckConsumed latched true)`);
+  assert(c._pendingLoadProbe === null,
+    'consumed loadAck resolves the pending probe (_pendingLoadProbe nulled)');
+
+  // And it survives the 100ms backstop deadline — consumption (not just
+  // non-rejection) is what suppresses the 2118 backstop fire.
+  await sleep(300);
+  const fired2118 = sink.securityEvents.some(
+    (e) => e.type === 'unauthorized_navigation'
+  ) || sink.errors.some(
+    (e) => e.code === protoMod.ErrorCodes.RENDERER_UNAUTHORIZED_NAVIGATION
+  );
+  assert(!fired2118,
+    `consumed loadAck in ${phase} suppresses the 2118 backstop deadline`);
   assert(c._terminated === false,
-    'container remains live after the in-phase :loadAck');
-  c._terminate();
+    `container remains live after the in-phase :loadAck (${phase})`);
+  if (!c._terminated) c._terminate();
 }
 
-{
-  console.log('\n5. #321 anti-forgery: forged :rendered / :failed / :render in omid-active STAY rejected');
+await loadAckConsumedInPhase(
+  '4. #321: :loadAck inbound during omid-active is CONSUMED (recovery enabler)',
+  'omid-active'
+);
+
+// ────────────────────────────────────────────────────────────────────────────
+// Anti-forgery under OMID, parameterized over the OMID phase. The handshake
+// types (`rendered` / `failed`) stay declared in `['attaching-renderer']` only
+// — adding `omid-active` / `omid-finishing` to the load-probe CONTROL channel
+// (#321) must NOT widen the handshake window — so a forged replay carrying a
+// valid nonce is still rejected out-of-phase in either OMID phase.
+// ────────────────────────────────────────────────────────────────────────────
+async function forgedHandshakeStaysRejected(label, phase) {
+  console.log('\n' + label);
   const errors = [];
   const securityEvents = [];
   const slot = freshSlot();
@@ -327,9 +382,9 @@ console.log('test-renderer-out-of-phase.js — 0.7.7 phase-enforcement coverage\
     origin: RENDERER_ORIGIN,
     source: c._iframe.contentWindow,
   }));
-  c.protocolRouter.transitionTo('omid-active');
-  assert(c.protocolRouter.getPhase() === 'omid-active',
-    'router parked in omid-active');
+  c.protocolRouter.transitionTo(phase);
+  assert(c.protocolRouter.getPhase() === phase,
+    `router parked in ${phase}`);
 
   // Forged :rendered with a VALID nonce — handshake type is declared ONLY in
   // `attaching-renderer`, so this must reject out-of-phase even under OMID.
@@ -345,11 +400,11 @@ console.log('test-renderer-out-of-phase.js — 0.7.7 phase-enforcement coverage\
   }));
   const renderedRej = securityEvents.find(
     (e) => e.type === 'unauthorized_protocol'
-      && e.details.phase === 'omid-active'
+      && e.details.phase === phase
       && e.details.reason === 'out-of-phase'
   );
   assert(renderedRej != null,
-    'forged :rendered in omid-active → unauthorized_protocol (out-of-phase)');
+    `forged :rendered in ${phase} → unauthorized_protocol (out-of-phase)`);
 
   // Forged :failed — also declared only in `attaching-renderer`.
   window.dispatchEvent(new dom.window.MessageEvent('message', {
@@ -364,11 +419,11 @@ console.log('test-renderer-out-of-phase.js — 0.7.7 phase-enforcement coverage\
   }));
   const failedRej = securityEvents.filter(
     (e) => e.type === 'unauthorized_protocol'
-      && e.details.phase === 'omid-active'
+      && e.details.phase === phase
       && e.details.reason === 'out-of-phase'
   );
   assert(failedRej.length >= 2,
-    'forged :failed in omid-active → unauthorized_protocol (out-of-phase)');
+    `forged :failed in ${phase} → unauthorized_protocol (out-of-phase)`);
 
   // :render is the OUTBOUND handshake type — an inbound forgery of it is
   // dropped at the direction gate (inbound !== outbound), never reaching the
@@ -389,6 +444,30 @@ console.log('test-renderer-out-of-phase.js — 0.7.7 phase-enforcement coverage\
     'forged handshake envelopes under OMID do not surface onError (RTR-D15)');
   c._terminate();
 }
+
+await forgedHandshakeStaysRejected(
+  '5. #321 anti-forgery: forged :rendered / :failed / :render in omid-active STAY rejected',
+  'omid-active'
+);
+
+// ────────────────────────────────────────────────────────────────────────────
+// #321 — `omid-finishing` coverage. The production change added
+// `omid-finishing` to the load-probe control channel's phase set
+// (src/sharc-container.js:1267,1269) but no case exercised it. Cases 6 & 7
+// mirror Cases 4 & 5 with the router parked in `omid-finishing`:
+//   6. inbound :loadAck is CONSUMED (control channel stays in-phase);
+//   7. forged :rendered / :failed stay rejected out-of-phase (anti-forgery
+//      holds in this phase too).
+// ────────────────────────────────────────────────────────────────────────────
+await loadAckConsumedInPhase(
+  '6. #321: :loadAck inbound during omid-finishing is CONSUMED',
+  'omid-finishing'
+);
+
+await forgedHandshakeStaysRejected(
+  '7. #321 anti-forgery: forged :rendered / :failed / :render in omid-finishing STAY rejected',
+  'omid-finishing'
+);
 
 if (failures === 0) {
   console.log('\n✓ All renderer-out-of-phase assertions passed.');

--- a/test/node/test-renderer-out-of-phase.js
+++ b/test/node/test-renderer-out-of-phase.js
@@ -230,6 +230,166 @@ console.log('test-renderer-out-of-phase.js — 0.7.7 phase-enforcement coverage\
   c._terminate();
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// #321 Phase 1a — load-probe control channel under OMID.
+//
+// When an OMID AdSession starts, the bridge parks the router in `omid-active`
+// (a window NARROWER than `creative-active`, opened after the container went
+// live). The renderer backstop's control channel (`loadAck` / `loadProbe`)
+// MUST remain in-phase there, or every post-render load under OMID is
+// misclassified as unrecoverable and blanket-fatal'd. These cases pin that the
+// `omid-active` / `omid-finishing` phases were added to the load-probe control
+// channel ONLY — the handshake types (`rendered` / `failed` / `render`) stay
+// `['attaching-renderer']` (anti-forgery), so a replay under OMID is still
+// rejected out-of-phase.
+// ────────────────────────────────────────────────────────────────────────────
+{
+  console.log('\n4. #321: :loadAck inbound during omid-active is ACCEPTED (recovery enabler)');
+  const errors = [];
+  const securityEvents = [];
+  const slot = freshSlot();
+  const c = new SHARCContainer({
+    creativeHtml: CREATIVE_HTML,
+    creativeRendererUrl: RENDERER_URL,
+    placementElement: slot,
+    timeouts: { rendererLoad: 5000, rendererReply: 5000 },
+    onError: (code, msg) => errors.push({ code, msg }),
+    onSecurityEvent: (ev) => securityEvents.push(ev),
+  });
+  c.load();
+  await c.protocolRouter.ready('SHARC:Renderer:');
+  c._iframe.contentWindow.postMessage = () => {};
+  c._iframe.dispatchEvent(new dom.window.Event('load'));
+  // Valid handshake → phase: rendered.
+  window.dispatchEvent(new dom.window.MessageEvent('message', {
+    data: {
+      type: 'SHARC:Renderer:rendered',
+      placementSessionId: c.placementSessionId,
+      sharcNonce: c._rendererProtocolNonce,
+      rendererOrigin: RENDERER_ORIGIN,
+    },
+    origin: RENDERER_ORIGIN,
+    source: c._iframe.contentWindow,
+  }));
+  // Park the router in `omid-active`, mirroring the OMID AdSession-start
+  // transition (`_onOmidLifecycleSignal('omid-active')`).
+  c.protocolRouter.transitionTo('omid-active');
+  assert(c.protocolRouter.getPhase() === 'omid-active',
+    'router parked in omid-active (OMID AdSession active)');
+
+  // Inbound :loadAck — the backstop's control-channel reply.
+  window.dispatchEvent(new dom.window.MessageEvent('message', {
+    data: {
+      type: 'SHARC:Renderer:loadAck',
+      placementSessionId: c.placementSessionId,
+      sharcNonce: c._rendererProtocolNonce,
+    },
+    origin: RENDERER_ORIGIN,
+    source: c._iframe.contentWindow,
+  }));
+  const loadAckRejection = securityEvents.find(
+    (e) => e.type === 'unauthorized_protocol' && e.details.phase === 'omid-active'
+  );
+  assert(loadAckRejection == null,
+    ':loadAck in omid-active is NOT rejected as unauthorized_protocol (#321)');
+  assert(errors.length === 0,
+    'accepting the :loadAck does not surface an error');
+  assert(c._terminated === false,
+    'container remains live after the in-phase :loadAck');
+  c._terminate();
+}
+
+{
+  console.log('\n5. #321 anti-forgery: forged :rendered / :failed / :render in omid-active STAY rejected');
+  const errors = [];
+  const securityEvents = [];
+  const slot = freshSlot();
+  const c = new SHARCContainer({
+    creativeHtml: CREATIVE_HTML,
+    creativeRendererUrl: RENDERER_URL,
+    placementElement: slot,
+    timeouts: { rendererLoad: 5000, rendererReply: 5000 },
+    onError: (code, msg) => errors.push({ code, msg }),
+    onSecurityEvent: (ev) => securityEvents.push(ev),
+  });
+  c.load();
+  await c.protocolRouter.ready('SHARC:Renderer:');
+  c._iframe.contentWindow.postMessage = () => {};
+  c._iframe.dispatchEvent(new dom.window.Event('load'));
+  // Valid handshake → phase: rendered.
+  window.dispatchEvent(new dom.window.MessageEvent('message', {
+    data: {
+      type: 'SHARC:Renderer:rendered',
+      placementSessionId: c.placementSessionId,
+      sharcNonce: c._rendererProtocolNonce,
+      rendererOrigin: RENDERER_ORIGIN,
+    },
+    origin: RENDERER_ORIGIN,
+    source: c._iframe.contentWindow,
+  }));
+  c.protocolRouter.transitionTo('omid-active');
+  assert(c.protocolRouter.getPhase() === 'omid-active',
+    'router parked in omid-active');
+
+  // Forged :rendered with a VALID nonce — handshake type is declared ONLY in
+  // `attaching-renderer`, so this must reject out-of-phase even under OMID.
+  window.dispatchEvent(new dom.window.MessageEvent('message', {
+    data: {
+      type: 'SHARC:Renderer:rendered',
+      placementSessionId: c.placementSessionId,
+      sharcNonce: c._rendererProtocolNonce,
+      rendererOrigin: RENDERER_ORIGIN,
+    },
+    origin: RENDERER_ORIGIN,
+    source: c._iframe.contentWindow,
+  }));
+  const renderedRej = securityEvents.find(
+    (e) => e.type === 'unauthorized_protocol'
+      && e.details.phase === 'omid-active'
+      && e.details.reason === 'out-of-phase'
+  );
+  assert(renderedRej != null,
+    'forged :rendered in omid-active → unauthorized_protocol (out-of-phase)');
+
+  // Forged :failed — also declared only in `attaching-renderer`.
+  window.dispatchEvent(new dom.window.MessageEvent('message', {
+    data: {
+      type: 'SHARC:Renderer:failed',
+      placementSessionId: c.placementSessionId,
+      sharcNonce: c._rendererProtocolNonce,
+      reason: 'forged-failed-under-omid',
+    },
+    origin: RENDERER_ORIGIN,
+    source: c._iframe.contentWindow,
+  }));
+  const failedRej = securityEvents.filter(
+    (e) => e.type === 'unauthorized_protocol'
+      && e.details.phase === 'omid-active'
+      && e.details.reason === 'out-of-phase'
+  );
+  assert(failedRej.length >= 2,
+    'forged :failed in omid-active → unauthorized_protocol (out-of-phase)');
+
+  // :render is the OUTBOUND handshake type — an inbound forgery of it is
+  // dropped at the direction gate (inbound !== outbound), never reaching the
+  // phase gate, so it does not surface as unauthorized_protocol. It must NOT
+  // be accepted into the handler regardless.
+  window.dispatchEvent(new dom.window.MessageEvent('message', {
+    data: {
+      type: 'SHARC:Renderer:render',
+      placementSessionId: c.placementSessionId,
+      sharcNonce: c._rendererProtocolNonce,
+    },
+    origin: RENDERER_ORIGIN,
+    source: c._iframe.contentWindow,
+  }));
+  assert(c._terminated === false,
+    'forged handshake envelopes under OMID do not terminate (non-terminating reject)');
+  assert(errors.length === 0,
+    'forged handshake envelopes under OMID do not surface onError (RTR-D15)');
+  c._terminate();
+}
+
 if (failures === 0) {
   console.log('\n✓ All renderer-out-of-phase assertions passed.');
   process.exit(0);


### PR DESCRIPTION
## #321 Phase 1a — keep the renderer load-probe channel in-phase under OMID

**High-priority compatibility fix: SHARC was terminating valid ad loads.**

### Root cause (verified)
When an OMID AdSession starts, the bridge parks the protocol router in the `omid-active` phase (`src/sharc-omid-bridge.js:970`; shadow guard `src/sharc-container.js:1686`). But the renderer protocol registered `loadAck`/`loadProbe` — the navigation backstop's "is the renderer still controlled?" control channel — with phases `['attaching-renderer','rendered','creative-active']`, omitting `omid-active`. So under OMID the `loadAck` was dropped out-of-phase, the 100ms `loadProbe` deadline expired, and **every** post-render load was misclassified as an unrecoverable navigation escape → blanket-fatal `2118`. The "navigation" was a controlled reopen the whole time.

### The change (2 lines)
Add `omid-active` + `omid-finishing` to the `phases` of `loadAck` and `loadProbe` **only**. Handshake types `rendered`/`failed`/`render` stay locked to `['attaching-renderer']` — anti-forgery property untouched.

### Corpus-proven
Applying only this change took the private 5-case DoubleVerify visual-validator corpus from **5/5 terminated → 0/5 terminated**: all render, reach `active`, and complete their OMID lifecycle (`sessionStarted` 0/5→5/5). The remaining 3/5 strict-attribution misses are the pre-existing #290 measurement-window gap — ads stay alive, not terminated.

### Tests
Extends `test/node/test-renderer-out-of-phase.js` (already wired into `test:all:built`):
- **RED→GREEN:** inbound `loadAck` in `omid-active` is accepted (not rejected out-of-phase).
- **Anti-forgery (green both ways):** forged `:rendered`/`:failed` in `omid-active` are still rejected out-of-phase — proving the handshake types were **not** widened, only the control channel.

### Scope
Phase 1a only. The broader `2118` taxonomy split (observed/blocked/terminating) and the `_armRendererBackstop` subsequent-load branch refactor are deferred to Phase 2 (separate PR; requires ratification of a fail-closed→gated-fail-open posture change).

### Review
Claude-lane pre-push review: Code Reviewer + Security Engineer, both clean (0 blocking, 0 important). Security: phase membership is gate #9 of 9, behind the origin + HMAC-nonce gates — escape termination unchanged, no forgery/replay vector.

Design: `docs/design/0.7.10-renderer-lifecycle-readiness-compat-creatives.md` lineage + the post-render-nav-policy ADR (v2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
