### PR TITLE
fix(protocol): converge multi-realm sessions + receive port messages via addEventListener (iOS WKWebView)

### DIFF
--- a/examples/renderer/index.html
+++ b/examples/renderer/index.html
@@ -1177,7 +1177,7 @@
     return await resp.text();
   }
 
-  async function installMraidCompatibilityWrapperPrelude(html) {
+  async function installMraidCompatibilityWrapperPrelude(html, placementSessionId) {
     var protocolSource = await fetchSameOriginRendererSource(
       'MRAID_WRAPPER_PROTOCOL_URL', 'mraid_wrapper_protocol');
     var creativeSource = await fetchSameOriginRendererSource(
@@ -1188,6 +1188,10 @@
     var code = ''
       + '(function(){'
       + 'window.__sharcMraidBridgeAutoInstall=true;'
+      // Expose the container-minted placement session id in the creative realm so the
+      // inlined creative SDK converges its session id with the renderer-frame SDK
+      // (SHARCCreativeProtocol.createSession adopts window.__sharcPlacementSessionId__).
+      + 'window.__sharcPlacementSessionId__=' + jsonForInlineScript(placementSessionId) + ';'
       + protocolSource + ';\n'
       + creativeSource + ';\n'
       + bridgeSource + ';\n'
@@ -1227,7 +1231,7 @@
   //   - Fetch/inject failure is fatal; silently rendering without the wrapper
   //     would recreate the raw-SafeFrame stall this closes.
   // ─────────────────────────────────────────────────────────────────────
-  async function installSafeFrameCompatibilityWrapperPrelude(html) {
+  async function installSafeFrameCompatibilityWrapperPrelude(html, placementSessionId) {
     var protocolSource = await fetchSameOriginRendererSource(
       'SAFEFRAME_WRAPPER_PROTOCOL_URL', 'safeframe_wrapper_protocol');
     var creativeSource = await fetchSameOriginRendererSource(
@@ -1238,6 +1242,10 @@
     var code = ''
       + '(function(){'
       + 'window.__sharcSafeFrameBridgeAutoInstall=true;'
+      // Expose the container-minted placement session id in the creative realm so the
+      // inlined creative SDK converges its session id with the renderer-frame SDK
+      // (SHARCCreativeProtocol.createSession adopts window.__sharcPlacementSessionId__).
+      + 'window.__sharcPlacementSessionId__=' + jsonForInlineScript(placementSessionId) + ';'
       + protocolSource + ';\n'
       + creativeSource + ';\n'
       + bridgeSource + ';\n'
@@ -1848,6 +1856,11 @@
       return bridgeName !== 'mraid' && bridgeName !== 'safeframe';
     });
 
+    // Expose the placement session id in the renderer realm unconditionally so the
+    // renderer-frame creative SDK converges its session id with any inlined
+    // compatibility-wrapper SDK (SHARCCreativeProtocol.createSession adopts it).
+    window.__sharcPlacementSessionId__ = placementSessionId;
+
     if (dynamicBridgesToLoad.length > 0) {
       // Thread :render session context to compatibility bridges before
       // dynamic import so auto-install timeout diagnostics identify the
@@ -2043,7 +2056,7 @@
     // and viewableChange(true). Native SHARC and plain HTML paths are skipped.
     if (shouldInstallMraidCompatibilityWrapper) {
       try {
-        html = await installMraidCompatibilityWrapperPrelude(html);
+        html = await installMraidCompatibilityWrapperPrelude(html, placementSessionId);
       } catch (mraidErr) {
         var mraidErrUrl = (mraidErr && /** @type {any} */ (mraidErr).url)
           ? /** @type {any} */ (mraidErr).url
@@ -2086,7 +2099,7 @@
     // and plain HTML paths are skipped.
     if (shouldInstallSafeFrameCompatibilityWrapper) {
       try {
-        html = await installSafeFrameCompatibilityWrapperPrelude(html);
+        html = await installSafeFrameCompatibilityWrapperPrelude(html, placementSessionId);
       } catch (safeframeErr) {
         var safeframeErrUrl = (safeframeErr && /** @type {any} */ (safeframeErr).url)
           ? /** @type {any} */ (safeframeErr).url

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -375,9 +375,18 @@ class SHARCProtocolBase {
    */
   _attachPort(port) {
     this._port = port;
-    this._port.onmessage = this._onPortMessage.bind(this);
-    // MessagePort needs start() if using addEventListener
-    // onmessage assignment implicitly starts it, but call it explicitly for safety
+    // Use addEventListener (NOT `onmessage =`) to receive messages. Rationale: when a
+    // host attaches its OWN listener to the port and start()s it BEFORE handing the port
+    // to this SDK in-realm — e.g. the example renderer binds a load-probe answerer via
+    // addEventListener('message', ...) + port.start() before pushing the port to the
+    // inlined creative SDK — iOS WKWebView delivers subsequent messages ONLY to that
+    // addEventListener listener; a later `onmessage =` assignment is silently never
+    // delivered to (a deviation from the HTML spec, which fans out to both). Binding via
+    // addEventListener lets this handler coexist with any pre-existing port listener so
+    // all container messages (Container:init, startCreative, ...) are delivered. The
+    // bound handler is retained so reset()/terminate() can removeEventListener it.
+    this._boundOnPortMessage = this._onPortMessage.bind(this);
+    this._port.addEventListener('message', this._boundOnPortMessage);
     if (typeof this._port.start === 'function') {
       this._port.start();
     }
@@ -625,7 +634,10 @@ class SHARCProtocolBase {
     this._pendingResponses = {};
     this._terminated = false;
     if (this._port) {
-      this._port.onmessage = null;
+      if (this._boundOnPortMessage) {
+        this._port.removeEventListener('message', this._boundOnPortMessage);
+      }
+      this._boundOnPortMessage = null;
       this._port = null;
     }
     if (this._onResetHook) {
@@ -649,8 +661,9 @@ class SHARCProtocolBase {
       cb({ type: ProtocolMessages.REJECT, args: { messageId: Number(msgId), value: termError } });
     });
     this._pendingResponses = {};
-    if (this._port) {
-      this._port.onmessage = null;
+    if (this._port && this._boundOnPortMessage) {
+      this._port.removeEventListener('message', this._boundOnPortMessage);
+      this._boundOnPortMessage = null;
     }
   }
 }

--- a/src/sharc-protocol.js
+++ b/src/sharc-protocol.js
@@ -1296,7 +1296,6 @@ class SHARCCreativeProtocol extends SHARCProtocolBase {
    * @returns {Promise<*>} Resolves when container accepts the session.
    */
   createSession() {
-    this.sessionId = generateUUID();
     // Keep the State-Delivery Contract's "_lastSentState reset everywhere
     // sessionId is set" invariant true on the creative side too. Inert today
     // (the creative subclass never calls sendStateChange), but this closes the
@@ -1305,6 +1304,30 @@ class SHARCCreativeProtocol extends SHARCProtocolBase {
     // Wait for the MessagePort bootstrap before sending — the container
     // delivers port2 asynchronously after the iframe load event.
     return this._portReadyPromise.then(() => {
+      // Multi-realm provisioning convergence. A single placement can provision the
+      // creative SDK in MORE THAN ONE realm — e.g. a renderer that loads this SDK in
+      // its own frame AND inlines a MRAID/SafeFrame compatibility-wrapper SDK into the
+      // creative document (a separate realm). Each realm's createSession() would
+      // otherwise mint an INDEPENDENT session id; the container adopts one and echoes
+      // it in Container:init, so the other realm drops that init on its
+      // `sessionId === this.sessionId` gate (silent) and the container then hits
+      // RESOLVE_TIMEOUT. When the host exposes the container-minted placement session
+      // id (`window.__sharcPlacementSessionId__`, a UUID v4 identical across realms),
+      // adopt it so every provisioning site converges on ONE session. Read at
+      // port-ready so the value is already exposed; fall back to a fresh UUID when no
+      // placement session id is available (legacy / non-renderer hosting).
+      let placementSessionId = null;
+      try {
+        if (typeof window !== 'undefined' &&
+            typeof window.__sharcPlacementSessionId__ === 'string') {
+          placementSessionId = window.__sharcPlacementSessionId__;
+        }
+      } catch (_e) { /* window may be inaccessible from some sandboxed realms */ }
+      const isUuidV4 =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      this.sessionId = (placementSessionId && isUuidV4.test(placementSessionId))
+        ? placementSessionId
+        : generateUUID();
       return this._sendMessage(ProtocolMessages.CREATE_SESSION, {
         placementType: this._placementType || 'inline',
         version: SHARC_VERSION,


### PR DESCRIPTION
## Summary

Two complementary fixes to the creative-side protocol that, together, let a SHARC creative loaded via the real-origin reference renderer reach `active` (paint) on **iOS WKWebView**, where it previously stalled at `RESOLVE_TIMEOUT` (2208) and terminated. Both were root-caused with cross-frame instrumentation and validated end-to-end by capturing **literal painted pixels** of a SHARC creative on the iOS simulator *and* the Android emulator.

### 1. Converge multi-realm creative-SDK sessions onto `placementSessionId`
A single placement can provision the creative SDK in **more than one realm** — e.g. the renderer loads the SDK in its own frame **and** inlines a MRAID/SafeFrame compatibility-wrapper SDK into the creative document (a separate realm). Each realm's `createSession()` minted an **independent** session UUID; the container adopts one and echoes it in `Container:init`, so the other realm silently drops that init on its `sessionId === this.sessionId` gate and the container hits `RESOLVE_TIMEOUT`.

`SHARCCreativeProtocol.createSession()` now adopts the container-minted placement session id (`window.__sharcPlacementSessionId__`, a UUID v4 identical across realms) when present, so every provisioning site converges on one session; it falls back to a fresh UUID for legacy / non-renderer hosting. The reference renderer (`examples/renderer/index.html`) now exposes that global in **every** SDK-booting realm: unconditionally in the renderer frame, and inside the MRAID & SafeFrame compatibility-wrapper preludes.

### 2. Receive `MessagePort` messages via `addEventListener`, not `onmessage`
`SHARCProtocolBase._attachPort` attached its handler with `port.onmessage =`. On **iOS WKWebView** this is silently starved when a host has already bound an `addEventListener('message')` listener to the **same port** and called `port.start()` *before* handing the port to the SDK in-realm — which is exactly what the reference renderer does (it binds a load-probe answerer + `start()`s the port, then pushes the port to the inlined creative SDK via `__attachRendererPort`). In that ordering, iOS WKWebView delivers subsequent messages **only** to the pre-existing `addEventListener` listener and **never** to the later `onmessage =` handler — a deviation from the HTML spec, which fans a message out to both. The creative SDK therefore never received `Container:init` / `startCreative`, `_handleInit` never ran, and the container timed out.

`_attachPort` now binds via `addEventListener('message', handler)` (retaining the bound handler), so it coexists with any pre-existing port listener. `reset()` / `terminate()` `removeEventListener` the retained handler instead of clearing `onmessage`.

## Evidence
- **Empirical confirmation:** with cross-frame tracing, the renderer's `addEventListener` answerer received `Container:init` on iOS WKWebView while the SDK's `onmessage` handler did not — the smoking gun for fix #2. After the fix, the SDK receives `resolve` → `init` → `startCreative` and the creative reaches `active`.
- **Pixels:** captured a fully-painted SHARC creative on the iOS simulator (`reachedActiveBlock=true`) and the Android emulator (`active|block` @153ms, PixelCopy SUCCESS) — same fixture, both platforms.

## Tests
- `npm run build` (rollup + types): clean.
- Node protocol/lifecycle suites pass (`protocol-router`, `onready-replay`, `creative-state-replay`, `renderer-protocol-retrofit`, MRAID lifecycle-binding, etc.). The Puppeteer browser suites couldn't run in my local env (no Chrome) — they should exercise the real-port handshake in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)