### PR TITLE
fix: make script-load-navigation validator fixture deterministic (#344)

### DIFF
--- a/tools/creative-validator/fixtures/script-load-navigation.js
+++ b/tools/creative-validator/fixtures/script-load-navigation.js
@@ -1,3 +1,49 @@
-setTimeout(function () {
-  window.location.href = 'https://click.example/script-load-navigation';
-}, 50);
+// Fires a top-of-frame navigation that the container's load-event backstop must
+// classify as `unauthorized_navigation` (outcome bucket `navigation-policy`).
+//
+// Determinism (#344): the navigation MUST land in the post-render window — after
+// the container has accepted `:rendered` and armed `_armRendererBackstop`. The
+// previous fixed 50ms timer raced render-completion: on slow CI the timer fired
+// before the backstop was armed, so the navigation was never bucketed and the
+// case flaked to `passed`.
+//
+// `window.SHARC.onReady` fires on `Container:init`, which the container sends
+// ~200ms after `:rendered` via `initChannel` — strictly AFTER the backstop is
+// armed (armed synchronously in `_onRendererRendered`, before the deferred
+// init). Gating the navigation on `onReady` guarantees it is a genuine
+// post-render load in any environment, so it is deterministically classified
+// `navigation-policy`. The validator harness injects `window.SHARC` into every
+// creative iframe, so the SDK is always present.
+//
+// This fixture is loaded synchronously at parse time (static <script src> in the
+// case markup) so its `onReady` registration always precedes the 200ms-deferred
+// `Container:init` — `onReady` is single-shot and not replayed to late
+// subscribers, so registering before init is part of the determinism contract.
+(function () {
+  function navigate() {
+    window.location.href = 'https://click.example/script-load-navigation';
+  }
+
+  var sharc = window.SHARC;
+  if (sharc && typeof sharc.onReady === 'function') {
+    // `Container:init` is post-render and post-backstop-arm. Navigate from the
+    // ready callback so the load is always a subsequent (unauthorized) load,
+    // never the first verified one.
+    sharc.onReady(function () {
+      navigate();
+    });
+    return;
+  }
+
+  // Defensive fallback if the SDK global is unavailable for any reason: defer to
+  // a macrotask after window load so the navigation still fires post-render.
+  // The deterministic path above is the contract; this only avoids a silent
+  // no-op if the harness changes how it injects the SDK.
+  if (document.readyState === 'complete') {
+    setTimeout(navigate, 0);
+  } else {
+    window.addEventListener('load', function () {
+      setTimeout(navigate, 0);
+    }, { once: true });
+  }
+})();

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -843,13 +843,14 @@ test('runner executes HTML cases and writes one report row per case', () => {
     creative: {
       mode: 'adm-html',
       admKind: 'html',
-      html: '<!doctype html><html><body><script>'
-        + 'window.addEventListener("load",function(){'
-        + 'var script=document.createElement("script");'
-        + 'script.src="/tools/creative-validator/fixtures/script-load-navigation.js";'
-        + 'document.body.appendChild(script);'
-        + '});'
-        + '</script></body></html>',
+      // #344: load the fixture synchronously at parse time (not on window.load)
+      // so its onReady registration always precedes the container's
+      // 200ms-deferred Container:init. onReady is single-shot and not replayed
+      // to late subscribers, so registering before init is what makes the
+      // post-render navigation fire deterministically (see the fixture header).
+      html: '<!doctype html><html><body>'
+        + '<script src="/tools/creative-validator/fixtures/script-load-navigation.js"></script>'
+        + '</body></html>',
       url: null,
       width: 320,
       height: 50,


### PR DESCRIPTION
The navigation-policy (security) validator test flaked in CI: the fixture fired `window.location.href` on a fixed 50ms timer racing render-completion. Now fires from `window.SHARC.onReady` (after the backstop is armed) → deterministically a post-render navigation, bucketed `navigation-policy` in any environment. Runner loads the fixture as a parse-time `<script src>` so `onReady` registration precedes `Container:init`. Assertion unchanged.

**Lifecycle-doc conformance:** relies on the lifecycle causal ordering (backstop armed synchronously at `:rendered`, ~200ms before `Container:init`/`onReady`) — not a bigger timeout.

**Claude-lane review:** Code Reviewer — clean. Determinism proven 11× runs; inversion test confirms the assertion still bites. Note: touches `test-runner.js` in a region disjoint from #339 → clean rebase. Ready for Codex + OpenClaw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)