### PR TITLE
fix(mraid-bridge): sync getState() on operator-initiated placement changes (closes #391)

### DIFF
--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -2050,6 +2050,13 @@ class SHARCContainer {
    */
   notifyPlacementChange(placementUpdate, extra) {
     const payload = this._buildPlacementChangePayload(placementUpdate);
+    // Expose the resolved placement intent on the outbound payload so the creative side
+    // (e.g. the MRAID compatibility bridge) can derive its placement state for
+    // OPERATOR-initiated placement changes — most notably the container's own dismiss
+    // button collapsing an expand. Without it a creative adapter can only commit a
+    // placement mode when it settles a request it itself made (its pending-intent latch),
+    // leaving getState() stale after an operator-driven collapse (#391).
+    payload.intent = this._currentIntent;
     // Send notification with extra fields merged at the args level
     const args = { placementUpdate: payload };
     if (extra) {

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -4225,6 +4225,7 @@ class SHARCContainer {
     if (placement == null) return;
 
     const payload = this._buildPlacementChangePayload(placement);
+    payload.intent = this._currentIntent; // match notifyPlacementChange shape so dedup compares the same payload
     if (this._placementPayloadUnchanged(payload)) return;
 
     this.notifyPlacementChange(placement);

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -682,18 +682,25 @@ function installMRAIDBridge(SHARC) {
     // stateChange here (off the placementChange macrotask) so getCurrentPosition()
     // reflects the new rect inside the handler.
     //
-    // NOTE: this does NOT yet close #391. Full #391 closure also tracks
-    // OPERATOR-initiated placement changes (a resize/expand the bridge did not
-    // request), which requires the container `placementChange` payload to carry
-    // the placement mode so the bridge can derive state without a pending latch.
-    // That payload enrichment is a later cross-layer slice; until then a
-    // no-pending-intent placementChange updates geometry/sizeChange but leaves
-    // getState() unchanged (asserted by L4b). #396 references #391 but does not
-    // close it.
+    // Operator-initiated path (#391): when there is no pending creative request, derive the
+    // placement mode from the intent the container now carries on the placementChange payload
+    // (container:notifyPlacementChange). This closes the gap where a placement change the
+    // creative did NOT request — most notably the container's own dismiss button collapsing an
+    // expand — updated geometry/sizeChange but left getState() stale. A collapse (intent null)
+    // returns the creative to 'default'; expand/fullscreen → 'expanded'; resize → 'resized'.
     if (pendingMode) {
       _s._pendingPlacementMode = null;
       _s._placementMode = pendingMode;
       _emitStateChange(getMraidState(_s));
+    } else if (placementUpdate.intent !== undefined) {
+      var operatorMode =
+        (placementUpdate.intent === 'expand' || placementUpdate.intent === 'fullscreen') ? 'expanded'
+        : (placementUpdate.intent === 'resize') ? 'resized'
+        : 'default';
+      if (operatorMode !== _s._placementMode) {
+        _s._placementMode = operatorMode;
+        _emitStateChange(getMraidState(_s));
+      }
     }
   });
 

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -692,11 +692,13 @@ function installMRAIDBridge(SHARC) {
       _s._pendingPlacementMode = null;
       _s._placementMode = pendingMode;
       _emitStateChange(getMraidState(_s));
+    // Operator path: pending-latch takes precedence above; this handles changes
+    // the creative did not request (e.g. container dismiss button collapse).
     } else if (placementUpdate.intent !== undefined) {
       var operatorMode =
         (placementUpdate.intent === 'expand' || placementUpdate.intent === 'fullscreen') ? 'expanded'
         : (placementUpdate.intent === 'resize') ? 'resized'
-        : 'default';
+        : 'default'; // null or unknown → default; container is trusted to validate intents
       if (operatorMode !== _s._placementMode) {
         _s._placementMode = operatorMode;
         _emitStateChange(getMraidState(_s));

--- a/test/node/test-mraid-lifecycle-binding.js
+++ b/test/node/test-mraid-lifecycle-binding.js
@@ -25,10 +25,11 @@
  *       first), NOT the requestPlacementChange().then() microtask — so
  *       getCurrentPosition() reflects the new rect inside the stateChange
  *       handler. This covers the CREATIVE-initiated path (a placementChange
- *       that settles an intent the bridge raised). L4b pins that an
- *       OPERATOR-initiated (no-pending-intent) placementChange updates geometry
- *       but does NOT sync state — full #391 closure (operator-initiated mode
- *       sync) needs container placementChange payload enrichment, a later slice.
+ *       that settles an intent the bridge raised). L4b pins that a bare
+ *       geometry-only placementChange (no `intent` field) updates geometry but
+ *       does NOT sync state. L4c asserts the operator-initiated path: a
+ *       placementChange carrying `intent` syncs MRAID placement mode and emits
+ *       stateChange without any pending creative request (closes #391).
  *   L5  RECURRENCE: sizeChange and viewableChange recur on later transitions
  *       (not one-shot).
  *   L6  RISK-2: orientation/window-resize fires SHARC constraintsChange (no
@@ -266,6 +267,15 @@ console.log('test-mraid-lifecycle-binding.js — MRAID 3.0 lifecycle-binding cor
   check(h.mraid.getState() === 'expanded', 'operator expand (intent:"expand") syncs getState() to "expanded"');
   check(tail.some((e) => e.type === 'stateChange' && e.args[0] === 'expanded'),
     'operator expand emits stateChange("expanded")');
+
+  // Operator RESIZE: intent 'resize' → 'resized'.
+  before = h.events.length;
+  h.drivePlacementChange({ position: { x: 0, y: 0, width: 320, height: 250 }, intent: 'resize' });
+  tail = h.events.slice(before);
+  check(h.mraid.getState() === 'resized',
+    'operator resize (intent:"resize") syncs getState() to "resized"');
+  check(tail.some((e) => e.type === 'stateChange' && e.args[0] === 'resized'),
+    'operator resize emits stateChange("resized")');
 
   // Operator COLLAPSE (e.g. container dismiss button): intent null → 'default'.
   before = h.events.length;

--- a/test/node/test-mraid-lifecycle-binding.js
+++ b/test/node/test-mraid-lifecycle-binding.js
@@ -225,14 +225,13 @@ console.log('test-mraid-lifecycle-binding.js — MRAID 3.0 lifecycle-binding cor
     'getCurrentPosition() reflects the expanded rect at stateChange time (no stale value)');
 }
 
-// ── L4b — geometry-only (no-pending-intent) placementChange: geometry, not state ──
+// ── L4b — geometry-only placementChange WITHOUT an intent: geometry, not state ──
 // A placementChange that settles an in-flight intent the bridge raised updates
-// _placementMode (L4); an unsolicited geometry-only placementChange (no pending
-// intent) does NOT change the MRAID state, it only re-fires sizeChange. This is
-// the CURRENT, accurate behavior: operator-initiated mode sync (full #391) is a
-// later slice that needs container placementChange payload enrichment.
+// _placementMode (L4); a bare geometry-only placementChange that carries NO `intent`
+// field leaves the MRAID state untouched and only re-fires sizeChange. (Operator-
+// initiated changes that DO carry `intent` sync state — see L4c.)
 {
-  console.log('L4b — geometry-only placementChange re-fires sizeChange without changing state:');
+  console.log('L4b — geometry-only (no-intent) placementChange re-fires sizeChange without changing state:');
   const h = await makeBridge();
   h.fireReady();
   await tick();
@@ -243,8 +242,38 @@ console.log('test-mraid-lifecycle-binding.js — MRAID 3.0 lifecycle-binding cor
   check(tail.some((e) => e.type === 'sizeChange' && e.args[0] === 300 && e.args[1] === 250),
     'geometry change re-fires sizeChange(300,250)');
   check(!tail.some((e) => e.type === 'stateChange'),
-    'no stateChange emitted for a geometry-only placementChange (no pending intent)');
+    'no stateChange emitted for a geometry-only placementChange (no intent field)');
   check(h.mraid.getState() === 'default', 'getState() stays "default"');
+}
+
+// ── L4c — operator-initiated placementChange WITH intent syncs state (#391) ──
+// When the container drives a placement change the creative did not request — most
+// notably its own dismiss button collapsing an expand — it carries `intent` on the
+// placementChange payload and the bridge derives the MRAID placement mode from it,
+// even with no pending creative request. Closes #391.
+{
+  console.log('L4c — operator-initiated placementChange carries intent and syncs getState() (#391):');
+  const h = await makeBridge();
+  h.fireReady();
+  await tick();
+  h.drivePlacementChange({ position: { x: 0, y: 190, width: 320, height: 50 }, intent: null }); // default
+  check(h.mraid.getState() === 'default', 'baseline getState() is "default"');
+
+  // Operator EXPAND (no pending creative request): intent drives 'expanded'.
+  let before = h.events.length;
+  h.drivePlacementChange({ position: { x: 0, y: 0, width: 320, height: 480 }, intent: 'expand' });
+  let tail = h.events.slice(before);
+  check(h.mraid.getState() === 'expanded', 'operator expand (intent:"expand") syncs getState() to "expanded"');
+  check(tail.some((e) => e.type === 'stateChange' && e.args[0] === 'expanded'),
+    'operator expand emits stateChange("expanded")');
+
+  // Operator COLLAPSE (e.g. container dismiss button): intent null → 'default'.
+  before = h.events.length;
+  h.drivePlacementChange({ position: { x: 0, y: 190, width: 320, height: 50 }, intent: null });
+  tail = h.events.slice(before);
+  check(h.mraid.getState() === 'default', 'operator collapse (intent:null) returns getState() to "default"');
+  check(tail.some((e) => e.type === 'stateChange' && e.args[0] === 'default'),
+    'operator collapse emits stateChange("default")');
 }
 
 // ── L5 — recurrence: sizeChange and viewableChange recur ─────────────────────


### PR DESCRIPTION
Closes #391.

> **Note on #391's status:** the issue is currently closed as `completed`, but the change it prescribes was never actually merged — upstream `main` still carries the `"this does NOT yet close #391"` comment in `sharc-mraid-bridge.js`, and `_placementMode` is still not synced on operator-initiated placement changes (verified: the fix below is absent from `main`). This PR is what implements it; happy to have #391 reopened/relinked however you prefer.

## Summary

An MRAID creative running through the SHARC MRAID compatibility bridge can get stuck in the `expanded` state after the **container's own dismiss button** collapses it: `mraid.getState()` keeps returning `expanded` and no `stateChange('default')` fires, so a creative that drives its layout off the MRAID state machine never returns to its default presentation.

## Reproduction

1. Inline MRAID creative calls `mraid.expand()` (no URL).
2. The container expands and renders its own dismiss button.
3. Tap the container's dismiss button to collapse.
4. The placement collapses (geometry returns to inline, `sizeChange` fires) but `mraid.getState()` stays `'expanded'` and no `stateChange('default')` is emitted.

## Root cause

The bridge's `placementChange` handler only commits a placement mode (and emits `stateChange`) when the change **settles an intent the creative itself requested** — i.e. when `_pendingPlacementMode` was set by `mraid.expand()` / `collapse()` / `resize()`.

An **operator-initiated** placement change — one the creative did not request, the canonical example being the container's own dismiss button — arrives with no pending intent, so it updated geometry/`sizeChange` but left `getState()` untouched. This is exactly the gap the existing in-code note (and #391) calls out:

> until then a no-pending-intent placementChange updates geometry/sizeChange but leaves getState() unchanged

## Fix

Thread the resolved placement **intent** from the container to the creative, and let the bridge derive the placement mode from it when there is no pending creative request.

- **`src/sharc-container.js`** — `notifyPlacementChange()` now sets `payload.intent = this._currentIntent` on the placementChange payload sent to the creative.
- **`src/sharc-mraid-bridge.js`** — in the `placementChange` handler, when `_pendingPlacementMode` is unset, derive the mode from `placementUpdate.intent` (`expand`/`fullscreen` → `expanded`, `resize` → `resized`, `null`/collapse → `default`) and emit `stateChange` (deduped) only when the mode actually changes.

## Behavior / compatibility

- **Creative-initiated** expand/resize/collapse is unchanged — that path still runs through `_pendingPlacementMode` exactly as before.
- A placementChange carrying **no** `intent` field (e.g. a bare geometry-only update) is a no-op for state — geometry/`sizeChange` only, identical to today.
- Additive `intent` field on the payload only; ignored by anything that doesn't read it.

## Tests

`test/node/test-mraid-lifecycle-binding.js`:
- **L4c (new)** — operator expand (`intent: 'expand'`) → `getState()` becomes `expanded` + `stateChange('expanded')`; operator collapse (`intent: null`) → `getState()` returns to `default` + `stateChange('default')`.
- **L4b (updated)** — now documents/asserts the no-intent fallback (geometry only, state unchanged).

`npm run test:mraid-lifecycle-binding` and the placement/state/lifecycle node suites pass; `npm run lint` clean.
