### PR TITLE
feat: gate every post-render load on controlled-context probe (#321 Phase 1)

### DIFF
--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -429,7 +429,10 @@ const SHARC_BUILD_MODE = /** @type {'dev'|'prod'} */ ('__SHARC_BUILD_MODE__');
  * `details.msSinceRender` mirrors the 2118 field — wall-clock delay between the
  * render-anchor and this load. `details.loadKind` is a coarse hint: `'first'`
  * for the first verified post-render load, `'subsequent'` for any later one.
- * No `errorCode` field — this is non-terminating and never reaches `onError`.
+ * No top-level `errorCode` field — this is non-terminating and never reaches
+ * `onError`. `details.code` carries 2121 (`RENDERER_LOAD_OBSERVED`) for
+ * numeric telemetry symmetry with the 2118 terminating event, WITHOUT
+ * promoting it to the terminating `errorCode` channel.
  *
  * @typedef {SHARCSecurityEventBase & {
  *   type: 'renderer_load_observed',
@@ -438,6 +441,7 @@ const SHARC_BUILD_MODE = /** @type {'dev'|'prod'} */ ('__SHARC_BUILD_MODE__');
  *     variant: 'markup' | 'url',
  *     msSinceRender: number,
  *     loadKind: 'first' | 'subsequent',
+ *     code: 2121,
  *   },
  * }} RendererLoadObservedEvent
  */
@@ -1427,6 +1431,20 @@ class SHARCContainer {
      * @private
      */
     this._rendererBackstopHandler = null;
+
+    /**
+     * Timer id for the controlled-context probe deadline armed by `runGate`
+     * inside `_armRendererBackstop`. Hoisted to an instance field (rather than
+     * living only in `runGate`'s closure) so a probe still outstanding when an
+     * unrelated external termination disarms the backstop can be cleared from
+     * `_disarmRendererBackstop`. The timeout callback is `_terminated`-guarded,
+     * so a survivor is inert — this is lifecycle tidiness, not a fix for a live
+     * behavior bug. `null` when no probe is pending.
+     *
+     * @type {ReturnType<typeof setTimeout> | null}
+     * @private
+     */
+    this._rendererProbeTimeoutId = null;
 
     /**
      * Session-level single-consume latch for the renderer `:loadAck`. The
@@ -4553,10 +4571,12 @@ class SHARCContainer {
       const loadKind = observedLoadCount === 1 ? 'first' : 'subsequent';
       const iframeWindow = this._iframe && this._iframe.contentWindow;
       const expectedOrigin = this._rendererOrigin;
-      let timeoutId = null;
       const cleanup = () => {
         this._pendingLoadProbe = null;
-        if (timeoutId !== null) clearTimeout(timeoutId);
+        if (this._rendererProbeTimeoutId !== null) {
+          clearTimeout(this._rendererProbeTimeoutId);
+          this._rendererProbeTimeoutId = null;
+        }
       };
       const onAck = () => {
         if (this._terminated) {
@@ -4585,7 +4605,7 @@ class SHARCContainer {
       // within a cycle.
       this._loadAckConsumed = false;
       this._pendingLoadProbe = onAck;
-      timeoutId = setTimeout(() => {
+      this._rendererProbeTimeoutId = setTimeout(() => {
         cleanup();
         probePending = false;
         loadWhileProbePending = false;
@@ -4655,6 +4675,16 @@ class SHARCContainer {
       } catch (_) { /* ignore */ }
     }
     this._rendererBackstopHandler = null;
