### PR TITLE
fix: operator-initiated getState() sync (#391) + placement re-sync dedup fix

### DIFF
--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -2050,6 +2050,13 @@ class SHARCContainer {
    */
   notifyPlacementChange(placementUpdate, extra) {
     const payload = this._buildPlacementChangePayload(placementUpdate);
+    // Expose the resolved placement intent on the outbound payload so the creative side
+    // (e.g. the MRAID compatibility bridge) can derive its placement state for
+    // OPERATOR-initiated placement changes — most notably the container's own dismiss
+    // button collapsing an expand. Without it a creative adapter can only commit a
+    // placement mode when it settles a request it itself made (its pending-intent latch),
+    // leaving getState() stale after an operator-driven collapse (#391).
+    payload.intent = this._currentIntent;
     // Send notification with extra fields merged at the args level
     const args = { placementUpdate: payload };
     if (extra) {

--- a/src/sharc-container.js
+++ b/src/sharc-container.js
@@ -2024,6 +2024,7 @@ class SHARCContainer {
    * @private
    */
   _buildPlacementChangePayload(placementUpdate) {
+    /** @type {Object} */
     const payload = { ...placementUpdate };
     if (this._iframe) {
       try {
@@ -2038,6 +2039,14 @@ class SHARCContainer {
         // Non-browser environment: skip position enrichment
       }
     }
+    // Stamp the resolved placement intent into the canonical outbound shape so
+    // the creative side (MRAID compatibility bridge) can derive its placement
+    // state for OPERATOR-initiated changes — e.g. the container's own dismiss
+    // button collapsing an expand, which carries no creative-side pending
+    // intent to latch on (#391). Stamping here (not at the send site) also keeps
+    // _syncPlacementState's dedup comparison building the SAME shape it sent, so
+    // an unchanged ACTIVE re-sync is correctly suppressed.
+    payload.intent = this._currentIntent;
     return payload;
   }
 
@@ -2050,13 +2059,6 @@ class SHARCContainer {
    */
   notifyPlacementChange(placementUpdate, extra) {
     const payload = this._buildPlacementChangePayload(placementUpdate);
-    // Expose the resolved placement intent on the outbound payload so the creative side
-    // (e.g. the MRAID compatibility bridge) can derive its placement state for
-    // OPERATOR-initiated placement changes — most notably the container's own dismiss
-    // button collapsing an expand. Without it a creative adapter can only commit a
-    // placement mode when it settles a request it itself made (its pending-intent latch),
-    // leaving getState() stale after an operator-driven collapse (#391).
-    payload.intent = this._currentIntent;
     // Send notification with extra fields merged at the args level
     const args = { placementUpdate: payload };
     if (extra) {

--- a/src/sharc-mraid-bridge.js
+++ b/src/sharc-mraid-bridge.js
@@ -682,18 +682,25 @@ function installMRAIDBridge(SHARC) {
     // stateChange here (off the placementChange macrotask) so getCurrentPosition()
     // reflects the new rect inside the handler.
     //
-    // NOTE: this does NOT yet close #391. Full #391 closure also tracks
-    // OPERATOR-initiated placement changes (a resize/expand the bridge did not
-    // request), which requires the container `placementChange` payload to carry
-    // the placement mode so the bridge can derive state without a pending latch.
-    // That payload enrichment is a later cross-layer slice; until then a
-    // no-pending-intent placementChange updates geometry/sizeChange but leaves
-    // getState() unchanged (asserted by L4b). #396 references #391 but does not
-    // close it.
+    // Operator-initiated path (#391): when there is no pending creative request, derive the
+    // placement mode from the intent the container now carries on the placementChange payload
+    // (container:notifyPlacementChange). This closes the gap where a placement change the
+    // creative did NOT request — most notably the container's own dismiss button collapsing an
+    // expand — updated geometry/sizeChange but left getState() stale. A collapse (intent null)
+    // returns the creative to 'default'; expand/fullscreen → 'expanded'; resize → 'resized'.
     if (pendingMode) {
       _s._pendingPlacementMode = null;
       _s._placementMode = pendingMode;
       _emitStateChange(getMraidState(_s));
+    } else if (placementUpdate.intent !== undefined) {
+      var operatorMode =
+        (placementUpdate.intent === 'expand' || placementUpdate.intent === 'fullscreen') ? 'expanded'
+        : (placementUpdate.intent === 'resize') ? 'resized'
+        : 'default';
+      if (operatorMode !== _s._placementMode) {
+        _s._placementMode = operatorMode;
+        _emitStateChange(getMraidState(_s));
+      }
     }
   });
 

--- a/test/node/test-mraid-lifecycle-binding.js
+++ b/test/node/test-mraid-lifecycle-binding.js
@@ -225,14 +225,13 @@ console.log('test-mraid-lifecycle-binding.js — MRAID 3.0 lifecycle-binding cor
     'getCurrentPosition() reflects the expanded rect at stateChange time (no stale value)');
 }
 
-// ── L4b — geometry-only (no-pending-intent) placementChange: geometry, not state ──
+// ── L4b — geometry-only placementChange WITHOUT an intent: geometry, not state ──
 // A placementChange that settles an in-flight intent the bridge raised updates
-// _placementMode (L4); an unsolicited geometry-only placementChange (no pending
-// intent) does NOT change the MRAID state, it only re-fires sizeChange. This is
-// the CURRENT, accurate behavior: operator-initiated mode sync (full #391) is a
-// later slice that needs container placementChange payload enrichment.
+// _placementMode (L4); a bare geometry-only placementChange that carries NO `intent`
+// field leaves the MRAID state untouched and only re-fires sizeChange. (Operator-
+// initiated changes that DO carry `intent` sync state — see L4c.)
 {
-  console.log('L4b — geometry-only placementChange re-fires sizeChange without changing state:');
+  console.log('L4b — geometry-only (no-intent) placementChange re-fires sizeChange without changing state:');
   const h = await makeBridge();
   h.fireReady();
   await tick();
@@ -243,8 +242,38 @@ console.log('test-mraid-lifecycle-binding.js — MRAID 3.0 lifecycle-binding cor
   check(tail.some((e) => e.type === 'sizeChange' && e.args[0] === 300 && e.args[1] === 250),
     'geometry change re-fires sizeChange(300,250)');
   check(!tail.some((e) => e.type === 'stateChange'),
-    'no stateChange emitted for a geometry-only placementChange (no pending intent)');
+    'no stateChange emitted for a geometry-only placementChange (no intent field)');
   check(h.mraid.getState() === 'default', 'getState() stays "default"');
+}
+
+// ── L4c — operator-initiated placementChange WITH intent syncs state (#391) ──
+// When the container drives a placement change the creative did not request — most
+// notably its own dismiss button collapsing an expand — it carries `intent` on the
+// placementChange payload and the bridge derives the MRAID placement mode from it,
+// even with no pending creative request. Closes #391.
+{
+  console.log('L4c — operator-initiated placementChange carries intent and syncs getState() (#391):');
+  const h = await makeBridge();
+  h.fireReady();
+  await tick();
+  h.drivePlacementChange({ position: { x: 0, y: 190, width: 320, height: 50 }, intent: null }); // default
+  check(h.mraid.getState() === 'default', 'baseline getState() is "default"');
+
+  // Operator EXPAND (no pending creative request): intent drives 'expanded'.
+  let before = h.events.length;
+  h.drivePlacementChange({ position: { x: 0, y: 0, width: 320, height: 480 }, intent: 'expand' });
+  let tail = h.events.slice(before);
+  check(h.mraid.getState() === 'expanded', 'operator expand (intent:"expand") syncs getState() to "expanded"');
+  check(tail.some((e) => e.type === 'stateChange' && e.args[0] === 'expanded'),
+    'operator expand emits stateChange("expanded")');
+
+  // Operator COLLAPSE (e.g. container dismiss button): intent null → 'default'.
+  before = h.events.length;
+  h.drivePlacementChange({ position: { x: 0, y: 190, width: 320, height: 50 }, intent: null });
+  tail = h.events.slice(before);
+  check(h.mraid.getState() === 'default', 'operator collapse (intent:null) returns getState() to "default"');
+  check(tail.some((e) => e.type === 'stateChange' && e.args[0] === 'default'),
+    'operator collapse emits stateChange("default")');
 }
 
 // ── L5 — recurrence: sizeChange and viewableChange recur ─────────────────────

--- a/test/node/test-mraid-lifecycle-binding.js
+++ b/test/node/test-mraid-lifecycle-binding.js
@@ -25,10 +25,12 @@
  *       first), NOT the requestPlacementChange().then() microtask — so
  *       getCurrentPosition() reflects the new rect inside the stateChange
  *       handler. This covers the CREATIVE-initiated path (a placementChange
- *       that settles an intent the bridge raised). L4b pins that an
- *       OPERATOR-initiated (no-pending-intent) placementChange updates geometry
- *       but does NOT sync state — full #391 closure (operator-initiated mode
- *       sync) needs container placementChange payload enrichment, a later slice.
+ *       that settles an intent the bridge raised). L4b pins the negative case:
+ *       an OPERATOR-initiated placementChange that carries NO `intent` updates
+ *       geometry but does NOT sync state. L4c pins #391 closure: an
+ *       OPERATOR-initiated placementChange that DOES carry `intent`
+ *       (expand/resize/collapse) syncs getState() with no pending creative
+ *       request — driven by container placementChange payload enrichment.
  *   L5  RECURRENCE: sizeChange and viewableChange recur on later transitions
  *       (not one-shot).
  *   L6  RISK-2: orientation/window-resize fires SHARC constraintsChange (no
@@ -274,6 +276,15 @@ console.log('test-mraid-lifecycle-binding.js — MRAID 3.0 lifecycle-binding cor
   check(h.mraid.getState() === 'default', 'operator collapse (intent:null) returns getState() to "default"');
   check(tail.some((e) => e.type === 'stateChange' && e.args[0] === 'default'),
     'operator collapse emits stateChange("default")');
+
+  // Operator RESIZE (intent:'resize'): syncs getState() to 'resized' with
+  // exactly one stateChange('resized').
+  before = h.events.length;
+  h.drivePlacementChange({ position: { x: 0, y: 100, width: 300, height: 250 }, intent: 'resize' });
+  tail = h.events.slice(before);
+  check(h.mraid.getState() === 'resized', 'operator resize (intent:"resize") syncs getState() to "resized"');
+  check(tail.filter((e) => e.type === 'stateChange' && e.args[0] === 'resized').length === 1,
+    'operator resize emits exactly one stateChange("resized")');
 }
 
 // ── L5 — recurrence: sizeChange and viewableChange recur ─────────────────────

--- a/test/node/test-placement-dedup.js
+++ b/test/node/test-placement-dedup.js
@@ -107,6 +107,74 @@ console.log('test-placement-dedup.js — issue #6 regression\n');
     'position.x off-by-one returns false');
 }
 
+// Cases 6 & 7 drive the full notifyPlacementChange → _syncPlacementState
+// round-trip, so notifyPlacementChange's `ContainerMessages.PLACEMENT_CHANGE`
+// reference must resolve. The container ESM destructures ContainerMessages from
+// window.SHARC.Protocol when neither `module` nor a Protocol global is present.
+// Set that up, then re-import the container under a cache-busting query so the
+// destructure re-evaluates with the enum available (the static import above ran
+// before the global existed and cached ContainerMessages as undefined).
+globalThis.window = globalThis.window || {};
+globalThis.window.SHARC = globalThis.window.SHARC || {};
+globalThis.window.SHARC.Protocol = {
+  ContainerMessages: { PLACEMENT_CHANGE: 'SHARC:Container:placementChange' },
+};
+const { SHARCContainer: SHARCContainerLive } =
+  await import(`../../dist/sharc-container.mjs?dedup=${Date.now()}`);
+const makeLiveContainer = () => Object.create(SHARCContainerLive.prototype);
+
+// -- Case 6: PR #402 regression — intent-stamped send must dedup on re-sync. --
+//          notifyPlacementChange() stamps `intent` onto the stored payload.
+//          _syncPlacementState() rebuilds the comparison payload and must
+//          produce the IDENTICAL shape (intent included) so an unchanged
+//          re-sync is suppressed. Pre-fix, the stored payload carried an
+//          `intent` key the rebuilt comparison payload lacked, so every
+//          ACTIVE re-sync re-sent a redundant placementChange.
+{
+  console.log('\nCase 6: intent-stamped send → unchanged re-sync is deduped (PR #402 regression)');
+  const c = makeLiveContainer();
+  const sent = [];
+  c._currentIntent = null;
+  c._protocol = { _sendMessage: (type, args) => sent.push({ type, args }) };
+  const placement = { width: 320, height: 480, position: { x: 0, y: 0, width: 320, height: 480 } };
+  c.environmentData = { currentPlacement: placement };
+
+  c.notifyPlacementChange(placement);
+  assert(sent.length === 1, 'first notifyPlacementChange sends exactly one message');
+
+  const syncPayload = c._buildPlacementChangePayload(placement);
+  assert(c._placementPayloadUnchanged(syncPayload) === true,
+    're-sync payload matches the intent-stamped stored payload (dedup returns true)');
+
+  c._syncPlacementState();
+  assert(sent.length === 1, '_syncPlacementState with unchanged intent emits NO second message');
+}
+
+// -- Case 7: intent genuinely changed since last send → re-sync must resend. --
+//          Guards against the fix over-suppressing: when _currentIntent differs
+//          from the value stamped on the last send, the shapes differ and the
+//          re-sync must go through.
+{
+  console.log('\nCase 7: intent changed since last send → re-sync resends (no over-suppression)');
+  const c = makeLiveContainer();
+  const sent = [];
+  c._currentIntent = null;
+  c._protocol = { _sendMessage: (type, args) => sent.push({ type, args }) };
+  const placement = { width: 320, height: 480, position: { x: 0, y: 0, width: 320, height: 480 } };
+  c.environmentData = { currentPlacement: placement };
+
+  c.notifyPlacementChange(placement);
+  assert(sent.length === 1, 'first notifyPlacementChange sends exactly one message');
+
+  c._currentIntent = 'expand';
+  const syncPayload = c._buildPlacementChangePayload(placement);
+  assert(c._placementPayloadUnchanged(syncPayload) === false,
+    'changed intent makes the re-sync payload differ (dedup returns false)');
+
+  c._syncPlacementState();
+  assert(sent.length === 2, '_syncPlacementState with changed intent emits a second message');
+}
+
 console.log('');
 if (failures > 0) {
   console.error(`✗ ${failures} placement-dedup assertion(s) failed.`);


### PR DESCRIPTION
## Summary

Carries @pleasesavemycat's #402 (operator-initiated `getState()` sync, closes #391) **plus** a fix for a dedup regression that #402 introduced — surfaced by the independent reviews on #402. Intended to **supersede #402** (it includes Kelly's commit verbatim, so authorship/credit is preserved).

## The regression #402 introduced

#402 stamped `payload.intent` onto outbound placement payloads at the send site in `notifyPlacementChange`, but `_syncPlacementState` rebuilt its comparison payload via `_buildPlacementChangePayload` **without** `intent`. So the stored `_lastSentPlacement` (carrying an `intent` key — true even for `intent: null`) never string-matched the rebuilt comparison payload, `_placementPayloadUnchanged` always returned `false`, and every ACTIVE re-sync resent a redundant `placementChange`. Latent: no test exercised a re-sync after an intent-stamped send, so the suite stayed green.

## The fix

Move the `intent` stamp **into** `_buildPlacementChangePayload` — the single canonical outbound shape that both `notifyPlacementChange` and the `_syncPlacementState` dedup comparison build. One source of truth → the comparison matches what was sent. (2-line production change in `src/sharc-container.js`; the only non-test edit.)

## Tests added (red-first)

- `test/node/test-placement-dedup.js` **Case 6** — intent-stamped send → unchanged-intent re-sync **dedups** (no second message). Confirmed RED before the fix, GREEN after.
- `test/node/test-placement-dedup.js` **Case 7** — intent genuinely changed since last send → re-sync **resends** (guards against over-suppression).
- `test/node/test-mraid-lifecycle-binding.js` — operator-**resize** lifecycle case (`intent:'resize'` → `getState() === 'resized'` + one `stateChange('resized')`); #402's L4c covered expand+collapse but not resize.
- Refreshed the stale "later slice" test header.

## Verification

- `npm run test:all` → 81 pass / 0 fail (incl. `test:types`)
- `npm run lint` → clean (`--max-warnings=0`)
- `npm run build` + `npm run build:prod` → clean

## Notes

- Slice-D clean: no new `_sharcState` reads; MRAID `state` stays on the placement axis (state ⊥ viewability).
- Credit: feature by @pleasesavemycat (#402); dedup regression caught by the Codex independent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
