### PR TITLE
test: MRAID wrapper prelude load-failure browser coverage + TEST_ONLY url knob (#328)

### DIFF
--- a/examples/renderer/index.html
+++ b/examples/renderer/index.html
@@ -348,6 +348,14 @@
     if (RENDERER_CONFIG.TEST_ONLY && testSafeFrameWrapperProtocolUrl != null) {
       RENDERER_CONFIG.SAFEFRAME_WRAPPER_PROTOCOL_URL = testSafeFrameWrapperProtocolUrl;
     }
+    // #328: matching TEST_ONLY knob for the MRAID wrapper's first
+    // component URL so the harness can exercise the wrapper provisioning
+    // failure path (the MRAID analogue of sharcTestSafeFrameWrapperProtocolUrl).
+    var testMraidWrapperProtocolUrl = new URLSearchParams(window.location.search)
+      .get('sharcTestMraidWrapperProtocolUrl');
+    if (RENDERER_CONFIG.TEST_ONLY && testMraidWrapperProtocolUrl != null) {
+      RENDERER_CONFIG.MRAID_WRAPPER_PROTOCOL_URL = testMraidWrapperProtocolUrl;
+    }
   } catch (_) { /* keep default config */ }
   // SECURITY: freeze the config post-construction. Closes the
   // post-load-mutation surface — once set at fork time, the bridge URL

--- a/test/browser/test-creative-sources-puppeteer.js
+++ b/test/browser/test-creative-sources-puppeteer.js
@@ -211,6 +211,36 @@ async function run() {
           'unparseable safeframe wrapper url: onSecurityEvent bridge_load_failed carries bridge and substituted URL');
       }
 
