### PR TITLE
fix(validator): product-scope DV OMID detection + vendor-fetch-failed classification

### DIFF
--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -100,14 +100,38 @@ function omidSidecarPresent(testCase) {
     && testCase.bidSignals.measurement.omid.sidecarPresent === true);
 }
 
+// Keep aligned with the normalizer's doubleverify omidProductPaths: only
+// DV's verification tags (dvtp_src.js, dvbm.js) carry an OMID client;
+// dvbs_src* is the non-OMID RTB blocking/monitoring loader (2026-06-12 G2
+// holdout discover). Re-checked here so case files normalized before
+// product-scoped detection neither synthesize a VerificationScriptResource
+// nor owe an OMID subscription. Validator fixture probes stay
+// expectation-bearing.
+function isOmidProductVendorScript(script) {
+  if (!script) return false;
+  if (script.vendor !== 'doubleverify') return true;
+  let path = script.url && typeof script.url.path === 'string' ? script.url.path : null;
+  if (path === null && typeof script.value === 'string') {
+    try {
+      path = new URL(script.value).pathname;
+    } catch (_) {
+      path = '';
+    }
+  }
+  return /(?:^|\/)dvtp_src\.js$/i.test(path || '')
+    || /(?:^|\/)dvbm\.js$/i.test(path || '')
+    || /^\/__sharc-validator-fixtures\//.test(path || '');
+}
+
 function omidInlineVendorScripts(testCase) {
   const omid = testCase
     && testCase.bidSignals
     && testCase.bidSignals.measurement
     && testCase.bidSignals.measurement.omid;
-  return omid && Array.isArray(omid.inlineVendorScripts)
+  const scripts = omid && Array.isArray(omid.inlineVendorScripts)
     ? omid.inlineVendorScripts
     : [];
+  return scripts.filter(isOmidProductVendorScript);
 }
 
 function omidInlineVendorVendors(testCase) {

--- a/tools/creative-validator/src/diagnose.js
+++ b/tools/creative-validator/src/diagnose.js
@@ -2,6 +2,8 @@
  * @file Creative validator diagnosis buckets.
  */
 
+import { isOmidProductVendorScript, omidVendorMatchesHostname } from './normalizer.js';
+
 const EMPTY_RUN = Object.freeze({
   durationMs: 0,
   constructionError: null,
@@ -134,13 +136,69 @@ function omidInlineVendorExpected(testCase) {
     && testCase.bidSignals
     && testCase.bidSignals.measurement
     && testCase.bidSignals.measurement.omid;
-  return !!(omid && omid.inlineVendorScriptPresent === true);
+  if (!omid || omid.inlineVendorScriptPresent !== true) return false;
+  // Product scoping (2026-06-12 G2 holdout discover): case files normalized
+  // before product-scoped detection may list non-OMID vendor products (e.g.
+  // DV dvbs_src*) under inlineVendorScripts. Re-derive the expectation from
+  // the recorded scripts so those entries owe no OMID subscription.
+  if (Array.isArray(omid.inlineVendorScripts) && omid.inlineVendorScripts.length > 0) {
+    return omid.inlineVendorScripts.some((script) => isOmidProductVendorScript(script));
+  }
+  return true;
 }
 
 function omidRun(run) {
   return run && run.measurement && run.measurement.omid
     ? run.measurement.omid
     : null;
+}
+
+function diagnosticCount(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function scriptCacheOriginDeliveredBytes(values) {
+  return diagnosticCount(values && values.hits) > 0
+    || diagnosticCount(values && values.stores) > 0
+    || diagnosticCount(values && values.bytesFromNetwork) > 0
+    || diagnosticCount(values && values.bytesFromCache) > 0;
+}
+
+/**
+ * True when the expected inline vendor's origin was asked for script bytes
+ * and never delivered any (cache lookups with zero hits/stores/network bytes
+ * — the `net::ERR_ABORTED` / dead-CDN signature). The vendor code never
+ * executed, so the subscription checks would measure the network, not the
+ * vendor. Creative/CDN-attributable, not SHARC-attributable.
+ */
+function expectedVendorScriptFetchFailed(testCase, run) {
+  const omid = testCase
+    && testCase.bidSignals
+    && testCase.bidSignals.measurement
+    && testCase.bidSignals.measurement.omid;
+  const vendors = omid && Array.isArray(omid.inlineVendorVendors)
+    ? omid.inlineVendorVendors
+    : [];
+  if (vendors.length === 0) return false;
+  const byOrigin = run && run.scriptCache && run.scriptCache.byOrigin
+    ? run.scriptCache.byOrigin
+    : {};
+  let vendorLookups = 0;
+  for (const [origin, values] of Object.entries(byOrigin)) {
+    let hostname;
+    try {
+      hostname = new URL(origin).hostname;
+    } catch (_) {
+      continue;
+    }
+    if (!vendors.some((vendor) => omidVendorMatchesHostname(vendor, hostname))) continue;
+    // Any expected-vendor origin that delivered bytes disqualifies the
+    // fetch-failed classification: the vendor code ran, so the unsoftened
+    // subscribe checks apply.
+    if (scriptCacheOriginDeliveredBytes(values)) return false;
+    vendorLookups += diagnosticCount(values && values.lookups);
+  }
+  return vendorLookups > 0;
 }
 
 function classifyOutcome(testCase, run) {
@@ -195,6 +253,16 @@ function classifyOutcome(testCase, run) {
     // omid3p (0.7.8 shim) channel below stays for creative-window clients.
     const servicePassed = !!(inlineVendor && inlineVendor.servicePassed === true);
     if (!servicePassed) {
+      // Distinct non-SHARC outcome: zero bytes of the expected vendor's code
+      // ever arrived. This does NOT soften the subscribe checks below — a
+      // vendor copy that loaded and stayed silent still fails them.
+      if (expectedVendorScriptFetchFailed(testCase, run)) {
+        return {
+          status: 'failed',
+          bucket: 'vendor-fetch-failed',
+          reason: 'vendor script fetch failed (network): expected OMID vendor origin delivered zero script bytes',
+        };
+      }
       if (!inlineVendor || inlineVendor.omid3pFound !== true) {
         return {
           status: 'failed',

--- a/tools/creative-validator/src/normalizer.js
+++ b/tools/creative-validator/src/normalizer.js
@@ -47,6 +47,19 @@ const OMID_VENDOR_SCRIPT_HOSTS = [
   {
     vendor: 'doubleverify',
     hosts: ['doubleverify.com'],
+    // DV ships multiple products from the same CDN host and only the
+    // verification tags (dvtp_src.js, dvbm.js) carry an OMID client.
+    // dvbs_src* is DV's RTB blocking/monitoring loader with zero OMID code,
+    // so a host-only match attached a subscription expectation the script
+    // never owed (2026-06-12 G2 holdout discover, 13/14 false fails). The
+    // fixture prefix keeps the validator's own DV-hosted probes
+    // expectation-bearing. Keep aligned with isOmidProductVendorScript in
+    // harness/markup-runner.html.
+    omidProductPaths: [
+      /(?:^|\/)dvtp_src\.js$/i,
+      /(?:^|\/)dvbm\.js$/i,
+      /^\/__sharc-validator-fixtures\//,
+    ],
   },
   {
     vendor: 'ias',
@@ -217,6 +230,33 @@ function classifyOmidVendorScript(url) {
     }
   }
   return null;
+}
+
+function omidVendorPathIsOmidProduct(vendor, path) {
+  const pattern = OMID_VENDOR_SCRIPT_HOSTS.find((item) => item.vendor === vendor);
+  if (!pattern || !Array.isArray(pattern.omidProductPaths)) return true;
+  return pattern.omidProductPaths.some((re) => re.test(typeof path === 'string' ? path : ''));
+}
+
+/**
+ * Whether a recorded inline vendor script entry bears an OMID expectation.
+ * Operates on normalized script entries (not raw adm) so case files written
+ * before product-scoped detection are re-checked at diagnosis time.
+ *
+ * @param {object} script
+ * @returns {boolean}
+ */
+function isOmidProductVendorScript(script) {
+  if (!script || typeof script.vendor !== 'string' || !script.vendor) return false;
+  let path = script.url && typeof script.url.path === 'string' ? script.url.path : null;
+  if (path === null && typeof script.value === 'string' && /^https:\/\//i.test(script.value)) {
+    try {
+      path = new URL(script.value).pathname;
+    } catch (_) {
+      path = '';
+    }
+  }
+  return omidVendorPathIsOmidProduct(script.vendor.toLowerCase(), path || '');
 }
 
 function sanitizeInlineVendorScriptUrl(value) {
@@ -405,18 +445,27 @@ function extractInlineOmidVendorScriptScan(adm) {
   if (typeof adm !== 'string' || !adm) {
     return {
       scripts: [],
+      nonOmidVendorVendors: [],
       admTruncatedForScan: false,
       scriptTagLimitReached: false,
     };
   }
   const scan = extractScriptTagSources(adm);
   const scripts = [];
+  const nonOmidVendors = new Set();
   let vendorScriptMatches = 0;
   let vendorMatchLimitReached = false;
   for (const src of scan.sources) {
     const url = sanitizeInlineVendorScriptUrl(src);
     const vendor = classifyOmidVendorScript(url);
     if (!vendor) continue;
+    if (!omidVendorPathIsOmidProduct(vendor, url.path)) {
+      // Known vendor host serving a non-OMID product (e.g. DV dvbs_src*):
+      // note the presence, but attach no OMID expectation and synthesize no
+      // VerificationScriptResource downstream.
+      nonOmidVendors.add(vendor);
+      continue;
+    }
     if (vendorScriptMatches >= MAX_OMID_VENDOR_SCRIPT_MATCHES) {
       vendorMatchLimitReached = true;
       continue;
@@ -444,6 +493,7 @@ function extractInlineOmidVendorScriptScan(adm) {
 
   return {
     scripts: uniqueOmidVendorScripts(scripts),
+    nonOmidVendorVendors: [...nonOmidVendors].sort(),
     admTruncatedForScan: scan.admTruncatedForScan,
     scriptTagLimitReached: vendorMatchLimitReached,
   };
@@ -795,7 +845,12 @@ function normalizeBid(row, rowIndex, auction, auctionIndex, bid, options) {
   const omidSidecar = extractOmidSidecar(bid);
   const inlineOmidVendorScan = mode === 'adm-html'
     ? extractInlineOmidVendorScriptScan(unwrapped.adm)
-    : { scripts: [], admTruncatedForScan: false, scriptTagLimitReached: false };
+    : {
+      scripts: [],
+      nonOmidVendorVendors: [],
+      admTruncatedForScan: false,
+      scriptTagLimitReached: false,
+    };
   const inlineOmidVendorScripts = inlineOmidVendorScan.scripts;
   const omidMeasurement = {
     declaredByApi: omidDeclared,
@@ -810,6 +865,9 @@ function normalizeBid(row, rowIndex, auction, auctionIndex, bid, options) {
   if (inlineOmidVendorScripts.length > 0) {
     omidMeasurement.inlineVendorVendors = [...new Set(inlineOmidVendorScripts.map((script) => script.vendor))].sort();
     omidMeasurement.inlineVendorScripts = inlineOmidVendorScripts;
+  }
+  if (inlineOmidVendorScan.nonOmidVendorVendors.length > 0) {
+    omidMeasurement.inlineNonOmidVendorVendors = inlineOmidVendorScan.nonOmidVendorVendors;
   }
   if (inlineOmidVendorScan.admTruncatedForScan) {
     omidMeasurement.inlineVendorScanTruncated = true;
@@ -921,6 +979,7 @@ function toJsonl(cases) {
 export {
   classifyAdmKind,
   extractInlineOmidVendorScripts,
+  isOmidProductVendorScript,
   normalizeCleanedCorpus,
   omidVendorMatchesHostname,
   sanitizeApiDeclarations,

--- a/tools/creative-validator/test/test-diagnose.js
+++ b/tools/creative-validator/test/test-diagnose.js
@@ -63,6 +63,30 @@ function makeInlineOmidVendorCase() {
   return testCase;
 }
 
+function makeStaleDvScriptCase(scripts) {
+  const testCase = makeCase(true);
+  testCase.bidSignals.measurement.omid = {
+    declaredByApi: false,
+    sidecarPresent: false,
+    inlineVendorScriptPresent: true,
+    inlineVendorScriptCount: scripts.length,
+    inlineVendorVendors: ['doubleverify'],
+    inlineVendorScripts: scripts.map((path) => ({
+      vendor: 'doubleverify',
+      source: 'adm-script-src',
+      value: `https://cdn.doubleverify.com${path}`,
+      url: {
+        protocol: 'https:',
+        origin: 'https://cdn.doubleverify.com',
+        hostname: 'cdn.doubleverify.com',
+        path,
+      },
+    })),
+    sources: [{ path: 'adm.script[src]', vendor: 'doubleverify' }],
+  };
+  return testCase;
+}
+
 function bucket(run, testCase = makeCase(true)) {
   return classifyOutcome(testCase, makeEmptyRun(run)).bucket;
 }
@@ -218,6 +242,125 @@ test('classifyOutcome covers non-browser buckets', () => {
   }), 'inconclusive');
   assert.equal(bucket({ pageErrors: [{ message: 'creative threw' }] }), 'creative-broken');
   assert.equal(bucket({}), 'inconclusive');
+});
+
+// 2026-06-12 G2 holdout discover: DV product scoping + vendor fetch failures.
+test('dvbs-only DV creative owes no OMID subscription', () => {
+  // dvbs_src* is DV's non-OMID RTB blocking/monitoring product. Even on a
+  // stale normalized case (inlineVendorScriptPresent:true written before
+  // product scoping) with no harness OMID diagnostics at all, the rendered
+  // creative passes.
+  const testCase = makeStaleDvScriptCase(['/dvbs_src.js']);
+  assert.equal(bucket({ creativeRendered: true }, testCase), 'passed');
+});
+
+test('dvtp/dvbm DV verification tags keep the unsoftened OMID expectation', () => {
+  for (const path of ['/dvtp_src.js', '/dvbm.js']) {
+    const testCase = makeStaleDvScriptCase([path]);
+    const outcome = classifyOutcome(testCase, makeEmptyRun({
+      creativeRendered: true,
+      measurement: {
+        omid: {
+          inlineVendor: {
+            expected: true,
+            omid3pFound: true,
+            subscriptionObserved: false,
+            servicePassed: false,
+            passed: false,
+          },
+        },
+      },
+    }));
+    assert.equal(outcome.bucket, 'measurement-omid');
+    assert.equal(outcome.reason, 'inline OMID vendor script did not subscribe to OMID');
+  }
+  // Mixed dvbs + dvtp keeps the expectation: one OMID product is enough.
+  const mixed = makeStaleDvScriptCase(['/dvbs_src.js', '/dvtp_src.js']);
+  assert.equal(bucket({ creativeRendered: true }, mixed), 'measurement-omid');
+});
+
+test('zero-byte expected-vendor fetch classifies as vendor-fetch-failed', () => {
+  const testCase = makeInlineOmidVendorCase();
+  // The linkedinlm dvtp signature: vendor origin looked up, zero bytes ever
+  // delivered (net::ERR_ABORTED) — neither the inline tag nor the injected
+  // copy received DV code. Creative/CDN-attributable, not SHARC-attributable.
+  const outcome = classifyOutcome(testCase, makeEmptyRun({
+    creativeRendered: true,
+    measurement: {
+      omid: {
+        inlineVendor: {
+          expected: true,
+          omid3pFound: true,
+          subscriptionObserved: false,
+          servicePassed: false,
+          passed: false,
+        },
+      },
+    },
+    scriptCache: {
+      enabled: true,
+      byOrigin: {
+        'https://cdn.doubleverify.com': {
+          lookups: 2, hits: 0, misses: 2, stores: 0, bytesFromNetwork: 0, bytesFromCache: 0,
+        },
+      },
+    },
+  }));
+  assert.equal(outcome.status, 'failed');
+  assert.equal(outcome.bucket, 'vendor-fetch-failed');
+  assert.match(outcome.reason, /vendor script fetch failed \(network\)/);
+});
+
+test('vendor-fetch-failed does not soften the subscribe check', () => {
+  const testCase = makeInlineOmidVendorCase();
+  const silentVendorRun = (scriptCache) => makeEmptyRun({
+    creativeRendered: true,
+    measurement: {
+      omid: {
+        inlineVendor: {
+          expected: true,
+          omid3pFound: true,
+          subscriptionObserved: false,
+          servicePassed: false,
+          passed: false,
+        },
+      },
+    },
+    scriptCache,
+  });
+  // GUARD (discover §8 Option 2 rejection): vendor bytes arrived and the copy
+  // ran but stayed silent — still the unsoftened did-not-subscribe failure.
+  // This is the original 86-case defect class and must keep failing.
+  const loaded = classifyOutcome(testCase, silentVendorRun({
+    enabled: true,
+    byOrigin: {
+      'https://cdn.doubleverify.com': {
+        lookups: 2, hits: 1, misses: 1, stores: 0, bytesFromNetwork: 0, bytesFromCache: 65182,
+      },
+    },
+  }));
+  assert.equal(loaded.bucket, 'measurement-omid');
+  assert.equal(loaded.reason, 'inline OMID vendor script did not subscribe to OMID');
+
+  // No script cache diagnostics at all (cache disabled): no fetch-failure
+  // claim, the subscribe check stands.
+  assert.equal(
+    classifyOutcome(testCase, silentVendorRun(null)).bucket,
+    'measurement-omid',
+  );
+
+  // Unrelated-origin fetch failures do not reclassify the vendor expectation.
+  assert.equal(
+    classifyOutcome(testCase, silentVendorRun({
+      enabled: true,
+      byOrigin: {
+        'https://cdn.unrelated.example': {
+          lookups: 3, hits: 0, misses: 3, stores: 0, bytesFromNetwork: 0, bytesFromCache: 0,
+        },
+      },
+    })).bucket,
+    'measurement-omid',
+  );
 });
 
 test('classifyOutcome buckets expected bridge probe failures', () => {

--- a/tools/creative-validator/test/test-normalizer.js
+++ b/tools/creative-validator/test/test-normalizer.js
@@ -13,6 +13,7 @@ import test from 'node:test';
 import {
   classifyAdmKind,
   extractInlineOmidVendorScripts,
+  isOmidProductVendorScript,
   normalizeCleanedCorpus,
   omidVendorMatchesHostname,
   sanitizeApiDeclarations,
@@ -134,6 +135,99 @@ test('canonical OMID vendor host matcher uses suffix registry entries only', () 
   assert.equal(omidVendorMatchesHostname('generic-omid3p', 'cdn.doubleverify.com'), false);
 });
 
+test('DV detection is product-scoped: dvbs_src* carries no OMID expectation', () => {
+  const scripts = extractInlineOmidVendorScripts(`
+    <script src="https://cdn.doubleverify.com/dvbs_src.js?ctx=818052&cmp=DV154857&sid=4135814"></script>
+    <script src="https://cdn.doubleverify.com/dvbs_src_internal140.js"></script>
+    <script src="https://cdn.doubleverify.com/dvtp_src.js?ctx=1"></script>
+    <script src="https://cdn.doubleverify.com/dvbm.js"></script>
+  `);
+  assert.deepEqual(scripts.map((script) => script.url.path), ['/dvtp_src.js', '/dvbm.js']);
+});
+
+test('dvbs-only creative records DV presence without an OMID expectation', () => {
+  const corpus = [{
+    id: 'row-dvbs',
+    auction: [{
+      bidder: 'rubicon',
+      mtype: 'banner',
+      bid_request: { id: 'req-dvbs', imp: [{ id: 'imp-dvbs', banner: { w: 300, h: 250 } }] },
+      bid_response: {
+        id: 'res-dvbs',
+        seatbid: [{
+          bid: [{
+            id: 'bid-dvbs',
+            impid: 'imp-dvbs',
+            crid: 'crid-dvbs',
+            adm: '<html><body><script src="https://cdn.doubleverify.com/dvbs_src.js?ctx=1"></script><div>ad</div></body></html>',
+            w: 300,
+            h: 250,
+          }],
+        }],
+      },
+    }],
+  }];
+  const [normalized] = normalizeCleanedCorpus(corpus, { sourceFile: 'inline' });
+  const omid = normalized.bidSignals.measurement.omid;
+  assert.equal(omid.inlineVendorScriptPresent, false);
+  assert.equal(omid.inlineVendorScriptCount, 0);
+  assert.equal(omid.inlineVendorVendors, undefined);
+  assert.equal(omid.inlineVendorScripts, undefined);
+  assert.deepEqual(omid.inlineNonOmidVendorVendors, ['doubleverify']);
+});
+
+test('isOmidProductVendorScript re-checks stale normalized script entries', () => {
+  assert.equal(isOmidProductVendorScript({
+    vendor: 'doubleverify',
+    value: 'https://cdn.doubleverify.com/dvbs_src.js?ctx=1',
+    url: { hostname: 'cdn.doubleverify.com', path: '/dvbs_src.js' },
+  }), false);
+  // Falls back to parsing value when the url object is absent.
+  assert.equal(isOmidProductVendorScript({
+    vendor: 'doubleverify',
+    value: 'https://cdn.doubleverify.com/dvbs_src_internal140.js',
+  }), false);
+  assert.equal(isOmidProductVendorScript({
+    vendor: 'doubleverify',
+    value: 'https://cdn.doubleverify.com/dvtp_src.js?dvtagver=6.1.src',
+  }), true);
+  assert.equal(isOmidProductVendorScript({
+    vendor: 'doubleverify',
+    url: { hostname: 'cdn.doubleverify.com', path: '/dvbm.js' },
+  }), true);
+  // Validator-owned DV-hosted fixture probes stay expectation-bearing.
+  assert.equal(isOmidProductVendorScript({
+    vendor: 'doubleverify',
+    url: { path: '/__sharc-validator-fixtures/omid-vendor-service-probe.js' },
+  }), true);
+  // Vendors without product scoping are unaffected.
+  assert.equal(isOmidProductVendorScript({
+    vendor: 'ias',
+    url: { hostname: 'static.adsafeprotected.com', path: '/anything.js' },
+  }), true);
+  assert.equal(isOmidProductVendorScript({
+    vendor: 'generic-omid3p',
+    source: 'adm-inline-script',
+    value: 'omid3p observer probe',
+    url: null,
+  }), true);
+});
+
+test('runner DV OMID product-path scoping stays aligned with normalizer', () => {
+  const normalizerSource = readFileSync(resolve('tools/creative-validator/src/normalizer.js'), 'utf8');
+  const block = normalizerSource.match(/omidProductPaths:\s*\[([^\]]*)\]/);
+  assert.ok(block, 'normalizer DV omidProductPaths block exists');
+  const patterns = [...block[1].matchAll(/\/(?:[^/\\\n]|\\.)+\/[a-z]*/g)].map((match) => match[0]);
+  assert.ok(patterns.length >= 3, 'normalizer DV omidProductPaths has product patterns');
+  const runnerSource = readFileSync(resolve('tools/creative-validator/harness/markup-runner.html'), 'utf8');
+  for (const pattern of patterns) {
+    assert.ok(
+      runnerSource.includes(pattern),
+      `runner harness contains DV product path pattern ${pattern}`,
+    );
+  }
+});
+
 test('inline OMID vendor script detection requires vendor script hosts', () => {
   const scripts = extractInlineOmidVendorScripts(`
     <script src="https://example.com/blog/about-moatads.html"></script>
@@ -153,8 +247,8 @@ test('inline OMID vendor script detection requires explicit HTTPS URLs', () => {
     <script src="javascript:void(0)"></script>
     <script src="//cdn.doubleverify.com/dvtp_src.js"></script>
     <script src="/dvtp_src.js"></script>
-    <script src="   https://cdn.doubleverify.com/padded.js   "></script>
-    <script src="HTTPS://cdn.doubleverify.com/upper.js"></script>
+    <script src="   https://cdn.doubleverify.com/padded/dvtp_src.js   "></script>
+    <script src="HTTPS://cdn.doubleverify.com/upper/dvbm.js"></script>
     <script src="https://cdn.doubleverify.com/dvtp_src.js"></script>
   `);
   assert.deepEqual(scripts.map((script) => script.vendor), [
@@ -163,8 +257,8 @@ test('inline OMID vendor script detection requires explicit HTTPS URLs', () => {
     'doubleverify',
   ]);
   assert.deepEqual(scripts.map((script) => script.value), [
-    'https://cdn.doubleverify.com/padded.js',
-    'https://cdn.doubleverify.com/upper.js',
+    'https://cdn.doubleverify.com/padded/dvtp_src.js',
+    'https://cdn.doubleverify.com/upper/dvbm.js',
     'https://cdn.doubleverify.com/dvtp_src.js',
   ]);
 });
@@ -328,7 +422,7 @@ test('inline OMID vendor script detection handles namespaced tags and trailing-d
 
 test('normalization bounds inline OMID vendor scans', () => {
   const longAdm = `${Array.from({ length: 300 }, (_, index) =>
-    `<script src="https://cdn.doubleverify.com/${index}.js"></script>`).join('')}${'x'.repeat(1_000_001)}`;
+    `<script src="https://cdn.doubleverify.com/${index}/dvtp_src.js"></script>`).join('')}${'x'.repeat(1_000_001)}`;
   const [bounded] = normalizeCleanedCorpus([{
     id: 'auction-row-omid-bounded',
     auction: [{


### PR DESCRIPTION
## Summary

Two validator-honesty fixes ratified by the 2026-06-12 G2 holdout discover (`~/Obsidian/dev-team/sharc/2026-06-12-g2-holdout-14-dv-discover.md`). The discover root-caused all 14 new `measurement-omid` failures in the 1,128-case G2 holdout: 13 were validator expectation bugs (DV's non-OMID `dvbs_src.js` blocking/monitoring product host-matched as an OMID vendor), 1 was a transient CDN fetch failure. Zero real measurement loss; the 0.7.11 runtime is untouched.

### Fix 1 — product-scoped DV inline detection (discover Option 1)

`OMID_VENDOR_SCRIPT_HOSTS` previously matched any `*.doubleverify.com` script by host alone. Only DV's verification tags carry an OMID client, so the DV entry now takes `omidProductPaths`: `dvtp_src.js`, `dvbm.js`, plus the validator's own `/__sharc-validator-fixtures/` probes. `dvbs_src*` (empirically zero `omid` tokens in the served bundle) no longer creates an OMID expectation nor synthesizes a `VerificationScriptResource`. Presence is still recorded: dvbs-only creatives get `inlineNonOmidVendorVendors: ["doubleverify"]` in bid signals.

Because the holdout corpus (and any private corpus) is already normalized, the product predicate is re-checked at consumption time too:
- `diagnose.js` re-derives the inline-vendor expectation from the recorded script entries (`isOmidProductVendorScript`, shared from `normalizer.js`)
- `harness/markup-runner.html` filters `inlineVendorScripts` before sidecar synthesis (duplicated page-side, with a source-alignment test mirroring the existing host-list alignment test)

IAS/Moat/Oracle host patterns are unchanged (no `omidProductPaths` → all paths expectation-bearing, exactly as before).

### Fix 2 — vendor-fetch-failure classification (discover Option 3)

When the expected vendor's origin was asked for script bytes and never delivered any (`scriptCache` per-origin `lookups > 0` with zero `hits`/`stores`/`bytesFromNetwork`/`bytesFromCache` — the `net::ERR_ABORTED` dead-CDN signature), the case now classifies as a new distinct bucket `vendor-fetch-failed` with reason `vendor script fetch failed (network): expected OMID vendor origin delivered zero script bytes`, instead of "inline OMID vendor script did not subscribe to OMID".

**Why a new bucket instead of `network-cors`:** `network-cors` fires only when the creative never reached terminal success and network diagnostics explain it. In this class the creative renders fine and only the measurement sidecar fetch died — reusing `network-cors` would mix render-blocking network failures with measurement-only CDN flakes and pollute both signals. A distinct bucket matches the discover's Option 3 naming, keeps `measurement-omid` clean against CDN weather, and is trivially greppable in triage (bucket maps are open-keyed; no enumeration to update). Any expected-vendor origin that delivered bytes disqualifies the classification.

### The subscribe check is untouched

Explicitly: this PR does **not** soften the subscribe check. A vendor copy that loaded (bytes delivered from cache or network) and stayed silent still fails `inline OMID vendor script did not subscribe to OMID` — guard tests pin this (`vendor-fetch-failed does not soften the subscribe check`, including the cache-disabled and unrelated-origin cases). Softening it ("injected copy ran but silent ⇒ pass") would have masked the original 86-case defect class closed in 0.7.11.

## Holdout verification (binary criterion)

Corpus: `tools/creative-validator/private/normalized/openrtb-parsing-20260612-g2-holdout-cases.jsonl` (1,128 cases, unchanged — stale-case handling is the point).

| Outcome | Before (holdout report) | After |
|---|---|---|
| passed/passed | 963 | full rerun in flight |
| skipped/unsupported-input | 151 | full rerun in flight |
| failed/measurement-omid | 14 | full rerun in flight |

Full rerun: `tools/creative-validator/private/reports/openrtb-parsing-20260612-g2-holdout-rerun2.jsonl` (in flight; table will be updated on completion).

**Targeted pre-check (the 14 previously-failing cases, re-run against this branch): 14/14 passed.**
- 13 dvbs rows: `inlineVendorScriptPresent:false`, `sidecarSynthesizedFromInlineVendor:false`, no OMID expectation → passed on render (DV presence still noted in bid signals on fresh normalization)
- 1 linkedinlm dvtp row: CDN recovered — `servicePassed:true`, `subscriptionsByVendor:{"doubleverify":45}` (matches the discover's live reproduction); had the CDN aborted again, it would land in `vendor-fetch-failed`

## Tests

- `npm run test:creative-validator-normalizer` — 37 pass (new: dvbs/dvtp/dvbm product scoping, `inlineNonOmidVendorVendors`, stale-entry predicate, runner/normalizer product-path alignment)
- `npm run test:creative-validator-diagnose` — 7 pass (new: dvbs-only → no expectation; dvtp/dvbm expectation unchanged; zero-byte fetch → `vendor-fetch-failed`; subscribe-check guard)
- `npm run test:creative-validator-runner` — 14 pass (browser-driven, incl. real-SDK service mode)
- `npm run test:creative-validator-triage` — 13 pass
- `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