+    // Lifecycle tidiness: clear any probe timeout still pending when an
+    // unrelated external termination disarms the backstop. The timer's
+    // callback (`emitUnauthorizedNavigation`) and `onAck` are both
+    // `_terminated`-guarded, so a survivor is harmless — but a dangling
+    // timer is still a leak. The probe timeout id lives on the instance
+    // (set in `runGate`) precisely so it can be cleared from out here.
+    if (this._rendererProbeTimeoutId !== null) {
+      clearTimeout(this._rendererProbeTimeoutId);
+      this._rendererProbeTimeoutId = null;
+    }
   }
 
   /**
@@ -4939,6 +4969,11 @@ class SHARCContainer {
           variant: variant,
           msSinceRender: msSinceRender,
           loadKind: loadKind,
+          // Numeric telemetry symmetry with the 2118 terminating event.
+          // Lives in `details` (NOT top-level `errorCode`) because this event
+          // is non-terminating and must never reach `onError` — tests pin
+          // `errorCode === undefined`.
+          code: ErrorCodes.RENDERER_LOAD_OBSERVED,
         },
       }));
     }

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -1447,20 +1447,23 @@ class SHARCContainer {
     this._rendererProbeTimeoutId = null;
 
     /**
-     * Session-level single-consume latch for the renderer `:loadAck`. The
-     * first-load probe armed by `_armRendererBackstop({ verifyFirstLoad })`
-     * accepts exactly ONE `loadAck` per container lifetime — it is the reply
-     * to the single `loadProbe` posted after the first post-`:rendered` load.
+     * Per-probe-cycle single-consume latch for the renderer `:loadAck`. Phase 1
+     * (#321) gates EVERY post-render load, so `runGate` arms a fresh probe per
+     * load and resets this latch to `false` at the start of each cycle. Within
+     * a single cycle the probe accepts exactly ONE `loadAck` — the reply to that
+     * cycle's `loadProbe`; `_dispatchRendererLoadAck` flips this `true` the
+     * instant it resolves the pending probe and refuses every further `loadAck`
+     * for the rest of that cycle. This makes the single-consume property an
+     * explicit, enforced invariant rather than an emergent side effect of
+     * `_pendingLoadProbe` happening to be null after the ack.
      *
-     * `_dispatchRendererLoadAck` flips this `true` the first time it resolves
-     * the pending probe, and refuses every subsequent `loadAck` outright.
-     * This makes the single-use property an explicit, enforced invariant
-     * rather than an emergent side effect of `_pendingLoadProbe` happening to
-     * be null after the first ack. Defense-in-depth for #269: a forged,
-     * replayed, or late second `loadAck` cannot re-resolve a probe or touch
-     * state regardless of the router phase it arrives in. The renderer nonce
-     * is already hidden from creative code (#254), so this closes the residual
-     * intent gap, not a live exploit.
+     * This latch is intentionally NOT the cross-cycle authenticity guard. An
+     * ack from a prior or unrelated cycle is rejected upstream by the router's
+     * nonce/origin/source/placementSessionId gate before it ever reaches the
+     * handler — that gate, not this per-cycle latch, is what defends against a
+     * forged, replayed, or stale `loadAck` re-resolving a probe (#269). The
+     * renderer nonce is already hidden from creative code (#254); the latch only
+     * closes the within-cycle double-consume gap.
      *
      * @type {boolean}
      * @private
@@ -4605,6 +4608,13 @@ class SHARCContainer {
       // within a cycle.
       this._loadAckConsumed = false;
       this._pendingLoadProbe = onAck;
+      // 100ms loadAck deadline. Inherited verbatim from the original first-load
+      // gate (0.7.7), which armed exactly one probe after the first post-render
+      // load. Phase 1 (#321) runs the gate on EVERY post-render load, so this
+      // same 100ms now applies per post-render load under the gate-every-load
+      // model — not once per container lifetime. The deadline value, plus a
+      // per-container rate/count ceiling on how many gate cycles may run, are
+      // deferred tuning tracked as Phase 2 in issue #332; do not adjust here.
       this._rendererProbeTimeoutId = setTimeout(() => {
         cleanup();
         probePending = false;

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -281,6 +281,8 @@ const SHARC_BUILD_MODE = /** @type {'dev'|'prod'} */ ('__SHARC_BUILD_MODE__');
  *   | RendererFailedEvent
  *   | BridgeLoadFailedEvent
  *   | UnauthorizedNavigationEvent
+ *   | RendererLoadObservedEvent
+ *   | RendererNavigationBlockedEvent
  *   | FeatureLoadFailedEvent
  *   | UnauthorizedProtocolEvent} SHARCSecurityEvent
  */
@@ -410,6 +412,52 @@ const SHARC_BUILD_MODE = /** @type {'dev'|'prod'} */ ('__SHARC_BUILD_MODE__');
  *     msSinceRender: number,
  *   },
  * }} UnauthorizedNavigationEvent
+ */
+
+/**
+ * Non-terminating post-render-load diagnostic (0.7.10 Phase 1). Fired when a
+ * post-render renderer-frame `load` event occurred AND the controlled-context
+ * gate (loadProbe/loadAck round-trip) was answered within the deadline — i.e.
+ * SHARC still holds the authenticated protocol channel to the renderer document.
+ * The ad is kept alive.
+ *
+ * This is the new default outcome for the corpus pattern (controlled reopen /
+ * document.write bootstrap / measurement-vendor bootstrap). It replaces the
+ * formerly blanket-fatal 2118 for the controlled case; 2118 is now narrowed to
+ * lost-control (gate unanswered) only.
+ *
+ * `details.msSinceRender` mirrors the 2118 field — wall-clock delay between the
+ * render-anchor and this load. `details.loadKind` is a coarse hint: `'first'`
+ * for the first verified post-render load, `'subsequent'` for any later one.
+ * No `errorCode` field — this is non-terminating and never reaches `onError`.
+ *
+ * @typedef {SHARCSecurityEventBase & {
+ *   type: 'renderer_load_observed',
+ *   severity: 'info',
+ *   details: {
+ *     variant: 'markup' | 'url',
+ *     msSinceRender: number,
+ *     loadKind: 'first' | 'subsequent',
+ *   },
+ * }} RendererLoadObservedEvent
+ */
+
+/**
+ * Non-terminating navigation-blocked diagnostic (0.7.10 — RESERVED for Phase 2).
+ * Will be fired when a genuine navigation *attempt* is classified and
+ * blocked-if-possible while SHARC still holds the channel (ad kept alive). The
+ * diagnostic type and error code (2122) are defined now so the contract is
+ * stable; NO call site emits it in Phase 1 (behavior classification is Phase 2,
+ * out of scope here). Carries the classified nav kind once Phase 2 lands.
+ *
+ * @typedef {SHARCSecurityEventBase & {
+ *   type: 'renderer_navigation_blocked',
+ *   severity: 'warning',
+ *   details: {
+ *     variant: 'markup' | 'url',
+ *     navKind: string,
+ *   },
+ * }} RendererNavigationBlockedEvent
  */
 
 /**
@@ -4406,10 +4454,27 @@ class SHARCContainer {
    */
   _armRendererBackstop(options = {}) {
     if (this._terminated || !this._iframe) return;
-    const verifyFirstLoad = options && options.verifyFirstLoad === true;
-    let verifiedFirstLoad = false;
-    let pendingFirstLoadProbe = false;
+    // 0.7.10 Phase 1: the controlled-context gate now runs on EVERY post-render
+    // load, not only the first. `gateEveryLoad` is true whenever a renderer
+    // protocol channel exists to answer the probe (Markup variant, armed with
+    // `verifyFirstLoad: true`). The URL variant arms without it: a plain
+    // creative-URL document has no SHARC prelude to answer a probe, so the gate
+    // would always go unanswered — its post-render-load policy is unchanged
+    // (any subsequent cross-document load terminates), preserving the URL
+    // variant's existing 2118 contract.
+    const gateEveryLoad = options && options.verifyFirstLoad === true;
+    // True only while a probe is outstanding (armed, awaiting ack or timeout).
+    // A second load arriving in this window is latched and re-evaluated once
+    // the outstanding probe resolves.
+    let probePending = false;
+    // Latched when a load fires while a probe is already pending. The
+    // additional load means the renderer document changed again before the
+    // first probe resolved; once the outstanding probe is answered we re-run the
+    // gate for the latched load rather than assuming it benign.
     let loadWhileProbePending = false;
+    // Monotonic count of post-render loads observed, for the `loadKind` hint on
+    // `renderer_load_observed` ('first' vs 'subsequent').
+    let observedLoadCount = 0;
     // Closure-scoped state for the router-routed loadAck. The router strips
     // the prefix, validates source/origin/nonce/placementSessionId/phase, and
     // invokes `_dispatchRendererLoadAck()` on the handler — which in turn
@@ -4476,70 +4541,97 @@ class SHARCContainer {
         { variant: variant, msSinceRender: msSinceRender }
       );
     };
