### PR TITLE
fix: surface OMID shim-install failures to the container (#249)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1440,6 +1440,8 @@ Reserved `reason` strings the reference renderer emits:
 | `missing_creative_html` | `event.data.creativeHtml` is missing or non-string |
 | `invalid_bridges_field` (0.7.1+) | `event.data.bridges` is present but not an array of strings |
 | `bridge_load_failed` (0.7.1+) | Dynamic `import()` of a compatibility bridge module rejected (404, MIME mismatch, network failure, same-origin assertion failure, evaluation throw). Payload includes a `bridge` field with the failed identifier; container routes to the `bridge_load_failed` `onSecurityEvent` variant. |
+| `omid_shim_inject_failed` (0.7.8+) | **Outer (pre-`document.write`):** the renderer could not BUILD the OMID shim prelude — the shim source 404'd, the fetch was MIME/CSP-blocked, or `OMID_SHIM_URL` was cross-origin. Fatal: the render is aborted before any creative markup is written. |
+| `omid_shim_install_failed` (0.7.8+, [#249](https://github.com/jeffreycarlson/SHARC/issues/249)) | **Inner (during `document.write`):** the prelude ran but `installOmidShim()` THREW (a half-install — e.g. `window.omid3p` partially set, listener unattached). Surfaced from the prelude's catch so the half-install is observable rather than a swallowed `console.error`. Container routes to the generic `renderer_failed` `onSecurityEvent` variant (`details.reason`). **#249 closes the THROWING variant only** — a non-throwing partial install (one that `installOmidShim()` returns from without throwing) stays silent by design. |
 | `document_write_failed: <message>` | `document.write` threw |
 
 Operator forks may extend the vocabulary; the container surfaces the renderer-supplied `reason` raw on the structured event channel and sanitized in dev-channel logs.

--- a/examples/renderer/index.html
+++ b/examples/renderer/index.html
@@ -611,12 +611,18 @@
   // @param {string} omidProtocolNonce  OMID protocol nonce (router-derived).
   // @param {string} placementSessionId
   // @param {string} containerOrigin
+  // @param {string} rendererNonce      Renderer-protocol nonce (router gate 7).
+  //                                    Baked so the inline shim-install catch can
+  //                                    echo it on the #249 :failed envelope. NOT
+  //                                    the OMID protocolNonce. Mirrors
+  //                                    installLoadProbePrelude's `ackNonce` param.
   // @returns {Promise<string>}         The HTML with the shim prelude prepended.
   // @throws if the shim URL is cross-origin/unparseable or the fetch fails —
   //         the caller routes this to `:failed` so OMID never silently no-ops.
   // ─────────────────────────────────────────────────────────────────────
   async function installOmidShimPrelude(html, omidProtocolNonce,
-                                        placementSessionId, containerOrigin) {
+                                        placementSessionId, containerOrigin,
+                                        rendererNonce) {
     var resolved;
     try {
       resolved = new URL(RENDERER_CONFIG.OMID_SHIM_URL, window.location.href);
@@ -649,6 +655,10 @@
       + 'var protocolNonce=' + jsonForInlineScript(omidProtocolNonce) + ';'
       + 'var placementSessionId=' + jsonForInlineScript(placementSessionId) + ';'
       + 'var containerOrigin=' + jsonForInlineScript(containerOrigin) + ';'
+      // 0.7.7 renderer-protocol nonce (NOT the OMID protocolNonce). Baked so the
+      // shim-install catch below can echo it on a :failed envelope the
+      // container's protocol router will accept (gate step 7).
+      + 'var rendererNonce=' + jsonForInlineScript(rendererNonce) + ';'
       + shimSource + ';'
       + 'try{(window.SHARC&&window.SHARC.installOmidShim||installOmidShim)({'
       + 'protocolNonce:protocolNonce,'
@@ -656,7 +666,29 @@
       + 'containerOrigin:containerOrigin'
       + '});}catch(e){'
       + 'if(window.console&&console.error)console.error('
-      + '"[SHARC Renderer] OMID shim install failed:",e&&e.message?e.message:e);}'
+      + '"[SHARC Renderer] OMID shim install failed:",e&&e.message?e.message:e);'
+      // #249: SURFACE the half-install to the container instead of swallowing it.
+      // The shim install runs synchronously DURING `document.write`, i.e. BEFORE
+      // the inner DOMContentLoaded posts :rendered — so the container is still in
+      // the `attaching-renderer` phase and a :failed envelope is in-phase (router
+      // table: `failed` → phases ['attaching-renderer']). We post the SAME wire
+      // shape the MRAID/SafeFrame wrapper-failure paths use (SHARC:Renderer:failed
+      // + a `reason`), reusing the existing renderer→container :failed channel —
+      // NO new wire type, NO new envelope field. `reason` is opaque-string
+      // passthrough: the container routes `omid_shim_install_failed` to the
+      // `renderer_failed` onSecurityEvent variant (details.reason), so a
+      // half-installed shim (window.omid3p present, listener unattached — the B1
+      // silent failure) is now DETECTABLE rather than a console.error buried in
+      // the untrusted creative iframe. A throw here means the shim cannot deliver
+      // the OMID measurement the container asked for, so it is fatal — parity with
+      // the bridge/wrapper load-failure paths.
+      + 'try{if(window.parent&&window.parent!==window){'
+      + 'window.parent.postMessage({'
+      + 'type:"SHARC:Renderer:failed",'
+      + 'placementSessionId:placementSessionId,'
+      + 'sharcNonce:rendererNonce,'
+      + 'reason:"omid_shim_install_failed"'
+      + '},containerOrigin);}}catch(_){}}'
       // SECURITY (#254): self-remove the prelude <script> as the FINAL
       // synchronous statement. `protocolNonce` is already captured into the
       // shim's private closure state by the installOmidShim call above, so the
@@ -1569,7 +1601,8 @@
     if (data.omid === true) {
       try {
         html = await installOmidShimPrelude(
-          html, data.omidProtocolNonce, placementSessionId, containerOrigin);
+          html, data.omidProtocolNonce, placementSessionId, containerOrigin,
+          nonce);
       } catch (omidErr) {
         var omidErrUrl = (omidErr && /** @type {any} */ (omidErr).url)
           ? /** @type {any} */ (omidErr).url

--- a/test/node/test-omid-renderer-prelude.js
+++ b/test/node/test-omid-renderer-prelude.js
@@ -252,13 +252,13 @@ console.log('\n6. inner installOmidShim() throw → :failed (omid_shim_install_f
   });
   const failed = failedReplies(parentMessages);
   const installFailed = failed.filter((m) => m.msg.reason === 'omid_shim_install_failed');
-  assert(installFailed.length >= 1,
-    'a half-installed shim surfaces a :failed reply (was a swallowed console.error pre-#249)');
-  assert(installFailed.length >= 1 && installFailed[0].msg.reason === 'omid_shim_install_failed',
+  assert(installFailed.length === 1,
+    'a half-installed shim surfaces exactly one :failed reply (was a swallowed console.error pre-#249; === 1 also guards against a double-post regression — one prelude, one catch)');
+  assert(installFailed.length === 1 && installFailed[0].msg.reason === 'omid_shim_install_failed',
     ':failed reason is omid_shim_install_failed — the container can observe the half-install');
-  assert(installFailed.length >= 1 && installFailed[0].msg.sharcNonce === NONCE,
+  assert(installFailed.length === 1 && installFailed[0].msg.sharcNonce === NONCE,
     ':failed echoes the renderer-protocol nonce so the container router accepts it (attaching-renderer phase)');
-  assert(installFailed.length >= 1 && installFailed[0].msg.placementSessionId === PSID,
+  assert(installFailed.length === 1 && installFailed[0].msg.placementSessionId === PSID,
     ':failed echoes the placementSessionId so the container correlates the envelope');
   assert(installFailed.every((m) => m.origin === CONTAINER_ORIGIN),
     ':failed targetOrigin is the validated containerOrigin (not a wildcard)');

--- a/test/node/test-omid-renderer-prelude.js
+++ b/test/node/test-omid-renderer-prelude.js
@@ -221,6 +221,72 @@ console.log('\n5. non-boolean omid → :failed (invalid_omid_field)');
     'non-boolean omid is rejected as invalid_omid_field');
 }
 
+// ── 6. inner installOmidShim() runtime THROW → surfaced to container (#249) ──
+//
+// The outer `installOmidShimPrelude` succeeds (URL resolves, fetch ok, source
+// parses) — but the shim's `installOmidShim(config)` call THROWS at runtime
+// inside the inline <script> during `document.write` (a half-install: a
+// pre-existing `window.omid3p`, a listener-attach failure, a new install-time
+// throw). Before #249 this throw was caught inside the creative iframe and only
+// `console.error`'d — INVISIBLE to the container. The renderer's :rendered
+// reply still fired, four green gates missed it, and the shim was half-installed
+// (window.omid3p present, listener unattached). This asserts the catch now
+// SURFACES the failure to the container as a `:failed` reply with reason
+// `omid_shim_install_failed` (an existing wire shape — `reason` is opaque-string
+// passthrough; the container routes it to onSecurityEvent renderer_failed).
+console.log('\n6. inner installOmidShim() throw → :failed (omid_shim_install_failed) (#249)');
+{
+  // A shim source that PARSES fine and self-attaches installOmidShim, but the
+  // install THROWS at runtime — modelling a half-install (e.g. the §11.3
+  // pre-existing-omid3p loud-fail, or a listener-attach error).
+  const throwingShimSource =
+    'window.SHARC = window.SHARC || {};'
+    + 'window.SHARC.installOmidShim = function () {'
+    + '  window.omid3p = { __halfInstalled: true };'  // partial state set …
+    + '  throw new Error("simulated half-install: listener attach failed");'  // … then throws
+    + '};';
+  const { parentMessages } = await runRender({
+    shimUrl: RENDERER_ORIGIN + '/dist/sharc-omid-shim.js',
+    fetchImpl: async () => ({ ok: true, status: 200, text: async () => throwingShimSource }),
+    renderData: { omid: true, omidProtocolNonce: 'omid-nonce-abc' },
+  });
+  const failed = failedReplies(parentMessages);
+  const installFailed = failed.filter((m) => m.msg.reason === 'omid_shim_install_failed');
+  assert(installFailed.length >= 1,
+    'a half-installed shim surfaces a :failed reply (was a swallowed console.error pre-#249)');
+  assert(installFailed.length >= 1 && installFailed[0].msg.reason === 'omid_shim_install_failed',
+    ':failed reason is omid_shim_install_failed — the container can observe the half-install');
+  assert(installFailed.length >= 1 && installFailed[0].msg.sharcNonce === NONCE,
+    ':failed echoes the renderer-protocol nonce so the container router accepts it (attaching-renderer phase)');
+  assert(installFailed.length >= 1 && installFailed[0].msg.placementSessionId === PSID,
+    ':failed echoes the placementSessionId so the container correlates the envelope');
+  assert(installFailed.every((m) => m.origin === CONTAINER_ORIGIN),
+    ':failed targetOrigin is the validated containerOrigin (not a wildcard)');
+}
+
+// ── 7. SUCCESSFUL install → NO false-positive failure signal (#249) ──────────
+//
+// Guards against a false positive: a shim whose installOmidShim() returns
+// cleanly must NOT trigger any `omid_shim_install_failed` :failed reply. The
+// successful-install path must be byte-for-byte the pre-#249 behaviour.
+console.log('\n7. successful installOmidShim() → NO omid_shim_install_failed reply (#249 no false positive)');
+{
+  const cleanShimSource =
+    'window.SHARC = window.SHARC || {};'
+    + 'window.SHARC.installOmidShim = function () {'
+    + '  window.omid3p = { registerSessionObserver: function () {}, sendMessage: function () {} };'
+    + '};';
+  const { parentMessages } = await runRender({
+    shimUrl: RENDERER_ORIGIN + '/dist/sharc-omid-shim.js',
+    fetchImpl: async () => ({ ok: true, status: 200, text: async () => cleanShimSource }),
+    renderData: { omid: true, omidProtocolNonce: 'omid-nonce-abc' },
+  });
+  const installFailed = failedReplies(parentMessages)
+    .filter((m) => m.msg.reason === 'omid_shim_install_failed');
+  assert(installFailed.length === 0,
+    'a clean install posts NO omid_shim_install_failed reply (successful path unchanged)');
+}
+
 // ── Done ────────────────────────────────────────────────────────────────────
 console.log('');
 if (failures > 0) {


### PR DESCRIPTION
Closes #249.

## Problem
`examples/renderer/index.html` wrapped the inline `installOmidShim(...)` (runs during `document.write` inside the creative iframe) in a try/catch that only `console.error`'d — **swallowing** a half-install (`window.omid3p` set, listener unattached) with NO signal to the container. This was the root of the 0.7.8 B1 silent bug: vendor scripts got zero callbacks and four green gates missed it because nothing propagated.

## Fix
The catch now posts the **existing** `SHARC:Renderer:failed` wire shape with `reason: 'omid_shim_install_failed'`, which the container surfaces as a `renderer_failed` security event (2115) with `details.reason`. A half-installed shim is now **detectable** instead of silent.

**Timing (the load-bearing claim):** the inline shim-install runs synchronously during `document.write`, strictly *before* the inner DCL posts `:rendered` — so the container is still in `attaching-renderer`, exactly the phase where the router accepts `:failed`. Guaranteed by JS execution order, not a race.

**No new wire:** reuses the existing `:failed`+`reason` shape (same as MRAID/SafeFrame `bridge_load_failed`); `reason` is opaque-string passthrough. No new message type, envelope field, router change, or container change. STOP-AND-ASK fence not hit.

## Scope
Renderer + test only. Distinct from the OUTER `installOmidShimPrelude` failure (`omid_shim_inject_failed`, pre-`document.write`) — the two are mutually exclusive. Closes the **throwing** variant (a non-throwing partial install stays silent by design; documented).

## Tests
`test/node/test-omid-renderer-prelude.js` case 6 simulates a shim-install throw and asserts the container observes `omid_shim_install_failed` (nonce + psid echoed, targetOrigin = container, not `*`); case 7 asserts a clean install posts nothing (no false positive). RED→GREEN, deterministic (3×). Inject-vs-install reason split documented in the operator failure-modes table (`docs/api-reference.md`).

## Claude-lane review
Code Reviewer **APPROVE** (timing/phase reachability verified, no new wire, no false positive). Security Engineer **APPROVE** (channel is gate-7 nonce-authenticated → forged `:failed` dropped; `reason` is a fixed literal → no leak; termination is fail-closed parity with `bridge_load_failed`; no cross-placement disruption; **net-positive observability, no new abuse surface**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
