### PR TITLE
release: 0.7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,33 +13,92 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ## [Unreleased]
 
+## [0.7.10] - 2026-06-10
+
+The lifecycle & state-delivery hardening release: closes the #321 arc (SHARC was
+terminating valid ad loads), makes OMID survive bfcache restore, and fixes a
+class of build-output correctness bugs.
+
+### Added
+
+- **Container→creative state-delivery contract (R1).** A test-enforced contract
+  (23 RFC-2119 invariants) for how the container delivers lifecycle state to the
+  creative: establish-push on session start, an honest `currentState` in
+  `Container:init`, creative-side replay-on-subscribe, and consecutive-identical
+  send-layer dedup. Fixes the out-of-phase / never-delivered state that left
+  MRAID/SafeFrame/OMID viewability stuck. (#342, #334, #336)
+- **R3 bfcache restore — dead-port relink + level-triggered visibility replay.**
+  After a bfcache round-trip, the container re-asserts current visibility as a
+  *level* (not just an edge) and relinks the discarded MessagePort under a single
+  restore authority, so OMID flips back to VISIBLE and creative-side bridges
+  re-sync. (#338)
+- **MRAID `exposureChange`** (MRAID 3.0 viewability-exposure), deduped. (#341)
+- **SafeFrame compatibility wrapper** in the renderer — a raw `$sf` creative
+  reaches the strict SHARC handshake without shipping the SDK (mirrors the MRAID
+  wrapper). (#339)
+- **Renderer-provisioned MRAID compatibility wrapper** so raw legacy MRAID
+  creatives reach the strict SHARC handshake without shipping the SHARC SDK. (#326)
+- **Direct `ACTIVE→FROZEN` / `PASSIVE→FROZEN` state edges** — a freeze no longer
+  fabricates a phantom `HIDDEN`. (#340)
+- **Controlled-context probe on every post-render renderer load** — the load
+  backstop authenticates renderer control on each load, with a fail-open
+  navigation policy that keeps recoverable ad loads alive. (#321 Phase 1, #333)
+- **Answered-probe-cycle rate ceiling** in `_armRendererBackstop` — bounds a
+  keep-alive / log-volume DoS window via a non-terminating diagnostic. (#332)
+- **OMID shim-install failures now surface to the container** as a
+  `renderer_failed` security event instead of being swallowed in the iframe. (#249)
+- **OMID lifecycle facet** (declared-vs-runtime cross-tab, per-bidder failure
+  attribution) and expected-vendor-script-cache facets in the creative-validator
+  triage summary, plus a `select` CLI command for rebuilding executable rerun
+  subsets from normalized cases. (#211 Part B, #317)
+
 ### Changed
 
-- Tightened size-history delta guard to detect suspicious shrinkage and
-  new-module appearance; documented pre-commit hook scope in CONTRIBUTING.md.
-- Tightened size-history growth-path override to require proportional limit
-  raise, mirroring the shrinkage-path symmetry from PR #316.
-- Updated docs/current-status.md with What Shipped in 0.7.9 section.
-- Generalized source type-check coverage to all `src/**/*.js` files, expanded
-  lint coverage across tests and creative-validator tooling, and documented
-  `npm run check:ci` as the local pre-push gate.
-- Added an opt-in zero-dependency pre-commit hook for version-sync and lint
-  checks.
-- Added a size-history delta guard to flag release-over-release bundle growth
-  above 10% unless a raised size limit documents the budget decision.
-- Extended version-sync coverage to the README current-version marker and
-  refreshed release docs for the broader version-reference audit.
+- **IIFE global assignment is first-assignment-wins for the whole `window.SHARC`
+  namespace** — the bundle no longer clobbers an operator-set property (e.g. a
+  custom `installNavigationBridge`), via a build-layer guard on every IIFE
+  export. (#365, #369, #370)
+- **Window-singleton boot guard** — a double-bundled SDK (compat wrapper +
+  creative-shipped SDK) no longer spins a second instance that stalls the ad at
+  `loading`. (#327)
+- **Single always-escaping prelude injector** routes the OMID / load-probe /
+  compat preludes through one `</script>`-escaping path. (#329)
+- **OMID bridge cleanup** — honest no-op handler, cached `adSessionId`, and a
+  test that exercises the shipped prelude rather than a stale copy. (#253)
+- **Size-history delta guard** — flags release-over-release bundle growth above
+  10% (and suspicious shrinkage / new-module appearance) unless a raised limit
+  documents the budget decision; the growth path now requires a proportional
+  limit raise, symmetric with the shrinkage path. (#316, #318)
+- **Expanded type-check + lint coverage** across all `src/**/*.js`, tests, and
+  creative-validator tooling; documented `npm run check:ci` as the local
+  pre-push gate; added an opt-in zero-dependency pre-commit hook for version-sync
+  and lint; extended version-sync coverage to the README current-version marker.
+- 0.7.10 ergonomics and measurement auditability. (#314)
+
+### Fixed
+
+- **Renderer load-probe kept in-phase under OMID** — the root #321 defect: under
+  OMID the `loadAck` was dropped out-of-phase, deadlining the probe and
+  terminating valid ad loads with a spurious unauthorized-navigation. (#330)
+- **OMID `sessionFinish` relayed before router teardown** in `_terminate`. (#337)
+- **MRAID bridge adapter-level lifecycle outputs deduped.** (#343)
+- **Validator bridge-probe `$sf.ext` no longer pollutes** the container's
+  content-scan (plain-HTML / OMID cases stopped mis-detecting SafeFrame). (#346)
+- **Deterministic validator nav fixtures** — quarantined the flaky
+  `script-load-navigation` batch case into a standalone, removing a recurring CI
+  flake. (#344, #351, #362)
+
+### Docs / Testing
+
+- ADRs: renderer-lifecycle / MRAID-compat, post-render nav-policy (fail-open),
+  state-delivery contract + R1 + lifecycle audit, R3 bfcache relink. (#324, #331,
+  #345, #357)
 - Documented creative-validator OMID attribution diagnostic buckets and
-  measurement-layer limitations, with focused regression coverage for mixed
-  subscriber attribution and vendor-host allowlist drift.
-- Documented the creative-validator inline OMID scanner's regex-literal
-  boundary (#261) and added a near-miss regression test for an adjacent
-  escaped-URL-regex shape; tokenizer-backed scanning remains tracked in #258.
-- Added creative-validator OMID triage facets for expected vendor script-cache
-  observations and a `select` CLI command for rebuilding executable rerun
-  subsets from original normalized cases.
-- Added a renderer-provisioned MRAID compatibility wrapper so raw legacy MRAID
-  creatives can reach the strict SHARC handshake without shipping the SHARC SDK.
+  measurement-layer limitations (mixed-subscriber attribution, vendor-host
+  allowlist drift), and the inline OMID scanner's regex-literal boundary (#261);
+  tokenizer-backed scanning tracked in #258. Updated docs/current-status.md.
+- Coverage: MRAID/SafeFrame wrapper load-failure browser tests, double-createSession
+  runner case, `test/node` lint sweep. (#328, #360, #327, #364, #376)
 
 ## [0.7.9] - 2026-06-03
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # SHARC (Secure HTML Ad Richmedia Container)
 
-![Package status](https://img.shields.io/badge/package-v0.7.9%20(pre--publish)-informational)
+![Package status](https://img.shields.io/badge/package-v0.7.10%20(pre--publish)-informational)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/jeffreycarlson/SHARC/actions/workflows/ci.yml/badge.svg)](https://github.com/jeffreycarlson/SHARC/actions/workflows/ci.yml)
 
 Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol reference implementation.
 
 > 📋 This repository is the current SHARC reference implementation and working specification set.
-> It is in active pre-1.0 development at package version `0.7.9` and is not yet published to npm.
+> It is in active pre-1.0 development at package version `0.7.10` and is not yet published to npm.
 > Start with the curated docs index at [docs/README.md](docs/README.md) and the current state summary at [docs/current-status.md](docs/current-status.md).
 
 ## Overview
@@ -240,9 +240,9 @@ All public entry points build into `dist/` as ESM (`.mjs`) plus browser/IIFE bun
 
 After the package is published, public CDN URL patterns should mirror the current `dist/` filenames:
 
-- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.9/dist/sharc-container.js`
-- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.9/dist/sharc-creative.js`
-- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.9/dist/sharc-protocol.js`
+- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.10/dist/sharc-container.js`
+- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.10/dist/sharc-creative.js`
+- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.10/dist/sharc-protocol.js`
 
 Versioning guidance:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-SHARC is currently in pre-1.0 development at package version `0.7.9` and is not yet publicly published to npm.
+SHARC is currently in pre-1.0 development at package version `0.7.10` and is not yet publicly published to npm.
 
 Until the first public release, the project supports the current development line on `main` / the latest `0.7.x` source state in this repository. Earlier snapshots are not maintained as supported release lines, and there is no backport commitment yet.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # SHARC API Reference
 
-**Document revision:** 1.3 (Reference Implementation, current through package v0.7.9)
+**Document revision:** 1.3 (Reference Implementation, current through package v0.7.10)
 **Status:** Authoritative for v1 implementation
 **Last Updated:** 2026-05-21
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -4,7 +4,7 @@
 
 SHARC is an IAB Tech Lab reference implementation in active **pre-1.0** development.
 
-- Repository package version: `0.7.9`
+- Repository package version: `0.7.10`
 - npm publication status: **not yet published**
 - Current implementation scope: **web iframe**, **iOS WKWebView**, **Android WebView**
 - Current repo posture: suitable for technical evaluation and standards review; not yet presented here as a broadly adopted production release line

--- a/docs/size-history/0.7.10.json
+++ b/docs/size-history/0.7.10.json
@@ -1,0 +1,50 @@
+[
+  {
+    "name": "sharc-protocol",
+    "path": "dist/sharc-protocol.js",
+    "size": 3390,
+    "limit": 15000
+  },
+  {
+    "name": "sharc-container",
+    "path": "dist/sharc-container.js",
+    "size": 25548,
+    "limit": 30000
+  },
+  {
+    "name": "sharc-creative",
+    "path": "dist/sharc-creative.js",
+    "size": 5843,
+    "limit": 8000
+  },
+  {
+    "name": "sharc-mraid-bridge",
+    "path": "dist/sharc-mraid-bridge.js",
+    "size": 3266,
+    "limit": 30000
+  },
+  {
+    "name": "sharc-safeframe-bridge",
+    "path": "dist/sharc-safeframe-bridge.js",
+    "size": 2159,
+    "limit": 30000
+  },
+  {
+    "name": "sharc-omid-bridge",
+    "path": "dist/sharc-omid-bridge.js",
+    "size": 4789,
+    "limit": 25000
+  },
+  {
+    "name": "sharc-omid-shim",
+    "path": "dist/sharc-omid-shim.js",
+    "size": 1418,
+    "limit": 4000
+  },
+  {
+    "name": "sharc-navigation-bridge",
+    "path": "dist/sharc-navigation-bridge.js",
+    "size": 1143,
+    "limit": 10000
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iabtechlab/sharc",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol",
   "type": "module",
   "files": [

--- a/src/lifecycle-adapters/base-adapter.js
+++ b/src/lifecycle-adapters/base-adapter.js
@@ -22,7 +22,7 @@
  * for the rationale that picked the adapter-class shape over inline-switch
  * or registry alternatives.
  *
- * @version 0.7.9
+ * @version 0.7.10
  */
 
 'use strict';

--- a/src/lifecycle-adapters/html-adapter.js
+++ b/src/lifecycle-adapters/html-adapter.js
@@ -30,7 +30,7 @@
  *   - jsdom does NOT ship an IntersectionObserver implementation. Tests
  *     stub `global.IntersectionObserver` with a manually-triggerable mock.
  *
- * @version 0.7.9
+ * @version 0.7.10
  */
 
 'use strict';

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -26,7 +26,7 @@
  * container.load();
  * ```
  *
- * @version 0.7.9
+ * @version 0.7.10
  */
 
 'use strict';

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -34,7 +34,7 @@
  * </script>
  * ```
  *
- * @version 0.7.9
+ * @version 0.7.10
  */
 
 'use strict';

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -14,7 +14,7 @@
  *   3. sharc-mraid-bridge.js → window.mraid (this file)
  *   4. <MRAID creative>
  *
- * @version 0.7.9
+ * @version 0.7.10
  * @see mraid-bridge-design.md
  */
 

--- a/src/sharc-navigation-bridge.js
+++ b/src/sharc-navigation-bridge.js
@@ -81,7 +81,7 @@
  *
  * Spec: docs/proposals/creative-sources.md § Click-through audit and policy boundary.
  *
- * @version 0.7.9
+ * @version 0.7.10
  */
 
 'use strict';

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -21,7 +21,7 @@
  *   - creativeType and impressionType MUST be set before impressionOccurred()
  *   - AdSession must be started before any events are fired
  *
- * @version 0.7.9
+ * @version 0.7.10
  * @see https://iabtechlab.com/standards/open-measurement-sdk/
  * @see https://github.com/IABTechLab/SHARC
  */

--- a/src/sharc-omid-shim.js
+++ b/src/sharc-omid-shim.js
@@ -35,7 +35,7 @@
  *     in-iframe `postMessage` broadcast (§ 7.2).
  *   - Throws synchronously on a pre-existing `window.omid3p` (§ 11.3 / OMID-D10).
  *
- * @version 0.7.9
+ * @version 0.7.10
  * @see docs/design/0.7.8-omid-spec-compliant-bridge.md
  * @see https://iabtechlab.com/standards/open-measurement-sdk/
  */

--- a/src/sharc-protocol-router.js
+++ b/src/sharc-protocol-router.js
@@ -19,7 +19,7 @@
  * `./sharc-protocol-router` public import subpath. Consumers should import
  * the container, creative SDK, or bridge modules instead.
  *
- * @version 0.7.9
+ * @version 0.7.10
  */
 
 'use strict';

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -13,7 +13,7 @@
  *
  * Both extend SHARCProtocolBase which provides the shared message bus.
  *
- * @version 0.7.9
+ * @version 0.7.10
  * @see https://github.com/IABTechLab/SHARC
  */
 
@@ -27,7 +27,7 @@
 // ---------------------------------------------------------------------------
 
 /** Current SHARC spec version this implementation conforms to. */
-const SHARC_VERSION = '0.7.9';
+const SHARC_VERSION = '0.7.10';
 
 /**
  * Placeholder AdCOM `APIFramework` integer code for SHARC.

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -19,7 +19,7 @@
  *   - exp-push (push expand) — deferred to v2; fires 'failed' callback
  *   - $sf.ext.cookie() — permanently excluded; fires 'failed' callback
  *
- * @version 0.7.9
+ * @version 0.7.10
  * @see safeframe-bridge-design.md
  */
 


### PR DESCRIPTION
## 0.7.10 — Lifecycle & state-delivery hardening

Cuts the **0.7.10** release. 32 PRs since 0.7.9; `check:ci` green (prod build, full dist test suite, bfcache, perf, size budgets, size-history delta, validated tarball).

**Headline:**
- Closes the **#321 arc** — SHARC was terminating valid ad loads; root-caused to the omid-active phase bug, reframed the nav policy to fail-open, and landed the R1 container→creative **state-delivery contract** (23 RFC-2119 invariants).
- **R3 bfcache restore** — OMID/MRAID/SafeFrame visibility now survives a bfcache round-trip (dead-port relink + level-triggered replay + single restore authority).
- **Build-output correctness** — IIFE `window.SHARC` is first-assignment-wins (operator overrides survive); window-singleton guard stops double-SDK stalls.
- **OMID robustness** — shim-install failures surface to the container; exposureChange; terminate-order; bridge cleanup.
- **Compat** — MRAID + SafeFrame renderer wrappers; nav-policy probe-cycle ceiling.

Full notes in CHANGELOG `[0.7.10]`.

### Cut contents
- CHANGELOG `[Unreleased]` → `[0.7.10] - 2026-06-10`.
- `npm version` 0.7.9 → 0.7.10 — `SHARC_VERSION` + all version markers propagated (18 files).
- `docs/size-history/0.7.10.json` snapshot — all bundles <5% growth, within budget.

### After merge (gated — held for Jeffrey)
Tag `v0.7.10` on the merged commit + `git push --tags` (triggers the release workflow; npm publish auto-skips — `NPM_TOKEN` not set, #19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)