+    // Arms one controlled-context probe/ack cycle for a single post-render
+    // load. Answered within the deadline ⇒ CONTROLLED ⇒ keep the ad alive +
+    // emit a non-terminating `renderer_load_observed`. Unanswered ⇒ LOST
+    // CONTROL ⇒ terminate (2118). This is the same authenticated round-trip the
+    // first load always used (0.7.7); Phase 1 (0.7.10) runs it on EVERY load.
+    const runGate = () => {
+      probePending = true;
+      loadWhileProbePending = false;
+      observedLoadCount += 1;
+      const loadKind = observedLoadCount === 1 ? 'first' : 'subsequent';
+      const iframeWindow = this._iframe && this._iframe.contentWindow;
+      const expectedOrigin = this._rendererOrigin;
+      let timeoutId = null;
+      const cleanup = () => {
+        this._pendingLoadProbe = null;
+        if (timeoutId !== null) clearTimeout(timeoutId);
+      };
+      const onAck = () => {
+        if (this._terminated) {
+          cleanup();
+          return;
+        }
+        cleanup();
+        probePending = false;
+        // CONTROLLED: the nonce-authenticated probe was answered → SHARC still
+        // holds the renderer channel. Keep the ad alive (Decision 0/2). If a
+        // further load latched while this probe was outstanding, re-run the
+        // gate for it rather than assuming it benign.
+        this._emitRendererLoadObserved(loadKind);
+        if (loadWhileProbePending) {
+          loadWhileProbePending = false;
+          runGate();
+        }
+      };
+      // 0.7.7: the loadAck reception is now router-routed. The renderer
+      // handler (`_handleRendererEnvelope`) calls `_dispatchRendererLoadAck`
+      // which invokes the callback below. Origin/source/nonce/placementSessionId
+      // and phase membership are already validated by the router's gate.
+      // Phase 1: arming a fresh probe resets the single-consume latch (#269) so
+      // each post-render load gets its own probe/ack cycle while the latch still
+      // guards against a forged/replayed/late ack re-resolving a stale probe
+      // within a cycle.
+      this._loadAckConsumed = false;
+      this._pendingLoadProbe = onAck;
+      timeoutId = setTimeout(() => {
+        cleanup();
+        probePending = false;
+        loadWhileProbePending = false;
+        // LOST CONTROL: the gate went unanswered within the deadline. This is
+        // the narrowed, genuinely-fatal 2118 (uncontrolled external-webpage
+        // escape / replaced controlled document with no prelude).
+        emitUnauthorizedNavigation();
+      }, 100);
+      try {
+        if (!iframeWindow || typeof iframeWindow.postMessage !== 'function') {
+          throw new Error('renderer contentWindow unavailable');
+        }
+        // 0.7.7 SEC-H1: the outbound `:loadProbe` deliberately omits
+        // `sharcNonce`. The probe is a wakeup ping consumed by the renderer-
+        // injected prelude listener; the inbound `:loadAck` is what the
+        // router authenticates (gate step 7 against `entry.protocolNonce`).
+        // Leaving the derived nonce off the wire here keeps it confidential
+        // from any creative-installed message listener observing the probe.
+        const probeMsg = {
+          type: 'SHARC:Renderer:loadProbe',
+          placementSessionId: this.placementSessionId,
+        };
+        iframeWindow.postMessage(probeMsg, expectedOrigin);
+      } catch (_) {
+        cleanup();
+        probePending = false;
+        loadWhileProbePending = false;
+        emitUnauthorizedNavigation();
+      }
+    };
     const backstop = (loadEvent) => {
       if (this._terminated) return;
-      if (verifyFirstLoad && !verifiedFirstLoad) {
-        if (pendingFirstLoadProbe) {
+      void loadEvent;
+      if (gateEveryLoad) {
+        // A load arriving while a probe is still outstanding is latched and
+        // re-evaluated when the outstanding probe resolves (preserves the
+        // double-load-in-one-window defense).
+        if (probePending) {
           loadWhileProbePending = true;
           return;
         }
-        pendingFirstLoadProbe = true;
-        loadWhileProbePending = false;
-        const iframeWindow = this._iframe && this._iframe.contentWindow;
-        const expectedOrigin = this._rendererOrigin;
-        let timeoutId = null;
-        const cleanup = () => {
-          this._pendingLoadProbe = null;
-          if (timeoutId !== null) clearTimeout(timeoutId);
-        };
-        const onAck = () => {
-          if (this._terminated) {
-            cleanup();
-            return;
-          }
-          cleanup();
-          verifiedFirstLoad = true;
-          pendingFirstLoadProbe = false;
-          if (loadWhileProbePending) {
-            loadWhileProbePending = false;
-            emitUnauthorizedNavigation();
-          }
-        };
-        // 0.7.7: the loadAck reception is now router-routed. The renderer
-        // handler (`_handleRendererEnvelope`) calls `_dispatchRendererLoadAck`
-        // which invokes the callback below. Origin/source/nonce/placementSessionId
-        // and phase membership are already validated by the router's gate.
-        this._pendingLoadProbe = onAck;
-        timeoutId = setTimeout(() => {
-          cleanup();
-          pendingFirstLoadProbe = false;
-          loadWhileProbePending = false;
-          emitUnauthorizedNavigation();
-        }, 100);
-        try {
-          if (!iframeWindow || typeof iframeWindow.postMessage !== 'function') {
-            throw new Error('renderer contentWindow unavailable');
-          }
-          // 0.7.7 SEC-H1: the outbound `:loadProbe` deliberately omits
-          // `sharcNonce`. The probe is a wakeup ping consumed by the renderer-
-          // injected prelude listener; the inbound `:loadAck` is what the
-          // router authenticates (gate step 7 against `entry.protocolNonce`).
-          // Leaving the derived nonce off the wire here keeps it confidential
-          // from any creative-installed message listener observing the probe.
-          const probeMsg = {
-            type: 'SHARC:Renderer:loadProbe',
-            placementSessionId: this.placementSessionId,
-          };
-          iframeWindow.postMessage(probeMsg, expectedOrigin);
-        } catch (_) {
-          cleanup();
-          pendingFirstLoadProbe = false;
-          loadWhileProbePending = false;
-          emitUnauthorizedNavigation();
-        }
+        runGate();
         return;
       }
-      void loadEvent;
+      // URL variant (no renderer protocol channel): unchanged policy — any
+      // post-render cross-document load is unauthorized navigation.
       emitUnauthorizedNavigation();
     };
     this._rendererBackstopHandler = backstop;
@@ -4808,6 +4900,50 @@ class SHARCContainer {
     // tags keep the failure grep-able across multi-container pages.
     console.warn('[SHARCContainer] [' + this.placementSessionId
       + '] [feature_load_failed] ' + message);
+  }
+
+  /**
+   * Emits a non-terminating `renderer_load_observed` structured security event
+   * (0.7.10 Phase 1). Fired when a post-render renderer-frame `load` event
+   * occurred and the controlled-context gate (loadProbe/loadAck) was answered
+   * within the deadline — SHARC still holds the authenticated protocol channel,
+   * so the ad is kept alive. This is the controlled half of the formerly
+   * blanket-fatal 2118.
+   *
+   * Mirrors `_emitFeatureLoadFailed`'s non-terminating shape: no
+   * `_handleFatalError` tail. The `variant` derivation is identical to the 2118
+   * call site so operators can correlate observed vs. terminating outcomes on
+   * the same discriminator.
+   *
+   * @param {'first' | 'subsequent'} loadKind - Coarse hint distinguishing the
+   *   first verified post-render load from later ones.
+   * @private
+   */
+  _emitRendererLoadObserved(loadKind) {
+    if (this._terminated) return;
+    const variant = (this.creativeSource === 'html') ? 'markup' : 'url';
+    const msSinceRender = (typeof this._renderedAt === 'number')
+      ? Math.max(0, Date.now() - this._renderedAt)
+      : 0;
+    const message = (variant === 'markup' ? 'Renderer' : 'Creative URL')
+      + ' iframe load observed ' + msSinceRender + 'ms post-render; '
+      + 'controlled-context gate answered — ad kept alive.';
+    if (typeof this._onSecurityEvent === 'function') {
+      this._invokeSecurityCallback(/** @type {SHARCSecurityEvent} */ ({
+        type: 'renderer_load_observed',
+        severity: 'info',
+        timestamp: Date.now(),
+        placementSessionId: this.placementSessionId,
+        message: message,
+        details: {
+          variant: variant,
+          msSinceRender: msSinceRender,
+          loadKind: loadKind,
+        },
+      }));
+    }
+    console.info('[SHARCContainer] [' + this.placementSessionId
+      + '] [renderer_load_observed] ' + message);
   }
 
   // -------------------------------------------------------------------------

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -204,6 +204,15 @@ const ErrorCodes = Object.freeze({
   RENDERER_ORIGIN_MISMATCH: 2116,
   RENDERER_PROTOCOL_ERROR: 2117,
   RENDERER_UNAUTHORIZED_NAVIGATION: 2118,
+  // 2121 / 2122: non-terminating post-render-load diagnostics (0.7.10 Phase 1).
+  // These split the formerly blanket-fatal 2118 into observed / blocked /
+  // terminating. They are NOT error codes in the fatal sense — they never reach
+  // `onError`/`_handleFatalError`; they ride the `onSecurityEvent` channel as
+  // non-terminating diagnostics so operators can distinguish a kept-alive
+  // controlled post-render load (2121) and a Phase-2 classified-blocked nav
+  // attempt (2122) from a genuinely-fatal lost-control escape (2118).
+  RENDERER_LOAD_OBSERVED: 2121,
+  RENDERER_NAVIGATION_BLOCKED: 2122,
   // 2119: synchronous postMessage(SHARC:Renderer:render) threw — DataCloneError,
   // null contentWindow, etc. Distinct from 2114 (timeout) for telemetry/alerting
   // accuracy: a transport-layer send failure is not a latency failure.

--- a/test/node/test-creative-sources-load.js
+++ b/test/node/test-creative-sources-load.js
@@ -110,6 +110,13 @@ function assert(condition, message) {
     failures++;
   }
 }
+// 0.7.10 Phase 1: a controlled (answered) post-render load now emits a
+// non-terminating `renderer_load_observed` diagnostic. Tests that previously
+// asserted "no security event" on a clean answered load must filter this benign
+// info event — they are asserting the absence of FATAL signals.
+function fatalEvents(securityEvents) {
+  return securityEvents.filter((e) => e.type !== 'renderer_load_observed');
+}
 function assertDevConsole(condition, message) {
   if (!IS_DEV_BUILD) {
     console.log('  ✓', `${message} (dev-console assertion skipped in prod bundle)`);
@@ -1944,8 +1951,8 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
         'first post-:rendered loadAck resolved a pending probe (rules out routed-but-inert: broken backstop arming)');
       assert(errors.length === 0,
         'first post-:rendered Markup load is verified as document.write completion');
-      assert(securityEvents.length === 0,
-        'first post-:rendered Markup load does not emit unauthorized_navigation');
+      assert(fatalEvents(securityEvents).length === 0,
+        'first post-:rendered Markup load does not emit a FATAL event (renderer_load_observed is the benign Phase-1 diagnostic)');
       // Now simulate the renderer iframe navigating: dispatch the next `load`
       // event. (jsdom never actually navigates the cross-origin iframe; we
       // synthesize the event the browser would have fired.)
@@ -2115,8 +2122,8 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       '14f: first loadAck latched _loadAckConsumed === true');
     assert(container._pendingLoadProbe === null,
       '14f: probe pointer cleared after first ack');
-    assert(errors.length === 0 && securityEvents.length === 0,
-      '14f: first ack is clean (no error, no security event)');
+    assert(errors.length === 0 && fatalEvents(securityEvents).length === 0,
+      '14f: first ack is clean (no error, no FATAL security event — renderer_load_observed is the benign Phase-1 diagnostic)');
 
     // Replay a second loadAck — same well-formed envelope the router accepts.
     window.dispatchEvent(new dom.window.MessageEvent('message', {
@@ -2137,8 +2144,8 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       '14f: second loadAck does NOT re-resolve a probe (latch dropped it before the pointer check)');
     assert(container._terminated === false,
       '14f: second loadAck did not terminate the container');
-    assert(errors.length === 0 && securityEvents.length === 0,
-      '14f: second loadAck altered no state — still no error, no security event');
+    assert(errors.length === 0 && fatalEvents(securityEvents).length === 0,
+      '14f: second loadAck altered no state — still no error, no FATAL security event');
 
     // The backstop must still bite on a genuine post-render navigation.
     iframe.dispatchEvent(new dom.window.Event('load'));
@@ -2221,8 +2228,9 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       '14h: late-but-first loadAck (70ms) STILL resolves the probe — single-consume guard does not reject the legitimate first ack');
     assert(container._loadAckConsumed === true,
       '14h: late-but-first loadAck latched _loadAckConsumed');
-    assert(container._terminated === false && errors.length === 0 && securityEvents.length === 0,
-      '14h: late-but-first ack is the clean document.write completion (no 2118, no timeout)');
+    assert(container._terminated === false && errors.length === 0
+        && fatalEvents(securityEvents).length === 0,
+      '14h: late-but-first ack is the clean document.write completion (no 2118, no timeout — renderer_load_observed is benign)');
   }
 
   // 14i — Fail-for-the-right-reason: with the single-consume latch defeated,
@@ -2340,8 +2348,9 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       '14j: the creative-active first loadAck latched _loadAckConsumed === true');
     assert(container._pendingLoadProbe === null,
       '14j: probe pointer cleared after the creative-active ack resolved it');
-    assert(container._terminated === false && errors.length === 0 && securityEvents.length === 0,
-      '14j: the creative-active first ack is clean (no 2118, no timeout, no termination)');
+    assert(container._terminated === false && errors.length === 0
+        && fatalEvents(securityEvents).length === 0,
+      '14j: the creative-active first ack is clean (no 2118, no timeout, no termination — renderer_load_observed is benign)');
   }
 
   flushContainers();

--- a/test/node/test-creative-sources-load.js
+++ b/test/node/test-creative-sources-load.js
@@ -2005,9 +2005,22 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       'unauthorized_navigation event.timestamp is a number (Date.now)');
   }
 
