### PR TITLE
chore: fix pre-existing no-unused-vars lint in test/node

### DIFF
--- a/test/node/test-container-state-establish-push.js
+++ b/test/node/test-container-state-establish-push.js
@@ -211,7 +211,7 @@ console.log('test-container-state-establish-push.js — R1 D1/D2 container sourc
   };
   // Establish a session so _handleCreateSession proceeds to build/send init.
   const sid = '22222222-2222-4222-8222-222222222222';
-  c._protocol.acceptSession = function (msg) { this.sessionId = sid; };
+  c._protocol.acceptSession = function () { this.sessionId = sid; };
   // Stub the deferred startCreative send so the post-init resolve does not float
   // a "No MessagePort available" console.error (the stubbed session has no port);
   // this measurement only cares about the init env, not the startCreative leg.
@@ -230,7 +230,7 @@ console.log('test-container-state-establish-push.js — R1 D1/D2 container sourc
   c2.setState('ready');
   let sentEnv2 = null;
   c2._protocol.sendInit = (environmentData) => { sentEnv2 = environmentData; return Promise.resolve({}); };
-  c2._protocol.acceptSession = function (msg) { this.sessionId = sid; };
+  c2._protocol.acceptSession = function () { this.sessionId = sid; };
   c2._sendStartCreative = () => {};
   c2._handleCreateSession({ sessionId: sid, args: { version: '0.7.9', placementType: 'inline' } });
   assert(sentEnv2 && sentEnv2.currentState === 'ready', 'at READY, env.currentState is "ready"');

--- a/test/node/test-creative-state-replay.js
+++ b/test/node/test-creative-state-replay.js
@@ -47,7 +47,7 @@ async function makeCreative() {
   dom.window.SHARC.Protocol = protoMod;
   const { ContainerMessages } = protoMod;
 
-  const mod = await import(`../../dist/sharc-creative.mjs?replay=${Date.now()}-${nonce++}`);
+  await import(`../../dist/sharc-creative.mjs?replay=${Date.now()}-${nonce++}`);
   const SHARC = dom.window.SHARC;
   const instance = SHARC._instance;
 

--- a/test/node/test-mraid-adapter-dedup.js
+++ b/test/node/test-mraid-adapter-dedup.js
@@ -27,8 +27,6 @@
  * its own globalThis.window via a cache-busting import query.
  */
 
-import assert from 'node:assert/strict';
-
 const BRIDGE_URL = '../../dist/sharc-mraid-bridge.mjs';
 
 let nonce = 0;

--- a/test/node/test-mraid-exposure-change.js
+++ b/test/node/test-mraid-exposure-change.js
@@ -38,8 +38,6 @@
  * globalThis.window via a cache-busting import query.
  */
 
-import assert from 'node:assert/strict';
-
 const BRIDGE_URL = '../../dist/sharc-mraid-bridge.mjs';
 
 let nonce = 0;

--- a/test/node/test-mraid-visibility-channel.js
+++ b/test/node/test-mraid-visibility-channel.js
@@ -36,8 +36,6 @@
  *   T10 → INV-1, INV-3, E2   single forward active flips once (genuine first active not suppressed)
  */
 
-import assert from 'node:assert/strict';
-
 const BRIDGE_URL = '../../dist/sharc-mraid-bridge.mjs';
 
 let nonce = 0;

--- a/test/node/test-state-dedup.js
+++ b/test/node/test-state-dedup.js
@@ -184,7 +184,7 @@ console.log('test-state-dedup.js — option-B send-layer dedup (Contract §3)\n'
 
   // Teardown reset: after a send, reset() must clear _lastSentState so a new
   // session's first identical send is NOT deduped against the prior session.
-  const { proto, sent } = makeProto();
+  const { proto } = makeProto();
   proto.sendStateChange('active');
   check(proto._lastSentState === 'active', 'after send, _lastSentState records "active"');
   proto.reset();


### PR DESCRIPTION
Sweeps 7 pre-existing `no-unused-vars` errors in `test/node/` (test-mraid-adapter-dedup, test-mraid-exposure-change, test-mraid-visibility-channel, test-container-state-establish-push, test-creative-state-replay, test-state-dedup). `npm run lint` 7 → 0; all 6 touched test files still pass. Dead-binding removal only; the one side-effectful import (`test-creative-state-replay`) kept its expression, dropped only the unused name. No production change, no test logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)