### PR TITLE
docs: post-render load policy ADR — fail-open toward ad survival (#321)

### DIFF
--- a/docs/design/0.7.10-post-render-nav-policy-omid-phase.md
+++ b/docs/design/0.7.10-post-render-nav-policy-omid-phase.md
@@ -1,0 +1,205 @@
+# ADR: Post-render load policy — fail-OPEN toward ad survival (phased)
+
+**Status:** **Accepted** — ratified by Jeffrey 2026-06-07. STOP-AND-ASK #1 (phase-membership widening) and #2 (fail-closed → gated-fail-open posture) both approved. **Phase 1a (Decision 3 — the phase-membership fix) shipped in PR #330 (`d018117`).** Phase 1 remainder (subsequent-load gate + `2118` diagnostic split) and Phase 2 (behavior classification) are open; build lane: Claude.
+**Version:** **REVISED v2 (2026-06-07)** — supersedes v1 (2026-06-07). v1's **Decision 1 ("keep blocking cross-origin nav / do not widen") is SUPERSEDED** by the priority + the corpus data below. v1's **phase-membership finding SURVIVES and is now the recovery enabler.**
+**Date:** 2026-06-07
+**Issue:** follow-on to [#321](https://github.com/jeffreycarlson/SHARC/issues/321)
+**Baseline measured:** `origin/main` @ `1913fbd` (#322 load-race fix + #326 MRAID wrapper), dist built from source.
+**Predecessors:**
+- 0.7.7 cross-frame protocol router — `docs/design/0.7.7-cross-frame-protocol-router.md` (phase machine, gate sequence, anti-forgery property)
+- 0.7.10 renderer-lifecycle / compat-creatives ADR — `docs/design/0.7.10-renderer-lifecycle-readiness-compat-creatives.md` (**Decision 2** — the navigation backstop this ADR refactors)
+- Discover — `0.7.10-omid-readd-readiness` re-measure of the DV corpus (design record; aggregate findings summarized in "The Experiment" below)
+
+---
+
+## The priority that frames this ADR (set by Jeffrey)
+
+**SHARC's blanket-fatal `2118` is destroying valid ad loads today. That is THE bug.** The #1 goal is to **stop aborting valid ad loads and get good ads working.** Precisely classifying and blocking genuine navigation escapes is **explicitly secondary and sequenced after.**
+
+Default posture is **fail-OPEN toward ad survival**, not fail-closed abort. "Another load happened" must NOT be fatal. Aborting the ad is the wrong call **except for a true lost-control / external-webpage escape.** When it is ambiguous whether a post-render load is a benign bootstrap or an escape, **keep the ad alive if SHARC still holds the control channel** (controlled context). Do not abort on ambiguity.
+
+This reverses v1's stance. v1 reasoned from "the container cannot attribute the initiator, therefore fail closed." The data below shows that framing was wrong: SHARC **can** tell controlled from lost-control — the loadProbe/loadAck round-trip is exactly that test — and on the real corpus the post-render load was a **controlled reopen**, not an escape. We were aborting ads that SHARC still controlled.
+
+---
+
+## Scope lock
+
+This ADR decides (1) the post-render load policy — refactoring the blanket-fatal `2118` into a controlled-context-gated keep-alive (Phase 1) plus a behavior-classified block/observe path (Phase 2); (2) the `omid-active` out-of-phase `loadAck` rejection (the recovery enabler); (3) OMID re-add sequencing.
+
+It does **not** redesign the 0.7.7 router/wire contract. The one router-touching change (phase-membership widening of `loadAck`/`loadProbe`) is **no wire change** but **is a phase-model change** — flagged STOP-AND-ASK below.
+
+---
+
+## Context
+
+On `origin/main` (`1913fbd`), all 5 real DoubleVerify-wrapped creatives in the private corpus render and reach `active`; the old #321 load-race timeout (2114) is gone; OMID measurement already fires (loaded + impression 5/5). The remaining symptom: **all 5 terminate at ~2.06s with `2118` `unauthorized_navigation`** — the Decision-2 backstop catching a post-render renderer-frame load ~577ms post-render. ~100ms before each 2118, a `SHARC:Renderer:` envelope is rejected **out-of-phase during `omid-active`** (`unauthorized_protocol`).
+
+### The mechanism (verified in code)
+
+The navigation backstop (`_armRendererBackstop`, `src/sharc-container.js:4407`) arms a load-event listener. On the **first** post-render load it sends a `SHARC:Renderer:loadProbe` and waits **100ms** for a `SHARC:Renderer:loadAck`:
+- **loadAck arrives → ad survives** (`verifiedFirstLoad = true`, container keeps running).
+- **loadAck does not arrive in 100ms → `2118`, terminate.**
+- On **every subsequent** load (`:4542`) it currently fires `2118` unconditionally.
+
+The loadProbe/loadAck round-trip is therefore already the **"is the renderer still controlled?" gate.** A controlled reopen re-injects the renderer prelude, which answers the probe; a genuine cross-document escape cannot answer it.
+
+**The bug that voids the gate under OMID:** the renderer protocol registers `loadAck`/`loadProbe` with phases `['attaching-renderer','rendered','creative-active']` (`src/sharc-container.js:1267,1269`). When an OMID AdSession starts, the bridge drives `transitionTo('omid-active')` (`src/sharc-omid-bridge.js:970`), and `setState`'s phase-shadow guard (`src/sharc-container.js:1686`) keeps the router parked in `omid-active` (it never re-enters `creative-active`). So **whenever OMID is active, an authentic `loadAck` is out-of-phase** → router drops it (`unauthorized_protocol`, `phase:'omid-active'`, `reason:'out-of-phase'`) → the 100ms probe deadline expires → **every post-render load looks unrecoverable → blanket-fatal 2118.**
+
+This is why all 5 corpus creatives die: not because they escaped, but because **under OMID the control-channel probe could never be answered.** The gate was crippled-toward-false-positive.
+
+---
+
+## THE EXPERIMENT — proving the priority works (aggregate only; corpus is PRIVATE)
+
+In a worktree on `origin/main` (`1913fbd`), built dist, applied **only** the phase-membership fix (add `omid-active` + `omid-finishing` to `loadAck`/`loadProbe`; `rendered`/`failed`/`render` untouched), rebuilt, and re-ran the 5-case DV corpus. Same faithful e2e harness as the discover (real container + real renderer, cross-origin, headless Chromium).
+
+| Signal (5 DV cases) | **Baseline (no fix)** | **With phase fix** |
+|---|---|---|
+| rendered | 5/5 | 5/5 |
+| reachedActive | 5/5 | 5/5 |
+| **terminated** | **5/5** | **0/5** |
+| **finalState** | terminated (5/5) | **active (5/5)** |
+| **2118 `unauthorized_navigation`** | **5 events** | **0 events** |
+| `unauthorized_protocol` (dropped loadAck, omid-active) | 5 events | **0 events** |
+| OMID `sessionStarted` | 0/5 | **5/5** |
+| OMID loaded / impression | 5/5 / 5/5 | 5/5 / 5/5 |
+| status = passed (full DV-attributed lifecycle) | 0/5 | **2/5** |
+| status = failed | 5/5 | 3/5 |
+
+**What the data proves:**
+
+1. **The 2118 destruction is eliminated. 0/5 terminate.** Every corpus ad now **survives, stays `active`, and completes its OMID lifecycle.** The "navigation" the backstop was killing was a **controlled reopen** — once the loadProbe could be answered in `omid-active`, the renderer **answered it**, proving SHARC held the control channel the entire time. v1's premise ("genuinely unauthorized cross-origin escape") is **empirically refuted on the corpus.**
+
+2. **OMID completes for free once the ad stays alive.** `sessionStarted` went 0→5/5; loaded/impression were already 5/5 and remain so. OMID re-add needs **no OMID code change** — it was downstream of the termination all along.
+
+3. **The remaining 3/5 `failed` are NOT terminations — all 5 stay `active`.** They fail on `diagnosticOutcome: 'no-subscription'`: the inline DV vendor script did not register a session observer within the measurement window. This is the **pre-existing strict-DV-attribution gap** (the discover's 2/5 strict-subscription, ties to **#290**) — a measurement-window question, not a render / control / escape failure. They render, reach active, fire loaded+impression, and survive. **This is correct Phase-1 behavior: keep the ad alive; surface the attribution gap as a diagnostic, not a termination.**
+
+4. **No still-too-aggressive Phase-1 gap, and no genuine escape masked.** Zero cases terminate, zero cases escape (all stay `active` in the placement under SHARC's control channel). The classifier did not need behavior analysis to make the right call here — the controlled-context gate alone was sufficient.
+
+**Conclusion: the controlled-context gate, repaired, stops destroying valid loads. This is what ships first.**
+
+---
+
+## Decision
+
+### Decision 0 (priority) — Default posture is fail-OPEN toward ad survival. A post-render load is NOT fatal when SHARC still holds a controlled execution context.
+
+Normal browser / ad-bootstrap load behavior is **not** an escape. Fatal termination is reserved for **lost control / uncontrolled external-webpage escape / publisher-safety threat**. This applies to **SHARC-native and plain-HTML creatives too** — their normal load behavior must never be fatal. The discriminator is the controlled-context gate (Decision 2), not the mere fact that a load occurred.
+
+### Decision 1 — SUPERSEDED. (v1: "post-render cross-origin nav is genuinely unauthorized; keep blocking 2118; do not widen.")
+
+**v1 Decision 1 is withdrawn.** Its reasoning — "the container cannot attribute the initiator, therefore any post-render renderer-frame load that doesn't answer must be treated as a blocked escape" — conflated **"can't attribute the initiator"** with **"can't tell controlled from lost-control."** SHARC *can* tell, via the loadProbe/loadAck round-trip, and the corpus data shows the round-trip is answered (controlled reopen). v1 was aborting ads SHARC still controlled. The new policy is the phased model below.
+
+The one piece of v1 that survives: the loadProbe/loadAck round-trip **is** the right boundary — v1 just had the phase membership broken under OMID and then mis-read the resulting false-positive as a real escape.
+
+### Decision 2 — Refactor the `2118` path: blanket-fatal → controlled-context-gated keep-alive (Phase 1) + behavior-classified block/observe (Phase 2). Split `2118` into observed / blocked / terminating diagnostics.
+
+**Phase 1 (priority — ships first). Model every post-render renderer-frame load as:**
+
+```
+post-render load → run loadProbe/loadAck round-trip (the controlled-context gate)
+  ├─ loadAck answered within deadline  ⇒ CONTROLLED  ⇒ keep ad alive + record a diagnostic
+  └─ loadAck NOT answered within deadline ⇒ LOST CONTROL ⇒ terminate
+```
+
+Concretely, in `_armRendererBackstop`:
+- **The enabler:** widen `loadAck`/`loadProbe` phase membership to include `omid-active` + `omid-finishing` (Decision 3) so the round-trip can complete in every post-render phase. Without this, the gate is dead under OMID and Phase 1 cannot work.
+- **The first-load path is already correct** (probe → ack → survive). Phase 1 keeps it, and it now works under OMID.
+- **The subsequent-load path (`:4542`) is the destructive blanket-fatal.** Refactor it to run the **same** loadProbe/loadAck gate on every post-render load rather than firing `2118` unconditionally. Answered ⇒ keep alive + diagnostic; unanswered within deadline ⇒ terminate (lost control).
+- Standard ad-bootstrap activity that produces ad content in the placement while SHARC retains the channel — `document.write`/`document.open`, same-frame document replacement inside the sandboxed renderer, measurement/vendor/OMID/SafeFrame/MRAID bootstraps, nested measurement iframes, pixel/script/css loads, hash/history changes, delayed script-driven writes — **keeps the ad alive + records a diagnostic.** These are the cases that answer the probe (or never replace the controlled document at all).
+
+**Split `2118` into three diagnostic outcomes (do NOT delete it):**
+- **`renderer_load_observed`** (non-terminating, Phase 1) — a post-render load happened; the controlled-context gate was answered; ad kept alive. Carries `msSinceRender` and a load-kind hint. This is the new default for the corpus pattern.
+- **`renderer_navigation_blocked`** (non-terminating, Phase 2) — a genuine nav *attempt* was classified and blocked-if-possible; ad kept alive because SHARC still holds the channel. Carries the classified nav kind.
+- **`unauthorized_navigation` / `2118`** (terminating) — **narrowed** to true lost-control: the controlled-context gate went unanswered within the deadline (uncontrolled external-webpage escape), or a Phase-2 publisher-safety threat / repeated unrecoverable attempts. The grep-stable `2118` operator signal is **preserved** for the genuinely-fatal case.
+
+**Phase 2 (close the gaps — later).** Layer behavior-classification on top of the gate, using the validator's existing document-activity diagnostics (`navigationDiagnostics.{documentWrite,windowOpen,bridgeCalls,scriptLoads,documentSources}` — confirmed present in the report). Classify genuine navigation attempts: unaudited `window.open` / `mraid.open` / `SHARC.requestNavigation`; top/parent/publisher nav; form submit to `_top`/`_parent`/external; meta refresh or `window.location` to a landing page; same-frame nav to a click destination without audited intent. Policy: **block-if-possible, record (`renderer_navigation_blocked`), keep the ad alive if still controlled.** Terminate (`2118`) ONLY for unrecoverable lost-control / uncontrolled external-webpage escape / publisher-safety threat / repeated unrecoverable attempts. Phase 2 does **not** relax the controlled-context gate; it adds intent classification *within* the kept-alive controlled path.
+
+**What ships first, explicitly:** Phase 1 = Decision 3 (the phase fix) + the subsequent-load refactor to gate-on-every-load + the `2118` diagnostic split. That alone stops destroying valid loads (proven: 0/5 terminate). Phase 2 ships after, separately.
+
+### Decision 3 — The recovery enabler: add `omid-active` + `omid-finishing` to the `loadAck`/`loadProbe` phase membership. **STOP-AND-ASK flagged.**
+
+```
+'loadAck':   { phases: ['attaching-renderer','rendered','creative-active','omid-active','omid-finishing'], direction: 'inbound' },
+'loadProbe': { phases: ['attaching-renderer','rendered','creative-active','omid-active','omid-finishing'], direction: 'outbound' },
+```
+
+`rendered`, `failed`, `render` stay narrowly scoped to the renderer handshake — they MUST NOT become re-acceptable later (the 0.7.7 anti-forgery property, untouched). This is the minimal change that revives the controlled-context gate across the full post-render lifecycle, including under OMID. It is **the** enabler: without it, a controlled reopen cannot answer the probe and every post-render load under OMID falsely looks unrecoverable.
+
+**Security analysis — does this reopen a hole? No.** Adding `omid-active` to `loadAck` does not let a creative forge a renderer envelope it could not already forge in `creative-active`. Gate steps 2–7 (source === renderer contentWindow, origin === renderer origin, derived protocol nonce, placementSessionId) are unchanged and remain the trust anchor. The phase gate (step 9) for `loadAck` is a **liveness window, not the authentication boundary**; widening a liveness window for a nonce-authenticated probe reply does not weaken authentication. **Verified by test (B/C below):** a replayed `:rendered` or `:failed` in `omid-active` is STILL rejected out-of-phase. The wire format is unchanged.
+
+### Decision 4 — OMID re-add is decoupled from any nav policy and needs no OMID change.
+
+OMID does not cause the post-render load and does not navigate the frame — it measures. What OMID *did* do was park the router in `omid-active`, which crippled the controlled-context gate. Decision 3 fixes that. The corpus experiment is the proof: with the phase fix and **zero OMID changes**, OMID `sessionStarted` went 0→5/5 and the full lifecycle completes. **OMID completes for free once the ad stays alive.** The strict-attribution gap (now 2/5 fully passing, 3/5 `no-subscription` while alive) is a separate measurement-window question (#290), lower priority, out of scope here.
+
+---
+
+## Security — how Phase-1 keep-alive stays safe
+
+- **The controlled-context gate is the safety boundary.** "Keep alive" is granted **only** when SHARC retains the protocol channel — i.e., the renderer answers the nonce-authenticated loadProbe with a loadAck. A genuine lost-control escape (the controlled document replaced by an uncontrolled external webpage with no SHARC prelude) **cannot** answer the probe and is still terminated (`2118`). Fail-open is gated, not blanket.
+- **Phase 1 introduces no escape worse than today.** Today's `2118` already *permits* a first-load reopen that answers the probe (that path exists at `:4481–4540`). Phase 1 extends that same answered-probe tolerance to (a) under-OMID phases and (b) subsequent loads — using the **identical** authentication. It does not add any new path by which an *unanswered* / uncontrolled load survives. The terminate-on-unanswered branch is preserved. The bar — per the priority — is "don't regress safety / keep the controlled-context gate," and Phase 1 keeps it intact.
+- **Anti-forgery preserved.** Decision 3 widens `loadAck`/`loadProbe` only. `rendered`/`failed`/`render` remain locked out of every post-handshake phase; a replayed handshake envelope under `omid-active` is still rejected (proven by tests B/C). No nonce, gate-step, or wire change.
+
+---
+
+## STOP-AND-ASK items for Jeffrey
+
+1. **Decision 3 phase-membership widening (router phase model, code-level — flagged per the "no router-contract change without STOP-AND-ASK" rule).** Adding `omid-active` + `omid-finishing` to the renderer `loadAck`/`loadProbe` membership is the first time a non-OMID protocol type is valid during `omid-active`. **Wire format unchanged; no gate/nonce change.** It is a deliberate phase-model coupling and should be ratified, not assumed. **Recommended: approve** — it is the minimal correct fix, it is the proven recovery enabler (0/5 terminate vs 5/5), and it does not weaken authentication (analysis + tests above). *(This is a phase-model change with no wire change — flagging it as required, not a redesign.)*
+
+2. **The Phase-1 `2118` refactor changes terminating behavior on `origin/main`.** Today `2118` is blanket-fatal on every subsequent post-render load. Phase 1 narrows it to lost-control-only (gate unanswered). This is the intended fix per the priority, but it **does change a security control's default from fail-closed to gated-fail-open.** The corpus data supports it (the fail-closed default was destroying 5/5 valid loads with zero real escapes), and the gate keeps it safe — but flagging because it is a posture change on a security boundary, exactly the kind of decision to ratify explicitly.
+
+3. **(Product, not engineering — informational.)** The corpus's 3/5 `no-subscription` is the pre-existing strict-DV-attribution gap (#290). Out of scope here; ads stay alive. No action needed for this ADR.
+
+---
+
+## Failing tests to write (design-first contract)
+
+Legend: **RED→GREEN** = fails on `origin/main`, passes after the fix. **GREEN (regression-guard)** = passes today, pinned. **node** = jsdom-expressible; **validator/puppeteer** = requires real renderer + real cross-origin.
+
+### Phase 1 — the four required reductions
+
+1. **document.write/document.open post-render bootstrap → must CONTINUE (keep-alive + diagnostic).** `[Phase 1]`
+   - **node, RED→GREEN** (`test/node/test-renderer-postrender-load-policy.js`, extend): arm the backstop, drive router to `omid-active`, fire a same-frame `document.write`-style reopen whose prelude answers `:loadAck`. Today: loadAck dropped out-of-phase → 100ms deadline → `2118` (RED). After fix: loadAck accepted → no `2118` → `renderer_load_observed` diagnostic recorded → container survives.
+   - **validator/puppeteer, RED→GREEN** (`test/browser/test-creative-sources-puppeteer.js`, extend): synthetic raw-MRAID creative reaches `active`, a real OMID AdSession drives `omid-active`, then a real same-origin `document.write` reopen (prelude re-injected) fires. Today: `2118`. After fix: survives, no `2118`. (Real-renderer-provisioning + real-OMID facts are puppeteer-only per the 0.7.10 precedent.)
+
+2. **MRAID interstitial gating on ready/viewable → must reach `viewableChange(true)`.** `[Phase 1]`
+   - **validator/puppeteer, RED→GREEN**: synthetic MRAID creative that gates its render on `ready` then `isViewable()`, under OMID. Today the `2118` termination interrupts the lifecycle before viewable. After fix: reaches `ready` → `default` → `viewableChange(true)`; container stays `active`.
+
+3. **same-frame landing-page redirect → block / terminate by recoverability.** `[Phase 2]`
+   - **validator/puppeteer, RED→GREEN (Phase 2)**: synthetic creative reaches `active`, then `window.location = <landing page>` replacing the controlled document with no prelude. The reopen cannot answer the probe ⇒ classified lost-control ⇒ terminate `2118` (correct). Pins that genuine escape still terminates after the Phase-1 fail-open.
+
+4. **top/parent navigation attempt → block + observe, keep alive if still controlled.** `[Phase 2]`
+   - **validator/puppeteer, RED→GREEN (Phase 2)**: synthetic creative attempts `top.location` / `parent.location`; classified, blocked-if-possible, `renderer_navigation_blocked` recorded, **ad kept alive** because the renderer document is still controlled (probe still answered). Pins block-without-terminate.
+
+### Recovery-enabler + anti-forgery (proven in this experiment; promote to committed tests)
+
+5. **`test/node/test-omid-active-loadack-phase.js`** — **node.** (A) RED→GREEN: authentic `:loadAck` in `omid-active` is accepted, reaches the backstop probe, container survives. (B) GREEN regression-guard: replayed `:rendered` in `omid-active` STILL fires `unauthorized_protocol` `reason:'out-of-phase'`. (C) GREEN regression-guard: replayed `:failed` in `omid-active` STILL out-of-phase. **(Authored + run in this experiment; A confirmed RED on `origin/main` and GREEN after the fix; B/C GREEN both ways.)**
+
+6. **`test/node/test-protocol-router.js`** (extend) — **node, RED→GREEN + GREEN guard.** Assert registered `loadAck`/`loadProbe` `phases` include `omid-active` + `omid-finishing` (RED→GREEN). Assert `rendered`/`failed`/`render` include NO omid phase (GREEN guard — protects anti-forgery).
+
+7. **`test/node/test-omid-router-consumption.js`** (extend) — **node, RED→GREEN.** With the OMID bridge present and an AdSession started (driving `omid-active`), a renderer `loadProbe`/`loadAck` round-trip completes (backstop probe resolves) rather than emitting `unauthorized_protocol`.
+
+### `2118` diagnostic split
+
+8. **`test/node/test-renderer-postrender-load-policy.js`** (extend) — **node, RED→GREEN.** Assert the kept-alive path emits `renderer_load_observed` (non-terminating) and the lost-control path emits `unauthorized_navigation`/`2118` (terminating). Pins the split (do-not-delete-2118).
+
+### Regression guards
+
+9. Native-SHARC + plain-HTML normal post-render load behavior is **not** fatal (node + puppeteer). Pins Decision 0 for non-OMID, non-DV creatives.
+10. Genuine lost-control escape (controlled document replaced by uncontrolled external webpage, no prelude, probe unanswered) STILL terminates `2118` (puppeteer). Pins that fail-open did not regress safety.
+
+---
+
+## Validator support (future)
+
+Surface, per case: document-activity-for-ad-loading (already: `navigationDiagnostics.{documentWrite,scriptLoads,documentSources}`), blocked nav attempts (`renderer_navigation_blocked`), renderer reload/recovery attempts (probe/ack round-trips + `renderer_load_observed` count), MRAID `ready`/`default` reached, `isViewable` became true, and whether OMID failed *because* termination interrupted the lifecycle (distinguish "OMID never started" from "OMID started but container terminated mid-lifecycle"). The corpus experiment is the motivating case: pre-fix `sessionStarted` 0/5 was a termination artifact, not an OMID failure — the validator should make that distinguishable without re-running.
+
+---
+
+## Consequences
+
+**Easier:** the corpus's 5/5 destruction of valid loads is **eliminated** (0/5 terminate, 5/5 stay active) with a two-line phase-membership change plus a subsequent-load refactor; OMID completes for free (`sessionStarted` 0→5/5) with no OMID change; the controlled-context gate becomes valid across the full post-render lifecycle; the `2118` split gives operators observed/blocked/terminating granularity instead of one blanket-fatal signal.
+
+**Harder / costs:** the security posture on the renderer load boundary moves from fail-closed-blanket to gated-fail-open (STOP-AND-ASK #2) — correct per the priority and the data, but a posture change to ratify. Phase 2 behavior-classification is net-new work (deferred). The decisive Phase-1/Phase-2 tests are puppeteer-tier (real renderer + real cross-origin + real OMID), not node-expressible.
+
+**Baseline-consistency summary:** Decision 3 is a phase-membership widening of two existing renderer types — no router primitive, gate, nonce, or wire change — flagged STOP-AND-ASK as a phase-model change. The `2118` refactor narrows a terminating control to lost-control-only and splits its diagnostic — flagged STOP-AND-ASK as a security-posture change. No silent router redesign. The corpus experiment (`origin/main` @ `1913fbd`, phase fix only) is the empirical basis: **0/5 terminate, 5/5 active, OMID 5/5, zero escapes.**


### PR DESCRIPTION
## In-tree copy of the post-render load policy ADR (#321)

Adds `docs/design/0.7.10-post-render-nav-policy-omid-phase.md` — the **Accepted v2 ADR** (0.7.10 family), so the design lives in-tree alongside its predecessors (0.7.7 router, 0.7.10 renderer-lifecycle/compat-creatives).

**Docs-only.** No code change.

**Decisions captured:**
- **Decision 0** — fail-OPEN toward ad survival: a post-render load is not fatal while SHARC holds a controlled execution context (applies to SHARC-native + plain-HTML too).
- **Decision 2** — refactor `2118` from blanket-fatal to controlled-context-gated keep-alive (Phase 1) + behavior-classified block/observe (Phase 2); split `2118` into `renderer_load_observed` / `renderer_navigation_blocked` / `unauthorized_navigation` (do not delete).
- **Decision 3** — the `omid-active`/`omid-finishing` loadAck/loadProbe phase-membership fix (the recovery enabler). **Shipped in #330 (`d018117`).**
- **Decision 4** — OMID re-add is decoupled; completes for free once the ad stays alive (corpus-proven 0/5 terminate, OMID `sessionStarted` 0→5/5, zero OMID change).

Ratified by Jeffrey: STOP-AND-ASK #1 (phase widening) + #2 (fail-closed → gated-fail-open posture) both approved. Phase 1 remainder + Phase 2 are the open follow-on (build lane: Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
