### PR TITLE
test(validator): teardown probe — exercise OMID sessionFinish delivery (#G3)

### DIFF
--- a/tools/creative-validator/harness/markup-runner.html
+++ b/tools/creative-validator/harness/markup-runner.html
@@ -446,6 +446,11 @@ function emptyOmidVendorDiagnostics(testCase, accessMode) {
     expectedVendorAddEventListenerCalls: 0,
     callbackEvents: 0,
     callbackEventsByType: {},
+    // Teardown probe: sessionFinish callbacks observed on the omid3p channel,
+    // attributed via the registering script's source URLs (captured at
+    // registration time and stamped onto every callback emit).
+    sessionFinishCallbacks: 0,
+    sessionFinishCallbacksByVendor: {},
     callsByVendorKey: {},
     callsByExpectedVendor: {},
     callsBySourceVendor: {},
@@ -619,6 +624,17 @@ function addOmidVendorDiagnostic(summary, payload) {
     if (Object.prototype.hasOwnProperty.call(summary.lifecycle, eventType)) {
       summary.lifecycle[eventType] = true;
     }
+    if (eventType === 'sessionFinish') {
+      summary.sessionFinishCallbacks += 1;
+      // Registration-time attribution: the prelude stamps the registering
+      // script's source URLs onto its callback emits, so a finish receipt is
+      // bound to the verification copy that subscribed — not to whichever
+      // code happened to be on the stack at dispatch.
+      const finishVendor = expectedOmidVendorForCall(summary, payload)
+        || sourceVendorsForPayload(payload)[0]
+        || 'unknown';
+      incrementMap(summary.sessionFinishCallbacksByVendor, finishVendor);
+    }
     if (summary.samples.length < 20) {
       summary.samples.push({
         kind: payload.kind,
@@ -685,6 +701,28 @@ function finalizeOmidVendorDiagnostics(summary, serviceDiagnostics) {
   return summary;
 }
 
+function findOmidExtension(container) {
+  if (!container || !Array.isArray(container._extensions)) return null;
+  return container._extensions.find((ext) => {
+    if (!ext) return false;
+    if (ext.name === 'com.iabtechlab.sharc.omid') return true;
+    if (typeof ext.getFeatureName === 'function') {
+      try { return ext.getFeatureName() === 'com.iabtechlab.sharc.omid'; } catch (_) { return false; }
+    }
+    return false;
+  }) || null;
+}
+
+/**
+ * Post-teardown-probe read of the extension's `sessionFinished` flag — set by
+ * the runtime's real `_finishSession()` (which `container.close()` drives via
+ * the extension lifecycle), never by the harness.
+ */
+function readOmidExtensionSessionFinished(container) {
+  const extension = findOmidExtension(container);
+  return !!(extension && extension._omid && extension._omid.sessionFinished === true);
+}
+
 function collectOmidDiagnostics(container, testCase, vendorDiagnostics, accessMode, serviceDiagnostics) {
   const expected = expectedOmid(testCase);
   const sidecarPresent = omidSidecarPresent(testCase);
@@ -709,16 +747,7 @@ function collectOmidDiagnostics(container, testCase, vendorDiagnostics, accessMo
       finalizedService,
     ),
   };
-  if (!container || !Array.isArray(container._extensions)) return out;
-
-  const extension = container._extensions.find((ext) => {
-    if (!ext) return false;
-    if (ext.name === 'com.iabtechlab.sharc.omid') return true;
-    if (typeof ext.getFeatureName === 'function') {
-      try { return ext.getFeatureName() === 'com.iabtechlab.sharc.omid'; } catch (_) { return false; }
-    }
-    return false;
-  });
+  const extension = findOmidExtension(container);
   if (!extension) return out;
 
   out.extensionPresent = true;
@@ -1431,13 +1460,17 @@ function validatorOmidVendorPreludeSource(probeNonce) {
       return ev && typeof ev.type === 'string' ? ev.type : 'unknown';
     }
 
-    function wrapCallback(method, callback) {
+    function wrapCallback(method, callback, sourceUrls) {
       if (typeof callback !== 'function') return callback;
       return function () {
         emit({
           kind: 'callback',
           method: method,
           eventType: eventType(arguments[0]),
+          // Registration-time source attribution: which script subscribed the
+          // callback now receiving this event (teardown probe uses this to
+          // attribute sessionFinish receipts per vendor).
+          sourceUrls: sourceUrls || [],
         });
         return callback.apply(this, arguments);
       };
@@ -1535,15 +1568,16 @@ function validatorOmidVendorPreludeSource(probeNonce) {
       if (typeof api.registerSessionObserver === 'function') {
         var originalRegister = api.registerSessionObserver;
         api.registerSessionObserver = mirrorFunctionShape(function (observer, vendorKey, injectionId) {
+          var registrationSourceUrls = captureSubscriptionSourceUrls();
           emit({
             kind: 'registerSessionObserver',
             vendorKey: vendorKey || '',
             injectionId: injectionId || '',
-            sourceUrls: captureSubscriptionSourceUrls(),
+            sourceUrls: registrationSourceUrls,
           });
           return originalRegister.call(
             this,
-            wrapCallback('registerSessionObserver', observer),
+            wrapCallback('registerSessionObserver', observer, registrationSourceUrls),
             vendorKey,
             injectionId
           );
@@ -1553,16 +1587,17 @@ function validatorOmidVendorPreludeSource(probeNonce) {
       if (typeof api.addEventListener === 'function') {
         var originalAddEventListener = api.addEventListener;
         api.addEventListener = mirrorFunctionShape(function (type, listener, injectionId) {
+          var listenerSourceUrls = captureSubscriptionSourceUrls();
           emit({
             kind: 'addEventListener',
             eventType: type || '',
             injectionId: injectionId || '',
-            sourceUrls: captureSubscriptionSourceUrls(),
+            sourceUrls: listenerSourceUrls,
           });
           return originalAddEventListener.call(
             this,
             type,
-            wrapCallback('addEventListener', listener),
+            wrapCallback('addEventListener', listener, listenerSourceUrls),
             injectionId
           );
         }, originalAddEventListener);
@@ -2079,6 +2114,110 @@ window.__sharcCreativeValidatorHarness = {
       }
     }
 
+    // G3 teardown probe: the gate clause "verification vendors receive
+    // sessionFinish at teardown" was never exercised — the harness used to
+    // snapshot diagnostics and only THEN close the container, so no run could
+    // ever observe a sessionFinish receipt. Drive the natural operator-unload
+    // path (`container.close()`) BEFORE the snapshot: `_initiateClose()`
+    // notifies extensions synchronously, the OMID bridge's `_finishSession()`
+    // calls the REAL `AdSession.finish()` (the service dispatches
+    // sessionFinish to its injected verification clients, canary included)
+    // and relays the terminal sessionFinish to the creative shim in the
+    // `omid-finishing` window (#337 ordering) while the iframe is still
+    // attached. Everything observed below therefore travelled the real
+    // delivery chain — nothing is synthesized into the diagnostics.
+    //
+    // Verdict conservativeness:
+    //   - The top-level result fields (`terminated`, `finalState`, event
+    //     arrays) are snapshotted BEFORE the probe so the probe-driven close
+    //     can never change an existing bucket (diagnose's passed gate is
+    //     `creativeRendered && !terminated`). Teardown-era entries are
+    //     reported separately under `measurement.omid.teardown`.
+    //   - The OMID diagnostics (incl. all finalize-derived fields like
+    //     `lifecycleComplete`, `passed`, `deliveryChannel`) are ALSO collected
+    //     pre-probe, freezing them at the established G2 semantics —
+    //     `_finishSession()` resets the extension's `sessionStarted` flag, so
+    //     a post-probe collection would corrupt the session-started evidence.
+    //     The vendor/service summaries are shared references, so the raw
+    //     finish accumulators (`lifecycle.sessionFinish`,
+    //     `sessionFinishCallbacks*`, `canary.sessionFinish`) updated by the
+    //     message handlers during the probe wait still surface in the report;
+    //     `sessionFinished` is re-read from the extension after the probe.
+    const preTeardown = {
+      terminated: isTerminated(),
+      finalState: container ? container.getState() : null,
+      stateHistoryLength: stateHistory.length,
+      securityEventsLength: securityEvents.length,
+      errorsLength: errors.length,
+      navigationEventsLength: navigationEvents.length,
+      interactionEventsLength: interactionEvents.length,
+      messagesLength: messages.length,
+    };
+    omidServiceFrames.summarize(omidServiceDiagnostics);
+    const omidDiagnostics = collectOmidDiagnostics(
+      container,
+      runTestCase,
+      omidVendorDiagnostics,
+      inlineVendorAccessMode,
+      omidServiceDiagnostics,
+    );
+    const omidTeardown = {
+      probed: false,
+      closeRequested: false,
+      closeError: null,
+      alreadyTerminated: preTeardown.terminated,
+      terminated: preTeardown.terminated,
+      waitTimedOut: false,
+      stateHistory: [],
+      securityEvents: [],
+      errors: [],
+      messages: [],
+    };
+    if (container && shouldEnableOmidForRun(runTestCase)) {
+      omidTeardown.probed = true;
+      if (!preTeardown.terminated) {
+        try {
+          container.close();
+          omidTeardown.closeRequested = true;
+        } catch (err) {
+          omidTeardown.closeError = err && err.message ? err.message : String(err);
+        }
+      }
+      // Bounded wait for the finish receipts to land through the real chain.
+      // Early-exits the moment every applicable channel has reported:
+      //   - omid3p channel: a creative-window copy registered a session
+      //     observer, so the #337 relay should reach it (callback emit).
+      //   - service channel: the canary loaded as a service-injected
+      //     verification client, so the service's sessionFinish dispatch
+      //     should reach it (canary report).
+      // Channels with no subscriber settle immediately. A timeout is recorded
+      // as evidence (waitTimedOut), never invented away.
+      const OMID_TEARDOWN_FINISH_EXTRA_MS = 4000;
+      const omid3pFinishSettled = () =>
+        omidVendorDiagnostics.registerSessionObserverCalls === 0
+        || omidVendorDiagnostics.lifecycle.sessionFinish === true;
+      const serviceFinishSettled = () =>
+        omidSdkMode !== 'service'
+        || omidServiceDiagnostics.canary.loaded !== true
+        || omidServiceDiagnostics.canary.sessionFinish === true;
+      const finishWait = await waitUntil(
+        () => omid3pFinishSettled() && serviceFinishSettled(),
+        OMID_TEARDOWN_FINISH_EXTRA_MS,
+      );
+      omidTeardown.waitTimedOut = finishWait.timedOut;
+      omidTeardown.terminated = isTerminated();
+      omidTeardown.stateHistory = stateHistory.slice(preTeardown.stateHistoryLength);
+      omidTeardown.securityEvents = securityEvents.slice(preTeardown.securityEventsLength);
+      omidTeardown.errors = errors.slice(preTeardown.errorsLength);
+      omidTeardown.messages = messages.slice(preTeardown.messagesLength);
+      // Re-read ONLY the finish flag from the extension (set by the real
+      // `_finishSession()`); every other extension-derived field keeps its
+      // pre-probe value (see conservativeness note above).
+      omidDiagnostics.sessionFinished =
+        readOmidExtensionSessionFinished(container) === true;
+    }
+    omidDiagnostics.teardown = omidTeardown;
+
     const result = {
       durationMs: Math.round(performance.now() - started),
       constructionError,
@@ -2086,28 +2225,19 @@ window.__sharcCreativeValidatorHarness = {
       timedOut: terminal.timedOut,
       creativeRendered: container ? container.creativeRendered === true : false,
       creativeInjected: container ? container.creativeInjected === true : false,
-      terminated: isTerminated(),
-      finalState: container ? container.getState() : null,
+      terminated: preTeardown.terminated,
+      finalState: preTeardown.finalState,
       placementSessionId: container ? container.placementSessionId : null,
-      stateHistory,
-      securityEvents,
-      errors,
-      navigationEvents,
-      interactionEvents,
-      messages,
+      stateHistory: stateHistory.slice(0, preTeardown.stateHistoryLength),
+      securityEvents: securityEvents.slice(0, preTeardown.securityEventsLength),
+      errors: errors.slice(0, preTeardown.errorsLength),
+      navigationEvents: navigationEvents.slice(0, preTeardown.navigationEventsLength),
+      interactionEvents: interactionEvents.slice(0, preTeardown.interactionEventsLength),
+      messages: messages.slice(0, preTeardown.messagesLength),
       bridgeProbes,
       navigationDiagnostics,
       measurement: {
-        omid: (() => {
-          omidServiceFrames.summarize(omidServiceDiagnostics);
-          return collectOmidDiagnostics(
-            container,
-            runTestCase,
-            omidVendorDiagnostics,
-            inlineVendorAccessMode,
-            omidServiceDiagnostics,
-          );
-        })(),
+        omid: omidDiagnostics,
       },
     };
 

--- a/tools/creative-validator/src/triage.js
+++ b/tools/creative-validator/src/triage.js
@@ -186,8 +186,27 @@ function emptySummary(files) {
           loaded: 0,
           sessionStart: 0,
           impression: 0,
+          sessionFinish: 0,
           deliveryComplete: 0,
         },
+        // G3 teardown probe: the harness drives `container.close()` before the
+        // diagnostics snapshot so sessionFinish delivery is exercised through
+        // the real chain. Evidence-only — finish receipt does not gate any
+        // verdict bucket (a future strictness bump may change that).
+        teardownProbe: {
+          rowsProbed: 0,
+          rowsCloseRequested: 0,
+          rowsWaitTimedOut: 0,
+          rowsSessionFinished: 0,
+          rowsCanarySessionFinish: 0,
+          rowsOmid3pSessionFinish: 0,
+        },
+        // Per inline-vendor row: which channel(s) demonstrably received the
+        // teardown sessionFinish — 'omid3p' (attributed creative-window
+        // callback), 'service-canary' (the canary, subscribed through the
+        // identical verification-service protocol, received the service's
+        // dispatch), 'both', 'none', or 'not-probed'.
+        inlineVendorRowsBySessionFinishReceipt: {},
         serviceInjectedResourceCount: {
           unit: 'distinct-service-injected-vendor-resources-per-session',
           rowsMeasured: 0,
@@ -855,7 +874,23 @@ function addOmidCorpusFacets(summary, row, fields) {
     if (canary.loaded === true) canaryRows.loaded += 1;
     if (canary.sessionStart === true) canaryRows.sessionStart += 1;
     if (canary.impression === true) canaryRows.impression += 1;
+    if (canary.sessionFinish === true) canaryRows.sessionFinish += 1;
     if (canary.deliveryComplete === true) canaryRows.deliveryComplete += 1;
+  }
+  const teardown = omid.teardown && typeof omid.teardown === 'object' ? omid.teardown : null;
+  const teardownProbed = !!(teardown && teardown.probed === true);
+  const canarySessionFinish = !!(service && service.canary
+    && service.canary.sessionFinish === true);
+  const omid3pSessionFinish = !!(omid.inlineVendor
+    && omid.inlineVendor.lifecycle
+    && omid.inlineVendor.lifecycle.sessionFinish === true);
+  if (teardownProbed) {
+    facet.teardownProbe.rowsProbed += 1;
+    if (teardown.closeRequested === true) facet.teardownProbe.rowsCloseRequested += 1;
+    if (teardown.waitTimedOut === true) facet.teardownProbe.rowsWaitTimedOut += 1;
+    if (omid.sessionFinished === true) facet.teardownProbe.rowsSessionFinished += 1;
+    if (canarySessionFinish) facet.teardownProbe.rowsCanarySessionFinish += 1;
+    if (omid3pSessionFinish) facet.teardownProbe.rowsOmid3pSessionFinish += 1;
   }
   increment(facet.byInstrumentationSignal, omidInstrumentationSignalKey(declaredByApi, inlineInstrumented));
   if (!declaredByApi && !inlineInstrumented) facet.rowsAbsent += 1;
@@ -903,6 +938,19 @@ function addOmidCorpusFacets(summary, row, fields) {
       // 'omid3p' (0.7.8 shim), 'service' (real omweb-v1 injected copy),
       // 'both', or 'none'.
       increment(facet.inlineVendorRowsByDeliveryChannel, inlineVendor.deliveryChannel || 'none');
+      // G3 teardown probe: per-row sessionFinish receipt column. Evidence
+      // only — does not feed the runtime/diagnostic outcome buckets above.
+      let sessionFinishReceipt = 'not-probed';
+      if (teardownProbed) {
+        sessionFinishReceipt = omid3pSessionFinish && canarySessionFinish
+          ? 'both'
+          : omid3pSessionFinish
+            ? 'omid3p'
+            : canarySessionFinish
+              ? 'service-canary'
+              : 'none';
+      }
+      increment(facet.inlineVendorRowsBySessionFinishReceipt, sessionFinishReceipt);
       increment(
         facet.inlineVendorRowsByExpectedAttribution,
         inlineVendor.expectedVendorSubscriptionObserved === true ? 'expected-vendor' : 'none',
@@ -944,6 +992,7 @@ function addOmidCorpusFacets(summary, row, fields) {
       increment(facet.inlineVendorRowsByExpectedAttribution, 'not-run');
       increment(facet.inlineVendorRowsByExpectedScriptCache, 'not-run');
       increment(facet.inlineVendorRowsByDeliveryChannel, 'not-run');
+      increment(facet.inlineVendorRowsBySessionFinishReceipt, 'not-run');
     }
   }
   if (omid.sidecarPresent === true) facet.rowsWithSidecar += 1;

--- a/tools/creative-validator/test/test-runner.js
+++ b/tools/creative-validator/test/test-runner.js
@@ -1395,6 +1395,17 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(omidReport.diagnostics.measurement.omid.loadedFired, true);
     assert.equal(omidReport.diagnostics.measurement.omid.impressionFired, true);
     assert.equal(omidReport.diagnostics.measurement.omid.verificationScriptCount, 1);
+    // G3 teardown probe: the harness drives container.close() before the
+    // snapshot, so the real _finishSession() runs and the extension records
+    // the finished session — while the verdict fields stay pre-teardown
+    // (passed bucket, terminated false above).
+    assert.equal(omidReport.diagnostics.measurement.omid.teardown.probed, true);
+    assert.equal(omidReport.diagnostics.measurement.omid.teardown.closeRequested, true);
+    assert.equal(omidReport.diagnostics.measurement.omid.teardown.closeError, null);
+    assert.equal(omidReport.diagnostics.measurement.omid.teardown.alreadyTerminated, false);
+    assert.equal(omidReport.diagnostics.measurement.omid.sessionFinished, true);
+    assert.equal(omidReport.outcome.terminated, false);
+    assert.notEqual(omidReport.outcome.finalState, 'terminated');
     assert.deepEqual(omidReport.diagnostics.bridgeProbes.at(-1).bridges.mraid.installed, false);
     // #346: this OMID case declares `apis: [7]`, which maps to an empty bridge
     // set (OMID is a measurement axis, not a bridge), so resolution falls
@@ -1459,6 +1470,24 @@ test('runner executes HTML cases and writes one report row per case', () => {
     assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.lifecycleObserved, true);
     assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.lifecycleComplete, true);
     assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.lifecycleNotObserved, false);
+    // G3 teardown probe (omid3p channel): close() drives the runtime's real
+    // _finishSession(), whose #337-ordered relay delivers the terminal
+    // sessionFinish to the creative-window vendor copy while the iframe is
+    // still attached. The receipt is attributed to the registering vendor via
+    // registration-time source URLs.
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.teardown.probed, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.teardown.closeRequested, true);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.teardown.waitTimedOut, false);
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.lifecycle.sessionFinish, true);
+    assert.ok(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.sessionFinishCallbacks >= 1);
+    assert.ok(
+      inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor
+        .sessionFinishCallbacksByVendor.doubleverify >= 1,
+    );
+    assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.sessionFinished, true);
+    // lifecycleComplete keeps the published G2 shape (start+loaded+impression)
+    // — asserted true above — and the verdict fields stay pre-teardown.
+    assert.equal(inlineOmidVendorReport.outcome.terminated, false);
     assert.equal(inlineOmidVendorReport.diagnostics.measurement.omid.inlineVendor.passed, true);
 
     const inlineOmidVendorAsyncReport = reports.find((row) =>
@@ -2637,6 +2666,19 @@ test(
       assert.equal(omid.service.canary.sessionStart, true);
       assert.equal(omid.service.canary.impression, true);
       assert.equal(omid.service.canary.deliveryComplete, true);
+      // G3 teardown probe: close() drives the REAL AdSession.finish(); the
+      // pinned service dispatches sessionFinish to its injected verification
+      // clients and the canary (subscribed through the same verification-
+      // service protocol as the vendor copies) records the receipt.
+      assert.equal(omid.teardown.probed, true);
+      assert.equal(omid.teardown.closeRequested, true);
+      assert.equal(omid.teardown.closeError, null);
+      assert.equal(omid.teardown.waitTimedOut, false);
+      assert.equal(omid.service.canary.sessionFinish, true);
+      assert.equal(omid.sessionFinished, true);
+      // Verdict fields stay pre-teardown — the probe-driven close never
+      // flips a passing row.
+      assert.equal(report.outcome.terminated, false);
       // The injected fixture copy subscribed through the verification-service
       // protocol and was attributed to the expected vendor.
       assert.equal(omid.service.expectedVendorServiceSubscriptionObserved, true);

--- a/tools/creative-validator/test/test-triage.js
+++ b/tools/creative-validator/test/test-triage.js
@@ -1540,8 +1540,18 @@ test('triageReports emits a stable empty OMID facet for a zero-row corpus', () =
         loaded: 0,
         sessionStart: 0,
         impression: 0,
+        sessionFinish: 0,
         deliveryComplete: 0,
       },
+      teardownProbe: {
+        rowsProbed: 0,
+        rowsCloseRequested: 0,
+        rowsWaitTimedOut: 0,
+        rowsSessionFinished: 0,
+        rowsCanarySessionFinish: 0,
+        rowsOmid3pSessionFinish: 0,
+      },
+      inlineVendorRowsBySessionFinishReceipt: {},
       serviceInjectedResourceCount: {
         unit: 'distinct-service-injected-vendor-resources-per-session',
         rowsMeasured: 0,
@@ -2063,8 +2073,13 @@ test('triageReports aggregates OMID service-path facets (#244)', () => {
       loaded: 2,
       sessionStart: 2,
       impression: 1,
+      sessionFinish: 0,
       deliveryComplete: 1,
     });
+    // Rows without a teardown probe land in 'not-probed' and never count
+    // toward the probe facet.
+    assert.deepEqual(facet.inlineVendorRowsBySessionFinishReceipt, { 'not-probed': 3 });
+    assert.equal(facet.teardownProbe.rowsProbed, 0);
     assert.equal(facet.serviceInjectedResourceCount.rowsMeasured, 2);
     assert.equal(facet.serviceInjectedResourceCount.max, 3);
     assert.equal(facet.serviceInjectedResourceCount.median, 1);
@@ -2072,6 +2087,159 @@ test('triageReports aggregates OMID service-path facets (#244)', () => {
       facet.serviceInjectedResourceCount.byResourceCount,
       { 1: 1, 3: 1 },
     );
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+});
+
+test('triageReports aggregates the OMID teardown probe facet (#G3 sessionFinish)', () => {
+  const privateRoot = resolve('tools/creative-validator/private');
+  mkdirSync(privateRoot, { recursive: true });
+  const workDir = mkdtempSync(resolve(privateRoot, 'test-triage-omid-teardown-'));
+  const reportPath = resolve(workDir, 'report.jsonl');
+
+  const inlineBidSignals = {
+    ...report().case.bidSignals,
+    measurement: {
+      omid: {
+        declaredByApi: true,
+        sidecarPresent: false,
+        inlineVendorScriptPresent: true,
+        inlineVendorScriptCount: 1,
+        inlineVendorVendors: ['ias'],
+      },
+    },
+  };
+
+  function teardownRow(bidder, { sessionFinished, lifecycle, canarySessionFinish, teardown }) {
+    return omidReport({
+      expected: true,
+      sidecarPresent: false,
+      sdkMode: 'service',
+      extensionPresent: true,
+      featureAdvertised: true,
+      sessionStarted: true,
+      sessionFinished,
+      verificationScriptCount: 1,
+      service: {
+        sdkMode: 'service',
+        injectedResourceCount: 1,
+        injectedVendors: ['ias'],
+        subscriptionMessages: 10,
+        subscriptionsByMethod: { addSessionListener: 2, addEventListener: 8 },
+        subscriptionsByVendor: { ias: 10 },
+        subscriptionEventTypes: { impression: 2 },
+        expectedVendorServiceSubscriptionObserved: true,
+        canary: {
+          injected: true,
+          loaded: true,
+          hasInjectionId: true,
+          sessionStart: true,
+          sessionFinish: canarySessionFinish,
+          impression: true,
+          loadedEvent: true,
+          geometryChangeCount: 1,
+          deliveryComplete: true,
+        },
+      },
+      inlineVendor: {
+        expected: true,
+        accessMode: 'limited',
+        omid3pFound: true,
+        subscriptionObserved: true,
+        expectedVendorSubscriptionObserved: true,
+        registerSessionObserverCalls: 1,
+        addEventListenerCalls: 2,
+        expectedVendorRegisterSessionObserverCalls: 1,
+        expectedVendorAddEventListenerCalls: 2,
+        callbackEvents: 4,
+        callbackEventsByType: { sessionStart: 1, loaded: 1, impression: 1, sessionFinish: 1 },
+        sessionFinishCallbacks: lifecycle.sessionFinish === true ? 1 : 0,
+        sessionFinishCallbacksByVendor: lifecycle.sessionFinish === true ? { ias: 1 } : {},
+        callsBySourceVendor: { ias: 3 },
+        callsBySourceOrigin: { 'https://pixel.adsafeprotected.com': 3 },
+        unattributedCallsBySourceVendor: {},
+        unattributedCallsBySourceOrigin: {},
+        lifecycle,
+        lifecycleObserved: true,
+        lifecycleComplete: true,
+        lifecycleNotObserved: false,
+        servicePassed: true,
+        omid3pPassed: true,
+        passed: true,
+        deliveryChannel: 'both',
+        diagnosticOutcome: 'expected-vendor-lifecycle',
+      },
+      teardown,
+    }, {
+      case: {
+        ...report().case,
+        source: { ...report().case.source, bidder, rowIndex: 0 },
+        bidSignals: inlineBidSignals,
+      },
+      outcome: { status: 'passed', bucket: 'passed', durationMs: 2500 },
+    });
+  }
+
+  try {
+    writeJsonl(reportPath, [
+      // Probed row: finish received on BOTH channels.
+      teardownRow('bidder-finish-both', {
+        sessionFinished: true,
+        lifecycle: { sessionStart: true, loaded: true, impression: true, sessionFinish: true },
+        canarySessionFinish: true,
+        teardown: {
+          probed: true,
+          closeRequested: true,
+          closeError: null,
+          alreadyTerminated: false,
+          terminated: true,
+          waitTimedOut: false,
+        },
+      }),
+      // Probed row: finish landed on the service channel only, and the
+      // omid3p wait timed out.
+      teardownRow('bidder-finish-service-only', {
+        sessionFinished: true,
+        lifecycle: { sessionStart: true, loaded: true, impression: true, sessionFinish: false },
+        canarySessionFinish: true,
+        teardown: {
+          probed: true,
+          closeRequested: true,
+          closeError: null,
+          alreadyTerminated: false,
+          terminated: true,
+          waitTimedOut: true,
+        },
+      }),
+      // Unprobed row (e.g. pre-probe report): receipt column stays explicit.
+      teardownRow('bidder-not-probed', {
+        sessionFinished: false,
+        lifecycle: { sessionStart: true, loaded: true, impression: true, sessionFinish: false },
+        canarySessionFinish: false,
+        teardown: { probed: false },
+      }),
+    ]);
+
+    const summary = triageReports([reportPath]);
+    const facet = summary.corpusDiagnostics.omid;
+    assert.deepEqual(facet.teardownProbe, {
+      rowsProbed: 2,
+      rowsCloseRequested: 2,
+      rowsWaitTimedOut: 1,
+      rowsSessionFinished: 2,
+      rowsCanarySessionFinish: 2,
+      rowsOmid3pSessionFinish: 1,
+    });
+    assert.deepEqual(facet.inlineVendorRowsBySessionFinishReceipt, {
+      'both': 1,
+      'service-canary': 1,
+      'not-probed': 1,
+    });
+    assert.equal(facet.serviceCanaryRows.sessionFinish, 2);
+    assert.equal(facet.rowsSessionFinished, 2);
+    // Verdict conservativeness: finish presence/absence never moved a bucket.
+    assert.equal(summary.totals.passed, 3);
   } finally {
     rmSync(workDir, { force: true, recursive: true });
   }


### PR DESCRIPTION
## The gap

The G3 gate letter says verification vendors "receive `sessionFinish` at teardown." **No validator run had ever exercised this** — for any vendor. The harness snapshotted diagnostics during the settle window and only then called `container.close()`, so `sessionFinished: false` appeared in every report ever produced (DV at scale, IAS, Pixalate, and the canary alike). Flagged in the 2026-06-12 G3 evidence note (§3) as the one remaining mechanism-level gap.

## The mechanism

The probe drives the **natural operator-unload path** — `container.close()` — *before* the diagnostics snapshot, then waits (bounded, 4s, early-exit) for finish receipts to land through the real delivery chain:

- `_initiateClose()` notifies extensions synchronously → the OMID bridge's `_finishSession()` calls the **REAL `AdSession.finish()`** — the pinned `omweb-v1.js` service dispatches `sessionFinish` to its injected verification clients (validator canary included), and the bridge relays the terminal `sessionFinish` to the creative shim in the `omid-finishing` window (#337 ordering) while the iframe is still attached (it survives the close flow ~100ms–2s).
- **Nothing is synthesized.** Receipts are observed where they actually arrive:
  - **service channel** — `service.canary.sessionFinish`: the canary subscribes through the identical verification-service protocol as the vendor copies and records the service's dispatch.
  - **omid3p channel** — `inlineVendor.lifecycle.sessionFinish` + `sessionFinishCallbacksByVendor`: the creative-window vendor copy's registered session observer receives the relayed event; receipts are attributed per vendor via **registration-time** source URLs (stamped onto callback emits).
  - **container** — `measurement.omid.sessionFinished` re-read from the extension after the probe (set by the runtime's `_finishSession()`).
- A timed-out wait is recorded as evidence (`teardown.waitTimedOut`), never invented away.

## Verdict conservativeness (no G2 churn)

- `terminated` / `finalState` / event arrays are snapshotted **pre-probe** — diagnose's passed gate (`creativeRendered && !terminated`) is untouched; teardown-era entries are reported separately under `measurement.omid.teardown`.
- All finalize-derived OMID fields (`lifecycleComplete`, `passed`, `deliveryChannel`, `diagnosticOutcome`) are frozen pre-probe. `lifecycleComplete` keeps the published start+loaded+impression shape. (Necessary anyway: `_finishSession()` resets the extension's `sessionStarted`, so a post-probe collection would corrupt that evidence.)
- Absence of `sessionFinish` fails **nothing** in this PR. It lands as diagnostics plus triage facet columns: `teardownProbe`, `inlineVendorRowsBySessionFinishReceipt`, `serviceCanaryRows.sessionFinish` — and the previously unreachable `byOutcome: session-finished` terminal key now populates.

## Evidence — rerun with #385's fixtures merged locally (real service, live vendor CDNs)

Reports: `private/reports/20260612-g3-sessionfinish-{vendor-fixtures,ias-organic}.jsonl` (+ triage summaries).

| Vendor | Leg | Cases | sessionFinish receipt | Detail |
|---|---|---|---|---|
| **IAS** | organic (8-case extract) | 8/8 passed | **both channels, 8/8** | attributed omid3p callback (`sessionFinishCallbacksByVendor.ias=1` each) + canary service receipt; 0 wait timeouts |
| **IAS** | fixtures (#385) | 3/3 passed | **both channels, 3/3** | same; incl. late-tag and multivendor |
| **DV** | multivendor fixture (IAS+DV) | 1/1 passed | **service channel** | DV held 3 attributed `addSessionListener` service subscriptions (45 subs total) in the session whose `sessionFinish` dispatch the canary received |
| **Pixalate** | fixtures (real tag, #385) | 2/2 passed | **service channel, 2/2** | pixalate-attributed `addSessionListener` + 4 event subs per row; canary received the finish dispatch; omid3p unused by their loader design (as at G3 capture) |

Aggregate (triage `teardownProbe` facet): 13/13 rows probed, 13/13 `closeRequested`, **0 `waitTimedOut`**, 13/13 `sessionFinished`, 13/13 canary `sessionFinish`, 11/13 omid3p `sessionFinish` (the 2 misses are the Pixalate rows — channel unused by design, not a delivery failure). Receipt column: `both: 11`, `service-canary: 2`.

Service-channel grounding: every vendor copy subscribed to session events through the real service (`addSessionListener`, attributed per vendor via the service's own injected-frame registry), and the canary — registered and dispatched through the same protocol in the same session — received `sessionFinish`. The pinned service (1.5.2) rejects listeners it did not inject, so the canary receipt proves the full inject → register → dispatch pipeline for that session's finish.

## Strictness-bump recommendation

**Recommended, as a follow-up once a full-corpus rerun confirms 0 timeouts at scale:** for probed OMID rows, require `service.canary.sessionFinish` (service mode) — and, when the expected vendor registered an omid3p session observer, `inlineVendor.lifecycle.sessionFinish` — for the row to keep `passed`. The 13/13 clean result here says the chain is reliable; gating now without the at-scale rerun would convert any canary flake into report churn. Not gated in this PR by design.

## Tests

- `test-runner.js`: mock-mode probe assertions (extension `sessionFinished`, attributed omid3p finish callback, verdict fields pre-teardown) + service-mode assertions (canary `sessionFinish`, no timeout).
- `test-triage.js`: new teardown-probe facet test (probed both/service-only/not-probed rows); empty-facet + service-facet shape tests updated.
- `npm run lint` + all four validator suites green (normalizer 37, diagnose 7, runner 14, triage 14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
