### PR TITLE
chore: remove stale no-new-func eslint-disable directives

### DIFF
--- a/test/node/test-creative-sdk-nav-bridge-override.js
+++ b/test/node/test-creative-sdk-nav-bridge-override.js
@@ -117,7 +117,6 @@ const IIFE_SRC = fs.readFileSync(
 // <script src> tag. `this` at the top of the bundle is the window (the trailer
 // is `})(this.SHARC = this.SHARC || {})`).
 function runIIFE() {
-  // eslint-disable-next-line no-new-func
   const fn = new Function(IIFE_SRC);
   fn.call(win);
 }

--- a/test/node/test-creative-sdk-singleton.js
+++ b/test/node/test-creative-sdk-singleton.js
@@ -138,7 +138,6 @@ const IIFE_SRC = fs.readFileSync(
 // each time). `this` at the top of the bundle is the window (the trailer is
 // `})(this.SHARC = this.SHARC || {})`).
 function runIIFE() {
-  // eslint-disable-next-line no-new-func
   const fn = new Function(IIFE_SRC);
   fn.call(win);
 }


### PR DESCRIPTION
Two `// eslint-disable-next-line no-new-func` directives (in `test-creative-sdk-singleton.js` and `test-creative-sdk-nav-bridge-override.js`) suppressed a rule that no longer fires → eslint reported them as **unused directives**, failing `npm run lint` (`--max-warnings=0`). Removed both comment lines; the `new Function(IIFE_SRC)` lines are unchanged (the rule isn't enabled in this config, so no error surfaces).

Pre-existing on main, unrelated to feature work — clean lint hygiene before the 0.7.10 cut.

Verified: `npm run lint` → exit 0; `test:creative-sdk-singleton` + `test:creative-sdk-nav-bridge-override` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)