-  // 14c — If a second iframe load arrives while the first-load probe is
-  //       still pending, latch it and classify it as unauthorized after the
-  //       expected document.write load is verified.
+  // 14c — A second iframe load arriving while the first-load probe is still
+  //       pending is latched. Under Phase 1 (0.7.10), the latched load is NOT
+  //       fatal-on-ack: when the outstanding probe's ack arrives, the gate
+  //       (a) treats the answered probe as a kept-alive load → emits a
+  //       non-terminating `renderer_load_observed`, then (b) RE-GATES for the
+  //       latched load (a fresh probe/ack cycle). No further ack is delivered,
+  //       so the re-gate's own 100ms timeout fires unanswered → LOST CONTROL →
+  //       `unauthorized_navigation` / 2118. The terminating 2118 therefore
+  //       comes from the RE-GATE'S TIMEOUT path, not from the ack path.
+  //
+  //       This test pins that keep-alive-then-re-gate SEQUENCE: a
+  //       `renderer_load_observed` (the answered cycle) MUST be emitted and
+  //       MUST precede the terminating 2118 (the re-gate timeout). Asserting
+  //       only the final error count would pass by coincidence and would not
+  //       notice if the keep-alive/re-gate mechanism regressed back to a
+  //       fatal-on-ack classification.
   {
     const { container, errors, securityEvents } = await buildPostRender();
     const iframe = container._iframe;
@@ -2024,18 +2037,27 @@ console.log('test-creative-sources-load.js — issue #41 Phase B+C regression\n'
       origin: RENDERER_ORIGIN,
       source: iframe.contentWindow,
     }));
