### PR TITLE
docs: land state-delivery contract + R1 ADR + lifecycle audit (0.7.10)

### DIFF
--- a/docs/design/0.7.10-lifecycle-state-mapping-audit.md
+++ b/docs/design/0.7.10-lifecycle-state-mapping-audit.md
@@ -1,0 +1,306 @@
+# SHARC Cross-Surface Lifecycle + State-Transition Mapping & Audit
+
+**Date:** 2026-06-07
+**Author:** Software Architect (Dev Team)
+**Type:** Research + Design reference artifact (NO code changes)
+**Baseline:** fresh worktree on `origin/main` @ `033a2d2` (post #322/#330/#333; #334 in-flight on `fix/334-mraid-visibility-seed`)
+**Scope:** canonical lifecycle ordering across six surfaces, the legal SHARC state graph (cycles + HIDDEN/FROZEN), a per-surface state map, and a code audit against both. Synthetic/aggregate reasoning only — no DV corpus data reproduced.
+
+---
+
+## 0. Thesis
+
+The bugs we have been fixing reactively (#322 load race, #330 `omid-active` phase gap, #333 post-render backstop, #334 MRAID visibility seed, #335 readiness timing, #336 container-active-delivery) are **one class with two roots**:
+
+1. **No state replay / no current-state push.** SHARC's container→creative state channel (`sendStateChange`) is **edge-triggered only**. The creative-side pub/sub (`sharc-creative.js`) and every creative-side bridge (`mraid`, `safeframe`) is a **late subscriber** that gets **no replay** of the current state. Any transition that fires before the subscriber attaches — or that is *suppressed because the container is already in that state* — is lost forever. This is the #334/#335/#336 root.
+
+2. **A single "current phase" / single "current state" with shadowing and no oscillation modeling.** The router has exactly one `_currentPhase` that, once it enters `omid-active`, permanently shadows `creative-active`. The state machine has one `state` with a transition table that **omits the direct ACTIVE→FROZEN edge and conflates bfcache with OS-freeze into one FROZEN**. Signals that arrive in the "wrong" phase are dropped (the #330 class), and oscillating transitions (ACTIVE↔FROZEN↔ACTIVE) round-trip through transient states that emit spurious signals or skip needed ones.
+
+Everything below maps the canonical truth, then audits the code against it.
+
+---
+
+## 1. Cross-Surface Handshake / Event Ordering Map
+
+### 1.1 The canonical bootstrap chain (happy path, SHARC-aware creative, URL variant)
+
+```
+Browser                Container (publisher frame)          Creative iframe
+───────                ───────────────────────────          ───────────────
+DOMContentLoaded
+  │
+  │  publisher calls container.load()
+  │       │ _createIframe()  → state = LOADING, router phase = init
+  │       │ adapter.attach() (IntersectionObserver + load + bfcache wires)
+  │       ▼
+iframe `load` ──────►  router.transitionTo('rendered')
+                       _renderedAt = now
+                       _armRendererBackstop()
+                       setTimeout(200ms) → initChannel(contentWindow)
+                            │  postMessage 'SHARC:Container:handshake' + port2
+                            ▼
+                                              ─────────────► creative proto.init()
+                                                             _onBootstrapMessage → _attachPort(port2)
+                                                             createSession() (waits on portReadyPromise)
+                       acceptSession() ◄───── SHARC:Creative:createSession
+                       sessionId set
+                       sendInit(env, features) ───────────► ContainerMessages.INIT
+                                                             onReady(env) callback runs
+                                                               ↳ MRAID/SafeFrame bridge SUBSCRIBES here
+                                                               ↳ MRAID emits ready + stateChange('default')
+                       _handleInitResolved ◄──────────────── resolve(INIT)
+                         setState(READY) → sendStateChange('ready')  [creative-queryable]
+                         autoStart → _sendStartCreative()
+                       sendStartCreative() ────────────────► START_CREATIVE
+                                                             onStart() runs
+                       _handleStartCreativeResolved ◄─────── resolve(START)
+                         iframe.style.display = 'block'
+                         _transitionToActive()
+                           setState(ACTIVE)
+                             → router.transitionTo('creative-active')   [phase]
+                             → sendStateChange('active') ─────► STATE_CHANGE('active')
+                                                             creative SHARC.on('stateChange') fires
+                                                               ↳ MRAID: _isViewable false→true → viewableChange(true)
+                                                               ↳ SafeFrame: first geom-update
+                             → onChange → OMID.onContainerStateChange('active')
+                                 _createSessionWhenReady() → AdSession.start()
+                                   → _signalOmidPhase('omid-active') → router phase = omid-active
+                                   → _relayOmidEvent('sessionStart')
+                                 _fireLoaded() / _fireImpression() (one-shot latches)
+```
+
+**Handoff points (where one surface's signal becomes another's trigger):**
+
+| From | Signal | To | Becomes |
+|------|--------|----|---------|
+| Browser | iframe `load` | Container | `router → rendered`, arm backstop, schedule `initChannel` |
+| Container | `initChannel` postMessage + port2 | Creative proto | `_attachPort`, unblock `createSession` |
+| Creative | `createSession` | Container | `acceptSession`, sessionId established |
+| Container | `Container:init` resolve | Container | `setState(READY)`, `_sendStartCreative` |
+| Creative | `onReady(env)` | MRAID/SafeFrame bridge | **bridge subscribes** + emits `ready`/`default` |
+| Container | `setState(ACTIVE)` | Creative + OMID | `stateChange('active')` to creative; `onChange`→OMID session start |
+| Creative | `stateChange('active')` | MRAID/SafeFrame | `viewableChange(true)` / first `geom-update` |
+| OMID | `AdSession.start()` success | Container | `transitionTo('omid-active')`, relay `sessionStart` |
+| OMID | `AdSession.finish()` | Container | `transitionTo('omid-finishing')`, relay `sessionFinish` |
+
+### 1.2 Per-surface event order requirements
+
+**Web/browser (authoritative for visibility + bfcache):**
+- `DOMContentLoaded` → document `load` → iframe `load`. The iframe `load` can fire **0, 1, or N times** (URL variant: 1 expected; Markup variant: 2 — renderer-doc then `document.write`; backstop catches N≥2).
+- `IntersectionObserver` callback: may fire **before or after** iframe `load`; the adapter coalesces via a microtask. Order is non-deterministic — this is the #322 race surface.
+- `visibilitychange`: can fire `hidden` without a preceding `blur` (mobile backgrounding) — container handles ACTIVE→HIDDEN directly.
+- **bfcache** (`pagehide`/`pageshow` with `persisted: true`): document is frozen wholesale. `performance.now()` and timers freeze. MessageChannel/BroadcastChannel are **closed by bfcache**. This is why post-restore the protocol channel may be dead.
+- `freeze`/`resume` (Page Lifecycle API): OS-suspends JS. Distinct event from bfcache but mapped to the **same** FROZEN state.
+
+**SHARC container states + router phases** (two independent state spaces):
+- Container states: `loading → ready → active ⇄ passive ⇄ hidden → frozen → (active/passive/hidden) … → terminated`.
+- Router phases (monotonic, single-current): `init → attaching-renderer → rendered → creative-active → omid-active → omid-finishing → terminated`. **Phases never oscillate** (by design — RTR § 4.3); states do.
+- Renderer handshake (Markup variant): `render`(out) → `rendered`(in) | `failed`(in); then `loadProbe`(out) → `loadAck`(in) per post-render load cycle.
+
+**MRAID 3.0** (creative-side bridge): `loading → default` on `ready`; `viewableChange(isViewable)` on viewability flips; `exposureChange` for partial visibility (NOT implemented — see audit F8); states `loading/default/expanded/resized/hidden`; `audioVolumeChange`. MRAID spec requires `viewableChange` be fired after `ready` to communicate initial viewability.
+
+**SafeFrame** (creative-side bridge): `$sf.ext.register(w,h,cb)` → host fires `geom-update`/`focus-change`/`expand`/`collapse` status callbacks. `$sf.host` intentionally absent (SHARC replaces it). First `geom-update` fires on `stateChange('active')`.
+
+**OMID** (publisher-frame bridge + iframe shim): OM SDK service script MUST load before `AdSession`. `registerSessionObserver` may be called by a verification script **before** `start()` — shim queues, posts `Register` only at `sessionStart`. Order: `start()` → `loaded()` → `impression()` → `geometryChange`/`stateChange` → `finish()`. `sessionFinish` has a ~1.5s grace window (`omid-finishing`).
+
+**HTML adapter (0.7.2):** `LOADING→ACTIVE` gated on (iframe `load` AND intersection ≥ 0.5) in permissive mode; yields to handshake in strict mode. Visibility toggles `ACTIVE⇄PASSIVE⇄HIDDEN`; bfcache/freeze → `*→FROZEN` (walks through HIDDEN).
+
+---
+
+## 2. The Legal State-Transition Graph (with cycles + FROZEN)
+
+### 2.1 The graph as the code currently defines it (`STATE_TRANSITIONS`, `sharc-protocol.js:148-160`)
+
+```
+                 ┌──────────────────────────── TERMINATED (terminal, no out-edges)
+                 │            ▲   ▲   ▲   ▲   ▲
+   LOADING ──────┤            │   │   │   │   │
+     │  │  └─► ACTIVE ────────┘   │   │   │   │
+     │  └────► READY ──► ACTIVE   │   │   │   │
+     ▼            (READY→ACTIVE)  │   │   │   │
+   (LOADING→READY|ACTIVE|TERM)    │   │   │   │
+                                  │   │   │   │
+   ACTIVE  ──► PASSIVE ──► ACTIVE │   │   │   │   (oscillation: focus blur/regain)
+   ACTIVE  ──► HIDDEN            ─┘   │   │   │
+   PASSIVE ──► HIDDEN ───────────────┘   │   │
+   HIDDEN  ──► PASSIVE ──► ACTIVE        │   │   (oscillation: scroll in/out)
+   HIDDEN  ──► FROZEN ───────────────────┘   │
+   FROZEN  ──► ACTIVE | PASSIVE | HIDDEN ─────┘   (restore from freeze/bfcache)
+```
+
+**Repeatable (oscillating) edges — marked `↻`:**
+- `↻ ACTIVE → PASSIVE → ACTIVE` (focus blur ↔ regain)
+- `↻ ACTIVE → HIDDEN → PASSIVE → ACTIVE` (scroll off ↔ on screen, mobile background ↔ foreground)
+- `↻ HIDDEN → FROZEN → {ACTIVE|PASSIVE|HIDDEN}` (freeze/bfcache enter ↔ restore, repeatable any number of times)
+- Full cycle: `PASSIVE → ACTIVE → HIDDEN → FROZEN → ACTIVE → … → TERMINATED`
+
+**Terminal / one-way edges:**
+- `* → TERMINATED` — one-way, no return. Reachable from every non-terminal state.
+- `LOADING → READY` / `LOADING → ACTIVE` — one-way bootstrap (never return to LOADING).
+- `READY → ACTIVE` — one-way (never return to READY).
+
+### 2.2 Gaps in the legal graph (architectural findings, not yet bugs)
+
+**G-A. No direct `ACTIVE → FROZEN` edge.** The table only has `HIDDEN → FROZEN`. So a page that goes ACTIVE → bfcache must be walked `ACTIVE → HIDDEN → FROZEN` (the HTML adapter does exactly this, `html-adapter.js:556-562`). **Consequence:** every bfcache/freeze entry from a visible state emits a **spurious transient `stateChange('hidden')`** to the creative before `frozen`. The bf-2 test contract (`LOADING→ACTIVE→HIDDEN→FROZEN`, bfcache doc line 110) **ratifies this as intended** — but it means measurement bridges see a phantom "went off-screen" event on every freeze. (See F5.)
+
+**G-B. No direct `READY → FROZEN`/`READY → HIDDEN`.** A bfcache during handshake (permissive) forces `READY → ACTIVE → HIDDEN → FROZEN` (adapter walks it). In strict mode the adapter no-ops (yields to handshake). The narrow `frozen → ready` invalid-transition warn is documented and accepted (`sharc-container.js:3671-3678`).
+
+**G-C. `LOADING → HIDDEN`/`LOADING → FROZEN` not direct.** Permissive adapter promotes `LOADING → ACTIVE` first, then walks down. Means a never-visible permissive creative still emits a transient `active` it never deserved.
+
+### 2.3 HIDDEN vs FROZEN — the central distinction
+
+**SHARC currently CONFLATES bfcache and OS-freeze into one FROZEN state.** Confirmed:
+- `ContainerStates.FROZEN = 'frozen'` with the doc comment *"OS has suspended JS execution"* (`sharc-protocol.js:128`).
+- The HTML adapter maps **both** `pagehide(persisted:true)` (bfcache) **and** `freeze` (OS Page-Lifecycle) to the **same** `_transitionToFrozen()` (`html-adapter.js:442-471`).
+- The bfcache design doc (`0.7.6-bfcache-puppeteer-wiring.md`) explicitly says *"No production code touched"* — the bfcache roundtrip rides the existing FROZEN state; there is no distinct BFCACHED state.
+
+| Dimension | HIDDEN | FROZEN (today: bfcache **and** OS-freeze) |
+|-----------|--------|-------------------------------------------|
+| Page alive? | Yes — page live, ad offscreen | No — JS suspended (freeze) OR document parked (bfcache) |
+| Authoritative signal | `IntersectionObserver` ratio 0 / `visibilitychange:hidden` | `pagehide persisted` (bfcache) / `freeze` (OS) |
+| JS executing? | Yes | No |
+| MessageChannel alive? | Yes | **bfcache: NO (closed by bfcache)**; OS-freeze: suspended, resumes |
+| Timers/RAF | Running | Suspended |
+| Creative should… | pause heavy work, keep state | not rely on `frozen` callback (may not run) |
+| OMID | `notVisible` (session survives) | `notVisible` (session survives across both) |
+| MRAID | viewableChange(false) | **suppressed** (`sharcState !== 'frozen'` guard) |
+
+**Recommendation on FROZEN modeling:** Keep ONE unified `FROZEN` state for the *creative-facing* contract — the creative cannot tell the difference and shouldn't (both mean "JS may be suspended, don't rely on me running"). The MRAID/OMID handling that suppresses spurious events during frozen is correct. **BUT** the **container** must distinguish them internally for one reason: **bfcache closes the MessageChannel and the router `window.message` listener survives but the port is dead.** On bfcache **restore**, the protocol channel may be broken, yet the container will happily `setState(ACTIVE)` and `sendStateChange('active')` into a dead port — the creative never receives it. OS-freeze/resume does NOT have this problem (the port resumes). This divergence is **unaudited and untested end-to-end** (bfcache restore is Chrome-only, the Puppeteer harness from 0.7.6 covers state transitions but not channel liveness). **Do not add a BFCACHED creative-facing state; do add internal bfcache-restore channel-liveness handling** (see Rec R3).
+
+---
+
+## 3. Per-Surface State Mapping Table
+
+How each surface's native state maps to the unified SHARC container state, and **which surface is authoritative** for each transition.
+
+| Unified SHARC | Browser signal | Router phase | MRAID state / viewable | SafeFrame | OMID session | HTML adapter | Authoritative for |
+|---------------|----------------|--------------|------------------------|-----------|--------------|--------------|-------------------|
+| LOADING | pre-load | `init` | `loading` / false | `loading` (geom zeroed) | not started | gate closed | container (bootstrap) |
+| READY | init resolved | `init`→(stays) | `default` / false | `loading`→ first geom on active | `_createSessionWhenReady` armed | n/a (handshake owns) | container |
+| ACTIVE | visible+focused; IO≥0.5 | `creative-active` then `omid-active` | `default` / **true** | `default`, geom-update, focus-change | started → loaded → impression → visible | promotes from LOADING/PASSIVE/HIDDEN | **browser** (visibility) + container (bootstrap) |
+| PASSIVE | visible, unfocused; 0<IO<0.5 | (unchanged) | `default` / false | `default`, focus-change(false) | `notVisible` | demote from ACTIVE | **browser** (focus/IO) |
+| HIDDEN | IO=0 / `visibilitychange:hidden` | (unchanged) | `default` / false (viewableChange false) | geom in-view=0 | `notVisible` | `*→HIDDEN` | **browser** (IO/visibility) |
+| FROZEN | `pagehide persisted` / `freeze` | (unchanged) | (events **suppressed**) | (geom-update **suppressed**) | `notVisible` (survives) | `*→FROZEN` via HIDDEN | **browser** (bfcache/freeze) |
+| TERMINATED | — | `terminated` | mapped to `hidden` (warn) | — | `finish()` | detach | **container** |
+
+**Key divergences (surface state ≠ unified state):**
+- **D-1 (#336):** When the HTML adapter promotes `LOADING→ACTIVE` and the handshake completes *after*, `_transitionToActive` **skips** `setState(ACTIVE)` (already ACTIVE) → no `stateChange('active')` to the late-subscribing creative. MRAID stays `isViewable=false` while unified state is ACTIVE.
+- **D-2 (#335):** Cases that never reach `onReady` keep MRAID at `loading` while the unified container may already be ACTIVE (permissive adapter). MRAID state diverges because the handshake (its only `default` trigger) never completes in-window.
+- **D-3 (OMID phase vs container state):** Once `omid-active`, the router phase is **decoupled** from container state — ACTIVE→PASSIVE→ACTIVE oscillation does NOT change the phase (correct, by design), but it means the phase is no longer a proxy for visibility.
+
+---
+
+## 4. Audit Findings (ranked)
+
+Severity: **P0** = creative-visible measurement/render failure; **P1** = wrong/missing signal under a real oscillation; **P2** = spurious signal / cosmetic; **P3** = latent / spec-silent.
+
+### F1 — [P0, EXPLAINS #336] Already-ACTIVE skip suppresses `stateChange('active')` to late subscribers
+**File:** `src/sharc-container.js:3777-3783` (`_transitionToActive`) + `:1759-1761` (send gate) + `:3683-3692` (`_handleInitResolved` skip).
+**Bad transition:** Adapter drives `LOADING→ACTIVE` (permissive) before handshake. Late handshake's `_transitionToActive` finds state already ACTIVE → skips `setState` → `onChange` never fires → `sendStateChange('active')` never sent. The creative-side bridge that subscribed in `onReady` (which ran *after* the promotion) never receives `active`.
+**Symptom:** MRAID `getState()==='default'` but `isViewable()===false` forever; OMID `onContainerStateChange('active')` never re-fires (loaded/impression rely on it, though they have a separate `getContainerState` fallback path); SafeFrame never fires first `geom-update`. DV visual sample stuck at `default + false`.
+**This is #336, filed.** #334 ships the bridge-local mitigation (bridge reads `getContainerState()` on install). F1 is the source-side root.
+
+### F2 — [P0, EXPLAINS #334] No state replay in creative pub/sub for late subscribers
+**File:** `src/sharc-creative.js:485-498` (`on()` — no replay) + `:222-224` (STATE_CHANGE listener) ; MRAID `src/sharc-mraid-bridge.js:466-488`, SafeFrame `src/sharc-safeframe-bridge.js:332-356`.
+**Bad ordering:** `SHARC.on('stateChange', …)` registered after a state was emitted gets no replay. Both creative-side bridges subscribe inside `onReady` and seed `_isViewable=false`; the only path to `viewableChange(true)` is a *subsequent* `stateChange('active')` flip. If `active` was emitted before subscription (F1) OR coalesced into the same tick, the flip is lost.
+**Symptom:** Same as F1 — `viewableChange(true)` / first `geom-update` never fires.
+**This is #334, in-flight.** The bridge-local fix (proactive `getContainerState()` read) is correct but is a workaround; the architectural fix is replay (Rec R1).
+
+### F3 — [P0/P1, EXPLAINS #330 — SHIPPED, regression-guard] Renderer `loadAck`/`loadProbe` out-of-phase under `omid-active`
+**File:** `src/sharc-container.js:1319-1321` (phase membership now includes `omid-active`/`omid-finishing`).
+**Status:** **Fixed in #330** (`d018117`). The map confirms the mechanism: `setState`'s phase-shadow guard (`:1754-1757`) parks the router in `omid-active`, which (pre-fix) made every authentic `loadAck` out-of-phase → 100ms probe deadline → blanket-fatal `2118`. The current membership is the correct minimal fix. **Audit confirms `rendered`/`failed`/`render` remain locked to `attaching-renderer` only** (`:1317-1320`) — anti-forgery preserved. No new action; this is the canonical example of the #330 class.
+
+### F4 — [P1, NEW] Hard-terminate relays `sessionFinish` after the router is already `terminated` + destroyed (OMID design R1, present on main)
+**File:** `src/sharc-container.js:4365-4367` then `:4385` (`_notifyExtensionsLifecycle('destroy')`) vs OMID `src/sharc-omid-bridge.js:1202-1231`.
+**Bad ordering:** `_terminate()` calls `protocolRouter.transitionTo('terminated')` AND `protocolRouter.destroy()` at 4366-4367, **before** firing `destroy` to extensions at 4385. OMID's `destroy` → `_finishSession()` → `_signalOmidPhase('omid-finishing')` (resets `_currentPhase` back) → `_relayOmidEvent('sessionFinish')` via `buildOutbound`. But the router's `window.message` listener is already detached, and the phase was just `terminated`. The terminal `sessionFinish` Event is relayed into a torn-down router.
+**Symptom:** On a **fatal-error / hard-terminate** path (not graceful close), the final OMID `sessionFinish` may not reach the iframe shim → vendor never sees clean session end → possible measurement-session leak / "session never finished" in vendor telemetry. The graceful `close()` path that finishes OMID *before* `_terminate` is unaffected.
+**This is OMID design Risk R1, and it is LIVE on main.** The 0.7.8 design says "ensure teardown enters `omid-finishing` and flushes `sessionFinish` **before** `terminated`." Current ordering does the opposite. **NEW — not filed** (R1 is noted in the 0.7.8 *design* as a to-pin test, but no issue exists against the shipped ordering).
+
+### F5 — [P2, NEW] Spurious transient `stateChange('hidden')` on every bfcache/freeze entry from a visible state
+**File:** `src/lifecycle-adapters/html-adapter.js:556-562` (`_transitionToFrozen` walks ACTIVE→HIDDEN→FROZEN) — forced by missing `ACTIVE→FROZEN` edge (G-A).
+**Bad transition:** Because `STATE_TRANSITIONS` has no `ACTIVE→FROZEN`, the adapter emits `setState(HIDDEN)` then `setState(FROZEN)`. The HIDDEN emission is a real `stateChange('hidden')` to the creative.
+**Symptom:** On every bfcache entry, MRAID fires `viewableChange(false)` (the HIDDEN flips viewable false — `frozen` is suppressed but HIDDEN is not), SafeFrame fires a `geom-update` with in-view=0, then both go quiet on FROZEN. A measurement vendor sees a phantom "scrolled off-screen" immediately before freeze. Low harm (the ad IS going non-visible) but it is a fabricated intermediate state, and it muddies viewability-duration accounting.
+**NEW — not filed.** Mitigation: either add a direct `ACTIVE→FROZEN` (and `PASSIVE→FROZEN`) edge, or have the adapter suppress the intermediate stateChange. Prefer the edge (Rec R2).
+
+### F6 — [P1, NEW] Re-ACTIVE after FROZEN does not re-assert OMID viewable when state was already reconciled
+**File:** `src/sharc-container.js:5085-5099` (`_onResume`) + `html-adapter.js:570-592` (`_transitionFromFrozen`) + OMID `:692-712`.
+**Bad oscillation:** Two FROZEN-restore drivers exist — the container's `_onResume` (focus/visibility based) AND the adapter's `_transitionFromFrozen` (intersection based) AND `_onPageshow`. On restore they can **both** run. The container's `_onResume` may resolve FROZEN→PASSIVE (no focus), then the adapter's `_onResume` augments PASSIVE→ACTIVE. Each `setState(ACTIVE)` fires `onChange`→OMID `onContainerStateChange('active')`→`_signalVisibility('visible')`. Fine. **BUT** if `_transitionFromFrozen` resolves directly FROZEN→ACTIVE while the container's `_onResume` *already* moved FROZEN→ACTIVE, the second `setState(ACTIVE)` is a no-op (already ACTIVE) → no `onChange` → if `lastVisibilityState` was somehow left at `visible` (e.g. the freeze never drove `notVisible` because the freeze came from a state where OMID was already notVisible), `_signalVisibility('visible')` early-returns and OMID never re-asserts VISIBLE.
+**Symptom:** After a bfcache round-trip, OMID can be stuck reporting `NON_VISIBLE` even though the ad is back on screen — viewability under-counts post-restore. Narrow but real on the oscillation path. Tied to the double-driver design (container chain + adapter both wired to `freeze`/`resume`/`pageshow`).
+**NEW — not filed.** Root: two uncoordinated restore drivers + edge-triggered OMID re-assertion. Mitigation in Rec R1 (replay) + R4 (single restore authority).
+
+### F7 — [P1, NEW] Re-ACTIVE after HIDDEN/PASSIVE oscillation loses the MRAID viewable re-flip when `active` is skipped
+**File:** `src/sharc-mraid-bridge.js:466-488` + container `_transitionToActive` skip (`:3778`).
+**Bad oscillation:** `ACTIVE→HIDDEN→ (scroll back) →PASSIVE→ACTIVE`. The IO path (`html-adapter.js:329-337`) steps HIDDEN→PASSIVE→ACTIVE — two `setState` calls, both fire `onChange`. MRAID gets `stateChange('passive')` (viewable stays false) then `stateChange('active')` (viewable false→true → `viewableChange(true)`). This works. **The failure is when `_transitionToActive` is the driver** (focus regain via `_onPageFocus`, `:5033-5037`): it calls `_transitionToActive` which skips if already ACTIVE — but from PASSIVE it isn't, so it fires. The genuine loss is only in the F1/F6 already-ACTIVE cases. **Net:** the IO-driven oscillation is OK; the focus-driven + already-promoted combination is the gap. Lower confidence than F1/F6 but worth a targeted test.
+**NEW — fold into #336 test matrix.**
+
+### F8 — [P3, SPEC GAP] MRAID `exposureChange` never implemented; PASSIVE (partial visibility) collapses to non-viewable
+**File:** `src/sharc-mraid-bridge.js` (no `exposureChange` emit anywhere); container PASSIVE = `0<IO<0.5`.
+**Spec:** MRAID 3.0 defines `exposureChange(exposedPercentage, visibleRect, occlusionRects)` for partial viewability. SHARC maps `viewable = (state === 'active')` only — PASSIVE (partially visible) reports `isViewable=false` with no exposure detail. The `terminated→hidden` handler even logs *"add exposureChange handler in v2"* (`:476`).
+**Symptom:** Creatives that drive behavior off `exposureChange` (e.g. video that plays at 50% exposure) get no signal; partial-viewability measurement is coarse (binary viewable). SHARC's own state model has the data (IO ratio) but doesn't forward it.
+**SPEC-SILENT in SHARC; governed by MRAID 3.0.** Deferred capability, correctly flagged in-code. **Not filed as a defect** (it's a known v2 gap) — recommend a tracking issue so it isn't lost.
+
+### F9 — [P3, NEW] `getContainerState()` returns a value the creative SDK can't always map; FROZEN unreachable via query during real freeze
+**File:** `src/sharc-creative.js:524-528` + container `_handleGetContainerState`.
+**Observation:** `getContainerState()` round-trips over the MessagePort. During real FROZEN (OS-freeze/bfcache) the port is suspended/dead, so the query **cannot resolve** — the creative's `await SHARC.getContainerState()` hangs until resume (or forever post-bfcache). The #334 bridge fix relies on `getContainerState()` at install time; if install races a freeze, the promise never settles.
+**Symptom:** Edge case for the #334 mitigation — a bridge installing during a freeze window hangs its viewability seed. Very narrow.
+**NEW — note as a caveat on the #334 fix; not a standalone issue.**
+
+### F10 — [P2, NEW] SafeFrame bridge has the identical late-subscriber gap as MRAID but no equivalent of the #334 fix
+**File:** `src/sharc-safeframe-bridge.js:312, 332-356`.
+**Observation:** SafeFrame's first `geom-update` "fires on `stateChange(active)`" (comment at `:312`). It has the same F1/F2 late-subscriber blindness as MRAID, but #334 only fixes the MRAID bridge. A SafeFrame creative behind an already-ACTIVE promotion never gets its first `geom-update` → `$sf.ext.geom()` reports stale/zeroed geometry → SafeFrame viewability measurement broken.
+**NEW — not filed.** Whatever replay fix lands for MRAID (#334/Rec R1) must cover SafeFrame too.
+
+---
+
+## 5. Recommendations
+
+**R1 — [addresses F1, F2, F6, F7, F10; the structural root] Add last-state replay to the container→creative state channel.**
+The container should deliver the *current* state to a newly-established session, and `SHARC.on('stateChange')` should optionally replay the last-known state to a new listener. Two viable layers:
+- *Container side (preferred, fixes #336 at root):* in `_handleInitResolved`/`acceptSession`, after the session is established, **always** `sendStateChange(currentState)` once, even if no transition occurred. This guarantees a late-handshaking creative behind an already-ACTIVE promotion gets the current state. Cost: one redundant message in the normal path (cheap).
+- *Creative side:* `sharc-creative.js` caches `_lastContainerState` and replays it to any `on('stateChange')` listener registered after the first state arrives. This fixes MRAID + SafeFrame + any future bridge uniformly (F10) without per-bridge `getContainerState()` polling.
+This makes the #334 bridge-local fix unnecessary long-term and closes F10 for free.
+
+**R2 — [addresses F5, G-A] Add direct `ACTIVE→FROZEN` and `PASSIVE→FROZEN` edges to `STATE_TRANSITIONS`.**
+Eliminates the spurious transient `stateChange('hidden')` on freeze/bfcache entry. The adapter's `_transitionToFrozen` can then go straight to FROZEN. **Caveat:** the bf-2 Puppeteer contract asserts `LOADING→ACTIVE→HIDDEN→FROZEN`; changing the edge changes that contract. This is a deliberate, ratifiable change — flag for Jeffrey (state-graph change). If we keep bf-2 as-is, alternatively suppress the intermediate `sendStateChange` for an adapter-driven walk-through.
+
+**R3 — [addresses the HIDDEN/FROZEN conflation, channel liveness] Internal bfcache-restore channel-liveness check.**
+Do NOT add a creative-facing BFCACHED state. DO have the container detect bfcache restore (`pageshow persisted`) and verify the MessagePort is still live before `sendStateChange('active')`; if dead, re-establish the channel (or fatal-error cleanly) rather than emitting into a closed port. This is the one place the bfcache/OS-freeze distinction is load-bearing. Requires a Chrome/Puppeteer test (jsdom can't model port closure).
+
+**R4 — [addresses F6] Single restore authority.**
+The container chain (`_onResume`) and the HTML adapter (`_transitionFromFrozen` + `_onResume` + `_onPageshow`) are two uncoordinated FROZEN-restore drivers. Designate one authority (the adapter has the intersection signal; let it own restore destination) and have the other yield, mirroring the LOADING→ACTIVE strict/permissive yield already in place.
+
+**R5 — [addresses F4] Reorder `_terminate` so OMID `omid-finishing` + `sessionFinish` flush before router `terminated`/`destroy`.**
+Move `_notifyExtensionsLifecycle('destroy')` (and any OMID finish flush) **above** `protocolRouter.transitionTo('terminated')` + `destroy()`. This is exactly OMID design R1's instruction. Pin the test the 0.7.8 design already specifies.
+
+**R6 — [process] Make "lifecycle ordering" a first-class test surface.**
+The recurring class warrants a dedicated `test/node/test-lifecycle-ordering.js` that drives every legal cycle (incl. oscillations) and asserts the creative-facing signal sequence per surface. The bf-* Puppeteer matrix covers container states; nothing covers the *bridge-facing emission sequence* across oscillations.
+
+---
+
+## 6. Issues to File
+
+| # | Title | Status | Severity | Finding |
+|---|-------|--------|----------|---------|
+| #336 | Container: deliver current lifecycle state to a creative that handshakes after already-ACTIVE | **FILED** | P0 | F1 — recommend resolving via R1 (container-side replay), not just the bridge mitigation |
+| #334 | MRAID bridge must reflect current container visibility (isViewable false→true) | **FILED (in-flight)** | P0 | F2 — bridge-local fix correct; R1 supersedes long-term |
+| #335 | MRAID getState() stuck at 'loading' for cases that miss onReady in-window | **FILED** | P0 | D-2 — readiness/handshake timing; not fixed by replay (the handshake never completes); needs the #322/#330 ordering work to land the handshake in-window |
+| #330 | Keep renderer load-probe channel in-phase under OMID | **FILED + MERGED** | — | F3 — canonical #330-class example; current membership correct, keep regression guard |
+| #332 | Phase 2: bound answered probe-cycle rate/count | **FILED** | P2 | adjacent (keep-alive ceiling); not lifecycle-ordering |
+| **NEW-A** | `_terminate` flushes OMID `sessionFinish` after router already `terminated`/destroyed (R1 live on main) | **NOT FILED** | P1 | F4 — reorder per R5 |
+| **NEW-B** | Spurious transient `stateChange('hidden')` on every bfcache/freeze entry (no direct ACTIVE→FROZEN edge) | **NOT FILED** | P2 | F5 — R2 |
+| **NEW-C** | OMID can stay NON_VISIBLE after bfcache restore (double restore driver + edge-triggered re-assert) | **NOT FILED** | P1 | F6 — R1 + R4 |
+| **NEW-D** | SafeFrame bridge has the same late-subscriber blind spot as MRAID; #334 fix doesn't cover it | **NOT FILED** | P2 | F10 — R1 covers both |
+| **NEW-E** | bfcache restore: verify MessagePort liveness before sending state into a closed port | **NOT FILED** | P1 | F9 + §2.3 — R3 (Chrome-only) |
+| **NEW-F** | MRAID `exposureChange` not implemented; partial visibility collapses to non-viewable | **NOT FILED** (known v2 gap) | P3 | F8 — tracking only |
+
+**Top 3 to file now:** NEW-A (P1, live measurement-session leak on hard terminate), NEW-C (P1, post-bfcache viewability under-count), NEW-D (P2, SafeFrame parity with #334).
+
+---
+
+## 7. Summary
+
+- **State-graph shape:** one container state machine (`loading→ready→active⇄passive⇄hidden→frozen→…→terminated`) with explicit oscillation (ACTIVE↔PASSIVE, ACTIVE↔HIDDEN, HIDDEN↔FROZEN, all repeatable; `*→TERMINATED` one-way) running in parallel with a **monotonic, non-oscillating** router phase line (`init→attaching-renderer→rendered→creative-active→omid-active→omid-finishing→terminated`). The two spaces decouple once `omid-active` shadows `creative-active`.
+- **FROZEN modeling:** SHARC **conflates** bfcache and OS-freeze into one FROZEN, and that is **correct for the creative-facing contract** (the creative can't and shouldn't distinguish). The conflation is only dangerous internally because **bfcache closes the MessagePort** while OS-freeze suspends it — recommend NOT a new creative-facing state, but an internal bfcache-restore channel-liveness check (R3). There is also **no direct ACTIVE→FROZEN edge**, forcing a phantom HIDDEN on freeze entry (R2).
+- **Top audit findings:** F1 (already-ACTIVE skip — **explains #336**) and F2 (no state replay — **explains #334**) are the same root: an **edge-triggered, no-replay** state channel against **late-subscribing** bridges. F3 (**explains #330**, shipped) is the phase-membership variant of the same family. #335 is a distinct *readiness-timing* problem (handshake never completes in-window) that replay does NOT fix.
+- **NEW gaps not yet filed:** F4/NEW-A (OMID `sessionFinish` flushed after router teardown on hard terminate — OMID design R1, live on main), F6/NEW-C (OMID stuck NON_VISIBLE after bfcache restore), F10/NEW-D (SafeFrame has MRAID's late-subscriber bug, uncovered by #334), F5/NEW-B (phantom HIDDEN on freeze), plus the MRAID `exposureChange` spec gap (F8).
+- **The one fix that retires the most findings:** R1 — add current-state replay to the container→creative channel (container-side push on session establish + creative-side last-state replay). It resolves #336 at the root and closes F2/F6/F7/F10 uniformly, making the per-bridge `getContainerState()` mitigations unnecessary. Formalized by the State-Delivery Contract (`state-delivery-contract.md`) and implemented in PR #342.

--- a/docs/design/0.7.10-unified-state-replay-r1.md
+++ b/docs/design/0.7.10-unified-state-replay-r1.md
@@ -1,0 +1,227 @@
+# ADR: R1 — Unified container→creative current-state replay (the ROOT fix for the edge-triggered/no-replay channel class)
+
+**Status:** **Accepted** — ratified by Jeffrey 2026-06-07. **Implemented in PR #342.**
+**Formalized by:** State-Delivery Contract `state-delivery-contract.md` (the durable, test-enforced normative contract for this channel). R1 implements its D1/D2/D3; the contract's §3 **option-B send-layer dedup** (skip identical consecutive sent state) **amends** R1 — it corrects R1's double-`active` asymmetry on the normal-transition path. **R1 + the dedup land together** (contract §13).
+**Date:** 2026-06-07
+**Baseline:** `origin/main` @ `033a2d2` (post #322/#330/#333). Experiment worktree built dist from this commit.
+**Supersedes:** the per-bridge #334 ADR ("minimal bridge-local seed + replay"). That ADR's bridge-local `getContainerState()` seed is **retired** by R1 — see §"Retiring the #334 seed." Its node tests **T1–T10 + the synthetic interstitial fixture TRANSFER to R1's suite** (branch `fix/334-mraid-visibility-seed`, commit `2045117`).
+**Closes:** #334 (MRAID `isViewable` stuck false), #336 (container `_transitionToActive` already-ACTIVE skip), #339/NEW-D (SafeFrame identical late-subscriber bug), audit F2/F6/F7/F10.
+**Does NOT close:** #335 (readiness-timing — separate), #337 (terminate-order). MAY help #338 (bfcache OMID) — characterized, not assumed.
+**Audit (canonical):** `0.7.10-lifecycle-state-mapping-audit.md` (Rec R1).
+**Precedent for design-with-experiment:** the post-render-nav-policy ADR (`0.7.10-post-render-nav-policy-omid-phase.md`), which proved its mechanism on the same DV corpus before ratification.
+
+---
+
+## Context
+
+The lifecycle audit established that #334, #336, #339 and audit F6/F7/F10 are **one bug with one root**: the container→creative state channel (`sendStateChange`) is **edge-triggered with no current-state replay**. A creative/bridge that subscribes after a transition — or behind a transition the container *suppressed because it was already in that state* — misses it forever. Three combining code facts (all re-verified at `033a2d2`):
+
+1. **No replay in the creative pub/sub.** `SHARCCreative.on()` (`src/sharc-creative.js:485-498`) just pushes to `_eventListeners`; `_emit()` (`:768-774`) iterates current listeners with no buffering. A listener registered after `stateChange('active')` arrived gets nothing. Both bridges subscribe via `SHARC.on('stateChange')` (MRAID `src/sharc-mraid-bridge.js:466`, SafeFrame `src/sharc-safeframe-bridge.js:332`) and seed viewability/geometry false; their only path to truth is a *subsequent* event.
+
+2. **The container can legitimately never re-send `active` post-handshake.** `_transitionToActive()` skips `setState(ACTIVE)` when already ACTIVE (`src/sharc-container.js:3777-3783`). In permissive mode the HTML adapter drives `LOADING→ACTIVE` before the handshake (#336/F1).
+
+3. **(Discovered during this experiment — the decisive fact the prior docs did not name.)** Even when `setState(ACTIVE)` *does* fire during the handshake (the corpus path is `loading→ready→active`, both transitions succeeding), the resulting `Container:stateChange('active')` is **silently dropped at the creative's port**: `_onPortMessage` rejects any non-CREATE_SESSION message whose `sessionId !== this.sessionId` (`src/sharc-protocol.js:494-501`). When `active` is emitted in the same tick as init, the creative has **not yet set its `sessionId`** from `Container:init` → the message is dropped before it reaches `_emit`. **No creative-side replay can recover a message dropped at the port.** This is why a pure creative-side cache (the prior R1 sketch and the #334 seed) is insufficient for the dominant corpus path, and why R1 **requires a container-side post-establish push.**
+
+The bridge-local #334 seed compensated only the MRAID bridge, only the viewability flag, via a `getContainerState()` round-trip — leaving SafeFrame (#339) and every future bridge uncovered, and depending on a port that is dead during bfcache (audit F9).
+
+---
+
+## THE EXPERIMENT — reconciling the harness + proving false→true (aggregate only; corpus is PRIVATE)
+
+Faithful e2e on `origin/main` @ `033a2d2`: `npm ci` + `npm run build`, real container + real reference renderer (cross-origin, headless Chromium), private 5-case DoubleVerify corpus symlinked (FILE only) into `tools/creative-validator/private/visual-review/`, output under `tools/creative-validator/private/reports/` (trashed). No creative markup / URLs / auction-bid-crid IDs reproduced.
+
+### Harness reconciliation — why the #334 build and the #334 discover disagreed
+
+The #334 build got `loading×4`; the #334 discover got `active+false×5`. **Root cause found in the harness, not the product:** the validator's bridge probe (`tools/creative-validator/harness/bridge-probe.js`) samples at **t=0, 50, 150, 300 ms relative to probe-script injection** (probe injected at `document.write`/render time). That window closes **before** `Container:init`/`onReady` lands and before the adapter-promotion + handshake settle. So the #334 *build* read `loading` (probes fired pre-`onReady`); the *discover* read a **later** capture (post-handshake) and saw `active`-but-`false`. **The two runs measured different moments of the same run.**
+
+**Repeatable measurement established:** add a **late probe at t=1500 ms** (post-settle), bump the probe-collection cap `5→6` (`markup-runner.html`), run with `--settle-ms 2500`. Harness-only change; no production code. Re-running the **baseline** (no fix) with the late probe:
+
+| Signal (5 DV cases) | Baseline @ `033a2d2`, late probe |
+|---|---|
+| reachedActive / finalState=active | 5/5 / 5/5 |
+| anyProbe isViewable=true | 0/5 |
+| **LATE-probe isViewable=true** | **0/5** |
+| **LATE-probe: container-active + bridge default/expanded + false** | **5/5** |
+
+The late probe proves the bug is **real and persistent**, not a probe-too-early artifact: at t=1500 ms every case has the container at `active` and the bridge at `default+false` (case4 `expanded+false`). This is the repeatable false-state baseline.
+
+### The false→true proof — R1 applied
+
+Same worktree, R1 applied (container post-establish push + creative replay; mechanism below), rebuilt, same harness:
+
+| Signal (5 DV cases) | **Baseline (no fix)** | **R1 applied** |
+|---|---|---|
+| reachedActive / finalState=active | 5/5 / 5/5 | 5/5 / 5/5 |
+| **LATE-probe isViewable=true** | **0/5** | **5/5** |
+| **LATE-probe: container-active + isViewable=true** | **0/5** | **5/5** |
+| getState reaching `default`/`expanded` (not stuck `loading`) | 3/5 | **5/5** |
+
+Per-case late-probe (clean diag-free build, re-confirmed): every case `default+true` (case4 `expanded+true`). **`default+false → default+true` is PROVEN on the full corpus at the validator tier** — the proof #334 could not produce. Mechanistic confirmation (instrumented run): the creative's inbound `stateChange=active` listener fired **5/5** under R1 (vs **0/5** on baseline, where it never fired at all because the mid-handshake `active` was dropped at the port).
+
+**Bonus, not promised by #334:** R1 also lifted the 2/5 stuck-`loading` cases to `default`. Those were stuck because `onReady`/`Container:init` had not become probe-visible *in the old 300ms window*; the post-establish push delivers a queryable `stateChange` after the session is established, and `getMraidState` resolves `default`. (This is a harness-window effect, not a fix for the distinct #335 readiness-timing thread — see scope.)
+
+---
+
+## Decision — the committed R1 mechanism
+
+R1 is **two coordinated changes**, container-side AND creative-side. The experiment proved the container-side push is **necessary** (the creative-side cache alone cannot recover a port-dropped message); the creative-side replay is **necessary** for the late-subscriber and oscillation cases and to cover SafeFrame/future bridges uniformly.
+
+### D1 — Container side: push the CURRENT lifecycle state on session-establish
+
+In `_handleStartCreativeResolved()` (`src/sharc-container.js:3752`), **after** `_transitionToActive()`, send the current queryable state unconditionally:
+
+```js
+const _r1State = this._stateMachine.getState();
+if (this._stateMachine.isCreativeQueryable(_r1State)) {
+  this._protocol.sendStateChange(_r1State);
+}
+```
+
+**Why this site, and why it is correct:** by the time `startCreative` has *resolved*, the creative's protocol session is fully established (its `sessionId` is set from `Container:init`), so this `stateChange` passes the creative-side session-validation gate (`_onPortMessage`, `sharc-protocol.js:494-501`) — unlike the mid-handshake `setState(ACTIVE)` that was dropped before the creative had a `sessionId`, and unlike the `active` that `_transitionToActive` skips when already-ACTIVE (#336). It is a precedent-following site: `_transitionToActive` already calls `_syncAudioState`/`_syncPlacementState` here to re-sync current env state to a late creative — R1 adds the missing *lifecycle*-state sync alongside them.
+
+### D2 — The container-side WIRE decision: send the REAL `currentState` in `Container:init` (NOT a wire/schema change)
+
+**Finding that settles the wire question:** the `Container:init` envelope **already carries a `currentState` field** — but it is hard-coded to `ContainerStates.READY` (`src/sharc-container.js:3628`), even when the adapter has already promoted past READY. R1 sends the **real** current queryable state:
+
+```js
+const _r1CurrentState = this._stateMachine.isCreativeQueryable(this._stateMachine.getState())
+  ? this._stateMachine.getState()
+  : ContainerStates.READY;
+// ... environmentData.currentState = _r1CurrentState
+```
+
+**This is a value change, not a wire change.** The field, its name, its type, and its position in the envelope are unchanged. **The #334 ADR's premise that a synchronous seed "would need a wire/`Container:init` env addition" was incorrect — the field is already there.** This is therefore **NOT a STOP-AND-ASK** under the "no wire change without asking" rule. (See STOP-AND-ASK §, item 1, for the one thing that IS flagged.)
+
+D2 gives bridges/creatives a *synchronously*-correct `currentState` in `onReady`'s `env`, closing the one-tick async gap the #334 seed accepted. It is complementary to D1: D1 guarantees delivery for the corpus path (where the adapter promotes to ACTIVE *after* init is sent, so `env.currentState` is still `ready` at init time); D2 covers the case where the container is already past READY *at init-send time*.
+
+### D3 — Creative side: last-state cache + replay to new `stateChange` subscribers
+
+In `src/sharc-creative.js`:
+- Cache `_lastContainerState` on every inbound `Container:stateChange` (`:222-225`) and seed it from `env.currentState` in `_handleInit` (when it is a real queryable state, not the READY default).
+- In `on(event, callback)`: when `event === 'stateChange'` and `_lastContainerState` is known, **replay the last value to that listener once on registration**.
+
+**Which events get replay:** the **lifecycle `stateChange`** event only — the latching current-state events. **One-shot events do NOT get replay**: `containerError`, `log`, `close`, `placementTransitionEnd`. (Rationale: replaying a stale error/log to a late listener is wrong; replaying current lifecycle state is the entire point.) `placementChange`/`constraintsChange`/`audioVolumeChange` are already re-synced by `_syncPlacementState`/`_syncAudioState` on ACTIVE; R1 does not add replay for them (out of scope; no symptom).
+
+**Ordering:** replay fires after `ready` (the cache is seeded in `_handleInit`, and `on('stateChange')` registrations from bridges happen during/after `onReady`). A creative never receives a replayed `stateChange` before `ready`.
+
+**Idempotency / no double-fire:** the MRAID handler fires `viewableChange` only when `_isViewable` flips (`src/sharc-mraid-bridge.js:485`); a replayed `active` followed by a live `active` is a no-op the second time. The replay delivers to **the registering listener only**, exactly once.
+
+**Non-latching preserved (critical):** R1 touches only *delivery of the current/missed value*. The live `SHARC.on('stateChange')` subscription is **untouched**, so the container's ongoing intersection toggles (audit/§ confirmed already emitted: `html-adapter.js:289-345` off-screen→HIDDEN, on-screen→ACTIVE, partial→PASSIVE; plus page focus/visibility) keep flowing. R1 does **not** latch viewability — offscreen→onscreen→offscreen still toggles. (Node test T6 is the binding proof; see test plan.)
+
+### How D1+D2+D3 close the family uniformly
+
+- **#334 (MRAID `isViewable` false):** D1 delivers `active` post-establish → live MRAID handler flips `_isViewable=true`, fires `viewableChange(true)`. D3 covers the late-listener variant; D2 covers already-ACTIVE-at-init. **Proven false→true 5/5.**
+- **#336 (container already-ACTIVE skip):** D1 sends the current state **regardless of whether a transition occurred** — the skip no longer suppresses the creative notification. The container is the source; D1 fixes it at source. (#334's seed only compensated in the bridge.)
+- **#339 / NEW-D (SafeFrame identical bug):** SafeFrame subscribes at the same `SHARC.on('stateChange')` layer. D1's push + D3's replay reach it with **no SafeFrame-specific code** — its first `geom-update` (which "fires on stateChange(active)", `src/sharc-safeframe-bridge.js:312`) now fires. One fix, both bridges, any future bridge.
+- **F6/F7 (oscillation re-assert):** D3's last-state cache + the untouched live subscription mean a re-ACTIVE after FROZEN/HIDDEN re-delivers `active` to any listener; D1 re-pushes on the establish path. (F6's deeper double-restore-driver issue is audit R4, out of R1 scope — characterized, not closed.)
+
+### Retiring the per-bridge #334 seed
+
+The #334 bridge-local `getContainerState()` seed (D1+D2 in `2045117`, in `src/sharc-mraid-bridge.js`) becomes **redundant and should be removed** when R1 lands: R1 delivers the current state through the channel itself, so the bridge no longer needs to poll. Removing it also eliminates audit **F9** (the `getContainerState()` round-trip hangs during a freeze window). **The seed's tests T1–T10 do NOT retire — they re-target the R1 mechanism** (the MRAID bridge's observable contract is unchanged: install behind already-ACTIVE ⇒ `isViewable()===true` + one `viewableChange(true)`; only the *delivery path* moves from bridge-poll to channel-replay). See test plan.
+
+---
+
+## Scope boundaries (held)
+
+- **#335 (readiness-timing) NOT closed.** Where `getState()` is stuck `loading` because `Container:init`/`onReady` never arrived in-window, no state-replay change helps — the handshake must complete. R1's incidental lift of the corpus's 2/5 is a harness-window effect (post-establish push lands a queryable state once the session establishes), not a fix for cases where the session never establishes. #335 stays its own thread (#322/#330 ordering work).
+- **#337 (terminate-order) NOT touched.** That is audit F4/R5 (OMID `sessionFinish` after router teardown).
+- **#338 (bfcache OMID visibility) — MAY help, NOT assumed.** D1/D3 re-deliver `active` on resume *if the channel is live*. But audit §2.3/R3: **bfcache closes the MessagePort**; a push into a dead port is lost. R1 does not add bfcache channel-liveness (that is R3, Chrome-only). **Characterization:** R1 helps #338 on OS-freeze/resume (port survives); it does **not** help post-bfcache-restore until R3 lands. Do not claim #338 closed.
+
+---
+
+## Security
+
+- **No cross-placement leakage.** Each container owns one `SHARCCreativeProtocol` with its own per-session `sessionId` and one MessagePort per creative. `sendStateChange` posts only on that container's own port; the creative-side `_onPortMessage` drops any message whose `sessionId` ≠ its own. R1 sends a creative **its own lifecycle state** — there is no path by which one placement observes another's state. D2 sends `currentState` in the same `Container:init` already scoped to that session.
+- **No new observability.** The state R1 delivers (`active`/`passive`/`hidden`/`ready`/`frozen`) is already creative-queryable on demand via `getContainerState()` (`CREATIVE_QUERYABLE_STATES`). R1 changes *when/how reliably* it is delivered, not *what* is observable. `loading`/`terminated` remain non-queryable and are never pushed (`isCreativeQueryable` gate on both D1 and D2).
+- **Native-SHARC + plain-HTML unaffected.** D1 fires only in `_handleStartCreativeResolved` (the handshake path); `sendStateChange` no-ops when `sessionId === ''` (non-handshake creatives never establish a session). D2/D3 require a `Container:init` (handshake-only). Pre-1.0 — no alias/deprecation needed.
+
+---
+
+## STOP-AND-ASK / decisions for Jeffrey
+
+1. **The container-side push is a container state-machine behavior change (NOT a wire change) — ratify.** D1 makes the container emit `stateChange(currentState)` on every session-establish, **even when no transition occurred** (the #336 root). This is the one behavioral change to flag: it means a creative that handshakes while already-ACTIVE now receives an `active` `stateChange` it previously never got. Bridges treat this correctly (idempotent — viewable flips only on change). The risk to name: a hypothetical creative that infers a *transition edge* from any `stateChange('active')` would now see one at establish. **Recommendation: approve** — it is the source-fix for #336, it is what makes #334/#339 close at root (not per-bridge), and the corpus proves it is correct (5/5 false→true, no regressions in the focused node suites). *(D2 — sending the real `currentState` instead of hard-coded READY — is explicitly NOT a wire change; the field already exists. Noted for the record, not flagged.)*
+
+2. **Retire the #334 bridge-local seed when R1 lands.** R1 makes the per-bridge `getContainerState()` seed (`2045117`) redundant and removing it also closes audit F9. **Decision:** land R1 and remove the seed in the same change (clean, pre-1.0), keeping T1–T10 re-targeted to R1. Confirm — or keep the seed as belt-and-suspenders (not recommended; it re-introduces F9).
+
+3. **Replay scope = lifecycle `stateChange` only.** D3 replays the latching current-state event; one-shot events (error/log/close) are explicitly excluded. Confirm this is the intended scope (it is broader than #334's `viewableChange`-only, by design, to cover SafeFrame and future bridges at the shared bus).
+
+4. **#338 (bfcache OMID) characterized, not closed.** R1 helps OS-freeze/resume; post-bfcache-restore needs R3 (dead-port relinking). Confirm #338 stays open pending R3.
+
+---
+
+## Failing-test plan
+
+Legend: **RED→GREEN** fails on `033a2d2`, passes after R1. **GREEN-guard** passes today, pinned. **node** = jsdom-expressible; **validator** = real renderer + real cross-origin (puppeteer-tier).
+
+### Node — MRAID bridge contract (TRANSFER T1–T10 from `2045117`, re-target to R1)
+
+The `fix/334-mraid-visibility-seed` suite `test/node/test-mraid-visibility-seed.js` (T1–T10) tests the bridge's *observable* contract. Re-target the fake-SHARC driver from "bridge calls `getContainerState()`" to "container delivers state via the channel" (seed `env.currentState` and/or fire a post-establish `stateChange`). The assertions are unchanged:
+- **T1** seed-from-active ⇒ `isViewable()===true` + one `viewableChange(true)`.
+- **T2** seed-from-non-active ⇒ `isViewable()===false`, no `viewableChange`.
+- **T3** `default ≠ false` invariant (state `default` + viewable `true` coexist).
+- **T4** late `addEventListener('viewableChange')` replay (now: late `on('stateChange')` replay drives it).
+- **T5** replay respects last value (active then offscreen ⇒ replay `false`).
+- **T6** non-latching toggle: offscreen→onscreen→offscreen→onscreen toggles each time (**binding proof the live subscription is untouched**).
+- **T7** no double-fire across both interleavings (seed-then-event, event-then-seed).
+- **T8** ordering: `ready`/`default` precede `viewableChange`.
+- **T9** defensive fallback (no/rejecting delivery API ⇒ no throw, live-only).
+- **T10** regression: single forward `active` flips once.
+
+### Node — creative bus replay (new `test/node/test-creative-state-replay.js`)
+
+- **N1 [RED→GREEN]** `on('stateChange', fn)` registered AFTER a `Container:stateChange('active')` arrived ⇒ `fn` replayed once with `'active'`. (Baseline: bus is transition-only.)
+- **N2 [RED→GREEN]** `_handleInit` with `env.currentState==='active'` seeds the cache ⇒ a `stateChange` listener registered post-init is replayed `'active'`; a listener registered pre-init (auto-installed bridge) is replayed when init seeds the cache.
+- **N3 [GREEN-guard]** one-shot events (`containerError`, `log`, `close`) are **NOT** replayed to late listeners. Pins the replay-scope decision.
+- **N4 [RED→GREEN]** replay reflects the LAST state, not the first (active→hidden ⇒ late listener gets `hidden`).
+- **N5 [GREEN-guard]** live subscription still toggles after a replay (replay does not latch / unsubscribe the live path).
+
+### Node — container source fix (new `test/node/test-container-state-establish-push.js`)
+
+- **C1 [RED→GREEN]** drive `_handleStartCreativeResolved` with state already ACTIVE (adapter-promoted) ⇒ a `Container:stateChange('active')` IS sent to the creative (baseline: `_transitionToActive` skip suppresses it; #336). Assert exactly one send of the current state.
+- **C2 [RED→GREEN]** the same `active` is delivered even when emitted post-`acceptSession` (port session established) — pins the §"decisive fact" port-gate timing: a state sent before the creative's `sessionId` is set is dropped; a state sent at `_handleStartCreativeResolved` is delivered.
+- **C3 [GREEN-guard]** `loading`/`terminated` are never pushed (`isCreativeQueryable` gate). Native/plain-HTML (`sessionId===''`) ⇒ `sendStateChange` no-ops (no throw).
+- **C4 [RED→GREEN]** `Container:init` env carries the REAL current state (set state ACTIVE pre-init ⇒ `env.currentState==='active'`, not hard-coded `'ready'`). Pins D2.
+
+### Validator / puppeteer (real adapter promotion — cannot be jsdom)
+
+- **V1 [RED→GREEN] — DV-sample false→true (THE acceptance gate for #334).** Run the private DV corpus on the built fix **with the late probe (t=1500ms)**; assert `diagnostics.bridgeProbes[last].bridges.mraid.methods.isViewable.value` moves `default+false → default+true` for every case reaching `active`. **PROVEN in this experiment: 5/5.** The late probe is required and must be committed to the harness (the 300ms ceiling is the documented reason #334 could not prove it).
+- **V2 [RED→GREEN] — synthetic interstitial fixture (TRANSFER from `2045117`).** The synthetic interstitial creative (gates its start on `mraid.isViewable()===true`, served through the real renderer + permissive adapter) hangs on baseline, proceeds under R1. Ships with R1 (in #334's acceptance). Synthetic markup only.
+- **V3 [RED→GREEN] — SafeFrame parity (NEW, closes #339).** A **synthetic** SafeFrame creative that registers `$sf.ext.register` and waits for its first `geom-update`, behind the adapter-promotes-before-handshake path. Baseline: first `geom-update` never fires (`geom()` zeroed). R1: fires via the same channel push. **#339 has no DV corpus** (the corpus is MRAID-only), so this synthetic fixture is the binding #339 proof.
+- **V4 [validator-if-feasible] — dynamic toggle under real intersection.** If the harness can script intersection (scroll out/in), assert `isViewable` `true→false→true` e2e (belt-and-suspenders on non-latching; node T6 is the binding proof).
+
+**Split:** node T1–T10 + N1–N5 + C1–C4; validator V1–V3 (V4 if feasible, else covered by T6/N5).
+
+### Acceptance (#334/#336/#339) mapped to tests
+
+| Criterion | Met by |
+|---|---|
+| bridge install behind already-ACTIVE ⇒ current state delivered | C1, C2, T1, V1 |
+| `getState()` reaches `default` (where session establishes) | T3, V1 (NOT the #335 never-handshake cases) |
+| `isViewable()` true when container active | T1, T3, V1 |
+| `viewableChange(true)` fires/replays for late listeners | T1, T4, T7, N1 |
+| DV visual sample `default+false → default+true` | **V1 — PROVEN 5/5** |
+| dynamic non-latching (offscreen→onscreen→offscreen) | T6, N5, V4 |
+| #336 container source-fix (no skip-suppression) | C1, C2 |
+| #339 SafeFrame parity | V3 |
+| `currentState` real in init env | C4 |
+
+---
+
+## Consequences
+
+**Easier:** one fix retires #334/#336/#339 + F2/F6/F7/F10 at the root, across MRAID + SafeFrame + any future bridge, with no per-bridge polling; the #334 seed and audit F9 both disappear; the DV false→true is proven and repeatable; no wire/schema change (the `currentState` field already existed); native-SHARC + plain-HTML untouched.
+
+**Harder / accepted:** the container now emits a `stateChange` on every session-establish even absent a transition (STOP-AND-ASK 1) — idempotent for bridges, a behavior to ratify; two emit/cache sites (container D1, creative D3) must stay consistent (covered by C1–C4 + N1–N5); #335 readiness-timing and #338 post-bfcache remain open (the latter needs R3 dead-port relinking); the validator proof requires committing the late probe to the harness (the 300ms window was the prior blind spot).
+
+---
+
+## Method notes (reproducibility)
+
+- Experiment worktree: detached `origin/main` @ `033a2d2`, `/tmp/sharc-r1-exp` (trashed after). `npm ci` + `npm run build` (dist required by harness).
+- Corpus: private DV `dv-five-cases.jsonl` symlinked (FILE) into `tools/creative-validator/private/visual-review/` (gitignored; lives in the SHARC-codex tree). Output under `tools/creative-validator/private/reports/`.
+- Harness reconciliation: added `setTimeout(runProbe, 1500)` to `bridge-probe.js`, bumped probe-collection cap `5→6` in `markup-runner.html`, ran with `--settle-ms 2500`. Harness-only; no production code in the measurement.
+- Run command (from repo root): `node tools/creative-validator/src/cli.js run tools/creative-validator/private/visual-review/dv-five-cases.jsonl --repo-root <worktree> --out tools/creative-validator/private/reports/<name>.jsonl --settle-ms 2500`.
+- Aggregate read from `diagnostics.bridgeProbes[].bridges.{mraid,safeframe}.methods.{getState,isViewable}.value` + `outcome.{reachedActive,finalState}`. No creative markup / URLs / auction-bid-crid IDs reproduced. Naming "DoubleVerify" is permitted.
+- Mechanism confirmed by instrumented run (iframe `console` captured via a temporary Puppeteer hook): creative inbound `stateChange=active` fired 0/5 baseline, 5/5 under R1.
+- Focused node regression (clean diag-free build): `test-mraid-readiness-sequence`, `test-html-lifecycle-adapter`, `test-creative-sources`, `test-omid-container-lifecycle` all PASS under R1.
+- No production code was shipped by this design — R1 was prototyped in the throwaway worktree only, to ground the ADR.

--- a/docs/design/state-delivery-contract.md
+++ b/docs/design/state-delivery-contract.md
@@ -1,0 +1,370 @@
+# SHARC Container→Creative State-Delivery Contract
+
+**Status:** Accepted — ratified by Jeffrey 2026-06-07. Decisions 1–3 and 5 ratified; decision #4 confirms the current `terminated → hidden` terminal mapping. Implemented in PR #342.
+**Type:** Normative specification (test-enforced contract). NOT an ADR footnote — this document is the durable, long-lived contract for the container→creative lifecycle-state channel; the conformance test plan in §9 IS the executable spec.
+**Date:** 2026-06-07
+**Author:** Software Architect (Dev Team)
+**RFC-2119:** MUST / MUST NOT / SHOULD / SHOULD NOT / MAY are used per RFC 2119.
+
+**Implemented by:** R1 (ADR `0.7.10-unified-state-replay-r1.md`) delivers D1/D2/D3. **This contract AMENDS R1** with the option-B send-layer dedup (§3), which corrects R1's double-`active` asymmetry. R1 + the dedup land together (§10).
+**Canonical state graph:** `0.7.10-lifecycle-state-mapping-audit.md` §2 (the legal transition graph and ordering) is the normative source for §5 here.
+
+---
+
+## 1. Purpose and scope
+
+### 1.1 What this contract governs
+
+The **container→creative lifecycle-state channel**: how a SHARC container delivers its current lifecycle state (`ready`/`active`/`passive`/`hidden`/`frozen`) to the creative running in its iframe, over the established `SHARCCreativeProtocol` MessagePort session, such that:
+
+- every creative — including one that establishes its session AFTER the container has already reached a state — observes the **correct current state exactly once**, and
+- every subsequent live transition flows without latching, and
+- a `stateChange` listener registered late is brought up to date exactly once.
+
+### 1.2 What this contract does NOT govern
+
+- The router **phase** line (`init→…→omid-active→…→terminated`). Phases are monotonic and non-oscillating (audit §1.2); they are a separate state space and out of scope here.
+- The creative→container direction (commands, queries, `getContainerState()` request/response).
+- Bridge-internal mapping (MRAID `viewableChange`, SafeFrame `geom-update`, OMID session signals). Bridges are **consumers** of this channel; their correctness follows from this contract but their internal rules live in the audit (§3) and bridge specs.
+- bfcache MessagePort liveness (audit R3) — characterized in §8, NOT closed here.
+- Readiness-timing (`#335` — the handshake never completing in-window). This contract delivers state correctly **once a session is established**; it does not cause a session to establish.
+
+### 1.3 Audience
+
+The container implementation (`sharc-container.js`, `sharc-protocol.js`), the creative SDK (`sharc-creative.js`), every creative-side bridge, and the conformance test suite that enforces this document.
+
+---
+
+## 2. Definitions
+
+| Term | Definition |
+|---|---|
+| **Session** | An established protocol session between one container and one creative iframe, identified by a non-empty `sessionId` (`sharc-protocol.js:919`). A creative with `sessionId === ''` has **no session**. |
+| **Lifecycle state** | One of `loading`, `ready`, `active`, `passive`, `hidden`, `frozen`, `terminated` (`ContainerStates`, the container state machine). |
+| **Creative-queryable state** | A lifecycle state the creative is permitted to observe: `{ ready, active, passive, hidden, frozen }` (`CREATIVE_QUERYABLE_STATES`, `sharc-protocol.js:136-142`). `loading` and `terminated` are **non-queryable** for the purposes of the query API, but see §6 for `terminated` **delivery**. |
+| **`stateChange`** | The container→creative message (`ContainerMessages.STATE_CHANGE`) carrying `{ containerState }`, delivered to creative-side `SHARC.on('stateChange', …)` listeners. The **latching** current-state event. |
+| **Delivery** | A `stateChange` value reaching the creative's event bus (`_emit`) and thus its listeners. A message dropped at the session gate (`sharc-protocol.js:494-501`) is **NOT delivered**. |
+| **Sent** | A `stateChange` message passed to `_sendMessage` by `sendStateChange` (`sharc-protocol.js:834`). The send layer is where the option-B dedup lives. |
+| **Replay** | Delivering the last-known state to a newly-registered listener once at registration time, without re-driving the live bus (§7). |
+| **Establish push (D1)** | The container's unconditional `sendStateChange(currentState)` after session-establish in `_handleStartCreativeResolved` (`sharc-container.js:3776-3779`). |
+| **Transition send** | The `sendStateChange(newState)` fired from the `setState` gate on a successful transition (`sharc-container.js:1759-1761`). |
+
+---
+
+## 3. The option-B send-layer dedup (THE exactly-once rule)
+
+### 3.1 Normative invariants
+
+> **INV-1 (Exactly-once consecutive).** The container MUST NOT deliver two **identical consecutive** `stateChange` values on a single session. For any session, if the most recently *sent* state is `S`, a subsequent `sendStateChange(S)` MUST be suppressed (not sent).
+
+> **INV-2 (Distinct values always flow).** The dedup MUST suppress ONLY a value identical to the immediately-preceding sent value on the same session. A `stateChange` whose value differs from the last sent value MUST be sent. Re-asserting a value after an intervening *different* value MUST be sent (the dedup is consecutive-only, NOT set-membership; the channel is non-latching — §5.4, §7.4).
+
+> **INV-3 (Symmetric single `active`).** After §3.2 is implemented, BOTH the normal LOADING→ACTIVE transition path AND the already-ACTIVE/#336 path MUST deliver `active` to the creative **exactly once**. The pre-dedup R1 asymmetry (normal path delivers `active` twice: transition send + D1 establish push; already-ACTIVE path delivers once) is eliminated.
+
+### 3.2 Where the dedup lives and how it works (normative implementation)
+
+The dedup is a **send-layer** mechanism in `SHARCCreativeProtocol.sendStateChange` (`sharc-protocol.js:824-835`). It tracks the last-sent queryable state **per session** and short-circuits an identical consecutive send.
+
+**Touch-points (for the implementation that follows ratification):**
+
+1. **New instance field `_lastSentState`** on `SHARCCreativeProtocol`, initialized to `undefined`. It MUST be reset to `undefined` everywhere `this.sessionId` is set or cleared, so it is strictly **per-session**:
+   - constructor init alongside `this.sessionId = ''` (`sharc-protocol.js:291`),
+   - session establish (`sharp-protocol.js:919`, where `this.sessionId = providedId`),
+   - session teardown / reset (`sharc-protocol.js:593`, where `this.sessionId = ''`).
+   Resetting on establish guarantees the FIRST send on a new session is never deduped against a stale prior-session value (per-session isolation, §8).
+
+2. **The dedup check in `sendStateChange`** (`sharc-protocol.js:824-835`), inserted **after** the queryable guard and the `sessionId === ''` no-op, **before** `_sendMessage`:
+
+   ```
+   sendStateChange(containerState):
+     if containerState NOT IN CREATIVE_QUERYABLE_STATES: warn; return        // existing
+     if this.sessionId === '': return                                        // existing (no-op, native/plain-HTML)
+     if containerState === this._lastSentState: return                       // NEW — INV-1 dedup
+     this._lastSentState = containerState                                    // NEW — record
+     this._sendMessage(STATE_CHANGE, { containerState })                     // existing
+   ```
+
+   Ordering within the function is normative: the queryable guard and the session no-op MUST run **before** the dedup (a non-queryable value or a sessionless container must short-circuit without touching `_lastSentState`).
+
+### 3.3 Why this site is correct (interaction proof)
+
+Both state-emitting paths route through this single function — confirmed in code:
+
+- **Transition send** — `setState` gate calls `this._protocol.sendStateChange(newState)` (`sharc-container.js:1759-1761`).
+- **Establish push (D1)** — `_handleStartCreativeResolved` calls `this._protocol.sendStateChange(r1State)` (`sharc-container.js:3776-3779`).
+
+Therefore a last-sent dedup inside `sendStateChange` is the single chokepoint that sees every send. Path analysis:
+
+| Path | Sends through `sendStateChange` | Net delivered `active` |
+|---|---|---|
+| **Normal LOADING→ACTIVE** | transition send `active` (sets `_lastSentState='active'`) → then D1 push `active` (**deduped** by INV-1) | **1** |
+| **Already-ACTIVE / #336** (adapter promoted to ACTIVE before handshake; `_transitionToActive` skips `setState`, so NO transition send) | D1 push `active` (only send; `_lastSentState` was `undefined`/`ready`) | **1** |
+
+Both paths now deliver `active` exactly once → INV-3 (symmetry) holds. The dedup does **not** weaken D1's completeness guarantee (§4): on the already-ACTIVE path the establish push is the only `active` send and is NOT deduped (the prior sent value is not `active`).
+
+### 3.4 What the dedup MUST NOT do
+
+- It MUST NOT be a set-membership filter (would break INV-2 / non-latching oscillation — §5.4). It is strictly **last-sent only**.
+- It MUST NOT live on the container state machine or in `setState` (that would not catch the D1 push, which originates outside `setState`). It MUST live at the send layer.
+- It MUST NOT persist across sessions (per-session reset, §3.2.1).
+- It MUST NOT be implemented as "make D1 conditional on whether a transition occurred" — that approach (the reviewer-rejected option) reverts #336's already-ACTIVE-skip handling. **Option B (this dedup) is chosen precisely because it preserves D1's unconditional push.**
+
+---
+
+## 4. Completeness — late-establishing creative MUST get current state (#334/#336)
+
+> **INV-4 (Establish completeness).** A creative that establishes its session AFTER the container has already reached a creative-queryable state MUST receive that current state. The container MUST issue the establish push (D1) unconditionally on session-establish — i.e. regardless of whether a state transition occurred at establish time.
+
+> **INV-5 (Establish→push ordering vs the session gate).** The establish push MUST be issued at a point where the creative's session is fully established — i.e. its `sessionId` is set from `Container:init` — so the push passes the creative-side session-validation gate (`sharc-protocol.js:494-501`). The normative site is `_handleStartCreativeResolved` (`sharc-container.js:3776-3779`), which runs after `startCreative` resolves and therefore after the creative has set its `sessionId`.
+
+**Rationale (the decisive port-gate fact, from the R1 ADR):** a `stateChange` sent *before* the creative has set its `sessionId` (e.g. a mid-handshake `setState(ACTIVE)` emitted in the same tick as init) is **dropped at the gate** (`sharc-protocol.js:498`: `sessionId !== this.sessionId`) and is therefore never delivered. No creative-side replay can recover a message dropped at the gate. The establish push at `_handleStartCreativeResolved` is the earliest container-side site guaranteed to be past that gate.
+
+**Interaction with D2 (`Container:init.currentState`):** D2 (§4.1) covers the complementary case where the container is already past `ready` *at init-send time*; D1 covers the corpus case where the adapter promotes to ACTIVE *after* init is sent. Together they cover both orderings.
+
+### 4.1 Real `currentState` in `Container:init` (D2)
+
+> **INV-6 (Honest init seed).** The `currentState` field in the `Container:init` envelope MUST carry the container's REAL current queryable state at init-send time, NOT a hard-coded value. If the current state is non-queryable, the field MUST carry `ready` (the queryable floor). Implementation: `sharc-container.js:3632` (already present in R1).
+
+This is a **value** change, not a wire change (§9 / STOP-AND-ASK). It lets a bridge subscribing in `onReady` seed its cache synchronously from `env.currentState`.
+
+---
+
+## 5. Ordering invariants (from the canonical graph)
+
+The legal graph (audit §2): `loading → ready → active ⇄ passive ⇄ hidden → frozen → {active|passive|hidden} → … → terminated`. The following are the **creative-facing delivery** ordering rules.
+
+> **INV-7 (`ready` precedes `active`).** The creative MUST NOT be delivered `active` before it has been delivered (or seeded with) `ready`. `ready` is the queryable floor; the establish push and init seed never deliver a queryable state below `ready`.
+
+> **INV-8 (No premature viewability).** A bridge MUST NOT signal viewability/active-equivalent (MRAID `isViewable===true` / `viewableChange(true)`; SafeFrame first `geom-update`) before the container has delivered `active`. Because viewability is driven off delivered `active` (audit §3), satisfying INV-3/INV-4 satisfies this; the test asserts the bridge-facing ordering.
+
+> **INV-9 (Queryable floor before `ready`).** The creative MUST NOT observe a queryable state that implies viewable/default (i.e. anything at/above `ready`) before `ready` is established. `loading` is non-queryable and is never delivered (§6); the first delivered/queryable value is `ready`.
+
+> **INV-10 (Oscillation is non-latching and repeatable).** The oscillating edges — `active⇄passive`, `active⇄hidden`, `hidden⇄frozen` (audit §2.1) — MUST continue to flow on every traversal. Each *distinct* state on an oscillation MUST be delivered. The dedup (§3) MUST NOT suppress a distinct value; it suppresses only an identical *consecutive* repeat (INV-2). Re-entering `active` after `passive`/`hidden`/`frozen` MUST deliver `active` again (the intervening different value resets the consecutive comparison).
+
+> **INV-11 (`terminated` is terminal).** Only `→ terminated` is terminal. After `terminated` is delivered (§6), no further `stateChange` MUST be delivered on that session.
+
+---
+
+## 6. Queryable-state gate
+
+> **INV-12 (Queryable-only on the wire).** `sendStateChange` MUST refuse to send any state not in `CREATIVE_QUERYABLE_STATES` (`sharc-protocol.js:825-828`). `loading` MUST NOT be delivered (it is the pre-`ready` bootstrap state the creative cannot act on; the creative's effective first state is `ready`).
+
+> **INV-13 (`terminated` delivery exception).** `terminated` is **non-queryable** for the `getContainerState()` query API, but the creative MUST be notified exactly once that the session is ending. The container MUST deliver the terminal notification through the lifecycle channel (current behavior maps `terminated` to a `hidden` `stateChange` with a warn at the container, audit §3 / state table row TERMINATED). **Normative requirement:** the creative MUST receive **exactly one** terminal lifecycle signal and MUST NOT receive any `stateChange` after it (INV-11). **Implementation note / STOP-AND-ASK candidate:** the current `terminated→hidden` mapping is preserved by this contract as-is; if a future change introduces a first-class `terminated` `stateChange` value, that would be a delivery-semantics change to re-ratify here (it is NOT required by this contract).
+
+**What the creative sees, by state:**
+
+| Container state | Queryable? | Delivered to creative? | Creative observes |
+|---|---|---|---|
+| `loading` | No | No | nothing (pre-`ready`) |
+| `ready` | Yes | Yes | `ready` (the floor) |
+| `active` | Yes | Yes (exactly once per entry) | `active` |
+| `passive` | Yes | Yes | `passive` |
+| `hidden` | Yes | Yes | `hidden` |
+| `frozen` | Yes | Yes | `frozen` (then quiet — bridges suppress further while frozen) |
+| `terminated` | No (query) | Yes, **as one terminal signal** (current: `hidden`) | one terminal `stateChange`, then nothing (INV-11/13) |
+
+---
+
+## 7. Replay-on-subscribe (D3)
+
+> **INV-14 (Replay exactly once).** A `stateChange` listener registered AFTER a state exists for the session MUST receive the current (last-known) state exactly once, synchronously, at registration (`sharc-creative.js:524-525`).
+
+> **INV-15 (Replay scope = lifecycle `stateChange` only).** Replay MUST be scoped to the latching `stateChange` event. One-shot events — `containerError`, `log`, `close`, `placementTransitionEnd` — MUST NOT be replayed. (Replaying a stale error/log/close to a late listener is semantically wrong.)
+
+> **INV-16 (Replay does not re-drive the live bus).** Replay MUST deliver to the **registering listener only**. It MUST NOT re-`_emit` to existing listeners and MUST NOT re-enter the live subscription path. The channel is non-latching: replay reflects the last value but does not cause the live bus to re-fire.
+
+> **INV-17 (Replay reflects the LAST value).** The replayed value MUST be the most-recent delivered state (`_lastContainerState`), not the first. After `active → hidden`, a late subscriber MUST be replayed `hidden`.
+
+> **INV-18 (Replay never precedes `ready`).** A creative MUST NOT receive a replayed `stateChange` before its cache is seeded — the cache is seeded in `_handleInit` (`sharc-creative.js:320`) from a real queryable `env.currentState`, or on the first inbound `Container:stateChange` (`:238`). Replay therefore fires at/after `ready`.
+
+> **INV-19 (No double-fire under interleaving).** For any interleaving of {init-seed, inbound `stateChange`, late `on('stateChange')` registration}, a listener MUST receive the current state exactly once (no duplicate from seed-then-replay or event-then-replay). Bridges remain idempotent (MRAID flips `viewableChange` only on `_isViewable` change), so even a defensive double would be a no-op — but the contract requires exactly-once at the bus.
+
+**Cache lifecycle (creative side):** `_lastContainerState` initialized `undefined` (`sharc-creative.js:158`), seeded in `_handleInit` (`:320`) and on every inbound `stateChange` (`:238`), replayed in `on()` (`:524-525`). It is per-creative-session; it MUST be reset if the session is torn down.
+
+---
+
+## 8. Per-session isolation
+
+> **INV-20 (Strict per-session state).** Lifecycle state delivery MUST be strictly scoped to the owning session. No container MUST deliver one session's state to another session/placement. The session gate (`sharc-protocol.js:494-501`) — which drops any inbound message whose `sessionId` ≠ the creative's own — is the boundary and MUST remain unchanged.
+
+> **INV-21 (Per-session dedup + cache state).** The send-layer `_lastSentState` (§3) and the creative-side `_lastContainerState` (§7) MUST be per-session and MUST be reset on session establish/teardown, so no value leaks across a session boundary (a re-established session starts with a clean dedup/cache).
+
+> **INV-22 (No cross-placement observability).** Each container owns one `SHARCCreativeProtocol`, one `sessionId`, one MessagePort. `sendStateChange` posts only on that container's own port. There MUST be no path by which one placement observes another's lifecycle state. (This contract changes *when/how reliably* a creative receives **its own** state, never *what* is observable.)
+
+---
+
+## 9. No wire / schema change (confirmation + STOP-AND-ASK)
+
+> **INV-23 (No wire change).** This contract MUST be satisfiable with the existing `Container:init` envelope and existing message types. CONFIRMED:
+> - The `currentState` field **already exists** in the `Container:init` envelope (`sharc-container.js:3632`); D2 changes its **value** (real state vs hard-coded `ready`), not its name/type/position. **NOT a wire change.**
+> - The dedup (§3) adds an internal instance field (`_lastSentState`) and a guard inside `sendStateChange`. **No message format change.**
+> - Replay (§7) reuses the existing `stateChange` message and the existing `on()` API. **No new message type, no new field.**
+
+**STOP-AND-ASK items for Jeffrey (ratification gate):**
+
+1. **[CONFIRM — no wire change] ✅ Recommended: approve as no-wire-change.** The contract is satisfiable with the existing envelope and message types (INV-23). Nothing here requires a schema/wire change. *Flagging explicitly per the "no wire change without asking" rule — but the answer is: none required.*
+2. **[RATIFY — option-B dedup amends R1].** Approve the send-layer last-sent dedup (§3) as the chosen fix for R1's double-`active` asymmetry, over the reviewer-rejected "make D1 conditional" (which would revert #336). This is the one behavioral amendment to R1.
+3. **[RATIFY — D1 unconditional push] (carried from R1 STOP-AND-ASK 1).** The container emits `stateChange(currentState)` on every session-establish even absent a transition. Idempotent for bridges; the dedup (§3) ensures it does not double on the normal path. Recommend approve (it is the #336 source-fix).
+4. **[CONFIRM — `terminated` delivery semantics].** This contract preserves the current `terminated → hidden` mapping for the terminal signal (INV-13). Confirm that is the intended terminal semantics, or flag if a first-class `terminated` `stateChange` value is wanted (that WOULD be a delivery-semantics re-ratification, and arguably a wire-value change).
+5. **[CONFIRM — replay scope].** Lifecycle `stateChange` only; one-shot events excluded (INV-15). Confirm.
+
+---
+
+## 10. Edge-case → expected-delivered-sequence matrix
+
+Each row maps to one conformance test (§11). "Delivered" = what reaches creative `on('stateChange')` listeners (post-dedup, post-gate). Subscriptions assumed at/after `onReady` unless the row says "late".
+
+| # | Scenario | Expected delivered `stateChange` sequence | Invariants | Test |
+|---|---|---|---|---|
+| E1 | **already-ACTIVE before handshake** (adapter promotes LOADING→ACTIVE pre-handshake; `_transitionToActive` skips `setState`) | `active` (×1, via D1 only) | INV-3, INV-4, INV-5 | C1, C2, T1, V1 |
+| E2 | **normal LOADING→ACTIVE transition** (transition send + D1 push) | `active` (×1, post-dedup — D1's identical-consecutive push suppressed) | INV-1, INV-3 | C5, T10 |
+| E3 | **rapid toggles** `active→passive→active→hidden→active` | `active, passive, active, hidden, active` (each distinct delivered; none wrongly deduped) | INV-2, INV-10 | C6, T6, N5, V4 |
+| E4 | **re-assert same state** (consecutive identical, e.g. `active` then `active` with no intervening value) | `active` (×1; the second suppressed) | INV-1 | C7 |
+| E5 | **late subscribe after active** (listener registered after `active` delivered) | replay `active` (×1) to the new listener | INV-14, INV-17 | N1, T4 |
+| E6 | **re-subscribe N times** (N listeners register late) | each of the N listeners replayed the current state once; bounded (one per registration) | INV-14, INV-19 | N6, T7 |
+| E7 | **init `currentState` seeding** (`env.currentState==='active'` at init) | cache seeded `active`; a post-init `stateChange` listener replayed `active`; non-queryable seed (`loading`) NOT seeded → no replay | INV-6, INV-9, INV-14, INV-18 | C4, N2 |
+| E8 | **terminated** | one terminal signal (current: `hidden`) ×1; no `stateChange` after | INV-11, INV-13 | C8 |
+| E9 | **freeze→restore** (`active→hidden→frozen→…→active`) | `active, hidden, frozen` on entry; `active` on restore (distinct from `frozen`, delivered) | INV-10, INV-2 | C9, T5 |
+| E10 | **native-SHARC / plain-HTML sessionless** (`sessionId===''`) | **nothing** — no establish push, `sendStateChange` no-ops (no throw); local state still transitions for operator `onStateChange` | INV-12 (no-op), §3.2 | C3 |
+
+**Notes on the matrix:**
+- E2 is the option-B payoff: pre-dedup R1 delivered `active` ×2 here; post-dedup ×1, matching E1 (symmetry, INV-3).
+- E3/E9 prove the dedup is consecutive-only: `active` reappears after a *different* value and MUST be delivered (INV-2).
+- E9's freeze entry currently walks `active→hidden→frozen` (audit §2.2 G-A: no direct `ACTIVE→FROZEN` edge); the `hidden` is a real delivered transient. That edge-graph question is audit Rec R2, **out of scope** for this contract — this contract specifies delivery semantics over whatever transitions the graph emits.
+
+---
+
+## 11. Conformance test plan (the executable spec)
+
+Legend: **RED→GREEN** = fails pre-implementation, passes after. **GREEN-guard** = passes today, pinned against regression. **node** = jsdom-expressible. **validator** = real renderer + real cross-origin (puppeteer-tier). One test per invariant + one per edge case; many invariants share a test where the assertion is the same observable.
+
+### 11.1 Node — send-layer dedup (NEW `test/node/test-state-dedup.js`)
+
+| ID | Tier | Type | Asserts | Invariant / edge |
+|---|---|---|---|---|
+| **D-1** | node | RED→GREEN | `sendStateChange('active')` twice consecutively on one session ⇒ `_sendMessage` called once | INV-1, E4 |
+| **D-2** | node | RED→GREEN | `active`→`passive`→`active` ⇒ three sends (consecutive-only, distinct flow) | INV-2, INV-10, E3 |
+| **D-3** | node | RED→GREEN | normal path: transition send `active` then D1 push `active` ⇒ one send; already-ACTIVE path: D1 push `active` only ⇒ one send (**symmetry assertion**) | INV-3, E1, E2 |
+| **D-4** | node | GREEN-guard | non-queryable (`loading`/`terminated`) ⇒ refused before touching `_lastSentState` | INV-12 |
+| **D-5** | node | GREEN-guard | `sessionId===''` ⇒ no-op, `_lastSentState` untouched, no throw | INV-12, E10 |
+| **D-6** | node | RED→GREEN | `_lastSentState` reset on session establish AND teardown ⇒ first send on a new session never deduped against a prior session's value | INV-21, INV-20 |
+
+### 11.2 Node — container source / establish push (NEW `test/node/test-container-state-establish-push.js`)
+
+| ID | Tier | Type | Asserts | Invariant / edge |
+|---|---|---|---|---|
+| **C1** | node | RED→GREEN | `_handleStartCreativeResolved` with state already ACTIVE (skip path) ⇒ exactly one `Container:stateChange('active')` sent | INV-4, E1 |
+| **C2** | node | RED→GREEN | `active` delivered only post-`acceptSession` (sessionId set); a state sent pre-sessionId is dropped at the gate | INV-5, E1 |
+| **C3** | node | GREEN-guard | native/plain-HTML (`sessionId===''`) ⇒ `sendStateChange` no-ops; local transition still fires `onStateChange` to operator | INV-12, E10 |
+| **C4** | node | RED→GREEN | set ACTIVE pre-init ⇒ `Container:init.currentState==='active'` (not hard-coded `ready`); non-queryable current ⇒ field is `ready` | INV-6, INV-9, E7 |
+| **C5** | node | RED→GREEN | normal LOADING→ACTIVE end-to-end through container ⇒ creative receives `active` exactly once (transition + D1, deduped) | INV-1, INV-3, E2 |
+| **C6** | node | RED→GREEN | drive `active→passive→active→hidden→active` ⇒ creative receives all five distinct in order | INV-2, INV-10, E3 |
+| **C7** | node | RED→GREEN | re-assert `active` twice with no intervening value ⇒ creative receives one | INV-1, E4 |
+| **C8** | node | GREEN-guard→RED→GREEN | drive to terminate ⇒ creative receives exactly one terminal signal (current: `hidden`), and NO `stateChange` after | INV-11, INV-13, E8 |
+| **C9** | node | RED→GREEN | `active→hidden→frozen→active` ⇒ `active, hidden, frozen, active` delivered (restore `active` not deduped against `frozen`) | INV-2, INV-10, E9 |
+
+### 11.3 Node — creative bus replay (NEW `test/node/test-creative-state-replay.js`)
+
+| ID | Tier | Type | Asserts | Invariant / edge |
+|---|---|---|---|---|
+| **N1** | node | RED→GREEN | `on('stateChange', fn)` after inbound `active` ⇒ `fn` replayed `active` once | INV-14, E5 |
+| **N2** | node | RED→GREEN | `_handleInit` with `env.currentState==='active'` seeds cache ⇒ post-init listener replayed `active`; `env.currentState==='loading'` ⇒ NOT seeded, no replay | INV-6, INV-18, E7 |
+| **N3** | node | GREEN-guard | one-shot events (`containerError`, `log`, `close`, `placementTransitionEnd`) NOT replayed to late listeners | INV-15 |
+| **N4** | node | RED→GREEN | replay reflects LAST state: `active`→`hidden` ⇒ late listener replayed `hidden` | INV-17, E9 |
+| **N5** | node | GREEN-guard | live subscription still toggles after a replay (offscreen→onscreen→offscreen) — replay does not latch/unsubscribe live path | INV-16, INV-10, E3 |
+| **N6** | node | RED→GREEN | N late listeners each replayed current state once (bounded: one replay per registration; no cross-fire) | INV-14, INV-19, E6 |
+
+### 11.4 Node — MRAID bridge contract (TRANSFER T1–T10 from `2045117`, re-targeted to R1+dedup)
+
+These pin the **bridge-observable** contract (unchanged assertions; delivery path now channel-based, dedup-respecting).
+
+| ID | Tier | Type | Asserts | Invariant / edge |
+|---|---|---|---|---|
+| **T1** | node | RED→GREEN | seed-from-active ⇒ `isViewable()===true` + exactly one `viewableChange(true)` | INV-3, INV-8, E1 |
+| **T2** | node | GREEN-guard | seed-from-non-active ⇒ `isViewable()===false`, no `viewableChange` | INV-8 |
+| **T3** | node | GREEN-guard | `default ≠ false` invariant (`default`+viewable `true` coexist) | INV-8 |
+| **T4** | node | RED→GREEN | late `on('stateChange')` replay drives `viewableChange(true)` | INV-14, E5 |
+| **T5** | node | RED→GREEN | replay respects last value (active→offscreen ⇒ replay `false`/`hidden`) | INV-17, E9 |
+| **T6** | node | GREEN-guard | non-latching toggle offscreen→onscreen→offscreen→onscreen toggles each time (**binding non-latch proof**) | INV-10, INV-16, E3 |
+| **T7** | node | GREEN-guard | no double-fire across interleavings (seed-then-event, event-then-seed) | INV-19, E6 |
+| **T8** | node | GREEN-guard | ordering: `ready`/`default` precede `viewableChange` | INV-7, INV-8 |
+| **T9** | node | GREEN-guard | defensive fallback (no/rejecting delivery API ⇒ no throw, live-only) | INV-16 |
+| **T10** | node | GREEN-guard | regression: single forward `active` flips once (and dedup does not suppress a genuine first `active`) | INV-1, INV-3, E2 |
+
+### 11.5 Validator / puppeteer (real adapter promotion — cannot be jsdom)
+
+| ID | Tier | Type | Asserts | Invariant / edge |
+|---|---|---|---|---|
+| **V1** | validator | RED→GREEN | **DV-sample false→true** with the late probe (t=1500ms): MRAID `isViewable` moves `default+false → default+true` for every case reaching `active` (PROVEN 5/5 in R1). Late probe committed to harness. | INV-3, INV-4, INV-8, E1 |
+| **V2** | validator | RED→GREEN | synthetic interstitial fixture (gates start on `isViewable()===true`) hangs baseline, proceeds under R1 (TRANSFER from `2045117`) | INV-4, INV-8, E1 |
+| **V3** | validator | RED→GREEN | **SafeFrame parity** (#339): synthetic SafeFrame creative behind adapter-promotes-before-handshake gets its first `geom-update` (baseline: never) | INV-4, INV-8, E1 |
+| **V4** | validator | validator-if-feasible | dynamic toggle under real intersection: `isViewable` `true→false→true` e2e (belt-and-suspenders on non-latching; node T6/C9 are the binding proofs) | INV-10, E3 |
+
+### 11.6 Coverage map (every invariant has ≥1 binding test)
+
+| Invariant | Binding test(s) |
+|---|---|
+| INV-1 (exactly-once consecutive) | D-1, C5, C7, T10 |
+| INV-2 (distinct always flows) | D-2, C6, C9 |
+| INV-3 (symmetric single active) | D-3, C1, C5, T1, V1 |
+| INV-4 (establish completeness) | C1, C2, T1, V1, V2, V3 |
+| INV-5 (establish→push ordering vs gate) | C2 |
+| INV-6 (honest init seed) | C4, N2 |
+| INV-7 (ready precedes active) | T8 |
+| INV-8 (no premature viewability) | T1, T2, T3, T8, V1, V2, V3 |
+| INV-9 (queryable floor before ready) | C4, N2 |
+| INV-10 (non-latching oscillation) | D-2, C6, C9, T6, N5, V4 |
+| INV-11 (terminated terminal) | C8 |
+| INV-12 (queryable-only gate) | D-4, D-5, C3 |
+| INV-13 (terminated delivery exception) | C8 |
+| INV-14 (replay exactly once) | N1, N6, T4 |
+| INV-15 (replay scope) | N3 |
+| INV-16 (no re-drive live bus) | N5, T6, T9 |
+| INV-17 (replay last value) | N4, T5 |
+| INV-18 (replay never precedes ready) | N2 |
+| INV-19 (no double-fire) | N6, T7 |
+| INV-20 (per-session isolation / gate unchanged) | D-6, C2 |
+| INV-21 (per-session dedup+cache reset) | D-6 |
+| INV-22 (no cross-placement) | covered by INV-20 gate tests + container single-protocol architecture (no new test surface needed) |
+| INV-23 (no wire change) | structural — asserted by C4 (value not schema) + absence of any new message type in the suite |
+
+**Split:** node D-1..D-6 + C1..C9 + N1..N6 + T1..T10; validator V1–V3 (V4 if feasible).
+
+---
+
+## 12. Channel Coverage (generalized invariant)
+
+**Generalized invariant:** the contract's "no redundant consecutive identical notification" applies not only to the container→creative `stateChange` channel but to **each adapter's value-typed lifecycle output**. Every channel that emits a value-typed lifecycle signal SHOULD suppress a redundant consecutive identical emission; the container→creative `stateChange` channel is the first to be formally deduped here, and the adapter-level channels are tracked for the same treatment.
+
+**Per-channel status table:**
+
+| Channel | Status |
+|---|---|
+| container→creative `stateChange` | **Deduped (this contract)** ✓ |
+| MRAID `viewableChange` | edge-guarded ✓ |
+| MRAID `stateChange` | **NOT deduped** — fires unconditionally; SHARC `active`+`passive` both map to MRAID `'default'` → spec-incorrect double → tracked **#343** |
+| MRAID `audioVolumeChange`, `sizeChange` | no same-value guard → **#343** |
+| SafeFrame `focus-change` | transition-only ✓ |
+| SafeFrame `geom-update` | assess (may be intentional geometry sample) → **#343** |
+| OMID `geometryChange` | rate-limited ✓ |
+| OMID `sessionStart`/`loaded`/`impression`/`sessionFinish` | one-shot flags ✓ |
+| container `onStateChange` (operator) | transition-based ✓ |
+
+**Note:** adapter-level dedup is tracked HIGH in **#343**; the CI-flaky nav fixture is **#344**.
+
+---
+
+## 13. Migration note
+
+- **R1 + the dedup land together.** The send-layer dedup (§3) is an amendment to R1, not a separate release. Shipping R1's double-`active` (E2 = 2×) and then fixing it would expose the asymmetry to integrators between releases. Land D1+D2+D3 (R1) and the `_lastSentState` dedup as one change, with §11's tests green.
+- **The per-bridge #334 `getContainerState()` seed stays retired** (R1 ADR §"Retiring the #334 seed"). The channel now delivers state directly; the bridge no longer polls. This also keeps audit F9 (poll hangs during freeze) closed. T1–T10 remain (re-targeted), proving the bridge-observable contract is unchanged.
+- **Pre-1.0:** no alias/deprecation. The dedup is internal; no public API changes.
+- **Out of scope (stay open):** #335 (readiness-timing), #337/audit F4 (terminate-order), #338/audit R3 (bfcache dead-port relinking), audit R2 (direct `ACTIVE→FROZEN` edge), audit R4 (single restore authority). This contract specifies *delivery semantics over the channel*; it does not change the transition graph or channel liveness.
+
+---
+
+## 14. Cross-links
+
+- **Implements:** R1 ADR `0.7.10-unified-state-replay-r1.md` (D1/D2/D3). **This contract amends R1** with §3 (option-B dedup).
+- **Canonical graph + ordering:** `0.7.10-lifecycle-state-mapping-audit.md` (§1 ordering, §2 graph, §3 per-surface map, Rec R1).
+- **Tests:** `test/node/test-state-dedup.js`, `test/node/test-container-state-establish-push.js`, `test/node/test-creative-state-replay.js`, `test/node/test-mraid-visibility-seed.js` (re-targeted T1–T10), validator V1–V3.


### PR DESCRIPTION
Lands three ratified Dev Team design docs into `docs/design/` (copied + lightly adapted from the design record). **Docs-only** — no `src/` or `test/` changes.

## What lands

1. **`docs/design/state-delivery-contract.md`** — the durable, test-enforced **normative contract** for the container→creative lifecycle-state channel. Status: **Accepted — ratified by Jeffrey 2026-06-07** (decisions 1–3 + 5 ratified; #4 confirms the current `terminated → hidden` terminal mapping). Implemented in **#342**.
   - Adds a new **"Channel Coverage (generalized invariant)"** section: generalizes the "no redundant consecutive identical notification" rule from the `stateChange` channel to **each adapter's value-typed lifecycle output**, with a per-channel status table. Adapter-level dedup gaps (MRAID `stateChange`/`audioVolumeChange`/`sizeChange`, SafeFrame `geom-update`) tracked HIGH in **#343**; CI-flaky nav fixture in **#344**.
2. **`docs/design/0.7.10-unified-state-replay-r1.md`** — the **R1 ADR** (D1/D2/D3). Status Accepted; implemented in **#342**; cross-links the contract.
3. **`docs/design/0.7.10-lifecycle-state-mapping-audit.md`** — the cross-surface lifecycle + state-transition **audit reference**.

## Adaptation notes (no technical content changed)

- Headers updated to Accepted status; `~/Obsidian/...` paths replaced with repo-relative `docs/design/...` references (or dropped, keeping the name).
- "Repo copy on ratification" notes removed.
- Cross-links between the three docs re-pointed at the new repo filenames.

## Leakage scan (private DV corpus)

Scanned all three docs for private creative data — markup, ad/click/landing URLs, auction/bid/request IDs, crids. **Clean: aggregate-only.** The only corpus references are the private corpus filename and aggregate signal reads (e.g. "5/5"). Naming "DoubleVerify" is permitted per project policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)