### PR TITLE
fix: deterministic batch-path capture for unauthorized-navigation termination (#351)

### DIFF
--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -1544,6 +1544,11 @@ window.__sharcCreativeValidatorHarness = {
     let constructionError = null;
     let loadError = null;
     let container = null;
+    // #351: epoch ms (Date.now clock) at which the container observed its
+    // Container:init resolve. Anchors the post-render navigation-verdict wait
+    // below. Same clock as `securityEvents[].timestamp`, so the two are
+    // directly comparable.
+    let initResolvedAt = 0;
     const rendererOrigin = new URL(options.rendererUrl).origin;
     const probeNonce = randomProbeNonce();
     const onMessageEvent = (event) => {
@@ -1628,11 +1633,22 @@ window.__sharcCreativeValidatorHarness = {
           });
         },
         onMessage: (direction, message) => {
-          messages.push({
+          const type = message && message.type ? message.type : null;
+          const entry = {
             t: Math.round(performance.now() - started),
             direction,
-            type: message && message.type ? message.type : null,
-          });
+            type,
+          };
+          // #351: stamp the Container:init resolve with an epoch timestamp so
+          // the post-render navigation-verdict wait below can anchor to it on
+          // the same clock as the security events. The fixture's onReady-driven
+          // navigation fires off this resolve, so init-resolve is the causal
+          // origin of the whole nav-adjudication window.
+          if (direction === 'sent-resolved' && type === 'SHARC:Container:init') {
+            entry.epochTs = Date.now();
+            initResolvedAt = entry.epochTs;
+          }
+          messages.push(entry);
         },
       });
     } catch (err) {
@@ -1667,41 +1683,51 @@ window.__sharcCreativeValidatorHarness = {
       }
       await sleep(options.settleMs);
       // #351: causal wait for the post-render navigation verdict. The settle
-      // sleep is a floor that keeps clean cases fast, but a post-render iframe
-      // load is adjudicated asynchronously by the container's backstop gate
-      // (sharc-container.js `_armRendererBackstop` -> `runGate`): every
-      // post-render load emits `renderer_load_observed` immediately, then a
-      // 100ms controlled-context probe runs. An ANSWERED probe keeps the ad
-      // alive and emits nothing further; an UNANSWERED probe fires
-      // `unauthorized_navigation` (2118). The outcome classifier (diagnose.js)
-      // buckets `navigation-policy` on the PRESENCE of that 2118 event, not on
-      // `terminated`. The nav fixture navigates ~200ms post-render, so under a
-      // short settle floor the snapshot can land after the load
-      // (`renderer_load_observed` present) but before the probe deadline emits
-      // the 2118 event -- misclassifying a failed nav case as `passed`.
+      // sleep is a floor that keeps clean cases fast, but the container
+      // adjudicates a post-render top-frame navigation asynchronously, and the
+      // verdict can land AFTER a short settle floor — misclassifying a failed
+      // nav case as `passed`. How the mechanism actually works (verified by
+      // measurement, sharc-container.js `_armRendererBackstop` -> the `onAck`
+      // path at ~4660 and `_emitRendererLoadObserved` at ~5027):
       //
-      // The verdict for a load is decided within the 100ms probe deadline of
-      // that load, so we wait only until the latest post-render load's probe
-      // window has closed (probe deadline + margin), measured from the event's
-      // own `timestamp`. We stop early the instant the 2118 verdict (or
-      // terminate) lands. A benign load emits no further event, so this is the
-      // only place its cost is bounded -- to the probe window past the load,
-      // NOT a flat multi-second timer. `renderer_load_observed` persists in the
-      // array for the run, so the bound MUST be relative to its timestamp (an
-      // absence check alone would make every benign post-render-load case wait
-      // the full ceiling).
-      const PROBE_VERDICT_WINDOW_MS = 400;
+      //   (a) The FIRST post-render renderer-frame load runs a 100ms
+      //       controlled-context probe. That probe is ANSWERED (the renderer is
+      //       still ours), so the container emits a non-terminating
+      //       `renderer_load_observed` — this is the marker of the first
+      //       *verified* load, and it is the ONLY load that emits it.
+      //   (b) The fixture's onReady (fired off Container:init) then drives a
+      //       cross-origin navigation. That SUBSEQUENT load is UNANSWERED, so
+      //       it emits NO `renderer_load_observed` — only an
+      //       `unauthorized_navigation` (2118) ~100ms later, once its probe
+      //       deadline lapses. The outcome classifier (diagnose.js) buckets
+      //       `navigation-policy` on the PRESENCE of that 2118 event.
+      //   (c) There is no harness-visible per-subsequent-load marker (the
+      //       outbound :loadProbe is not routed through onMessage). So we anchor
+      //       the wait to the Container:init RESOLVE instead: the navigation is
+      //       dispatched from init's onReady, so init-resolve is the causal
+      //       origin of the entire nav-adjudication window. The window need only
+      //       span onReady dispatch + the navigation load + the 100ms probe
+      //       deadline + margin (measured ~100-130ms; 250ms is ample).
+      //
+      // WHY anchor at init rather than the first load: the navigation's verdict
+      // trails Container:init, which the container itself defers ~200ms after
+      // :rendered via a setTimeout. That deferral can DRIFT LATER under CI load.
+      // The first-load timestamp does NOT move with that drift, so a load-anchored
+      // deadline has only ~78ms of headroom that the drift can eat. The
+      // init-resolve timestamp already reflects whatever drift occurred, so an
+      // init-anchored deadline absorbs it entirely — fixed headroom regardless of
+      // deferral jitter. Benign cases pay ~0: init resolves ~200ms post-render,
+      // so the deadline (~200+250=450ms) falls before the 500ms settle floor has
+      // elapsed, and waitUntil returns immediately. We also stop early the
+      // instant the 2118 verdict (or terminate) lands.
+      const VERDICT_WINDOW_MS = 250;
       const hasNavVerdict = () =>
         securityEvents.some((event) => event.type === 'unauthorized_navigation');
-      const lastPostRenderLoadTs = () => securityEvents.reduce((max, event) =>
-        event.type === 'renderer_load_observed' && typeof event.timestamp === 'number'
-          ? Math.max(max, event.timestamp)
-          : max, 0);
-      if (!isTerminated() && !hasNavVerdict() && lastPostRenderLoadTs() > 0) {
-        const verdictDeadline = lastPostRenderLoadTs() + PROBE_VERDICT_WINDOW_MS;
+      if (!isTerminated() && !hasNavVerdict() && initResolvedAt > 0) {
+        const verdictDeadline = initResolvedAt + VERDICT_WINDOW_MS;
         await waitUntil(
           () => isTerminated() || hasNavVerdict() || Date.now() >= verdictDeadline,
-          PROBE_VERDICT_WINDOW_MS,
+          VERDICT_WINDOW_MS,
         );
       }
     }

--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -1666,6 +1666,44 @@ window.__sharcCreativeValidatorHarness = {
         container.setState('active');
       }
       await sleep(options.settleMs);
+      // #351: causal wait for the post-render navigation verdict. The settle
+      // sleep is a floor that keeps clean cases fast, but a post-render iframe
+      // load is adjudicated asynchronously by the container's backstop gate
+      // (sharc-container.js `_armRendererBackstop` -> `runGate`): every
+      // post-render load emits `renderer_load_observed` immediately, then a
+      // 100ms controlled-context probe runs. An ANSWERED probe keeps the ad
+      // alive and emits nothing further; an UNANSWERED probe fires
+      // `unauthorized_navigation` (2118). The outcome classifier (diagnose.js)
+      // buckets `navigation-policy` on the PRESENCE of that 2118 event, not on
+      // `terminated`. The nav fixture navigates ~200ms post-render, so under a
+      // short settle floor the snapshot can land after the load
+      // (`renderer_load_observed` present) but before the probe deadline emits
+      // the 2118 event -- misclassifying a failed nav case as `passed`.
+      //
+      // The verdict for a load is decided within the 100ms probe deadline of
+      // that load, so we wait only until the latest post-render load's probe
+      // window has closed (probe deadline + margin), measured from the event's
+      // own `timestamp`. We stop early the instant the 2118 verdict (or
+      // terminate) lands. A benign load emits no further event, so this is the
+      // only place its cost is bounded -- to the probe window past the load,
+      // NOT a flat multi-second timer. `renderer_load_observed` persists in the
+      // array for the run, so the bound MUST be relative to its timestamp (an
+      // absence check alone would make every benign post-render-load case wait
+      // the full ceiling).
+      const PROBE_VERDICT_WINDOW_MS = 400;
+      const hasNavVerdict = () =>
+        securityEvents.some((event) => event.type === 'unauthorized_navigation');
+      const lastPostRenderLoadTs = () => securityEvents.reduce((max, event) =>
+        event.type === 'renderer_load_observed' && typeof event.timestamp === 'number'
+          ? Math.max(max, event.timestamp)
+          : max, 0);
+      if (!isTerminated() && !hasNavVerdict() && lastPostRenderLoadTs() > 0) {
+        const verdictDeadline = lastPostRenderLoadTs() + PROBE_VERDICT_WINDOW_MS;
+        await waitUntil(
+          () => isTerminated() || hasNavVerdict() || Date.now() >= verdictDeadline,
+          PROBE_VERDICT_WINDOW_MS,
+        );
+      }
     }
 
     const result = {


### PR DESCRIPTION
Closes #351.

## Problem
`tools/creative-validator/test/test-runner.js` batch test #2 ("runner executes HTML cases…") intermittently captured `bid-runner-script-load-navigation` as outcome `passed` instead of `failed`/`navigation-policy`, reddening CI on trees byte-identical to `main`. #344/#350 fixed the *standalone* nav test (#6); the *batch* path was still flaky.

## Root cause
The in-page harness (`markup-runner.html`) settled with a flat `await sleep(options.settleMs)`, then snapshotted `securityEvents`. The post-render navigation's `2118 unauthorized_navigation` verdict lands ~100ms after the nav load; under the batch's short `--settle-ms 500` floor that verdict can arrive **after** the snapshot. The outcome classifier (`diagnose.js`) buckets `navigation-policy` on the **presence** of the 2118 event — so a missed verdict misclassifies a failed nav case as `passed`.

## Fix (harness-only, +67/−3)
After the settle floor, causally wait for the navigation verdict — bounded, early-exit on verdict/terminate. The deadline is anchored to the **Container:init resolve** timestamp (observed via the existing `onMessage('sent-resolved', SHARC:Container:init)` hook), not to the first verified load:
- The fixture's navigation is dispatched from `onReady` (fired off Container:init), so init-resolve is the causal origin of the whole nav-adjudication window.
- Container:init is deferred ~200ms after `:rendered` via a `setTimeout` that **drifts later under CI load**. A first-load anchor doesn't move with that drift (~78ms headroom); the init-resolve anchor already reflects the drift, so headroom is drift-immune (~130ms measured).
- Benign cases pay ~0: init resolves ~200ms post-render → deadline ~450ms < the 500ms floor → `waitUntil` returns immediately.

No production/container change — the fix only **reads** the existing init signal. No new test file (existing batch test #2 + standalone #6 are the regression guards), so no `test:all:built` change.

## Lifecycle-doc conformance
Test-harness timing only; does not touch the container→creative protocol, the state machine, or any RFC-2119 invariant in `docs/design/state-delivery-contract.md`. The container's post-render navigation policy and event semantics are unchanged.

## Verification
- **RED window (settle=250, where the wait does the work):** nav case → `failed`/`navigation-policy` **5/5**; measured init→verdict gap stable 116–122ms.
- **Full suite green:** `npm run test:creative-validator-runner` → 9/9, **8× consecutive** (5× builder + 3× independent re-verify).
- **Benign non-regression (settle=500):** `bid-runner-test` 559ms, `bid-runner-script-load-ok` 563ms, nav 560ms — ~0 extra wait.

## Claude-lane review
Code Reviewer (fresh context) initially returned **blocking** ("gate never engages"). That claim was **refuted by instrumented data** — `renderer_load_observed` is present (it's the *first verified* load's marker, which the gate correctly anchors against). Two valid secondary findings from the review were fixed: an inverted explanatory comment (corrected) and the thin first-load margin (re-anchored to init). Trust-boundary review (Security Engineer) not required — harness test infra, no production boundary touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