+    // Wait past the re-gate's 100ms deadline so the unanswered re-gate times
+    // out (the terminating 2118 arrives via the timeout path, not the ack).
     await new Promise((r) => setTimeout(r, 140));
     const ackCounts = loadAckSpy();
     assert(ackCounts.dispatched === 1,
       'latched-load ack traverses the router → _dispatchRendererLoadAck invoked exactly once');
     assert(ackCounts.resolved === 1,
-      'latched-load ack resolved a pending probe → emits unauthorized_navigation via the ack-driven path, not the 100ms timeout');
+      'the single delivered ack resolved exactly one probe (the first cycle); the re-gate cycle receives no ack and is left to time out');
     assert(errors.length >= 1 && errors[0].code === ErrorCodes.RENDERER_UNAUTHORIZED_NAVIGATION,
-      'load during first-load probe → classified as RENDERER_UNAUTHORIZED_NAVIGATION after ack');
-    assert(securityEvents.some((e) => e.type === 'unauthorized_navigation'),
-      'load during first-load probe → emits unauthorized_navigation');
+      'latched load → after the answered cycle is kept alive, the unanswered re-gate times out → RENDERER_UNAUTHORIZED_NAVIGATION (2118)');
+    // Pin the keep-alive-then-re-gate sequence, not just the final count.
+    const observedIdx = securityEvents.findIndex((e) => e.type === 'renderer_load_observed');
+    const navIdx = securityEvents.findIndex((e) => e.type === 'unauthorized_navigation');
+    assert(observedIdx !== -1,
+      'answered first cycle keeps the ad alive → a non-terminating renderer_load_observed is emitted (proves ack was NOT classified as fatal navigation)');
+    assert(navIdx !== -1,
+      'latched load → unanswered re-gate times out → terminating unauthorized_navigation is emitted');
+    assert(observedIdx !== -1 && navIdx !== -1 && observedIdx < navIdx,
+      'sequence contract: renderer_load_observed (answered cycle) PRECEDES the terminating 2118 (re-gate timeout) — proves keep-alive-then-re-gate, not fatal-on-ack');
     assert(container._terminated === true,
-      'load during first-load probe → container terminated');
+      'latched load → re-gate timeout terminates the container');
   }
 
   // 14d — Backstop detached on _terminate. The iframe is removed from the

