### PR TITLE
chore: restore installNavigationBridge named export (guarded by #369) + reconcile docs (#370)

### DIFF
--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -294,7 +294,7 @@ Supported package entry points are already defined for eventual publication:
 - `@iabtechlab/sharc/sharc-mraid-bridge`
 - `@iabtechlab/sharc/sharc-safeframe-bridge`
 - `@iabtechlab/sharc/sharc-omid-bridge`
-- `@iabtechlab/sharc/sharc-navigation-bridge` (new in 0.7.0; also re-exported from `sharc-creative` for ESM consumers)
+- `@iabtechlab/sharc/sharc-navigation-bridge` (new in 0.7.0; `installNavigationBridge` and `SHARCNavigationError` are also re-exported from `sharc-creative` for ESM consumers)
 
 ## Security Model Snapshot
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,7 +47,7 @@ The repository builds one package with subpath exports:
 - `@iabtechlab/sharc/sharc-mraid-bridge`
 - `@iabtechlab/sharc/sharc-safeframe-bridge`
 - `@iabtechlab/sharc/sharc-omid-bridge`
-- `@iabtechlab/sharc/sharc-navigation-bridge` (new in 0.7.0; also re-exported from `sharc-creative`)
+- `@iabtechlab/sharc/sharc-navigation-bridge` (new in 0.7.0; `installNavigationBridge` and `SHARCNavigationError` are also re-exported from `sharc-creative`)
 
 When the package is published, those are the supported import paths.
 

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -59,13 +59,14 @@ import {
 // but the gate avoids a redundant call). +1.1 kB is acceptable for a non-
 // optional dependency in the URL flow. Synchronous install at module
 // evaluation avoids the first-click race that a dynamic import would
-// introduce. Only `SHARCNavigationError` is re-exported from this module
-// (#367) so ESM consumers that load only `sharc-creative` get the error
-// class for `instanceof` parity without a second import.
-// `installNavigationBridge` is deliberately NOT re-exported here — see the
-// export-trailer note near the bottom of this file for why. ESM consumers
-// that need the install function import it from the standalone
-// `sharc-navigation-bridge` module. Verified by `npm run test:smoke`.
+// introduce. Both `installNavigationBridge` and `SHARCNavigationError` are
+// re-exported from this module (#370) so ESM consumers that load only
+// `sharc-creative` get the install function and the error class for
+// `instanceof` parity without a second import — see the export-trailer note
+// near the bottom of this file. The IIFE epilogue clobber that originally
+// forced `installNavigationBridge` to be dropped (#367) is now neutralized by
+// #369's build-layer first-assignment-wins guard. Verified by
+// `npm run test:smoke`.
 import { installNavigationBridge, SHARCNavigationError } from './sharc-navigation-bridge.js';
 
 // ---------------------------------------------------------------------------
@@ -1033,22 +1034,26 @@ const creative = _bootedHere ? _instance : null;
 export { SHARCCreative, creative, SHARC };
 
 // Phase E deliverable 2: re-export the bundled navigation bridge surface.
-// ESM consumers that load `sharc-creative` get the error class for free;
-// no second import required. The standalone `sharc-navigation-bridge`
-// module continues to ship for operators that prefer to load it
-// separately (e.g. inside the reference renderer, where it imports the
-// standalone module to keep the renderer's single-purpose). Both paths
-// share the same exported references — `instanceof` checks against
+// ESM consumers that load `sharc-creative` get both the install function and
+// the error class for free; no second import required. The standalone
+// `sharc-navigation-bridge` module continues to ship for operators that
+// prefer to load it separately (e.g. inside the reference renderer, where it
+// imports the standalone module to keep the renderer's single-purpose). Both
+// paths share the same exported references — `instanceof` checks against
 // `SHARCNavigationError` work regardless of which import was used.
 //
-// `installNavigationBridge` is deliberately NOT re-exported here (#365):
-// in the IIFE build the rollup epilogue turns every top-level named export
-// into an UNCONDITIONAL `window.SHARC.<name> = <name>` assignment that runs
-// AFTER the module body — clobbering the first-assignment-wins guard above
-// (`if (typeof window.SHARC.installNavigationBridge !== 'function')`) and
-// silently overwriting an operator's pre-set override. Routing the install
-// surface onto the namespace ONLY through that guarded in-source assignment
-// keeps the override contract intact. ESM consumers that need the install
-// function import it from the standalone `sharc-navigation-bridge` module
-// (the canonical source) — no in-repo consumer imported it from here.
-export { SHARCNavigationError };
+// `installNavigationBridge` is re-exported here again as of #370. It was
+// dropped in #367 as a point-fix for the IIFE epilogue clobber: rollup turned
+// every top-level named export into an UNCONDITIONAL `window.SHARC.<name> =
+// <name>` assignment that ran AFTER the module body, overwriting the
+// first-assignment-wins guard above (`if (typeof
+// window.SHARC.installNavigationBridge !== 'function')`) and silently
+// replacing an operator's pre-set override. #369 generalized that fix at the
+// build layer — the `firstAssignmentWinsGlobalExports` rollup plugin rewrites
+// every IIFE `exports.X = X;` into `if (!('X' in exports)) exports.X = X;`, so
+// the epilogue now PRESERVES an operator's pre-set value for EVERY named
+// export, including `installNavigationBridge`. With that guard in place the
+// #367 drop is redundant, so the named export is restored for parity with
+// `SHARCNavigationError` and the standalone bridge module. The operator
+// override contract is held by #369's epilogue guard.
+export { installNavigationBridge, SHARCNavigationError };

--- a/test/node/test-creative-sdk-nav-bridge-override.js
+++ b/test/node/test-creative-sdk-nav-bridge-override.js
@@ -157,6 +157,10 @@ if (MODE === 'a') {
 
   check(win.SHARC && typeof win.SHARC.installNavigationBridge === 'function',
     '(b) fresh load installs the bundled default installNavigationBridge');
+  check('installNavigationBridge' in win.SHARC,
+    '(b) installNavigationBridge is a named export of the creative bundle again '
+    + '(#370) — present on window.SHARC after a clean IIFE eval; the IIFE '
+    + 'epilogue assignment is guarded by #369 so scenario (a) override still wins');
 } else {
   console.error(`✗ unknown SHARC_NAV_OVERRIDE_MODE: ${MODE}`);
   process.exit(1);

--- a/test/node/test-iife-global-first-assignment-wins.js
+++ b/test/node/test-iife-global-first-assignment-wins.js
@@ -181,6 +181,10 @@ if (MODE === 'a') {
     '(b) fresh load exposes the bundled SHARCCreative class');
   check(win.SHARC && typeof win.SHARC.SHARCNavigationError === 'function',
     '(b) fresh load exposes the bundled SHARCNavigationError class');
+  check(win.SHARC && typeof win.SHARC.installNavigationBridge === 'function',
+    '(b) fresh load exposes the bundled installNavigationBridge — the restored '
+    + 'named export (#370) installs as the default when none is pre-set, while '
+    + 'scenario (a) proves an operator pre-set still survives (#369 guard)');
   check(win.SHARC && ('creative' in win.SHARC),
     '(b) fresh load exposes the `creative` namespace property');
   check(win.SHARC && win.SHARC.creative

--- a/test/node/test-smoke.js
+++ b/test/node/test-smoke.js
@@ -36,22 +36,25 @@ const esmModules = [
     path: '../../dist/sharc-creative.mjs',
     // Phase E deliverable 2: the navigation bridge is now bundled into
     // the SDK so the Creative URL flow auto-installs it at SDK init.
-    // `SHARCNavigationError` stays a named SDK export (for `instanceof`
-    // parity). This locks in the +1.1 kB bundling decision against a
-    // future change that accidentally tree-shakes the bridge out of the
-    // SDK build (which would silently regress URL-flow click-through
-    // audit coverage).
+    // `installNavigationBridge` + `SHARCNavigationError` are named SDK
+    // exports (the install function for the override extension point, the
+    // error class for `instanceof` parity). This locks in the +1.1 kB
+    // bundling decision against a future change that accidentally
+    // tree-shakes the bridge out of the SDK build (which would silently
+    // regress URL-flow click-through audit coverage).
     //
-    // `installNavigationBridge` is intentionally NOT a named export of the
-    // creative bundle (#365): in the IIFE build a top-level named export
-    // becomes an unconditional `window.SHARC.installNavigationBridge = …`
-    // epilogue assignment that clobbers an operator's first-assignment-wins
-    // override. The bridge RUNTIME stays bundled regardless — it's pulled in
-    // by the SDK's guarded in-source install path — so the anti-tree-shake
-    // intent above holds without the named re-export. ESM consumers import
-    // `installNavigationBridge` from the standalone `sharc-navigation-bridge`
-    // module (asserted below), the canonical source.
-    expectedExports: ['SHARCCreative', 'creative', 'SHARCNavigationError']
+    // `installNavigationBridge` was dropped from this list in #367 as a
+    // point-fix for the IIFE epilogue clobber (an unconditional
+    // `window.SHARC.installNavigationBridge = …` epilogue assignment that
+    // overwrote an operator's first-assignment-wins override). #369
+    // generalized that fix at the build layer — the rollup
+    // `firstAssignmentWinsGlobalExports` plugin guards EVERY IIFE named
+    // export, so the named re-export no longer clobbers the override. #370
+    // restored the export for parity with `SHARCNavigationError` and the
+    // standalone bridge module. The operator override surviving the IIFE
+    // eval is proven by test-creative-sdk-nav-bridge-override.js and
+    // test-iife-global-first-assignment-wins.js.
+    expectedExports: ['SHARCCreative', 'creative', 'SHARCNavigationError', 'installNavigationBridge']
   },
   {
     name: 'sharc-protocol',

--- a/test/types/consumer.ts
+++ b/test/types/consumer.ts
@@ -19,6 +19,13 @@
 
 import { SHARCContainer, type SHARCSecurityEvent, type SHARCSecurityEventCallback } from '../../dist/sharc-container';
 import { SHARCCreative } from '../../dist/sharc-creative';
+// #370: installNavigationBridge + SHARCNavigationError are re-exported from
+// sharc-creative again (the #367 drop is redundant under #369's IIFE epilogue
+// guard). Type-only import asserts the .d.ts top-level re-export resolves.
+import type {
+  installNavigationBridge as _installNavigationBridgeReexport,
+  SHARCNavigationError as _SHARCNavigationErrorReexport,
+} from '../../dist/sharc-creative';
 import { MRAIDCompatBridge } from '../../dist/sharc-mraid-bridge';
 import { SafeFrameCompatBridge } from '../../dist/sharc-safeframe-bridge';
 import { OmidCompatBridge } from '../../dist/sharc-omid-bridge';


### PR DESCRIPTION
Closes #370.

#367 dropped `installNavigationBridge` from `sharc-creative.js`'s named exports to stop the IIFE epilogue clobbering an operator override. #369 then made the epilogue first-assignment-wins for **all** exports (the `renderChunk` plugin). So the #367 drop is now redundant — this **restores the named export**, guarded automatically by #369.

**Load-bearing verification** — the restored export's dist epilogue line is **GUARDED**, not clobbering:
```
if (!('installNavigationBridge' in exports)) exports.installNavigationBridge = installNavigationBridge;
```
The #365/#369 override tests stay green — operator pre-set `installNavigationBridge` still survives the IIFE eval even as a named export, because #369's guard protects it exactly like `SHARCNavigationError`.

Also: docs (`getting-started.md`, `current-status.md`) + in-source comment reconciled (both symbols re-exported again); smoke export-list + `.d.ts` + the override/iife tests updated. No runtime behavior change.

Code Reviewer **APPROVE** — guarded epilogue confirmed against real `dist`; override tests cover export-present AND override-wins; additive/safe consumer + type impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)