+      // #328: MRAID is wrapper-provisioned (installMraidCompatibilityWrapperPrelude),
+      // so — like SafeFrame — its provisioning-failure path is driven via an
+      // unparseable MRAID wrapper component URL. The renderer reports a fatal
+      // bridge_load_failed for mraid and refuses to render (:failed), reaching
+      // the throw in fetchSameOriginRendererSource before any creative script.
+      console.log('\nbridge_load_failed. unparseable MRAID wrapper URL');
+      {
+        const result = await page.evaluate(() =>
+          window.__sharcCreativeSourcesHarness.runMraidWrapperLoadFailureProbe());
+        const bridgeFailedLog = result.messages.find((m) =>
+          m.payload && m.payload.reason === 'bridge_load_failed'
+            && m.payload.bridge === 'mraid');
+        const bridgeEvent = result.securityEvents.find((event) =>
+          event.type === 'bridge_load_failed');
+        const firstError = result.errors[0];
+
+        assert(result.terminated === true,
+          'unparseable mraid wrapper url: container terminates');
+        assert(result.creativeRendered === false,
+          'unparseable mraid wrapper url: renderer does not report :rendered');
+        assert(Boolean(bridgeFailedLog),
+          'unparseable mraid wrapper url: renderer logs bridge_load_failed for mraid');
+        assert(firstError && firstError.code === 2115,
+          'unparseable mraid wrapper url: onError fires RENDERER_FAILED (2115)');
+        assert(bridgeEvent && bridgeEvent.errorCode === 2115
+            && bridgeEvent.details && bridgeEvent.details.bridge === 'mraid'
+            && bridgeEvent.details.url === 'http://[invalid',
+          'unparseable mraid wrapper url: onSecurityEvent bridge_load_failed carries bridge and substituted URL');
+      }
+
       console.log('\nunknown_bridge_skipped. future bridge identifier');
       {
         const result = await page.evaluate(() =>

--- a/test/browser/test-creative-sources.html
+++ b/test/browser/test-creative-sources.html
@@ -469,6 +469,44 @@ window.runBridgeLoadFailureProbe = async function () {
   }
 };
 
+window.runMraidWrapperLoadFailureProbe = async function () {
+  const messages = [];
+  const onMessage = (event) => {
+    if (event && event.data && event.data.type === 'SHARC:Test:rendererSecurityLog') {
+      messages.push(event.data);
+    }
+  };
+  window.addEventListener('message', onMessage);
+
+  // #328: MRAID is wrapper-provisioned (installMraidCompatibilityWrapperPrelude),
+  // so its provisioning-failure path is driven via the MRAID wrapper's first
+  // component URL (MRAID_WRAPPER_PROTOCOL_URL) rather than BRIDGE_URL_TEMPLATE.
+  // An unparseable URL makes fetchSameOriginRendererSource throw, which the
+  // renderer reports as a fatal bridge_load_failed for mraid — the MRAID
+  // analogue of runBridgeLoadFailureProbe (SafeFrame).
+  const rendererUrl = RENDERER_BASE + '/examples/renderer/'
+    + '?sharcTestReportSecurityLog=1'
+    + '&sharcTestMraidWrapperProtocolUrl=' + encodeURIComponent('http://[invalid');
+  const c = buildContainer(rendererUrl, {
+    bridges: ['mraid'],
+    timeouts: { rendererLoad: 8000, rendererReply: 4000 },
+  });
+
+  try {
+    c.load();
+    await waitFor(() => c._terminated, 10000);
+    return {
+      messages,
+      errors: c.errors,
+      securityEvents: c.securityEvents,
+      creativeRendered: c.creativeRendered,
+      terminated: c._terminated,
+    };
+  } finally {
+    window.removeEventListener('message', onMessage);
+  }
+};
+
 window.runUnknownBridgeProtocolProbe = async function () {
   const nonce = (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function')
     ? crypto.randomUUID()
@@ -681,6 +719,7 @@ window.__sharcCreativeSourcesHarness = {
   runScenario: window.runScenario,
   runNavigationProbe: window.runNavigationProbe,
   runBridgeLoadFailureProbe: window.runBridgeLoadFailureProbe,
+  runMraidWrapperLoadFailureProbe: window.runMraidWrapperLoadFailureProbe,
   runUnknownBridgeProtocolProbe: window.runUnknownBridgeProtocolProbe,
   runInterstitialViewableProbe: window.runInterstitialViewableProbe,
   runSafeframeSessionGeomProbe: window.runSafeframeSessionGeomProbe,


### PR DESCRIPTION
Closes #328.

## What
Adds the missing in-browser test for the MRAID compatibility-wrapper prelude **load-failure** path (404/cross-origin/unparseable module URL → `bridge_load_failed` bridge `'mraid'` → `:failed`, renderer refuses to render).

## Why a one-line production change
Unlike SafeFrame (#339) and OMID (#250) — which each shipped a `TEST_ONLY`-gated URL-override knob in their feat commit — the MRAID wrapper (#321) never added one, and `RENDERER_CONFIG` is `Object.freeze`'d, so the failure path was unreachable from the harness. **Jeffrey authorized** adding the missing `sharcTestMraidWrapperProtocolUrl` knob, mirroring the SafeFrame sibling exactly.

## Changes
- `examples/renderer/index.html` — the one authorized `TEST_ONLY`-gated knob (applied before `Object.freeze`; inert in production forks).
- `test/browser/test-creative-sources.html` + `test-creative-sources-puppeteer.js` — new `runMraidWrapperLoadFailureProbe` + assertions (bridge==='mraid', error 2115, no `:rendered`, terminated). Deterministic (gates on `:failed`, not a timer). Runs under `test:browser` → `test:all:built`.

## Claude-lane review
Code Reviewer **ship-ready** + Security Engineer **no blocking**. Knob mirrors its siblings byte-for-byte; `TEST_ONLY` is a hardcoded literal with no runtime-flip path; even in test mode the same-origin fetch check + container-side production guard bound the blast radius to "fetch fails." Only production change is the knob; 3× green, no regressions. (Speculative `0.7.11` comment tag dropped per review.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