--- a/test/node/test-creative-sources.js
+++ b/test/node/test-creative-sources.js
@@ -129,6 +129,13 @@ console.log('test-creative-sources.js — issue #41 Phase A regression\n');
     'RENDERER_UNAUTHORIZED_NAVIGATION === 2118');
   assert(ErrorCodes.RENDERER_INTEGRITY_FAIL === 2120,
     'RENDERER_INTEGRITY_FAIL === 2120');
+  // 0.7.10 Phase 1: the formerly blanket-fatal 2118 is split into observed /
+  // blocked / terminating diagnostics. 2121 (observed) and 2122 (blocked) are
+  // non-terminating; 2118 stays as the narrowed lost-control terminating code.
+  assert(ErrorCodes.RENDERER_LOAD_OBSERVED === 2121,
+    'RENDERER_LOAD_OBSERVED === 2121 (non-terminating, Phase 1)');
+  assert(ErrorCodes.RENDERER_NAVIGATION_BLOCKED === 2122,
+    'RENDERER_NAVIGATION_BLOCKED === 2122 (non-terminating, reserved for Phase 2)');
 }
 
 // -- 1b. _validateCreativeSources direct unit surface (#64) ────────────────

--- a/test/node/test-renderer-postrender-load-policy.js
+++ b/test/node/test-renderer-postrender-load-policy.js
@@ -222,6 +222,8 @@ console.log('test-renderer-postrender-load-policy.js — #321 reframed, Decision
       'renderer_load_observed carries a details.loadKind hint');
     assert(ev.errorCode === undefined,
       'renderer_load_observed is non-terminating (no errorCode)');
+    assert(ev.details?.code === protoMod.ErrorCodes.RENDERER_LOAD_OBSERVED,
+      'renderer_load_observed carries details.code === 2121 for numeric telemetry symmetry (NOT promoted to top-level errorCode)');
   }
   if (!c._terminated) c._terminate();
 }

