### PR TITLE
test(validator): IAS + Pixalate OMID vendor fixtures (#G3)

### DIFF
--- a/tools/creative-validator/fixtures/reductions/008-omid-real-vendor-tags/README.md
+++ b/tools/creative-validator/fixtures/reductions/008-omid-real-vendor-tags/README.md
@@ -1,0 +1,46 @@
+# 008 OMID Real Vendor Tags
+
+G3 evidence corpus: controlled creatives embedding REAL verification vendor
+tags (IAS, Pixalate, DoubleVerify) so the validator's service-mode OMID path
+can be proven against live vendor code instead of synthetic probes.
+
+All placement/client identifiers are synthetic. Both vendor CDNs were verified
+live (2026-06-12) to serve their real scripts for synthetic identifiers:
+
+- **IAS** — `https://pixel.adsafeprotected.com/rjss/st/<entityId>/<placementId>/skeleton.js`.
+  The rjss skeleton endpoint serves the identical ~330 KB OMID-aware loader
+  regardless of the ID path segments. This is the exact tag shape observed on
+  all 8 IAS-inline cases in the private corpus.
+- **Pixalate** — `https://q.adrta.com/s/<clientId>/aa.js?cb=<cb>#<clientId>;paid=...`
+  (documented analytics tag, pixalate.com knowledge base). The aa.js bootstrap
+  loads `q.adrta.com/r.js`, then `pix.adrta.com/cdnf.js`, which bundles the
+  official IAB `OmidVerificationClient` (`1.6.1-iab283`, lazily fetched from
+  `pix.adrta.com/1.6.1-iab283/omid.js`). Real tag shape — not approximated.
+- **DoubleVerify** — `https://cdn.doubleverify.com/dvtp_src.js?ctx=...` with
+  synthetic campaign parameters (multi-vendor case only; DV is already proven
+  at corpus scale).
+
+Cases:
+
+| id | proves |
+|----|--------|
+| `g3-ias-banner-early` | IAS tag in head of a simple banner |
+| `g3-ias-late-tag` | IAS tag as the last element of the body |
+| `g3-ias-plus-dv-multivendor` | IAS + DV side by side in one creative |
+| `g3-pixalate-inline` | Pixalate analytics tag inline in the adm (organic shape) |
+| `g3-pixalate-sidecar` | Pixalate tag delivered as a bid-ext `VerificationScriptResource` |
+
+Run (service mode, requires the pinned vendored OM SDK binaries and live
+network access to the vendor CDNs):
+
+```
+node tools/creative-validator/src/cli.js normalize \
+  tools/creative-validator/fixtures/reductions/008-omid-real-vendor-tags/cleaned-corpus.fixture.json \
+  --out tools/creative-validator/private/normalized/omid-real-vendor-tags.jsonl
+node tools/creative-validator/src/cli.js run \
+  tools/creative-validator/private/normalized/omid-real-vendor-tags.jsonl \
+  --out tools/creative-validator/private/reports/omid-real-vendor-tags-report.jsonl
+```
+
+A run without network access to the vendor CDNs fails with the
+`vendor-fetch-failed` bucket — that is a finding, not a skip.

--- a/tools/creative-validator/fixtures/reductions/008-omid-real-vendor-tags/cleaned-corpus.fixture.json
+++ b/tools/creative-validator/fixtures/reductions/008-omid-real-vendor-tags/cleaned-corpus.fixture.json
@@ -1,0 +1,214 @@
+[
+  {
+    "id": "g3-ias-banner-early",
+    "auction": [
+      {
+        "bidder": "fixture-ias-banner",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "g3-req-ias-1",
+          "imp": [
+            {
+              "id": "g3-imp-ias-1",
+              "instl": 0,
+              "secure": 1,
+              "banner": { "w": 300, "h": 250, "api": [7] }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "g3-res-ias-1",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "g3-bid-ias-1",
+                  "impid": "g3-imp-ias-1",
+                  "crid": "g3-crid-ias-banner-early",
+                  "adomain": ["advertiser.example"],
+                  "w": 300,
+                  "h": 250,
+                  "price": 1.0,
+                  "adm": "<!doctype html><html><head><script src=\"https://pixel.adsafeprotected.com/rjss/st/999999/99999999/skeleton.js\"></script></head><body><div style=\"width:300px;height:250px;background:#1a73e8;color:#fff;font:16px/250px sans-serif;text-align:center\">SHARC G3 IAS banner fixture</div></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "g3-ias-late-tag",
+    "auction": [
+      {
+        "bidder": "fixture-ias-late",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "g3-req-ias-2",
+          "imp": [
+            {
+              "id": "g3-imp-ias-2",
+              "instl": 0,
+              "secure": 1,
+              "banner": { "w": 300, "h": 250, "api": [7] }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "g3-res-ias-2",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "g3-bid-ias-2",
+                  "impid": "g3-imp-ias-2",
+                  "crid": "g3-crid-ias-late-tag",
+                  "adomain": ["advertiser.example"],
+                  "w": 300,
+                  "h": 250,
+                  "price": 1.0,
+                  "adm": "<!doctype html><html><body><div id=\"frame\" style=\"width:300px;height:250px;position:relative;background:#202124;color:#fff;font:14px sans-serif\"><h1 style=\"margin:8px\">SHARC G3</h1><p style=\"margin:8px\">IAS tag late in body</p><a href=\"https://advertiser.example/landing\" style=\"color:#8ab4f8;margin:8px;display:inline-block\">Learn more</a></div><script>document.getElementById('frame').setAttribute('data-fixture-ready','1');</script><script src=\"https://pixel.adsafeprotected.com/rjss/st/999999/99999998/skeleton.js\"></script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "g3-ias-plus-dv-multivendor",
+    "auction": [
+      {
+        "bidder": "fixture-ias-dv",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "g3-req-ias-dv",
+          "imp": [
+            {
+              "id": "g3-imp-ias-dv",
+              "instl": 0,
+              "secure": 1,
+              "banner": { "w": 300, "h": 250, "api": [7] }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "g3-res-ias-dv",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "g3-bid-ias-dv",
+                  "impid": "g3-imp-ias-dv",
+                  "crid": "g3-crid-ias-plus-dv",
+                  "adomain": ["advertiser.example"],
+                  "w": 300,
+                  "h": 250,
+                  "price": 1.0,
+                  "adm": "<!doctype html><html><body><div style=\"width:300px;height:250px;background:#0b8043;color:#fff;font:16px/250px sans-serif;text-align:center\">SHARC G3 multi-vendor fixture</div><script src=\"https://pixel.adsafeprotected.com/rjss/st/999999/99999997/skeleton.js\"></script><script src=\"https://cdn.doubleverify.com/dvtp_src.js?ctx=818052&cmp=DV000000&sid=sharc&plc=validatorfixture&advid=0&adsrv=0&dvtagver=6.1.src\"></script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "g3-pixalate-inline",
+    "auction": [
+      {
+        "bidder": "fixture-pixalate-inline",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "g3-req-px-1",
+          "imp": [
+            {
+              "id": "g3-imp-px-1",
+              "instl": 0,
+              "secure": 1,
+              "banner": { "w": 300, "h": 250, "api": [7] }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "g3-res-px-1",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "g3-bid-px-1",
+                  "impid": "g3-imp-px-1",
+                  "crid": "g3-crid-pixalate-inline",
+                  "adomain": ["advertiser.example"],
+                  "w": 300,
+                  "h": 250,
+                  "price": 1.0,
+                  "adm": "<!doctype html><html><body><div style=\"width:300px;height:250px;background:#a50e0e;color:#fff;font:16px/250px sans-serif;text-align:center\">SHARC G3 Pixalate inline fixture</div><script type=\"text/javascript\" src=\"https://q.adrta.com/s/sharcx/aa.js?cb=123456#sharcx;paid=0;avid=0;publisherId=sharc-validator-fixture;kv24=d\"></script></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "g3-pixalate-sidecar",
+    "auction": [
+      {
+        "bidder": "fixture-pixalate-sidecar",
+        "mtype": "banner",
+        "bid_request": {
+          "id": "g3-req-px-2",
+          "imp": [
+            {
+              "id": "g3-imp-px-2",
+              "instl": 0,
+              "secure": 1,
+              "banner": { "w": 300, "h": 250, "api": [7] }
+            }
+          ]
+        },
+        "bid_response": {
+          "id": "g3-res-px-2",
+          "seatbid": [
+            {
+              "bid": [
+                {
+                  "id": "g3-bid-px-2",
+                  "impid": "g3-imp-px-2",
+                  "crid": "g3-crid-pixalate-sidecar",
+                  "adomain": ["advertiser.example"],
+                  "ext": {
+                    "measurement": {
+                      "omid": {
+                        "verificationScripts": [
+                          {
+                            "resourceUrl": "https://q.adrta.com/s/sharcx/aa.js?cb=123456#sharcx;paid=0;avid=0;publisherId=sharc-validator-fixture;kv24=d",
+                            "vendor": "pixalate",
+                            "verificationParameters": "sharc-validator-fixture",
+                            "accessMode": "limited"
+                          }
+                        ],
+                        "creativeType": "display",
+                        "mediaType": "display",
+                        "impressionType": "beginToRender"
+                      }
+                    }
+                  },
+                  "w": 300,
+                  "h": 250,
+                  "price": 1.0,
+                  "adm": "<!doctype html><html><body><div style=\"width:300px;height:250px;background:#5f6368;color:#fff;font:16px/250px sans-serif;text-align:center\">SHARC G3 Pixalate sidecar fixture</div></body></html>"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -157,6 +157,36 @@ function omidInlineVendorVendors(testCase) {
   return vendors;
 }
 
+// Keep aligned with the normalizer's classifyOmidVendorResourceUrl: sidecar
+// VerificationScriptResources whose URL the product-scoped vendor table can
+// attribute (DV dvtp_src/dvbm, Pixalate aa/aaom, IAS host shapes) carry an
+// expected-vendor obligation exactly like inline detection creates (#385
+// review). Unknown/unrecognized resource URLs create NO expectation — an
+// operator may declare anything in bid.ext.
+function omidSidecarVendorScripts(testCase) {
+  const sidecar = testCase
+    && testCase.sharcOptions
+    && testCase.sharcOptions.creativeMeta
+    && testCase.sharcOptions.creativeMeta.measurement
+    && testCase.sharcOptions.creativeMeta.measurement.omid;
+  const scripts = sidecar && Array.isArray(sidecar.verificationScripts)
+    ? sidecar.verificationScripts
+    : [];
+  const out = [];
+  for (const script of scripts) {
+    if (!script || typeof script.resourceUrl !== 'string') continue;
+    if (isOmidCanaryScript(script)) continue;
+    // Resources synthesized from inline detection already count as inline
+    // expectations; do not double-count them here.
+    if (script.verificationParameters === 'sharc-validator-inline-vendor') continue;
+    const vendor = classifyOmidVendorSourceUrl(script.resourceUrl);
+    if (!vendor) continue;
+    if (!isOmidProductVendorScript({ vendor, value: script.resourceUrl })) continue;
+    out.push({ vendor, resourceUrl: script.resourceUrl });
+  }
+  return out;
+}
+
 function shouldProbeOmidVendors(testCase) {
   return omidInlineVendorScripts(testCase).length > 0;
 }
@@ -435,12 +465,22 @@ function finalizeOmidServiceDiagnostics(summary) {
   return summary;
 }
 
-function emptyOmidVendorDiagnostics(testCase, accessMode) {
-  const vendorsExpected = omidInlineVendorVendors(testCase).sort();
+function emptyOmidVendorDiagnostics(testCase, accessMode, sdkMode) {
+  // Sidecar copies are delivered exclusively by the REAL verification service,
+  // so only service-mode runs carry their expected-vendor obligation; mock
+  // runs never inject them (#385 review).
+  const sidecarVendorScripts = sdkMode === 'service'
+    ? omidSidecarVendorScripts(testCase)
+    : [];
+  const vendorsExpected = uniqueNonEmpty(
+    omidInlineVendorVendors(testCase)
+      .concat(sidecarVendorScripts.map((script) => script.vendor)),
+  ).sort();
   return {
-    expected: shouldProbeOmidVendors(testCase),
+    expected: shouldProbeOmidVendors(testCase) || sidecarVendorScripts.length > 0,
     accessMode,
-    scriptsExpected: omidInlineVendorScripts(testCase).length,
+    scriptsExpected: omidInlineVendorScripts(testCase).length + sidecarVendorScripts.length,
+    sidecarScriptsExpected: sidecarVendorScripts.length,
     vendorsExpected,
     omid3pFound: false,
     subscriptionObserved: false,
@@ -714,7 +754,11 @@ function collectOmidDiagnostics(container, testCase, vendorDiagnostics, accessMo
     verificationScriptCount: 0,
     service: finalizedService,
     inlineVendor: finalizeOmidVendorDiagnostics(
-      vendorDiagnostics || emptyOmidVendorDiagnostics(testCase, accessMode),
+      vendorDiagnostics || emptyOmidVendorDiagnostics(
+        testCase,
+        accessMode,
+        finalizedService ? finalizedService.sdkMode : 'mock',
+      ),
       finalizedService,
     ),
   };
@@ -1838,7 +1882,7 @@ window.__sharcCreativeValidatorHarness = {
     const messages = [];
     const bridgeProbes = [];
     const navigationDiagnostics = emptyNavigationDiagnostics();
-    const omidVendorDiagnostics = emptyOmidVendorDiagnostics(runTestCase, inlineVendorAccessMode);
+    const omidVendorDiagnostics = emptyOmidVendorDiagnostics(runTestCase, inlineVendorAccessMode, omidSdkMode);
     const omidServiceDiagnostics = emptyOmidServiceDiagnostics(omidSdkMode);
     const omidServiceFrames = createOmidServiceFrameRegistry();
     // Verification-service traffic listener (#244): observes the omid_v1

--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -109,7 +109,7 @@ function omidSidecarPresent(testCase) {
 // expectation-bearing.
 function isOmidProductVendorScript(script) {
   if (!script) return false;
-  if (script.vendor !== 'doubleverify') return true;
+  if (script.vendor !== 'doubleverify' && script.vendor !== 'pixalate') return true;
   let path = script.url && typeof script.url.path === 'string' ? script.url.path : null;
   if (path === null && typeof script.value === 'string') {
     try {
@@ -117,6 +117,12 @@ function isOmidProductVendorScript(script) {
     } catch (_) {
       path = '';
     }
+  }
+  if (script.vendor === 'pixalate') {
+    // Keep aligned with the normalizer's pixalate omidProductPaths: only the
+    // analytics tag family (aa.js / aaom.js) bootstraps the OMID-bearing
+    // cdnf.js|cdno.js payload.
+    return /(?:^|\/)aa(?:om)?\.js$/i.test(path || '');
   }
   return /(?:^|\/)dvtp_src\.js$/i.test(path || '')
     || /(?:^|\/)dvbm\.js$/i.test(path || '')
@@ -494,6 +500,9 @@ function classifyOmidVendorSourceUrl(value) {
   if (['oracle.com', 'oraclecloud.com', 'grapeshot.co.uk']
     .some((host) => hostMatchesSuffix(hostname, host))) {
     return 'oracle';
+  }
+  if (['adrta.com'].some((host) => hostMatchesSuffix(hostname, host))) {
+    return 'pixalate';
   }
   return '';
 }

--- a/tools/creative-validator/src/diagnose.js
+++ b/tools/creative-validator/src/diagnose.js
@@ -2,7 +2,11 @@
  * @file Creative validator diagnosis buckets.
  */
 
-import { isOmidProductVendorScript, omidVendorMatchesHostname } from './normalizer.js';
+import {
+  classifyOmidVendorResourceUrl,
+  isOmidProductVendorScript,
+  omidVendorMatchesHostname,
+} from './normalizer.js';
 
 const EMPTY_RUN = Object.freeze({
   durationMs: 0,
@@ -147,6 +151,40 @@ function omidInlineVendorExpected(testCase) {
   return true;
 }
 
+function omidSidecarVerificationScripts(testCase) {
+  const omid = testCase
+    && testCase.sharcOptions
+    && testCase.sharcOptions.creativeMeta
+    && testCase.sharcOptions.creativeMeta.measurement
+    && testCase.sharcOptions.creativeMeta.measurement.omid;
+  return omid && Array.isArray(omid.verificationScripts)
+    ? omid.verificationScripts
+    : [];
+}
+
+/**
+ * Vendors a sidecar (`bid.ext` measurement) delivery owes a subscription for:
+ * declared `VerificationScriptResource` URLs that the product-scoped vendor
+ * table can attribute. Sidecar-only delivery previously carried no vendor
+ * obligation, so a broken vendor CDN still classified `passed` (#385 review).
+ * Derived from the recorded sidecar — not from normalizer-time flags — so case
+ * files normalized before this rule gain the expectation on rerun. Unknown
+ * resource URLs create NO expectation.
+ */
+function omidSidecarVendorsExpected(testCase) {
+  const vendors = new Set();
+  for (const script of omidSidecarVerificationScripts(testCase)) {
+    const vendor = classifyOmidVendorResourceUrl(script && script.resourceUrl);
+    if (vendor) vendors.add(vendor);
+  }
+  return [...vendors].sort();
+}
+
+function omidServiceModeRun(run) {
+  const omid = run && run.measurement && run.measurement.omid;
+  return !!(omid && omid.sdkMode === 'service');
+}
+
 function omidRun(run) {
   return run && run.measurement && run.measurement.omid
     ? run.measurement.omid
@@ -171,14 +209,15 @@ function scriptCacheOriginDeliveredBytes(values) {
  * executed, so the subscription checks would measure the network, not the
  * vendor. Creative/CDN-attributable, not SHARC-attributable.
  */
-function expectedVendorScriptFetchFailed(testCase, run) {
+function expectedVendorScriptFetchFailed(testCase, run, sidecarVendors = []) {
   const omid = testCase
     && testCase.bidSignals
     && testCase.bidSignals.measurement
     && testCase.bidSignals.measurement.omid;
-  const vendors = omid && Array.isArray(omid.inlineVendorVendors)
+  const inlineVendors = omid && Array.isArray(omid.inlineVendorVendors)
     ? omid.inlineVendorVendors
     : [];
+  const vendors = [...new Set([...inlineVendors, ...sidecarVendors])];
   if (vendors.length === 0) return false;
   const byOrigin = run && run.scriptCache && run.scriptCache.byOrigin
     ? run.scriptCache.byOrigin
@@ -243,7 +282,15 @@ function classifyOutcome(testCase, run) {
     return { status: 'failed', bucket: 'measurement-omid', reason: 'feature load failed' };
   }
 
-  if (omidInlineVendorExpected(testCase)) {
+  const inlineVendorExpected = omidInlineVendorExpected(testCase);
+  // Sidecar-declared known-vendor resources carry the same expected-vendor
+  // obligation inline detection creates (#385 review). The REAL verification
+  // service is the only channel that delivers sidecar copies, so the
+  // obligation exists only on service-mode runs; mock runs never inject them.
+  const sidecarVendorsExpected = omidServiceModeRun(run)
+    ? omidSidecarVendorsExpected(testCase)
+    : [];
+  if (inlineVendorExpected || sidecarVendorsExpected.length > 0) {
     const omid = omidRun(run);
     const inlineVendor = omid && omid.inlineVendor;
     // #244: two valid delivery channels (design D4). `servicePassed` means the
@@ -256,11 +303,22 @@ function classifyOutcome(testCase, run) {
       // Distinct non-SHARC outcome: zero bytes of the expected vendor's code
       // ever arrived. This does NOT soften the subscribe checks below — a
       // vendor copy that loaded and stayed silent still fails them.
-      if (expectedVendorScriptFetchFailed(testCase, run)) {
+      if (expectedVendorScriptFetchFailed(testCase, run, sidecarVendorsExpected)) {
         return {
           status: 'failed',
           bucket: 'vendor-fetch-failed',
           reason: 'vendor script fetch failed (network): expected OMID vendor origin delivered zero script bytes',
+        };
+      }
+      // Sidecar-only expectation: service-injected copies never touch the
+      // creative window's omid3p shim, so the verification-service protocol is
+      // their only subscription channel. Loaded-but-silent fails here — the
+      // #381 rule is not softened.
+      if (!inlineVendorExpected) {
+        return {
+          status: 'failed',
+          bucket: 'measurement-omid',
+          reason: 'sidecar-declared OMID vendor script did not produce an attributed verification-service subscription',
         };
       }
       if (!inlineVendor || inlineVendor.omid3pFound !== true) {

--- a/tools/creative-validator/src/normalizer.js
+++ b/tools/creative-validator/src/normalizer.js
@@ -272,6 +272,27 @@ function isOmidProductVendorScript(script) {
   return omidVendorPathIsOmidProduct(script.vendor.toLowerCase(), path || '');
 }
 
+/**
+ * Classifies a sidecar `VerificationScriptResource` URL against the known
+ * vendor table. Returns the vendor name only when the URL's host belongs to a
+ * known OMID vendor AND its path matches that vendor's OMID product patterns
+ * (DV dvtp_src/dvbm, Pixalate aa/aaom, IAS host shapes). Unknown or
+ * unrecognized resource URLs return null: an operator may declare anything in
+ * bid.ext, and the validator only enforces what the vendor table can
+ * attribute. Keep aligned with omidSidecarVendorScripts in
+ * harness/markup-runner.html.
+ *
+ * @param {string} value
+ * @returns {string|null}
+ */
+function classifyOmidVendorResourceUrl(value) {
+  const url = sanitizeInlineVendorScriptUrl(value);
+  if (!url) return null;
+  const vendor = classifyOmidVendorScript(url);
+  if (!vendor) return null;
+  return omidVendorPathIsOmidProduct(vendor, url.path) ? vendor : null;
+}
+
 function sanitizeInlineVendorScriptUrl(value) {
   if (typeof value !== 'string' || !value.trim()) return null;
   const trimmed = value.trim();
@@ -991,6 +1012,7 @@ function toJsonl(cases) {
 
 export {
   classifyAdmKind,
+  classifyOmidVendorResourceUrl,
   extractInlineOmidVendorScripts,
   isOmidProductVendorScript,
   normalizeCleanedCorpus,

--- a/tools/creative-validator/src/normalizer.js
+++ b/tools/creative-validator/src/normalizer.js
@@ -73,6 +73,19 @@ const OMID_VENDOR_SCRIPT_HOSTS = [
     vendor: 'oracle',
     hosts: ['oracle.com', 'oraclecloud.com', 'grapeshot.co.uk'],
   },
+  {
+    vendor: 'pixalate',
+    hosts: ['adrta.com'],
+    // Pixalate's analytics tag family (aa.js / aaom.js, served from
+    // q.adrta.com with optional /s/<clientId>/ path) bootstraps
+    // pix.adrta.com/cdnf.js|cdno.js, which bundles the official IAB
+    // OmidVerificationClient (verified live 2026-06-12, G3 evidence). Scope
+    // to the documented analytics tags so adrta-hosted pixels and
+    // loader-internal scripts carry no OMID expectation.
+    omidProductPaths: [
+      /(?:^|\/)aa(?:om)?\.js$/i,
+    ],
+  },
 ];
 const INLINE_OMID_SIGNALS = [
   /\bomid3p\s*\.\s*(?:registerSessionObserver|addEventListener)\s*\(/i,

--- a/tools/creative-validator/test/test-diagnose.js
+++ b/tools/creative-validator/test/test-diagnose.js
@@ -363,6 +363,126 @@ test('vendor-fetch-failed does not soften the subscribe check', () => {
   );
 });
 
+// #385 review: sidecar-only delivery of a KNOWN vendor's OMID product carries
+// the same expected-vendor obligation inline detection creates.
+function makeSidecarVendorCase(resourceUrl) {
+  const testCase = makeOmidSidecarCase();
+  testCase.sharcOptions = {
+    creativeMeta: {
+      apis: [7],
+      measurement: {
+        omid: {
+          verificationScripts: [{
+            resourceUrl,
+            vendor: 'declared-vendor-label-is-not-trusted',
+            verificationParameters: 'sharc-validator-fixture',
+            accessMode: 'limited',
+          }],
+          creativeType: 'display',
+          impressionType: 'beginToRender',
+          mediaType: 'display',
+        },
+      },
+    },
+  };
+  return testCase;
+}
+
+function sidecarServiceRun(overrides = {}, scriptCache = undefined) {
+  return makeEmptyRun({
+    creativeRendered: true,
+    measurement: {
+      omid: {
+        sdkMode: 'service',
+        extensionPresent: true,
+        featureAdvertised: true,
+        sessionStarted: true,
+        inlineVendor: { expected: false, diagnosticOutcome: 'not-run', passed: false },
+        ...overrides,
+      },
+    },
+    scriptCache,
+  });
+}
+
+test('sidecar-declared known vendor with zero subscriptions never passes (#385 review repro)', () => {
+  const testCase = makeSidecarVendorCase('https://q.adrta.com/s/sharcx/aa.js?cb=123456#sharcx');
+  // The reviewer's repro: session started, canary delivery complete, ZERO
+  // pixalate subscriptions — previously classified `passed`.
+  const outcome = classifyOutcome(testCase, sidecarServiceRun());
+  assert.equal(outcome.status, 'failed');
+  assert.equal(outcome.bucket, 'measurement-omid');
+  assert.match(outcome.reason, /sidecar-declared OMID vendor script did not produce an attributed verification-service subscription/);
+
+  // Old-harness report shape (no inlineVendor diagnostics at all) fails closed.
+  const stale = sidecarServiceRun({ inlineVendor: undefined });
+  assert.equal(classifyOutcome(testCase, stale).bucket, 'measurement-omid');
+});
+
+test('sidecar-declared known vendor with zero-byte origin classifies as vendor-fetch-failed (#381 path)', () => {
+  const testCase = makeSidecarVendorCase('https://q.adrta.com/s/sharcx/aa.js?cb=123456#sharcx');
+  const outcome = classifyOutcome(testCase, sidecarServiceRun({}, {
+    enabled: true,
+    byOrigin: {
+      'https://q.adrta.com': {
+        lookups: 2, hits: 0, misses: 2, stores: 0, bytesFromNetwork: 0, bytesFromCache: 0,
+      },
+    },
+  }));
+  assert.equal(outcome.status, 'failed');
+  assert.equal(outcome.bucket, 'vendor-fetch-failed');
+});
+
+test('sidecar vendor loaded-but-silent keeps the unsoftened subscribe failure', () => {
+  const testCase = makeSidecarVendorCase('https://q.adrta.com/s/sharcx/aa.js?cb=123456#sharcx');
+  // Vendor bytes arrived and the copy ran but stayed silent — the #381 rule
+  // stands: never a pass, and not a fetch failure either.
+  const outcome = classifyOutcome(testCase, sidecarServiceRun({}, {
+    enabled: true,
+    byOrigin: {
+      'https://q.adrta.com': {
+        lookups: 2, hits: 1, misses: 1, stores: 1, bytesFromNetwork: 9000, bytesFromCache: 0,
+      },
+    },
+  }));
+  assert.equal(outcome.bucket, 'measurement-omid');
+});
+
+test('sidecar vendor service subscription satisfies the expectation', () => {
+  const testCase = makeSidecarVendorCase('https://q.adrta.com/s/sharcx/aa.js?cb=123456#sharcx');
+  const outcome = classifyOutcome(testCase, sidecarServiceRun({
+    inlineVendor: {
+      expected: true,
+      servicePassed: true,
+      deliveryChannel: 'service',
+      passed: true,
+    },
+  }));
+  assert.equal(outcome.status, 'passed');
+});
+
+test('unknown sidecar resource URLs create no vendor expectation', () => {
+  // An operator may declare anything; only what the product-scoped vendor
+  // table can attribute is enforced. Non-OMID products on known vendor hosts
+  // (pixalate r.js) are equally expectation-free.
+  for (const url of [
+    'https://verification.example/omid-verify.js',
+    'https://q.adrta.com/r.js?v=24.000',
+  ]) {
+    const testCase = makeSidecarVendorCase(url);
+    assert.equal(classifyOutcome(testCase, sidecarServiceRun()).status, 'passed');
+  }
+});
+
+test('mock-mode runs carry no sidecar vendor obligation', () => {
+  // The REAL service is the only channel that injects sidecar copies; a mock
+  // run never delivers them, so it owes only the extension/session checks.
+  const testCase = makeSidecarVendorCase('https://q.adrta.com/s/sharcx/aa.js?cb=123456#sharcx');
+  const run = sidecarServiceRun();
+  run.measurement.omid.sdkMode = 'mock';
+  assert.equal(classifyOutcome(testCase, run).status, 'passed');
+});
+
 test('classifyOutcome buckets expected bridge probe failures', () => {
   const mraidCase = makeCase(true, { declared: ['mraid'] });
   assert.equal(bucket({

--- a/tools/creative-validator/test/test-normalizer.js
+++ b/tools/creative-validator/test/test-normalizer.js
@@ -12,6 +12,7 @@ import { tmpdir } from 'node:os';
 import test from 'node:test';
 import {
   classifyAdmKind,
+  classifyOmidVendorResourceUrl,
   extractInlineOmidVendorScripts,
   isOmidProductVendorScript,
   normalizeCleanedCorpus,
@@ -232,6 +233,33 @@ test('isOmidProductVendorScript re-checks stale normalized script entries', () =
     value: 'omid3p observer probe',
     url: null,
   }), true);
+});
+
+test('classifyOmidVendorResourceUrl attributes only known-vendor OMID products (#385 review)', () => {
+  // Sidecar VerificationScriptResource URLs: known vendor + OMID product path.
+  assert.equal(classifyOmidVendorResourceUrl('https://q.adrta.com/s/sharcx/aa.js?cb=1#sharcx'), 'pixalate');
+  assert.equal(classifyOmidVendorResourceUrl('https://q.adrta.com/aaom.js?cb=1'), 'pixalate');
+  assert.equal(classifyOmidVendorResourceUrl('https://cdn.doubleverify.com/dvtp_src.js?ctx=1'), 'doubleverify');
+  assert.equal(classifyOmidVendorResourceUrl('https://cdn.doubleverify.com/dvbm.js'), 'doubleverify');
+  assert.equal(classifyOmidVendorResourceUrl('https://pixel.adsafeprotected.com/rjss/st/1/2/skeleton.js'), 'ias');
+  // Known vendor host, non-OMID product: no expectation.
+  assert.equal(classifyOmidVendorResourceUrl('https://q.adrta.com/r.js?v=24.000'), null);
+  assert.equal(classifyOmidVendorResourceUrl('https://cdn.doubleverify.com/dvbs_src.js?ctx=1'), null);
+  // Unknown hosts and non-HTTPS resources: no expectation.
+  assert.equal(classifyOmidVendorResourceUrl('https://verification.example/omid-verify.js'), null);
+  assert.equal(classifyOmidVendorResourceUrl('http://q.adrta.com/s/sharcx/aa.js'), null);
+  assert.equal(classifyOmidVendorResourceUrl(''), null);
+  assert.equal(classifyOmidVendorResourceUrl(undefined), null);
+});
+
+test('runner derives sidecar expected-vendor obligations from the sidecar record', () => {
+  // The harness mirrors classifyOmidVendorResourceUrl (host allowlist + product
+  // scoping are covered by the alignment tests above); this guards the wiring:
+  // sidecar-declared known vendors must flip the expected-vendor flag so the
+  // service-delivery wait does not settle early.
+  const runnerSource = readFileSync(resolve('tools/creative-validator/harness/markup-runner.html'), 'utf8');
+  assert.ok(runnerSource.includes('function omidSidecarVendorScripts('), 'harness sidecar vendor extractor exists');
+  assert.match(runnerSource, /expected: shouldProbeOmidVendors\(testCase\) \|\| sidecarVendorScripts\.length > 0/);
 });
 
 test('runner DV OMID product-path scoping stays aligned with normalizer', () => {

--- a/tools/creative-validator/test/test-normalizer.js
+++ b/tools/creative-validator/test/test-normalizer.js
@@ -145,6 +145,27 @@ test('DV detection is product-scoped: dvbs_src* carries no OMID expectation', ()
   assert.deepEqual(scripts.map((script) => script.url.path), ['/dvtp_src.js', '/dvbm.js']);
 });
 
+test('Pixalate detection is product-scoped: only the aa.js/aaom.js analytics tags carry an OMID expectation', () => {
+  assert.equal(omidVendorMatchesHostname('pixalate', 'q.adrta.com'), true);
+  assert.equal(omidVendorMatchesHostname('pixalate', 'pix.adrta.com'), true);
+  assert.equal(omidVendorMatchesHostname('pixalate', 'pixalate.com'), false);
+  const scripts = extractInlineOmidVendorScripts(`
+    <script src="https://q.adrta.com/s/abcCLID/aa.js?cb=123"></script>
+    <script src="https://q.adrta.com/aaom.js?cb=123"></script>
+    <script src="https://q.adrta.com/r.js?v=24.000"></script>
+  `);
+  assert.deepEqual(scripts.map((script) => script.url.path), ['/s/abcCLID/aa.js', '/aaom.js']);
+  assert.deepEqual(scripts.map((script) => script.vendor), ['pixalate', 'pixalate']);
+  assert.equal(isOmidProductVendorScript({
+    vendor: 'pixalate',
+    value: 'https://q.adrta.com/s/abcCLID/aa.js?cb=1',
+  }), true);
+  assert.equal(isOmidProductVendorScript({
+    vendor: 'pixalate',
+    url: { hostname: 'pix.adrta.com', path: '/cdnf.js' },
+  }), false);
+});
+
 test('dvbs-only creative records DV presence without an OMID expectation', () => {
   const corpus = [{
     id: 'row-dvbs',


### PR DESCRIPTION
## What

G3 evidence corpus (1.0 DoD: real verification vendors confirmed end-to-end): controlled creatives embedding REAL vendor tags, plus the runner glue to classify Pixalate.

- **`fixtures/reductions/008-omid-real-vendor-tags/`** — 5 cases:
  - 3 IAS: banner (tag in head), late-tag (tag last in body), IAS+DV multi-vendor. Real `pixel.adsafeprotected.com/rjss/st/<id>/<id>/skeleton.js` shape (the only IAS shape in the private corpus) with synthetic IDs — the CDN serves identical bytes for any IDs (verified live 2026-06-12).
  - 2 Pixalate: inline analytics tag (organic shape) + bid-ext `VerificationScriptResource` delivery. Real documented tag `https://q.adrta.com/s/<clid>/aa.js?cb=..#..` — its `pix.adrta.com/cdnf.js` payload bundles the official IAB `OmidVerificationClient` (`1.6.1-iab283`). Real tag shape, not approximated.
- **normalizer** — add `pixalate` to `OMID_VENDOR_SCRIPT_HOSTS` (`adrta.com`), product-scoped to `aa.js`/`aaom.js` so adrta pixels and loader-internal scripts carry no OMID expectation (same pattern as the DV `dvtp_src`/`dvbs_src` split).
- **harness** — mirror pixalate in `classifyOmidVendorSourceUrl` + `isOmidProductVendorScript`; alignment is enforced by the existing host/path alignment tests.
- **tests** — pixalate product-scoping coverage in `test-normalizer.js`.

## Evidence (service mode, real pinned omweb-v1)

5/5 passed:

| case | deliveryChannel | facet outcome | attribution |
|---|---|---|---|
| ias-banner-early | both | expected-vendor-lifecycle | ias: omid3p lifecycle complete + 10 service subs |
| ias-late-tag | both | expected-vendor-lifecycle | same |
| ias-plus-dv | both | expected-vendor-lifecycle | ias 10 + doubleverify 45 service subs, both injected |
| pixalate-inline | service | expected-vendor-service-delivery | 5 attributed pixalate subs (addSessionListener + impression/loaded/geometryChange/media), canary deliveryComplete |
| pixalate-sidecar | service (sidecar) | n/a (no inline expectation) | 5 attributed pixalate subs, sessionStarted, canary deliveryComplete |

Pixalate's inline copy ignores `omid3p` and works only through the service-injected copy — same loader pattern as DV's `dvtp_src.js`.

## Verification

- `node --test tools/creative-validator/test/` — 72/72 pass (per-file)
- `npx eslint` clean on changed JS
- Fixture corpus normalize + run: 5/5 passed (requires network access to vendor CDNs; a blocked run fails as `vendor-fetch-failed`, not a silent skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)