### PR TITLE
release: 0.7.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
 
 ---
 
-## [Unreleased]
+## [0.7.11] - 2026-06-12
+
+The OMID spec-true measurement release: SHARC now boots the real IAB OM SDK Web
+service (`omweb-v1.js`) so verification vendors connect via the official OMID
+discovery protocol instead of a mock — corpus-proven with a 940/940 executable
+burn-down pass plus 976/977 on a fresh 1,128-case unseen holdout, zero
+SHARC-attributable failures (the single miss is vendor-CDN-attributed).
 
 ### Added
 
@@ -44,6 +50,33 @@ and this project adheres to a `MAJOR.MINOR.PATCH` convention where:
   reaches `SHARC:Omid:` handlers, never raises `unauthorized_protocol`, draws
   no publisher-side response (no nonce leak surface); SHARC envelopes fail the
   OM SDK's own structural admission gate.
+
+### Changed
+
+- **Docs: retired Moat and the redundant "Integral" entry from live vendor
+  lists (#380).** Moat was shut down by Oracle; Integral is the same company as
+  IAS. Present-tense landscape descriptions only — frozen design records keep
+  their point-in-time vendor lists.
+
+### Fixed
+
+- **Validator honesty: DV detection is product-scoped (#381).** Only
+  DoubleVerify's verification tags (`dvtp_src.js`, `dvbm.js`) carry an OMID
+  client; `dvbs_src*` is the RTB blocking/monitoring loader with zero OMID
+  code. A host-only match on `cdn.doubleverify.com` attached a subscription
+  expectation the script never owed. dvbs-only creatives now record presence
+  via `inlineNonOmidVendorVendors` without an OMID expectation; stale
+  normalized corpora are re-checked at diagnosis and synthesis time. The
+  subscribe check itself is untouched (guard tests pin it).
+- **Validator: zero-byte expected-vendor fetches classify as
+  `vendor-fetch-failed` (#381).** The dead-CDN signature (origin looked up,
+  zero script bytes delivered) is creative/CDN-attributable, not
+  SHARC-attributable — a distinct bucket keeps the measurement-omid signal
+  clean against CDN weather.
+
+### Security
+
+**Security — OMID verification-service isolation (#244).** 0.7.11 boots the real IAB OM SDK Web service (`omweb-v1.js`) on the publisher window, which installs OMID's own cross-frame verification-service protocol — unauthenticated by the spec's design. SHARC's mitigation is **strict isolation**, not authentication: the OM SDK surface coexists *beside* the nonce-gated SHARC protocol router on the same message bus, never *through* it. Security review confirmed the boundary holds in both directions — omid_v1 traffic is silently dropped by the router's prefix/nonce gate and never reaches a SHARC handler or leaks nonce material, while SHARC envelopes fail the OM SDK's own structural admission gate. Every capability the unauthenticated surface grants a hostile creative is either pre-existing (reading its own ad's events, firing pixels, eval in its own frame) or blocked by the service's server-side enforcement that session events are delivered only to verification clients it injected itself (verified in the pinned binary). The new `MAX_OMID_VERIFICATION_RESOURCES` cap (provisional 16) bounds SHARC's container-controlled input to the service's injection fan-out with loud, non-terminating truncation. Vendored OM SDK binaries are private/gitignored CI fixtures, excluded from the npm tarball by an enforced tarball guard and never pushed to the public IAB tree. No new cross-tenant disclosure, no publisher-page privilege escalation, no reach into SHARC's control channel.
 
 ## [0.7.10] - 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # SHARC (Secure HTML Ad Richmedia Container)
 
-![Package status](https://img.shields.io/badge/package-v0.7.10%20(pre--publish)-informational)
+![Package status](https://img.shields.io/badge/package-v0.7.11%20(pre--publish)-informational)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/jeffreycarlson/SHARC/actions/workflows/ci.yml/badge.svg)](https://github.com/jeffreycarlson/SHARC/actions/workflows/ci.yml)
 
 Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol reference implementation.
 
 > 📋 This repository is the current SHARC reference implementation and working specification set.
-> It is in active pre-1.0 development at package version `0.7.10` and is not yet published to npm.
+> It is in active pre-1.0 development at package version `0.7.11` and is not yet published to npm.
 > Start with the curated docs index at [docs/README.md](docs/README.md) and the current state summary at [docs/current-status.md](docs/current-status.md).
 
 ## Overview
@@ -240,9 +240,9 @@ All public entry points build into `dist/` as ESM (`.mjs`) plus browser/IIFE bun
 
 After the package is published, public CDN URL patterns should mirror the current `dist/` filenames:
 
-- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.10/dist/sharc-container.js`
-- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.10/dist/sharc-creative.js`
-- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.10/dist/sharc-protocol.js`
+- Container: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.11/dist/sharc-container.js`
+- Creative: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.11/dist/sharc-creative.js`
+- Protocol: `https://cdn.jsdelivr.net/npm/@iabtechlab/sharc@0.7.11/dist/sharc-protocol.js`
 
 Versioning guidance:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-SHARC is currently in pre-1.0 development at package version `0.7.10` and is not yet publicly published to npm.
+SHARC is currently in pre-1.0 development at package version `0.7.11` and is not yet publicly published to npm.
 
 Until the first public release, the project supports the current development line on `main` / the latest `0.7.x` source state in this repository. Earlier snapshots are not maintained as supported release lines, and there is no backport commitment yet.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # SHARC API Reference
 
-**Document revision:** 1.3 (Reference Implementation, current through package v0.7.10)
+**Document revision:** 1.3 (Reference Implementation, current through package v0.7.11)
 **Status:** Authoritative for v1 implementation
 **Last Updated:** 2026-05-21
 

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -4,7 +4,7 @@
 
 SHARC is an IAB Tech Lab reference implementation in active **pre-1.0** development.
 
-- Repository package version: `0.7.10`
+- Repository package version: `0.7.11`
 - npm publication status: **not yet published**
 - Current implementation scope: **web iframe**, **iOS WKWebView**, **Android WebView**
 - Current repo posture: suitable for technical evaluation and standards review; not yet presented here as a broadly adopted production release line

--- a/docs/size-history/0.7.11.json
+++ b/docs/size-history/0.7.11.json
@@ -1,0 +1,50 @@
+[
+  {
+    "name": "sharc-protocol",
+    "path": "dist/sharc-protocol.js",
+    "size": 3391,
+    "limit": 15000
+  },
+  {
+    "name": "sharc-container",
+    "path": "dist/sharc-container.js",
+    "size": 25728,
+    "limit": 30000
+  },
+  {
+    "name": "sharc-creative",
+    "path": "dist/sharc-creative.js",
+    "size": 5845,
+    "limit": 8000
+  },
+  {
+    "name": "sharc-mraid-bridge",
+    "path": "dist/sharc-mraid-bridge.js",
+    "size": 3266,
+    "limit": 30000
+  },
+  {
+    "name": "sharc-safeframe-bridge",
+    "path": "dist/sharc-safeframe-bridge.js",
+    "size": 2159,
+    "limit": 30000
+  },
+  {
+    "name": "sharc-omid-bridge",
+    "path": "dist/sharc-omid-bridge.js",
+    "size": 4918,
+    "limit": 25000
+  },
+  {
+    "name": "sharc-omid-shim",
+    "path": "dist/sharc-omid-shim.js",
+    "size": 1418,
+    "limit": 4000
+  },
+  {
+    "name": "sharc-navigation-bridge",
+    "path": "dist/sharc-navigation-bridge.js",
+    "size": 1143,
+    "limit": 10000
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iabtechlab/sharc",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iabtechlab/sharc",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Secure HTML Ad Richmedia Container (SHARC) — IAB Tech Lab protocol",
   "type": "module",
   "files": [

--- a/src/lifecycle-adapters/base-adapter.js
+++ b/src/lifecycle-adapters/base-adapter.js
@@ -22,7 +22,7 @@
  * for the rationale that picked the adapter-class shape over inline-switch
  * or registry alternatives.
  *
- * @version 0.7.10
+ * @version 0.7.11
  */
 
 'use strict';

--- a/src/lifecycle-adapters/html-adapter.js
+++ b/src/lifecycle-adapters/html-adapter.js
@@ -30,7 +30,7 @@
  *   - jsdom does NOT ship an IntersectionObserver implementation. Tests
  *     stub `global.IntersectionObserver` with a manually-triggerable mock.
  *
- * @version 0.7.10
+ * @version 0.7.11
  */
 
 'use strict';

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -26,7 +26,7 @@
  * container.load();
  * ```
  *
- * @version 0.7.10
+ * @version 0.7.11
  */
 
 'use strict';

--- a/src/sharc-creative.js
+++ b/src/sharc-creative.js
@@ -34,7 +34,7 @@
  * </script>
  * ```
  *
- * @version 0.7.10
+ * @version 0.7.11
  */
 
 'use strict';

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -14,7 +14,7 @@
  *   3. sharc-mraid-bridge.js → window.mraid (this file)
  *   4. <MRAID creative>
  *
- * @version 0.7.10
+ * @version 0.7.11
  * @see mraid-bridge-design.md
  */
 

--- a/src/sharc-navigation-bridge.js
+++ b/src/sharc-navigation-bridge.js
@@ -81,7 +81,7 @@
  *
  * Spec: docs/proposals/creative-sources.md § Click-through audit and policy boundary.
  *
- * @version 0.7.10
+ * @version 0.7.11
  */
 
 'use strict';

--- a/src/sharc-omid-bridge.js
+++ b/src/sharc-omid-bridge.js
@@ -21,7 +21,7 @@
  *   - creativeType and impressionType MUST be set before impressionOccurred()
  *   - AdSession must be started before any events are fired
  *
- * @version 0.7.10
+ * @version 0.7.11
  * @see https://iabtechlab.com/standards/open-measurement-sdk/
  * @see https://github.com/IABTechLab/SHARC
  */

--- a/src/sharc-omid-shim.js
+++ b/src/sharc-omid-shim.js
@@ -35,7 +35,7 @@
  *     in-iframe `postMessage` broadcast (§ 7.2).
  *   - Throws synchronously on a pre-existing `window.omid3p` (§ 11.3 / OMID-D10).
  *
- * @version 0.7.10
+ * @version 0.7.11
  * @see docs/design/0.7.8-omid-spec-compliant-bridge.md
  * @see https://iabtechlab.com/standards/open-measurement-sdk/
  */

--- a/src/sharc-protocol-router.js
+++ b/src/sharc-protocol-router.js
@@ -19,7 +19,7 @@
  * `./sharc-protocol-router` public import subpath. Consumers should import
  * the container, creative SDK, or bridge modules instead.
  *
- * @version 0.7.10
+ * @version 0.7.11
  */
 
 'use strict';

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -13,7 +13,7 @@
  *
  * Both extend SHARCProtocolBase which provides the shared message bus.
  *
- * @version 0.7.10
+ * @version 0.7.11
  * @see https://github.com/IABTechLab/SHARC
  */
 
@@ -27,7 +27,7 @@
 // ---------------------------------------------------------------------------
 
 /** Current SHARC spec version this implementation conforms to. */
-const SHARC_VERSION = '0.7.10';
+const SHARC_VERSION = '0.7.11';
 
 /**
  * Placeholder AdCOM `APIFramework` integer code for SHARC.

--- a/src/sharc-safeframe-bridge.js
+++ b/src/sharc-safeframe-bridge.js
@@ -19,7 +19,7 @@
  *   - exp-push (push expand) — deferred to v2; fires 'failed' callback
  *   - $sf.ext.cookie() — permanently excluded; fires 'failed' callback
  *
- * @version 0.7.10
+ * @version 0.7.11
  * @see safeframe-bridge-design.md
  */
 

--- a/test/node/test-omid-verification-resource-cap.js
+++ b/test/node/test-omid-verification-resource-cap.js
@@ -45,7 +45,7 @@ if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.subtle?
 const protoMod = await import('../../dist/sharc-protocol.mjs');
 window.SHARC = window.SHARC || {};
 window.SHARC.Protocol = protoMod;
-const { SHARCContainer } = await import('../../dist/sharc-container.mjs');
+const { SHARCContainer, SHARC_BUILD_MODE } = await import('../../dist/sharc-container.mjs');
 const { OmidCompatBridge, MAX_OMID_VERIFICATION_RESOURCES } = await import('../../dist/sharc-omid-bridge.mjs');
 
 let failures = 0;
@@ -53,6 +53,13 @@ function section(name) { console.log('\n' + name); }
 function assert(condition, message) {
   if (condition) console.log('  ✓', message);
   else { console.error('  ✗', message); failures++; }
+}
+function assertDevConsole(condition, message) {
+  if (SHARC_BUILD_MODE !== 'dev') {
+    console.log('  ✓', `${message} (dev-console assertion skipped in prod bundle)`);
+    return;
+  }
+  assert(condition, message);
 }
 
 function freshSlot() {
@@ -232,7 +239,7 @@ section('D. container-less trip still warns');
   }
   assert(capture.contextScripts.length === MAX_OMID_VERIFICATION_RESOURCES,
     'truncation still applies without a container');
-  assert(warns.some((w) => w.includes('verification-script resources capped')),
+  assertDevConsole(warns.some((w) => w.includes('verification-script resources capped')),
     'dev-channel warn emitted when no container chokepoint is available');
 }
 


### PR DESCRIPTION
## [0.7.11] - 2026-06-12

The OMID spec-true measurement release: SHARC now boots the real IAB OM SDK Web
service (`omweb-v1.js`) so verification vendors connect via the official OMID
discovery protocol instead of a mock — corpus-proven with a 940/940 executable
burn-down pass plus 976/977 on a fresh 1,128-case unseen holdout, zero
SHARC-attributable failures (the single miss is vendor-CDN-attributed).

### Added

- **Creative validator: real pinned OM SDK replaces the mock for OMID runs
  (#244, #211A, #211B).** The harness top window now boots the real
  `omweb-v1.js` + session client (vendored, checksummed — see
  `tools/creative-validator/VENDORED.md`; binaries stay private/gitignored).
  Success signal moves to service-path delivery: a validator canary
  `VerificationScriptResource` records what the service actually dispatches,
  and omid_v1 subscription traffic is observed beside the protocol and
  attributed via the service's injected-iframe registry
  (`inlineVendor.deliveryChannel: omid3p|service|both|none`). Injectable SDK
  load failure (`--omid-sdk-load-failure`) makes the
  `feature_load_failed → measurement-omid` branch reachable and tested (#211A
  Part A). Triage gains `rowsBySdkMode`, delivery-channel, service-vendor,
  canary, and `serviceInjectedResourceCount` facets (#211B / D7 evidence).
  `getOmidSessionClient()` now unwraps the real session client's
  version-keyed namespace via `'default'` (the #244 D6 upgrade seam).
- **OMID verification resource cap (D7, #244).** Finite
  `MAX_OMID_VERIFICATION_RESOURCES` (provisional 16) on distinct
  verification-script resources per OM SDK `Context` — the container-controlled
  input to the real service's vendor-copy injection fan-out. Tripping truncates
  to the first N declared resources and emits the new non-terminating
  `omid_resource_cap` security event (severity `warning`); never silent, never
  terminates the ad. Value owned by #244 corpus evidence; re-measured
  post-integration.
- **omid_v1 ↔ router isolation tests (D5, #244).** Pins the boundary the #244
  security verdict is conditional on: OM SDK verification-service traffic
  coexists beside the protocol router on the same window message bus — never
  reaches `SHARC:Omid:` handlers, never raises `unauthorized_protocol`, draws
  no publisher-side response (no nonce leak surface); SHARC envelopes fail the
  OM SDK's own structural admission gate.

### Changed

- **Docs: retired Moat and the redundant "Integral" entry from live vendor
  lists (#380).** Moat was shut down by Oracle; Integral is the same company as
  IAS. Present-tense landscape descriptions only — frozen design records keep
  their point-in-time vendor lists.

### Fixed

- **Validator honesty: DV detection is product-scoped (#381).** Only
  DoubleVerify's verification tags (`dvtp_src.js`, `dvbm.js`) carry an OMID
  client; `dvbs_src*` is the RTB blocking/monitoring loader with zero OMID
  code. A host-only match on `cdn.doubleverify.com` attached a subscription
  expectation the script never owed. dvbs-only creatives now record presence
  via `inlineNonOmidVendorVendors` without an OMID expectation; stale
  normalized corpora are re-checked at diagnosis and synthesis time. The
  subscribe check itself is untouched (guard tests pin it).
- **Validator: zero-byte expected-vendor fetches classify as
  `vendor-fetch-failed` (#381).** The dead-CDN signature (origin looked up,
  zero script bytes delivered) is creative/CDN-attributable, not
  SHARC-attributable — a distinct bucket keeps the measurement-omid signal
  clean against CDN weather.

### Security

**Security — OMID verification-service isolation (#244).** 0.7.11 boots the real IAB OM SDK Web service (`omweb-v1.js`) on the publisher window, which installs OMID's own cross-frame verification-service protocol — unauthenticated by the spec's design. SHARC's mitigation is **strict isolation**, not authentication: the OM SDK surface coexists *beside* the nonce-gated SHARC protocol router on the same message bus, never *through* it. Security review confirmed the boundary holds in both directions — omid_v1 traffic is silently dropped by the router's prefix/nonce gate and never reaches a SHARC handler or leaks nonce material, while SHARC envelopes fail the OM SDK's own structural admission gate. Every capability the unauthenticated surface grants a hostile creative is either pre-existing (reading its own ad's events, firing pixels, eval in its own frame) or blocked by the service's server-side enforcement that session events are delivered only to verification clients it injected itself (verified in the pinned binary). The new `MAX_OMID_VERIFICATION_RESOURCES` cap (provisional 16) bounds SHARC's container-controlled input to the service's injection fan-out with loud, non-terminating truncation. Vendored OM SDK binaries are private/gitignored CI fixtures, excluded from the npm tarball by an enforced tarball guard and never pushed to the public IAB tree. No new cross-tenant disclosure, no publisher-page privilege escalation, no reach into SHARC's control channel.


---

**Release mechanics**

- `npm version patch` 0.7.10 → 0.7.11 — `SHARC_VERSION` in `src/sharc-protocol.js` plus all README/SECURITY/docs version markers propagated by `sync-version` (18 files).
- `docs/size-history/0.7.11.json` snapshot committed; `size-history:check` green (max growth: sharc-omid-bridge +2.7%, sharc-container +0.7% — well under the 10% delta guard).
- `npm run check:ci` exits 0 (version guard, prod build, full dist suite, types, bfcache, perf, size budgets, size-history delta, tarball validation — 32 validated package files). `npm run lint` clean.
- Includes one precursor commit, `fix(test): gate D7 cap dev-channel warn assertion on build mode` — the #378 cap test asserted a `console.warn` the prod bundle strips (`drop_console`), so `check:ci` failed on main since #378; CI never caught it because `ci.yml` tests the dev build. Fixed with the established `assertDevConsole` pattern. Without this, the v0.7.11 tag workflow (which runs `check:ci`) would fail.

**Post-merge:** tag `v0.7.11` will be pushed by the maintainer after merge. The release workflow's npm publish step auto-skips cleanly — `NPM_TOKEN` is absent per #19 — and still uploads the dist artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