--- a/test/node/test-renderer-postrender-load-policy.js
+++ b/test/node/test-renderer-postrender-load-policy.js
@@ -262,6 +262,69 @@ console.log('test-renderer-postrender-load-policy.js — #321 reframed, Decision
   if (!c._terminated) c._terminate();
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// URL VARIANT (fail-closed) — Phase 1 changes NOTHING for the Creative URL
+// variant. A plain creative-URL document has no SHARC prelude to answer a
+// probe, so `_armRendererBackstop()` is armed WITHOUT `verifyFirstLoad`
+// (gateEveryLoad === false). In that branch the backstop never runs a
+// probe/ack round-trip: any subsequent post-render load terminates IMMEDIATELY
+// with 2118 unauthorized_navigation (fail-closed). The gate-every-load model
+// (sections 3–4 above) is Markup-only; this section pins that the URL branch's
+// pre-existing fail-closed contract is untouched by Phase 1.
+//
+// The policy file's `rendered()` helper builds Markup-variant containers only,
+// so this section uses its own URL-variant harness (mirrors `buildPostUrlLoad`
+// in test-creative-sources-load.js section 18): a `creativeUrl` container whose
+// first iframe `load` arms the backstop without verifyFirstLoad, exercising the
+// `gateEveryLoad === false` path directly in this policy-focused file.
+// ────────────────────────────────────────────────────────────────────────────
+{
+  console.log('\n5. URL variant: subsequent post-render load terminates 2118 immediately (fail-closed; gateEveryLoad === false)');
+  const errors = [];
+  const securityEvents = [];
+  const c = new SHARCContainer({
+    creativeUrl: 'https://ads.example/creative.html',
+    placementElement: freshSlot(),
+    onError: (code, msg) => errors.push({ code, msg }),
+    onSecurityEvent: (ev) => securityEvents.push(ev),
+  });
+  c.load();
+  // URL variant wires MessageChannel 200ms after load into the real
+  // contentWindow; stub postMessage so that deferral is inert under test.
+  c._iframe.contentWindow.postMessage = () => {};
+  // First iframe load: the URL variant's load listener arms the backstop
+  // synchronously WITHOUT verifyFirstLoad ⇒ gateEveryLoad === false.
+  c._iframe.dispatchEvent(new dom.window.Event('load'));
+  await sleep(10);
+
+  assert(c.creativeSource === 'url',
+    'precondition: URL variant (creativeSource === "url")');
+  assert(typeof c._rendererBackstopHandler === 'function',
+    'precondition: backstop armed after first URL-variant load');
+
+  // Second post-render load. No loadProbe is posted for the URL variant — the
+  // backstop's gateEveryLoad === false branch fires 2118 directly.
+  c._iframe.dispatchEvent(new dom.window.Event('load'));
+  await sleep(60);
+
+  const got2118 = errors.some((e) =>
+    e.code === protoMod.ErrorCodes.RENDERER_UNAUTHORIZED_NAVIGATION)
+    || securityEvents.some((e) => e.type === 'unauthorized_navigation');
+  assert(got2118,
+    'URL variant subsequent post-render load terminates 2118 (fail-closed, no probe)');
+  assert(c._terminated === true,
+    'URL variant container terminates on the subsequent load (gateEveryLoad === false path)');
+  // Meaningfulness pin: a probe/ack round-trip was NOT used — no pending probe
+  // and the per-cycle latch was never touched, distinguishing the fail-closed
+  // URL path from the Markup gate-every-load path (sections 3–4).
+  assert(c._pendingLoadProbe == null,
+    'URL variant never armed a loadProbe (no controlled-context gate on this branch)');
+  const navEvent = securityEvents.find((e) => e.type === 'unauthorized_navigation');
+  assert(navEvent && navEvent.details && navEvent.details.variant === 'url',
+    'URL variant 2118 carries details.variant === "url" (distinct from Markup gate path)');
+  if (!c._terminated) c._terminate();
+}
+
 if (failures === 0) {
   console.log('\n✓ All post-render-load-policy assertions passed.');
   process.exit(0);

--- a/test/node/test-renderer-postrender-load-policy.js
+++ b/test/node/test-renderer-postrender-load-policy.js
@@ -77,6 +77,21 @@ function freshSlot() {
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// Answers the most-recently-armed loadProbe by dispatching an authentic
+// :loadAck envelope through the router (source/origin/nonce/placementSessionId
+// match — exactly what a re-injected renderer prelude would post).
+function answerLoadProbe(c) {
+  window.dispatchEvent(new dom.window.MessageEvent('message', {
+    data: {
+      type: 'SHARC:Renderer:loadAck',
+      placementSessionId: c.placementSessionId,
+      sharcNonce: c._rendererProtocolNonce,
+    },
+    origin: RENDERER_ORIGIN,
+    source: c._iframe.contentWindow,
+  }));
+}
+
 async function rendered() {
   const errors = [];
   const securityEvents = [];
@@ -161,6 +176,87 @@ console.log('test-renderer-postrender-load-policy.js — #321 reframed, Decision
     'ack\'d same-origin reopen produces no fatal error (neither 2118 nor 2114)');
   assert(c._terminated !== true,
     'container survives an ack\'d same-origin reopen');
+  if (!c._terminated) c._terminate();
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// PHASE 1 — Reduction #1: a SECOND post-render same-frame reopen whose prelude
+// answers :loadAck must keep the container alive and emit a NON-terminating
+// `renderer_load_observed` diagnostic.
+//
+// RED on main: the subsequent-load branch (`:4542`) fires 2118 UNCONDITIONALLY
+// — the second load never gets a probe/ack round-trip, so it terminates.
+// GREEN after fix: every post-render load runs the controlled-context gate;
+// answered ⇒ keep-alive + `renderer_load_observed`.
+// ────────────────────────────────────────────────────────────────────────────
+{
+  console.log('\n3. Second answered reopen → keep-alive + renderer_load_observed (Phase 1; RED on main)');
+  const { c, errors, securityEvents } = await rendered();
+  assert(c.creativeRendered === true, 'precondition: rendered');
+
+  // First post-render load — answered.
+  c._iframe.dispatchEvent(new dom.window.Event('load'));
+  answerLoadProbe(c);
+  await sleep(150);
+  assert(c._terminated !== true, 'survives first answered reopen');
+
+  // Second post-render load — also answered. This is the corpus pattern.
+  c._iframe.dispatchEvent(new dom.window.Event('load'));
+  answerLoadProbe(c);
+  await sleep(300);
+
+  const got2118 = errors.some((e) =>
+    e.code === protoMod.ErrorCodes.RENDERER_UNAUTHORIZED_NAVIGATION)
+    || securityEvents.some((e) => e.type === 'unauthorized_navigation');
+  assert(!got2118, 'no 2118 on a second ANSWERED reopen');
+  assert(c._terminated !== true, 'container survives a second answered reopen');
+
+  const observed = securityEvents.filter((e) => e.type === 'renderer_load_observed');
+  assert(observed.length >= 1,
+    'emits non-terminating renderer_load_observed for the kept-alive load');
+  if (observed.length >= 1) {
+    const ev = observed[observed.length - 1];
+    assert(typeof ev.details?.msSinceRender === 'number',
+      'renderer_load_observed carries details.msSinceRender');
+    assert(typeof ev.details?.loadKind === 'string',
+      'renderer_load_observed carries a details.loadKind hint');
+    assert(ev.errorCode === undefined,
+      'renderer_load_observed is non-terminating (no errorCode)');
+  }
+  if (!c._terminated) c._terminate();
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// 2118 DIAGNOSTIC SPLIT (do-not-delete-2118): a subsequent load whose probe is
+// UNANSWERED still terminates with unauthorized_navigation / 2118.
+// GREEN both ways — pins that the genuinely-fatal lost-control case survives the
+// split. The narrowed 2118 must still fire for lost control.
+// ────────────────────────────────────────────────────────────────────────────
+{
+  console.log('\n4. Subsequent UNANSWERED reopen still terminates 2118 (lost control; split-guard)');
+  const { c, errors, securityEvents } = await rendered();
+  assert(c.creativeRendered === true, 'precondition: rendered');
+
+  // First post-render load — answered, ad kept alive.
+  c._iframe.dispatchEvent(new dom.window.Event('load'));
+  answerLoadProbe(c);
+  await sleep(150);
+  assert(c._terminated !== true, 'survives first answered reopen');
+
+  // Second post-render load — NO ack (controlled document replaced by an
+  // uncontrolled external webpage with no prelude). Must terminate.
+  c._iframe.dispatchEvent(new dom.window.Event('load'));
+  // 100ms probe deadline + _handleFatalError's async sendFatalError tail; the
+  // stubbed protocol channel falls back to the 1s force-terminate, so wait past
+  // it to observe the terminal flag deterministically.
+  await sleep(1200);
+
+  const got2118 = errors.some((e) =>
+    e.code === protoMod.ErrorCodes.RENDERER_UNAUTHORIZED_NAVIGATION)
+    || securityEvents.some((e) => e.type === 'unauthorized_navigation');
+  assert(got2118,
+    'unanswered subsequent reopen still terminates unauthorized_navigation/2118');
+  assert(c._terminated === true, 'lost-control subsequent load terminates the container');
   if (!c._terminated) c._terminate();
 }
 


### PR DESCRIPTION
## #321 Phase 1 — gate every post-render load on the controlled-context probe

**Stops destroying valid ad loads** (the second half of the fix; Phase 1a / the `omid-active` phase fix shipped in #330).

### Problem
The navigation backstop fired `2118 unauthorized_navigation` **unconditionally** on every post-render renderer-frame load after the first — terminating ads SHARC still controlled (standard `document.write`/reopen/measurement bootstraps).

### Change (Decision 2, Phase 1 — see `docs/design/0.7.10-post-render-nav-policy-omid-phase.md`)
- `_armRendererBackstop`: a reusable `runGate()` runs the **same** `loadProbe`/`loadAck` controlled-context gate on **every** post-render load (not just the first). Answered within deadline ⇒ keep ad alive + non-terminating `renderer_load_observed`; unanswered ⇒ `2118` (now narrowed to genuine lost-control). A load arriving while a probe is pending is latched and re-gated on resolve (double-load defense preserved). URL-variant policy unchanged.
- **`2118` split (not deleted):** `RENDERER_LOAD_OBSERVED` (2121, non-terminating) / `RENDERER_NAVIGATION_BLOCKED` (2122, reserved for Phase 2) / `unauthorized_navigation` (2118, narrowed to lost-control; grep-stable signal preserved).
- `_loadAckConsumed` single-consume latch (#269) made per-probe-cycle (reset on arming a fresh probe); within-cycle replay defense preserved.

### Security
Authentication unchanged — source/origin/HMAC-nonce/placementSessionId gate runs identically on every cycle; lost-control still terminates on every cycle (3 paths). Anti-forgery (`rendered`/`failed`/`render`) untouched; no router/nonce/wire change. Posture moves fail-closed-blanket → **gated-fail-open** (ratified: ADR STOP-AND-ASK #2).

### Reviews
Code Reviewer + Security Engineer — both SHIP, 0 blocking. All 5 security threat categories cleared (esp. cross-cycle replay — the router nonce+origin gate, unchanged, is the anti-replay primitive; the latch was always within-cycle). Review nits folded (`8ba528d`→ rebased): 14c contract pinned (assert `renderer_load_observed` precedes `2118`), probe-timer lifecycle tidied, `2121` surfaced in `details`.

### Scope / follow-ups
Phase 1 only. Phase 2 (behavior classification — reductions #3/#4, the reserved `2122`) and the answered-probe-cycle ceiling (**#332**) are tracked separately. MRAID-interstitial→viewable reduction is validator/puppeteer-tier (not node-expressible) — follow-up.

Full `test:all:built` green; RED→GREEN on the Phase-1 reductions + diagnostic split; regression guards (native/plain-HTML not fatal; genuine lost-control still 2118).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
