### PR TITLE
chore: OMID bridge cleanup — honest no-op comment, test false-pass fix, cached adSessionId (#253)

### DIFF
--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -432,6 +432,15 @@ function OmidCompatBridge(options) {
   this._omidPendingRelays = [];
   /** @private Last emission timestamp for the geometryChange rate-limit. */
   this._omidLastGeometryEmitMs = 0;
+  /**
+   * Per-session OM SDK AdSession id, resolved ONCE when the session starts
+   * (§ 5.2 — "reused for every event") and read by every relayed Event.
+   * `null` outside an active session; re-resolved on the next session start
+   * and invalidated by `_resetSessionRefs` on teardown.
+   * @private
+   * @type {string|null}
+   */
+  this._omidCachedAdSessionId = null;
   /** @private */
   this._sdkLoadPromise = null;
   /** @private */
@@ -960,6 +969,9 @@ OmidCompatBridge.prototype = /** @type {any} */ ({
       self._omid.adSession.start();
       self._omid.sessionStarted = true;
       self._omid.sessionFinished = false;
+      // Resolve the AdSession id ONCE now that the session has started (§ 5.2),
+      // so every relayed Event reads the cached value instead of re-deriving it.
+      self._omidCachedAdSessionId = self._resolveOmidAdSessionId();
       // Record the creative-iframe origin for outbound posting (§ 6.2 step 2).
       if (self._container) {
         self._omidIframeOrigin = self._container._rendererOrigin || self._omidIframeOrigin;
@@ -1247,6 +1259,10 @@ OmidCompatBridge.prototype = /** @type {any} */ ({
     // rather than continuing the prior session's monotonic counter.
     this._omidSequence = 0;
     this._omidLastGeometryEmitMs = 0;
+    // The cached AdSession id is per-session (§ 5.2). Invalidate on teardown so
+    // the next session re-resolves it at start rather than relaying the prior
+    // session's id.
+    this._omidCachedAdSessionId = null;
     // C5 (extended): drop any active-burst relays still queued against the
     // dead session. `onReady` fires at most once per registration
     // (`_registerOmidProtocol` early-returns once registered), so the only way
@@ -1405,6 +1421,15 @@ OmidCompatBridge.prototype = /** @type {any} */ ({
    * the observer registration (`Register`); `Event` is outbound only, so it
    * never reaches this handler.
    *
+   * The inbound `Register` is an intentional publisher-side NO-OP: the relay
+   * model broadcasts every AdSession event to the iframe, where the shim
+   * materializes the local subscription and fans out (§ 7.2). The publisher
+   * keeps NO per-subscription registry — there is nothing to record, ack, or
+   * correlate (OMID is observer-only; no vendor unregister surface, so the
+   * deferred `Unregister`/ack machinery was removed in #262/#282). The handler
+   * shape-validates only as a defensive type-narrowing on the inbound surface;
+   * a malformed `Register` is dropped silently.
+   *
    * @param {Object} envelope - router-validated `event.data`
    * @param {Object} context  - frozen `{ type, phase, protocolNonce, raisedAt }`
    * @private
@@ -1417,13 +1442,7 @@ OmidCompatBridge.prototype = /** @type {any} */ ({
       if (!sub || typeof sub !== 'object') return;
       if (typeof sub.subscriptionId !== 'string' || sub.subscriptionId.length === 0) return;
       if (sub.kind !== 'sessionObserver' && sub.kind !== 'eventListener') return;
-      // 0.7.8 PR 1 relays publisher AdSession events to the iframe shim; the
-      // shim materializes the local subscription and replays the cached log.
-      // The publisher side records the handshake for diagnostics; no
-      // per-subscription publisher state is required for the relay model
-      // (events are broadcast to the iframe, the shim fans out per § 7.2).
-      // Registrations are never unregistered (OMID is observer-only; no vendor
-      // unregister surface), so there is no ack-correlation to maintain.
+      // No-op: nothing is recorded or acked publisher-side (see method doc).
     }
   },
 
@@ -1532,15 +1551,33 @@ OmidCompatBridge.prototype = /** @type {any} */ ({
   },
 
   /**
-   * Reads the OM SDK AdSession id off the publisher-page session, when the SDK
-   * exposes it. Reused for every event in the session (§ 5.2). Falls back to
-   * the container `placementSessionId` only as a stable correlation handle when
-   * the stub/SDK does not surface a session id.
+   * Returns the per-session OM SDK AdSession id for an outbound Event. The id is
+   * resolved ONCE at session start (`_createSession`) and cached; every relayed
+   * Event reads the cached value (§ 5.2 — "reused for every event"), so the
+   * derivation never runs per-event. Falls back to a fresh resolution only if
+   * the cache is unset (e.g. a relay racing ahead of `_createSession`).
    *
    * @returns {string}
    * @private
    */
   _omidAdSessionId: function () {
+    if (typeof this._omidCachedAdSessionId === 'string') {
+      return this._omidCachedAdSessionId;
+    }
+    return this._resolveOmidAdSessionId();
+  },
+
+  /**
+   * Derives the AdSession id off the publisher-page session, when the SDK
+   * exposes it. Falls back to the container `placementSessionId` only as a
+   * stable correlation handle when the stub/SDK does not surface a session id.
+   * Called once per session by `_createSession`; the result is cached in
+   * `_omidCachedAdSessionId` and read by `_omidAdSessionId` for every event.
+   *
+   * @returns {string}
+   * @private
+   */
+  _resolveOmidAdSessionId: function () {
     var session = this._omid && this._omid.adSession;
     if (session) {
       if (typeof session.sessionId === 'string' && session.sessionId.length > 0) {

--- a/test/node/test-omid-bridge-edge-fixes.js
+++ b/test/node/test-omid-bridge-edge-fixes.js
@@ -515,6 +515,109 @@ section('C6. _resetSessionRefs zeroes _omidSequence and _omidLastGeometryEmitMs'
     'sessionFinished flag still set (existing _resetSessionRefs behavior preserved)');
 }
 
+// ════════════════════════════════════════════════════════════════════════════
+// C7 — the OM SDK AdSession id is resolved ONCE at session start and reused
+// for every relayed event (#253 Part 4). The JSDoc promised "Reused for every
+// event" but `_omidAdSessionId()` re-read `adSession.sessionId` on every relay.
+// We count reads of `adSession.sessionId` via a getter: across a full burst of
+// relayed events (sessionStart → loaded → impression + a sessionError) the
+// derivation source must be read at most once, every relayed Event must carry
+// the SAME cached id, and that id must equal the SDK session id.
+// ════════════════════════════════════════════════════════════════════════════
+section('C7. AdSession id resolved once at sessionStart, reused for every event (#253)');
+{
+  let sessionIdReads = 0;
+  let registeredObserver = null;
+  const adSession = {
+    get sessionId() { sessionIdReads++; return 'omsdk-session-c7'; },
+    setCreativeType() {}, setImpressionType() {}, registerAdView() {},
+    registerSessionObserver(cb) { registeredObserver = cb; },
+    addFriendlyObstruction() {}, removeFriendlyObstruction() {},
+    start() {}, finish() {},
+    _emitError(data) { if (registeredObserver) registeredObserver({ type: 'sessionError', data: data || {} }); },
+  };
+  window.OmidSessionClient = {
+    Partner: function () {},
+    Context: function () { this.setContentUrl = function () {}; this.setServiceScriptUrl = function () {}; },
+    AdSession: function () { return adSession; },
+    AdEvents: function () { return { loaded() {}, impressionOccurred() {}, stateChange() {} }; },
+    MediaEvents: function () { return { playerStateChange() {} }; },
+    VerificationScriptResource: function () {},
+    VastProperties: function () {},
+  };
+
+  const bridge = new OmidCompatBridge({
+    omSdkServiceScriptUrl: 'https://cdn.example/omid/omweb-v1.js',
+    omSdkSessionClientUrl: 'https://cdn.example/omid/omid-session-client-v1.js',
+    creativeType: 'display', mediaType: 'display',
+  });
+  const c = new SHARCContainer({
+    creativeHtml: CREATIVE_HTML,
+    creativeRendererUrl: RENDERER_URL,
+    placementElement: freshSlot(),
+    extensions: [bridge],
+    timeouts: { rendererLoad: 5000, rendererReply: 5000 },
+  });
+  c.load();
+  await c.protocolRouter.ready('SHARC:Renderer:');
+  const posted = [];
+  c._iframe.contentWindow.postMessage = (msg) => { posted.push(msg); };
+  c._iframe.dispatchEvent(new dom.window.Event('load'));
+  window.dispatchEvent(new dom.window.MessageEvent('message', {
+    data: {
+      type: 'SHARC:Renderer:rendered',
+      placementSessionId: c.placementSessionId,
+      sharcNonce: c._rendererProtocolNonce,
+      rendererOrigin: RENDERER_ORIGIN,
+    },
+    origin: RENDERER_ORIGIN,
+    source: c._iframe.contentWindow,
+  }));
+  await c.protocolRouter.ready('SHARC:Omid:');
+
+  // Drive the active burst (sessionStart → loaded → impression) then an extra
+  // SDK-sourced sessionError, so the relay path runs for ≥4 events.
+  if (typeof c._transitionToActive === 'function' && c.getState() !== 'active') {
+    c._transitionToActive();
+  }
+  adSession._emitError({ code: 13 });
+
+  const burst = omidEvents(posted);
+  assert(burst.length >= 4,
+    'relayed at least four events (sessionStart, loaded, impression, sessionError) — got ' + burst.length);
+
+  // The derivation runs ONCE at session start, NOT per relayed event. The
+  // getter may be touched a small constant number of times during that single
+  // resolution (the typeof/length/return reads), so the load-bearing assertion
+  // is that the read count does NOT scale with the number of relayed events:
+  // relaying several MORE events must add ZERO new sessionId reads.
+  const readsAfterBurst = sessionIdReads;
+  assert(readsAfterBurst < burst.length,
+    'sessionId reads (' + readsAfterBurst + ') are fewer than relayed events (' + burst.length
+      + ') — not a per-event recompute');
+  const postedBefore = posted.length;
+  bridge._relayOmidEvent('sessionError', { code: 21 });
+  bridge._relayOmidEvent('geometryChange', { adView: {} });
+  bridge._relayOmidEvent('sessionError', { code: 22 });
+  assert(posted.length > postedBefore,
+    'precondition: the extra relays actually posted (the relay path ran again)');
+  assert(sessionIdReads === readsAfterBurst,
+    'relaying MORE events adds ZERO new sessionId reads (id resolved once, cached) — was '
+      + readsAfterBurst + ', now ' + sessionIdReads);
+  assert(bridge._omidCachedAdSessionId === 'omsdk-session-c7',
+    'the cached adSessionId is the SDK session id');
+  const ids = burst.map((m) => m.event && m.event.adSessionId);
+  assert(ids.every((id) => id === 'omsdk-session-c7'),
+    'every relayed Event carries the same cached adSessionId === the SDK session id (got ['
+      + Array.from(new Set(ids)).join(', ') + '])');
+
+  // Teardown must invalidate the cache so a subsequent session re-resolves.
+  bridge._resetSessionRefs(true);
+  assert(bridge._omidCachedAdSessionId === null,
+    '_resetSessionRefs invalidates the cached adSessionId (next session re-resolves)');
+  c._terminate();
+}
+
 // ── Summary ─────────────────────────────────────────────────────────────────
 if (failures > 0) {
   console.error(`\n✗ ${failures} omid-bridge-edge-fixes assertion(s) failed.`);

--- a/test/node/test-omid-markup-delivery.js
+++ b/test/node/test-omid-markup-delivery.js
@@ -12,20 +12,26 @@
  *   2. CONTAINER OMID-OFF: with `exposeOmid3p: false`, the render envelope is
  *      byte-identical to the pre-0.7.8 shape — no `omid`/`omidProtocolNonce`.
  *      (additive-only invariant)
- *   3. RENDERER: the renderer's `installOmidShimPrelude` source-rewrites the
- *      shim into the markup with the OMID nonce baked as a CLOSURE CONSTANT
- *      before document.write. After the written document runs, `window.omid3p`
- *      exposes EXACTLY the two probed methods, and the nonce is NOT readable
- *      from any global / location surface. (§ 4.1, § 4.3, § 5.1)
+ *   3. RENDERER: the renderer's REAL `installOmidShimPrelude` (extracted and
+ *      eval'd from `examples/renderer/index.html`, then driven through a real
+ *      `SHARC:Renderer:render` envelope — NOT a source-grep and NOT an inlined
+ *      copy) source-rewrites the shim into the markup with the OMID nonce baked
+ *      as a CLOSURE CONSTANT before document.write. After the written document
+ *      runs, `window.omid3p` exposes EXACTLY the two probed methods, and the
+ *      nonce is NOT readable from any global / location surface. (§ 4.1, § 4.3,
+ *      § 5.1)
  *   4. END-TO-END: a vendor stub calls `window.omid3p.registerSessionObserver`
  *      and receives the session callback when an inbound `SHARC:Omid:Event`
  *      (sessionStart) arrives over the (shim-gated) channel. (§ 5.4)
  *
- * The renderer ships as `examples/renderer/index.html`; this test is the
- * source-of-truth check that the file contains the real `installOmidShimPrelude`
- * + the `omid` accept-path, and exercises an inlined copy of that function's
- * logic against the BUILT shim (`dist/sharc-omid-shim.js`) under jsdom — the
- * same harness strategy as test-renderer-domparser-fallback.js.
+ * #253 Part 3: sections 3 & 4 previously SOURCE-GREPPED for
+ * `installOmidShimPrelude` and ran a HAND-INLINED COPY of its body. That can
+ * stay green while the shipped renderer prelude diverges (e.g. the copy here
+ * never baked the `rendererNonce` or self-removed the prelude <script>, yet
+ * still passed). This version extracts+evals the renderer inline script (same
+ * harness as test-omid-renderer-prelude.js) and EXERCISES the real shipped
+ * `installOmidShimPrelude` via a `:render` envelope, so a renderer-prelude
+ * divergence (wrong omid3p surface, nonce leak, broken delivery) now FAILS.
  *
  * Runs in Node after `npm run build`. Uses jsdom. No test framework.
  *
@@ -33,7 +39,7 @@
  */
 
 import fs from 'node:fs';
-import { JSDOM } from 'jsdom';
+import { JSDOM, VirtualConsole } from 'jsdom';
 
 const PUBLISHER_ORIGIN = 'https://publisher.example';
 const RENDERER_URL = 'https://renderer.example/render.html';
@@ -179,110 +185,167 @@ section('2. container render envelope (OMID off — exposeOmid3p:false)');
   c._terminate();
 }
 
-// ── Source-of-truth: the renderer file ships the real markup-wiring code ────
-section('3. renderer source ships the OMID markup-wiring path');
+// ── Extract the REAL renderer inline script (source of truth) ───────────────
+//
+// #253 Part 3: exercise the SHIPPED `installOmidShimPrelude` by extracting the
+// renderer's main inline <script> (LONGEST <script>…</script>) and eval'ing it
+// in a fresh jsdom window — the same harness pattern as
+// test-omid-renderer-prelude.js. The renderer file is the single source of
+// truth; we drive a real `:render` envelope and let the renderer's own prelude
+// source-rewrite the BUILT shim into the document.
 const RENDERER_PATH = new URL('../../examples/renderer/index.html', import.meta.url);
 const rendererSrc = fs.readFileSync(RENDERER_PATH, 'utf8');
-assert(/function\s+installOmidShimPrelude\s*\(/.test(rendererSrc),
-  'renderer ships installOmidShimPrelude (§ 4.3 mechanism i)');
-assert(/data\.omid\s*===\s*true/.test(rendererSrc),
-  'renderer gates the shim install on `data.omid === true`');
-assert(/OMID_SHIM_URL/.test(rendererSrc),
-  'renderer has the OMID_SHIM_URL config knob');
-assert(/var\s+protocolNonce\s*=\s*['"]?\s*\+\s*jsonForInlineScript\(omidProtocolNonce\)/.test(rendererSrc)
-  || /protocolNonce=['"]?\s*\+\s*jsonForInlineScript\(omidProtocolNonce\)/.test(rendererSrc),
-  'renderer bakes the OMID nonce as a closure-constant `var` (not a global/hash)');
-assert(!/location\.hash\s*=\s*[^=]*omidProtocolNonce/.test(rendererSrc),
-  'renderer never writes the OMID nonce to location.hash');
 
-// ── 4. Renderer source-rewrite → window.omid3p live; nonce is a closure const ─
-//
-// Inlined copy of the renderer's `installOmidShimPrelude` body (sans the
-// fetch — the test reads the BUILT shim source directly), driven against the
-// dist shim. The renderer file is the source of truth; the assertions above
-// confirm the shipped function matches this shape.
-section('4. shim source-rewrite installs window.omid3p with baked nonce');
-const shimSource = fs.readFileSync(
-  new URL('../../dist/sharc-omid-shim.js', import.meta.url), 'utf8');
+function extractInlineScript(src) {
+  const re = /<script>([\s\S]*?)<\/script>/g;
+  let match; let longest = '';
+  while ((match = re.exec(src)) !== null) {
+    if (match[1].length > longest.length) longest = match[1];
+  }
+  return longest;
+}
+const inlineScript = extractInlineScript(rendererSrc);
 
-function jsonForInlineScript(value) {
-  return JSON.stringify(String(value)).replace(/</g, '\\u003c');
+const SHIM_PATH = new URL('../../dist/sharc-omid-shim.js', import.meta.url);
+const shimSource = fs.readFileSync(SHIM_PATH, 'utf8');
+
+const RENDER_NONCE = 'render-nonce-markup';
+
+/**
+ * Boots a fresh renderer instance in jsdom (real inline script eval'd), points
+ * the OMID shim URL same-origin at the built shim source via the
+ * `sharcTestOmidShimUrl` knob with a `fetch` stub that serves `shimSource`,
+ * dispatches a `SHARC:Renderer:render` envelope with `omid: true` + a valid
+ * nonce, lets the renderer's real `installOmidShimPrelude` + document.write
+ * run, and returns the renderer window + every message posted to its parent.
+ *
+ * The renderer writes the shim-injected markup into its OWN document
+ * (document.open/write/close) with runScripts:'dangerously', so the baked
+ * prelude executes in `win` and installs `window.omid3p` there.
+ *
+ * @returns {Promise<{ win: any, parentMessages: Array }>}
+ */
+async function runRenderWithRealPrelude() {
+  const virtualConsole = new VirtualConsole();
+  virtualConsole.on('jsdomError', () => {});
+  ['log', 'info', 'warn', 'error', 'debug'].forEach((level) => {
+    virtualConsole.on(level, () => {});
+  });
+
+  const shimUrl = RENDERER_ORIGIN + '/dist/sharc-omid-shim.js';
+  const url = RENDERER_ORIGIN + '/0.7.0/?sharcTestOmidShimUrl='
+    + encodeURIComponent(shimUrl) + '#sharcNonce=' + RENDER_NONCE;
+
+  const idom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>', {
+    url,
+    runScripts: 'dangerously',
+    virtualConsole,
+  });
+  const win = idom.window;
+
+  // Serve the built shim source same-origin so installOmidShimPrelude's
+  // same-origin guard passes and the fetch returns the real shim IIFE.
+  win.fetch = async (fetchUrl) => {
+    if (String(fetchUrl).indexOf('sharc-omid-shim.js') !== -1) {
+      return { ok: true, status: 200, text: async () => shimSource };
+    }
+    return { ok: false, status: 404, text: async () => '' };
+  };
+  win.eval('this.fetch = window.fetch;');
+
+  const parentMessages = [];
+  const fakeParent = {
+    postMessage: (msg, origin) => { parentMessages.push({ msg, origin }); },
+  };
+  Object.defineProperty(win, 'parent', { configurable: true, get: () => fakeParent });
+
+  win.__sharcRenderer = { installNavigationBridge: () => {} };
+
+  win.eval(inlineScript);
+
+  await Promise.resolve();
+  await Promise.resolve();
+
+  const renderEvent = new win.MessageEvent('message', {
+    data: {
+      type: 'SHARC:Renderer:render',
+      placementSessionId: psid,
+      containerOrigin: PUBLISHER_ORIGIN,
+      sharcNonce: RENDER_NONCE,
+      sharcVersion: '0.7.0',
+      rendererProtocolVersion: '1',
+      omid: true,
+      omidProtocolNonce: omidNonce,
+      creativeHtml: CREATIVE_HTML,
+    },
+    origin: PUBLISHER_ORIGIN,
+    source: fakeParent,
+  });
+  win.dispatchEvent(renderEvent);
+
+  // Flush the async :render handler (swCheckPromise + acceptAndRender + the
+  // awaited installOmidShimPrelude fetch + document.write).
+  for (let i = 0; i < 12; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+  for (let i = 0; i < 6; i++) await Promise.resolve();
+
+  return { win, parentMessages };
 }
 
-// Mirror of installOmidShimPrelude's inline-script construction (renderer §4.3).
-function buildShimInjectedHtml(html, nonce, placementSessionId, containerOrigin) {
-  const code = ''
-    + '(function(){'
-    + 'var protocolNonce=' + jsonForInlineScript(nonce) + ';'
-    + 'var placementSessionId=' + jsonForInlineScript(placementSessionId) + ';'
-    + 'var containerOrigin=' + jsonForInlineScript(containerOrigin) + ';'
-    + shimSource + ';'
-    + 'try{(window.SHARC&&window.SHARC.installOmidShim||installOmidShim)({'
-    + 'protocolNonce:protocolNonce,'
-    + 'placementSessionId:placementSessionId,'
-    + 'containerOrigin:containerOrigin'
-    + '});}catch(e){if(window.console&&console.error)console.error('
-    + '"[SHARC Renderer] OMID shim install failed:",e&&e.message?e.message:e);}'
-    + '}());';
-  const parsed = new DOMParser().parseFromString(html, 'text/html');
-  const script = parsed.createElement('script');
-  script.text = code;
-  const parent = parsed.head || parsed.body || parsed.documentElement;
-  parent.insertBefore(script, parent.firstChild);
-  return parsed.documentElement.outerHTML;
-}
-
-const injectedHtml = buildShimInjectedHtml(
-  CREATIVE_HTML, omidNonce, psid, PUBLISHER_ORIGIN);
-assert(injectedHtml.indexOf(omidNonce) !== -1,
-  'baked nonce literal is present in the injected markup (closure constant)');
-
-// Write the shim-injected markup into a fresh creative-iframe window and let
-// the injected script run. A single-window jsdom: window.parent === window,
-// so the shim's default parentWindow is this window and we can drive the
-// inbound transport by dispatching a message with source === window.
+// ── 3. The real shipped prelude installs window.omid3p with a baked nonce ───
+section('3. real installOmidShimPrelude → window.omid3p live; nonce is a closure const');
+const { win: rwin, parentMessages } = await runRenderWithRealPrelude();
 {
-  const idom = new JSDOM(
-    '<!DOCTYPE html><html><head></head><body></body></html>',
-    { url: RENDERER_ORIGIN + '/render.html', runScripts: 'dangerously' });
-  const iwin = idom.window;
-  const idoc = iwin.document;
-  iwin.SHARC = iwin.SHARC || {};
-
-  idoc.open();
-  idoc.write(injectedHtml);
-  idoc.close();
+  // No :failed reply: the prelude resolved + fetched + installed cleanly.
+  const failed = parentMessages.filter((m) => m.msg && m.msg.type === 'SHARC:Renderer:failed');
+  assert(failed.length === 0,
+    'the real prelude install posts NO :failed reply (clean source-rewrite + install) — got '
+      + (failed.length ? failed.map((m) => m.msg.reason).join(',') : 0));
 
   // omid3p surface (§ 5.1) — exactly the two probed methods, both functions.
-  assert(iwin.omid3p && typeof iwin.omid3p === 'object',
-    'window.omid3p installed by the source-rewritten shim');
-  assert(typeof iwin.omid3p.registerSessionObserver === 'function',
+  assert(rwin.omid3p && typeof rwin.omid3p === 'object',
+    'window.omid3p installed by the shipped source-rewritten shim');
+  assert(typeof rwin.omid3p.registerSessionObserver === 'function',
     'omid3p.registerSessionObserver is a function (isSupported probe)');
-  assert(typeof iwin.omid3p.addEventListener === 'function',
+  assert(typeof rwin.omid3p.addEventListener === 'function',
     'omid3p.addEventListener is a function (isSupported probe)');
-  const surfaceKeys = Object.keys(iwin.omid3p).sort().join(',');
+  const surfaceKeys = Object.keys(rwin.omid3p).sort().join(',');
   assert(surfaceKeys === 'addEventListener,registerSessionObserver',
     'omid3p exposes EXACTLY the two methods (' + surfaceKeys + ')');
 
   // Nonce confidentiality (§ 4.3 / § 5.2): the baked nonce is a closure
   // constant — it must NOT be reachable from any global or location surface.
-  assert(iwin.omid3p.protocolNonce === undefined,
+  assert(rwin.omid3p.protocolNonce === undefined,
     'OMID nonce is NOT on window.omid3p');
-  assert(iwin.protocolNonce === undefined,
+  assert(rwin.protocolNonce === undefined,
     'OMID nonce is NOT a global (window.protocolNonce undefined)');
-  assert(iwin.location.hash.indexOf(omidNonce) === -1,
+  assert(rwin.location.hash.indexOf(omidNonce) === -1,
     'OMID nonce is NOT on the creative iframe location.hash');
-  assert(JSON.stringify(iwin.omid3p).indexOf(omidNonce) === -1,
+  assert(JSON.stringify(rwin.omid3p).indexOf(omidNonce) === -1,
     'OMID nonce does not serialize out through omid3p');
 
-  // End-to-end delivery (§ 5.4): a vendor stub registers a session observer and
-  // receives the session callback when an inbound SHARC:Omid:Event arrives.
-  let observed = null;
-  iwin.omid3p.registerSessionObserver(function (ev) { observed = ev; }, 'vendor-key', 'inj-1');
+  // #254: the prelude <script> self-removes after capturing the nonce into the
+  // shim closure, so the nonce literal is no longer DOM-readable as source text.
+  const preludeScripts = rwin.document.querySelectorAll('script[data-sharc-prelude="omid-shim"]');
+  assert(preludeScripts.length === 0,
+    'the prelude <script> self-removed after install (#254 — nonce source-text unreachable)');
+  const anyScriptCarriesNonce = Array.prototype.some.call(
+    rwin.document.scripts, (s) => (s.textContent || '').indexOf(omidNonce) !== -1);
+  assert(!anyScriptCarriesNonce,
+    'no surviving <script> source text carries the OMID nonce literal');
+}
 
-  // Drive an inbound sessionStart Event over the shim-gated channel. The shim
-  // validates source===parent, origin, nonce, placementSessionId — supply all.
-  const evt = new iwin.MessageEvent('message', {
+// ── 4. End-to-end delivery through the shipped shim ─────────────────────────
+section('4. inbound SHARC:Omid:Event delivered through the shipped shim');
+{
+  // A vendor stub registers a session observer and receives the session
+  // callback when an inbound SHARC:Omid:Event arrives over the shim-gated
+  // channel. The shim's default parentWindow is rwin.parent (the fakeParent),
+  // so we dispatch with source === rwin.parent and the validated origin/nonce.
+  let observed = null;
+  rwin.omid3p.registerSessionObserver(function (ev) { observed = ev; }, 'vendor-key', 'inj-1');
+
+  const evt = new rwin.MessageEvent('message', {
     data: {
       type: 'SHARC:Omid:Event',
       sharcNonce: omidNonce,
@@ -290,9 +353,9 @@ assert(injectedHtml.indexOf(omidNonce) !== -1,
       event: { type: 'sessionStart', data: { context: { apiVersion: '1.0' } } },
     },
     origin: PUBLISHER_ORIGIN,
-    source: iwin.parent,
+    source: rwin.parent,
   });
-  iwin.dispatchEvent(evt);
+  rwin.dispatchEvent(evt);
 
   assert(observed !== null,
     'registered observer received a callback for the inbound sessionStart Event');
@@ -304,7 +367,7 @@ assert(injectedHtml.indexOf(omidNonce) !== -1,
   // Reject a forged inbound Event carrying the WRONG nonce — the shim-side
   // inbound validator drops it; no second callback.
   observed = null;
-  const forged = new iwin.MessageEvent('message', {
+  const forged = new rwin.MessageEvent('message', {
     data: {
       type: 'SHARC:Omid:Event',
       sharcNonce: 'wrong-nonce',
@@ -312,9 +375,9 @@ assert(injectedHtml.indexOf(omidNonce) !== -1,
       event: { type: 'impression', data: {} },
     },
     origin: PUBLISHER_ORIGIN,
-    source: iwin.parent,
+    source: rwin.parent,
   });
-  iwin.dispatchEvent(forged);
+  rwin.dispatchEvent(forged);
   assert(observed === null,
     'forged inbound Event with the wrong nonce is dropped by the shim validator');
 }

--- a/test/node/test-omid-router-consumption.js
+++ b/test/node/test-omid-router-consumption.js
@@ -266,6 +266,91 @@ section('C. router phase gating for inbound Register');
   c._terminate();
 }
 
+// ── C2. inbound Register is an honest publisher-side no-op (#253 Part 1) ─────
+// The handler shape-validates an in-phase Register then does NOTHING: no
+// per-subscription publisher registry, no recorded handshake, no security
+// event. (Pre-#253 a stale comment claimed "the publisher side records the
+// handshake for diagnostics" — nothing was ever recorded; the dead callbackMap
+// + Unregister ack machinery were already removed by #262/#282.) This pins the
+// no-op as honest AND proves the live relay is undisturbed by an inbound
+// Register: events still reach the iframe exactly as before.
+section('C2. inbound Register is an honest no-op; live relay undisturbed (#253)');
+{
+  installOmSdkStub();
+  const security = [];
+  const bridge = new OmidCompatBridge({
+    omSdkServiceScriptUrl: 'https://cdn.example/omid/omweb-v1.js',
+    omSdkSessionClientUrl: 'https://cdn.example/omid/omid-session-client-v1.js',
+    creativeType: 'display', mediaType: 'display',
+  });
+  const c = new SHARCContainer({
+    creativeHtml: CREATIVE_HTML,
+    creativeRendererUrl: RENDERER_URL,
+    placementElement: freshSlot(),
+    extensions: [bridge],
+    onSecurityEvent: (e) => security.push(e),
+    timeouts: { rendererLoad: 5000, rendererReply: 5000 },
+  });
+  c.load();
+  await c.protocolRouter.ready('SHARC:Renderer:');
+  const posted = [];
+  c._iframe.contentWindow.postMessage = (msg) => { posted.push(msg); };
+  c._iframe.dispatchEvent(new dom.window.Event('load'));
+  window.dispatchEvent(new dom.window.MessageEvent('message', {
+    data: {
+      type: 'SHARC:Renderer:rendered',
+      placementSessionId: c.placementSessionId,
+      sharcNonce: c._rendererProtocolNonce,
+      rendererOrigin: RENDERER_ORIGIN,
+    },
+    origin: RENDERER_ORIGIN,
+    source: c._iframe.contentWindow,
+  }));
+  await c.protocolRouter.ready('SHARC:Omid:');
+  const omidNonce = c.protocolRouter.getProtocol('SHARC:Omid:').protocolNonce;
+
+  // Drive to omid-active so an in-phase Register reaches the handler.
+  if (typeof c._transitionToActive === 'function' && c.getState() !== 'active') {
+    c._transitionToActive();
+  }
+  assert(c.protocolRouter.getPhase() === 'omid-active',
+    'precondition: router is in omid-active (in-phase Register reaches the handler)');
+
+  // Snapshot bridge own-property keys before the Register: an honest no-op adds
+  // no per-subscription publisher state (no registry/map keyed on the handshake).
+  const keysBefore = Object.keys(bridge).sort().join(',');
+  const postedBefore = posted.length;
+  security.length = 0;
+
+  const reg = new dom.window.MessageEvent('message', {
+    data: {
+      type: 'SHARC:Omid:Register',
+      sharcNonce: omidNonce,
+      placementSessionId: c.placementSessionId,
+      subscription: { kind: 'sessionObserver', subscriptionId: 'diag-sub-1' },
+    },
+    origin: RENDERER_ORIGIN,
+    source: c._iframe.contentWindow,
+  });
+  window.dispatchEvent(reg);
+
+  assert(security.length === 0,
+    'an in-phase inbound Register raises NO security event (router gate already passed; handler is a no-op)');
+  assert(Object.keys(bridge).sort().join(',') === keysBefore,
+    'the handler records NO new publisher-side state for the registration (honest no-op, no diagnostics registry)');
+  assert(posted.length === postedBefore,
+    'the inbound Register triggers NO outbound post (it is not echoed/acked)');
+
+  // The live relay path is undisturbed by the inbound Register: a subsequent
+  // SDK-sourced event still relays to the iframe exactly as before.
+  const beforeErr = posted.filter((m) => m && m.event && m.event.type === 'sessionError').length;
+  bridge._relayOmidEvent('sessionError', { code: 11 });
+  const afterErr = posted.filter((m) => m && m.event && m.event.type === 'sessionError').length;
+  assert(afterErr === beforeErr + 1,
+    'the live relay still posts events after an inbound Register (dead-machinery removal did not touch the live path)');
+  c._terminate();
+}
+
 // ── D. #240 placementSessionId structural immutability ──────────────────────
 section('D. placementSessionId immutability (#240)');
 {


### PR DESCRIPTION
Closes #253 (the remaining parts — part 2 was already done by #329).

**Part 1 — dead/misleading machinery:** the issue's `callbackMap`/`Unregister` were *already* removed (#262/#282, grep-verified). Only `_handleOmidEnvelope`'s false 'records the handshake for diagnostics' comment remained → corrected to an honest no-op note (the `Register` branch shape-validates then no-ops; the router discards the handler return). Comment-only.

**Part 3 — test false-pass:** `test-omid-markup-delivery.js` was source-grepping + running a hand-inlined COPY of the prelude (already drifting — never baked `rendererNonce` nor self-removed). Rewritten to **extract+eval the shipped `installOmidShimPrelude`** via a real `:render` envelope (mirrors `test-omid-renderer-prelude.js`). Divergence proof: drifting the renderer's baked-nonce line → RED; restored → GREEN.

**Part 4 — per-event recompute:** `_omidAdSessionId()` was re-derived on every relayed event despite 'reused for every event' JSDoc. Now cached (`_omidCachedAdSessionId`), resolved once at `_createSession` after `start()`, invalidated to null in `_resetSessionRefs` (every session-end path). 15→0 extra reads across 5 events; cache test in `test-omid-bridge-edge-fixes.js`.

No OMID wire/envelope/router/nonce/relay change — all 9 OMID suites green. *(Diff also carries the `test-omid-bridge-edge-fixes`/`test-omid-router-consumption` coverage that hosts the Part-1/Part-4 assertions — net-additive, no production touch.)*

Code Reviewer **APPROVE** — cache invalidation traced clean across all session-end paths; no stale-id hazard; test rewrite genuinely exercises the shipped prelude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)